### PR TITLE
fix(observability): include gRPC workers in GET /engine_metrics

### DIFF
--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -266,6 +266,10 @@ pub(crate) fn init_metrics() {
         "smg_manual_policy_cache_entries",
         "Number of routing entries in manual policy cache"
     );
+    describe_counter!(
+        "smg_engine_metrics_scrape_total",
+        "Engine /metrics scrape attempts by connection_mode and result (success/failure/skipped)"
+    );
 
     // Layer 3: Worker resilience metrics (circuit breaker)
     describe_gauge!(
@@ -530,6 +534,8 @@ pub mod metrics_labels {
     pub const RESULT_ERROR: &str = "error";
     pub const RESULT_TIMEOUT: &str = "timeout";
     pub const RESULT_NOT_FOUND: &str = "not_found";
+    pub const RESULT_FAILURE: &str = "failure";
+    pub const RESULT_SKIPPED: &str = "skipped";
 
     // Discovery sources
     pub const DISCOVERY_STATIC: &str = "static";
@@ -1092,6 +1098,21 @@ impl Metrics {
             "worker_type" => worker_type,
             "connection_mode" => connection_mode,
             "error_type" => error_type
+        )
+        .increment(1);
+    }
+
+    /// Record an engine `/metrics` scrape attempt.
+    ///
+    /// `result` is one of [`metrics_labels::RESULT_SUCCESS`],
+    /// [`metrics_labels::RESULT_FAILURE`], or [`metrics_labels::RESULT_SKIPPED`]
+    /// (skipped = no scrape endpoint known for the worker). Both labels are
+    /// static, so no interning is needed.
+    pub fn record_engine_metrics_scrape(connection_mode: &'static str, result: &'static str) {
+        counter!(
+            "smg_engine_metrics_scrape_total",
+            "connection_mode" => connection_mode,
+            "result" => result
         )
         .increment(1);
     }

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -835,6 +835,14 @@ const SGLANG_GRPC_KEYS: &[&str] = &[
     "is_embedding",
     "vocab_size",
     "weight_version",
+    // Engine /metrics scrape discovery (W1). Consumed by
+    // `discover_metadata::derive_grpc_metrics_url` to compute the `metrics_url`
+    // label; never scraped unless `enable_metrics` is truthy.
+    "metrics_url",
+    "prometheus_port",
+    "enable_metrics",
+    "host",
+    "port",
 ];
 
 /// Keys worth extracting from TokenSpeed gRPC `server_args` (post-rename: bare

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -33,7 +33,7 @@ use crate::{
         metrics_aggregator::{self, MetricPack},
         monitor::WorkerMonitor,
         registry::{WorkerDescriptor, WorkerId},
-        worker::WorkerTypeExt,
+        worker::{ConnectionModeExt, WorkerTypeExt},
         ConnectionMode, Worker, WorkerOrigin, WorkerRegistry, WorkerResult, WorkerType,
     },
     workflow::{Job, JobQueue},
@@ -43,40 +43,76 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_CONCURRENT: usize = 32;
 const MAX_CONCURRENT_HEALTH_PROBES: usize = 128;
 
-/// Result of a fan-out request to a single worker
-struct WorkerResponse {
+/// Result of an engine-metrics scrape against a single worker.
+struct ScrapeResponse {
+    /// Worker identity label (rank-stripped `worker.base_url()`), kept distinct
+    /// from the scrape endpoint so gRPC workers are labelled by their gRPC
+    /// address and DP ranks sharing an endpoint collapse to one label.
     url: String,
-    result: Result<reqwest::Response, reqwest::Error>,
+    connection_mode: &'static str,
+    /// Outer `None`: no known scrape endpoint (skipped). `Some(None)`: the
+    /// fetch or body read failed, or the response was non-2xx. `Some(Some(_))`:
+    /// the response body. The body is read inside the per-worker future so
+    /// downloads run concurrently rather than serialized in the consumer.
+    result: Option<Option<String>>,
 }
 
-/// Fan out requests to workers in parallel
-async fn fan_out(
+/// Fan out engine `/metrics` scrapes in parallel.
+///
+/// The scrape endpoint is resolved per worker via [`Worker::metrics_url`]: HTTP
+/// workers scrape their base `/metrics`, gRPC workers scrape the HTTP endpoint
+/// discovered during metadata discovery. Workers with no known endpoint are
+/// returned with `result: None` so the caller can count them as skipped instead
+/// of dropping them silently.
+///
+/// DP-aware backends register one worker per rank that all share a single engine
+/// `/metrics` endpoint (same host + `prometheus_port`). Scraping every rank would
+/// fetch identical bodies and inflate each summed series by `dp_size`, so workers
+/// are collapsed by scrape endpoint (falling back to the rank-stripped `base_url`
+/// when no endpoint is known) and each is fetched once.
+async fn scrape_engine_metrics(
     workers: &[Arc<dyn Worker>],
     client: &reqwest::Client,
-    endpoint: &str,
-    method: reqwest::Method,
-) -> Vec<WorkerResponse> {
-    let futures: Vec<_> = workers
-        .iter()
-        .map(|worker| {
-            let client = client.clone();
-            let url = worker.url().to_string();
-            let full_url = format!("{url}/{endpoint}");
-            let api_key = worker.api_key().cloned();
-            let method = method.clone();
-
-            async move {
-                let mut req = client.request(method, &full_url).timeout(REQUEST_TIMEOUT);
-                if let Some(key) = api_key {
-                    req = req.bearer_auth(key);
-                }
-                WorkerResponse {
+) -> Vec<ScrapeResponse> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut futures = Vec::new();
+    for worker in workers {
+        let metrics_url = worker.metrics_url();
+        let dedupe_key = metrics_url
+            .clone()
+            .unwrap_or_else(|| worker.base_url().to_string());
+        if !seen.insert(dedupe_key) {
+            continue;
+        }
+        let client = client.clone();
+        // Label by the rank-stripped base URL: the scrape represents the whole
+        // engine, not the arbitrary rank that won deduplication.
+        let url = worker.base_url().to_string();
+        let connection_mode = worker.connection_mode().as_metric_label();
+        let api_key = worker.api_key().cloned();
+        futures.push(async move {
+            let Some(metrics_url) = metrics_url else {
+                return ScrapeResponse {
                     url,
-                    result: req.send().await,
-                }
+                    connection_mode,
+                    result: None,
+                };
+            };
+            let mut req = client.get(&metrics_url).timeout(REQUEST_TIMEOUT);
+            if let Some(key) = api_key {
+                req = req.bearer_auth(key);
             }
-        })
-        .collect();
+            let body = match req.send().await {
+                Ok(resp) if resp.status().is_success() => resp.text().await.ok(),
+                _ => None,
+            };
+            ScrapeResponse {
+                url,
+                connection_mode,
+                result: Some(body),
+            }
+        });
+    }
 
     stream::iter(futures)
         .buffer_unordered(MAX_CONCURRENT)
@@ -985,24 +1021,51 @@ impl WorkerManager {
             return EngineMetricsResult::Err("No available workers".to_string());
         }
 
-        let responses = fan_out(&workers, client, "metrics", reqwest::Method::GET).await;
+        let responses = scrape_engine_metrics(&workers, client).await;
+        // Targets are deduplicated (DP ranks sharing an endpoint collapse to
+        // one), so the skipped/attempted accounting is per endpoint, not per
+        // worker.
+        let total_targets = responses.len();
 
         let mut metric_packs = Vec::new();
+        let mut skipped = 0usize;
         for resp in responses {
-            if let Ok(r) = resp.result {
-                if r.status().is_success() {
-                    if let Ok(text) = r.text().await {
-                        metric_packs.push(MetricPack {
-                            labels: vec![("worker_addr".into(), resp.url)],
-                            metrics_text: text,
-                        });
-                    }
+            let Some(text) = resp.result else {
+                skipped += 1;
+                Metrics::record_engine_metrics_scrape(
+                    resp.connection_mode,
+                    metrics_labels::RESULT_SKIPPED,
+                );
+                continue;
+            };
+            match text {
+                Some(text) => {
+                    Metrics::record_engine_metrics_scrape(
+                        resp.connection_mode,
+                        metrics_labels::RESULT_SUCCESS,
+                    );
+                    metric_packs.push(MetricPack {
+                        labels: vec![("worker_addr".into(), resp.url)],
+                        metrics_text: text,
+                    });
                 }
+                None => Metrics::record_engine_metrics_scrape(
+                    resp.connection_mode,
+                    metrics_labels::RESULT_FAILURE,
+                ),
             }
         }
 
         if metric_packs.is_empty() {
-            return EngineMetricsResult::Err("All backend requests failed".to_string());
+            let msg = if skipped == total_targets {
+                "No workers expose a metrics endpoint".to_string()
+            } else {
+                let attempted = total_targets - skipped;
+                format!(
+                    "All {attempted} scrape request(s) failed ({skipped} endpoint(s) skipped — no metrics endpoint)"
+                )
+            };
+            return EngineMetricsResult::Err(msg);
         }
 
         match metrics_aggregator::aggregate_metrics(metric_packs) {
@@ -1472,5 +1535,56 @@ mod tests {
         assert!(result.successful.is_empty());
         assert!(result.failed.is_empty());
         assert!(result.message.contains("No worker matching"));
+    }
+
+    // ── Engine-metrics scrape URL selection per connection mode ──────
+
+    fn grpc_worker_with_labels(url: &str, labels: &[(&str, &str)]) -> Arc<dyn Worker> {
+        let labels = labels
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .connection_mode(ConnectionMode::Grpc)
+                .labels(labels)
+                .build(),
+        )
+    }
+
+    #[test]
+    fn metrics_url_http_appends_metrics_path() {
+        let worker = make_worker("http://w:8080", 1, 1);
+        assert_eq!(
+            worker.metrics_url().as_deref(),
+            Some("http://w:8080/metrics")
+        );
+    }
+
+    #[test]
+    fn metrics_url_grpc_prefers_explicit_label() {
+        let worker = grpc_worker_with_labels(
+            "grpc://w:30001",
+            &[("metrics_url", "http://sidecar:9000/metrics")],
+        );
+        assert_eq!(
+            worker.metrics_url().as_deref(),
+            Some("http://sidecar:9000/metrics")
+        );
+    }
+
+    #[test]
+    fn metrics_url_grpc_derives_from_prometheus_port() {
+        let worker = grpc_worker_with_labels("grpc://w:30001", &[("prometheus_port", "9100")]);
+        assert_eq!(
+            worker.metrics_url().as_deref(),
+            Some("http://w:9100/metrics")
+        );
+    }
+
+    #[test]
+    fn metrics_url_grpc_none_when_unknown() {
+        let worker = grpc_worker_with_labels("grpc://w:30001", &[]);
+        assert_eq!(worker.metrics_url(), None);
     }
 }

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -48,6 +48,21 @@ pub const MOONCAKE_CONNECTOR: &str = "MooncakeConnector";
 /// vLLM NIXL KV connector name
 pub const NIXL_CONNECTOR: &str = "NixlConnector";
 
+/// Format `host:port` into a URL authority, bracketing the host when it is a
+/// bare IPv6 literal.
+///
+/// IPv6 address literals must be bracketed in an HTTP authority (RFC 3986), so
+/// `::1` becomes `[::1]:9100`; otherwise `reqwest`/`url` reject the target and
+/// the scrape silently fails. Hosts that are already bracketed or not IPv6
+/// (no `:`) pass through unchanged, so this is idempotent.
+pub(crate) fn metrics_authority(host: &str, port: &str) -> String {
+    if host.contains(':') && !(host.starts_with('[') && host.ends_with(']')) {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
 /// POST an admin endpoint on an HTTP worker and map the outcome to a
 /// [`WorkerResult`].
 async fn admin_http_post(
@@ -394,6 +409,11 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
         self.metadata().endpoint_url(route)
     }
 
+    /// HTTP `/metrics` scrape endpoint for this worker, if known.
+    fn metrics_url(&self) -> Option<String> {
+        self.metadata().metrics_url()
+    }
+
     /// Check if this worker is DP-aware.
     fn is_dp_aware(&self) -> bool {
         self.metadata().is_dp_aware()
@@ -672,6 +692,38 @@ impl WorkerMetadata {
     /// Compose an endpoint URL for a specific route.
     pub fn endpoint_url(&self, route: &str) -> String {
         format!("{}{}", self.base_url(), route)
+    }
+
+    /// HTTP `/metrics` endpoint for this worker, if known.
+    ///
+    /// HTTP workers expose `/metrics` on their own URL. gRPC workers have no
+    /// HTTP URL, so the scrape endpoint is discovered from `server_args` during
+    /// metadata discovery and stored in labels. Precedence: an explicit
+    /// `metrics_url` label, then a `prometheus_port` label combined with the
+    /// gRPC host. Returns `None` when no endpoint is known (the worker is then
+    /// skipped by the engine-metrics fan-out rather than scraped on a dark port).
+    pub fn metrics_url(&self) -> Option<String> {
+        match self.spec.connection_mode {
+            ConnectionMode::Http => Some(format!("{}/metrics", self.spec.url)),
+            ConnectionMode::Grpc => self.grpc_metrics_url(),
+        }
+    }
+
+    fn grpc_metrics_url(&self) -> Option<String> {
+        let labels = &self.spec.labels;
+        if let Some(url) = labels.get("metrics_url").filter(|s| !s.is_empty()) {
+            return Some(url.clone());
+        }
+        // Discovery sets an explicit `metrics_url` whenever one is derivable, so
+        // this is a fallback for workers configured out-of-band. Use the worker's
+        // own URL host (`bootstrap_host`, parsed from `spec.url`); skip when it's
+        // empty rather than emitting a hostless scrape target.
+        let port = labels.get("prometheus_port").filter(|s| !s.is_empty())?;
+        let host = self.spec.bootstrap_host.as_str();
+        if host.is_empty() {
+            return None;
+        }
+        Some(format!("http://{}/metrics", metrics_authority(host, port)))
     }
 
     // ── DP awareness ────────────────────────────────────────────────
@@ -2357,5 +2409,35 @@ mod tests {
         assert!(worker.supports_model("text-embedding-3-small"));
         assert!(!worker.supports_model("non-existent-model"));
         assert!(worker.has_models_discovered());
+    }
+
+    #[test]
+    fn test_metrics_authority_brackets_bare_ipv6() {
+        assert_eq!(metrics_authority("::1", "9100"), "[::1]:9100");
+        assert_eq!(
+            metrics_authority("2001:db8::1", "9100"),
+            "[2001:db8::1]:9100"
+        );
+        // Already bracketed and non-IPv6 hosts pass through (idempotent).
+        assert_eq!(metrics_authority("[::1]", "9100"), "[::1]:9100");
+        assert_eq!(metrics_authority("10.0.0.5", "9100"), "10.0.0.5:9100");
+        assert_eq!(metrics_authority("node-7", "9100"), "node-7:9100");
+    }
+
+    #[test]
+    fn test_grpc_metrics_url_ipv6_fallback_is_bracketed() {
+        use crate::worker::BasicWorkerBuilder;
+        let mut labels = std::collections::HashMap::new();
+        labels.insert("prometheus_port".to_string(), "9100".to_string());
+        let worker = BasicWorkerBuilder::new("grpc://[::1]:30001")
+            .connection_mode(ConnectionMode::Grpc)
+            .labels(labels)
+            .build();
+        // The prometheus_port fallback must keep the IPv6 host bracketed so the
+        // scrape URL is a valid authority.
+        assert_eq!(
+            worker.metrics_url().as_deref(),
+            Some("http://[::1]:9100/metrics")
+        );
     }
 }

--- a/model_gateway/src/workflow/steps/local/discover_metadata.rs
+++ b/model_gateway/src/workflow/steps/local/discover_metadata.rs
@@ -11,7 +11,10 @@ use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowRe
 
 use crate::{
     routers::grpc::client::{flat_labels, GrpcClient},
-    worker::{sampling_defaults::SamplingDefaults, ConnectionMode, DEFAULT_SAMPLING_PARAMS_LABEL},
+    worker::{
+        sampling_defaults::SamplingDefaults, worker::metrics_authority, ConnectionMode,
+        DEFAULT_SAMPLING_PARAMS_LABEL,
+    },
     workflow::{
         data::{WorkerKind, WorkerWorkflowData},
         steps::util::{grpc_base_url, http_base_url},
@@ -254,7 +257,106 @@ async fn fetch_grpc_metadata(
     }
 
     normalize_grpc_keys(&mut labels);
+    derive_grpc_metrics_url(&mut labels, &grpc_url);
     Ok((labels, runtime_type.to_string()))
+}
+
+/// Resolve the engine `/metrics` scrape endpoint for a gRPC worker into a
+/// canonical `metrics_url` label, consuming the transient `server_args` keys it
+/// derives from.
+///
+/// Precedence:
+/// 1. explicit `metrics_url` — but only when its host matches the worker's gRPC
+///    host (see below),
+/// 2. `prometheus_port` (+ gRPC host),
+/// 3. derived `http://{host}:{port}/metrics` — only when an `enable_metrics`
+///    flag is truthy, so a dark port is never advertised.
+///
+/// The host always comes from the gRPC worker URL, never from the `server_args`
+/// `host` (which is the bind address — often `0.0.0.0`/`::`/empty — and not a
+/// routable scrape target). This keeps the scrape and its bearer token on the
+/// worker's own host. The `host` key is consumed but not used.
+///
+/// An explicit `metrics_url` is backend-advertised and therefore untrusted; we
+/// accept it only when its host matches the worker's gRPC host so a backend
+/// cannot redirect the scrape (and any attached credentials) to an arbitrary
+/// origin. Scheme and port are not constrained — the metrics port differs from
+/// the gRPC port by design. A mismatching `metrics_url` is dropped and we fall
+/// back to the derived endpoint (or none).
+fn derive_grpc_metrics_url(labels: &mut HashMap<String, String>, grpc_url: &str) {
+    let enable_metrics = labels.remove("enable_metrics");
+    let prometheus_port = labels.remove("prometheus_port").filter(|s| !s.is_empty());
+    labels.remove("host");
+    let port = labels.remove("port").filter(|s| !s.is_empty());
+
+    let worker_host = grpc_host(grpc_url);
+    let explicit = labels
+        .get("metrics_url")
+        .filter(|s| !s.is_empty())
+        .filter(|url| url_host(url).as_deref() == Some(worker_host.as_str()))
+        .cloned();
+
+    let resolved = explicit
+        .or_else(|| {
+            prometheus_port
+                .map(|p| format!("http://{}/metrics", metrics_authority(&worker_host, &p)))
+        })
+        .or_else(|| {
+            (is_truthy(enable_metrics.as_deref()) && port.is_some()).then(|| {
+                let p = port.unwrap_or_default();
+                format!("http://{}/metrics", metrics_authority(&worker_host, &p))
+            })
+        });
+
+    match resolved {
+        Some(url) => {
+            labels.insert("metrics_url".to_string(), url);
+        }
+        None => {
+            labels.remove("metrics_url");
+        }
+    }
+}
+
+/// Truthy flag values as emitted by `server_args` (bools become `"true"`, ints
+/// like a port number become e.g. `"1"`).
+fn is_truthy(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("true" | "1" | "yes" | "on")
+    )
+}
+
+/// Host portion of a gRPC URL (`grpc://host:port` → `host`,
+/// `grpc://[::1]:port` → `::1`), falling back to the stripped input.
+fn grpc_host(grpc_url: &str) -> String {
+    let stripped = grpc_url
+        .strip_prefix("grpc://")
+        .or_else(|| grpc_url.strip_prefix("grpcs://"))
+        .unwrap_or(grpc_url);
+    // `rsplit_once` keeps bracketed IPv6 literals intact (`[::1]:port`); a
+    // plain `split_once(':')` would cut at the first colon of the address.
+    let host = stripped.rsplit_once(':').map_or(stripped, |(h, _)| h);
+    host.strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host)
+        .to_string()
+}
+
+/// Host of an arbitrary URL in unbracketed form, for comparison against
+/// [`grpc_host`] (which is also unbracketed). Returns `None` if the URL has no
+/// parsable host, so an unparsable explicit `metrics_url` is rejected rather
+/// than silently trusted.
+fn url_host(url: &str) -> Option<String> {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_string))
+        .map(|h| {
+            h.strip_prefix('[')
+                .and_then(|s| s.strip_suffix(']'))
+                .unwrap_or(&h)
+                .to_string()
+        })
 }
 
 /// Rename gRPC-specific keys to canonical names and strip transient state.
@@ -458,6 +560,141 @@ mod tests {
             labels.get("max_running_requests").map(String::as_str),
             Some("256")
         );
+    }
+
+    fn labels_of(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn derive_grpc_metrics_url_prefers_explicit() {
+        // Explicit URL on the worker's own host (only the port differs) is
+        // trusted and wins over the derived candidates.
+        let mut labels = labels_of(&[
+            ("metrics_url", "http://host:9000/metrics"),
+            ("prometheus_port", "9100"),
+            ("enable_metrics", "true"),
+        ]);
+        derive_grpc_metrics_url(&mut labels, "grpc://host:30001");
+        assert_eq!(
+            labels.get("metrics_url").map(String::as_str),
+            Some("http://host:9000/metrics")
+        );
+        // Transient derivation keys are consumed.
+        assert!(!labels.contains_key("prometheus_port"));
+        assert!(!labels.contains_key("enable_metrics"));
+    }
+
+    #[test]
+    fn derive_grpc_metrics_url_rejects_explicit_on_foreign_host() {
+        // A backend-advertised metrics_url pointing at a different host is an
+        // SSRF vector; it must be dropped and the derived endpoint used instead.
+        let mut labels = labels_of(&[
+            ("metrics_url", "http://evil.example.com:9000/metrics"),
+            ("prometheus_port", "9100"),
+        ]);
+        derive_grpc_metrics_url(&mut labels, "grpc://host:30001");
+        assert_eq!(
+            labels.get("metrics_url").map(String::as_str),
+            Some("http://host:9100/metrics")
+        );
+    }
+
+    #[test]
+    fn derive_grpc_metrics_url_drops_foreign_explicit_without_fallback() {
+        // No derivable fallback: a foreign explicit URL is removed entirely
+        // rather than scraped.
+        let mut labels = labels_of(&[("metrics_url", "http://evil.example.com:9000/metrics")]);
+        derive_grpc_metrics_url(&mut labels, "grpc://host:30001");
+        assert!(!labels.contains_key("metrics_url"));
+    }
+
+    #[test]
+    fn derive_grpc_metrics_url_from_prometheus_port() {
+        let mut labels = labels_of(&[("prometheus_port", "9100")]);
+        derive_grpc_metrics_url(&mut labels, "grpc://10.0.0.5:30001");
+        assert_eq!(
+            labels.get("metrics_url").map(String::as_str),
+            Some("http://10.0.0.5:9100/metrics")
+        );
+    }
+
+    #[test]
+    fn derive_grpc_metrics_url_derives_when_enabled() {
+        // The bind `host` (often a wildcard) is dropped; the scrape host comes
+        // from the worker's gRPC URL so the endpoint is routable.
+        let mut labels = labels_of(&[
+            ("enable_metrics", "true"),
+            ("host", "0.0.0.0"),
+            ("port", "30000"),
+        ]);
+        derive_grpc_metrics_url(&mut labels, "grpc://node-7:30001");
+        assert_eq!(
+            labels.get("metrics_url").map(String::as_str),
+            Some("http://node-7:30000/metrics")
+        );
+    }
+
+    #[test]
+    fn derive_grpc_metrics_url_ipv6_host_from_grpc_url() {
+        // An IPv6 gRPC host must stay bracketed in the scrape URL authority
+        // (`http://[::1]:9100/metrics`), otherwise the target is an invalid URI.
+        let mut labels = labels_of(&[("prometheus_port", "9100")]);
+        derive_grpc_metrics_url(&mut labels, "grpc://[::1]:30001");
+        assert_eq!(
+            labels.get("metrics_url").map(String::as_str),
+            Some("http://[::1]:9100/metrics")
+        );
+
+        // Same for the enable_metrics + port branch.
+        let mut labels = labels_of(&[("enable_metrics", "true"), ("port", "30000")]);
+        derive_grpc_metrics_url(&mut labels, "grpc://[2001:db8::1]:30001");
+        assert_eq!(
+            labels.get("metrics_url").map(String::as_str),
+            Some("http://[2001:db8::1]:30000/metrics")
+        );
+    }
+
+    #[test]
+    fn derive_grpc_metrics_url_accepts_explicit_ipv6_same_host() {
+        // Explicit metrics_url on the same IPv6 host (brackets vs. grpc_host's
+        // unbracketed form must still compare equal) is trusted.
+        let mut labels = labels_of(&[("metrics_url", "http://[::1]:9100/metrics")]);
+        derive_grpc_metrics_url(&mut labels, "grpc://[::1]:30001");
+        assert_eq!(
+            labels.get("metrics_url").map(String::as_str),
+            Some("http://[::1]:9100/metrics")
+        );
+    }
+
+    #[test]
+    fn derive_grpc_metrics_url_uses_grpc_host_when_host_absent() {
+        let mut labels = labels_of(&[("enable_metrics", "true"), ("port", "30000")]);
+        derive_grpc_metrics_url(&mut labels, "grpc://node-7:30001");
+        assert_eq!(
+            labels.get("metrics_url").map(String::as_str),
+            Some("http://node-7:30000/metrics")
+        );
+    }
+
+    #[test]
+    fn derive_grpc_metrics_url_skips_when_disabled() {
+        // enable_metrics absent/falsy and no explicit port keys: never advertise
+        // a dark scrape endpoint.
+        let mut labels = labels_of(&[("host", "0.0.0.0"), ("port", "30000")]);
+        derive_grpc_metrics_url(&mut labels, "grpc://host:30001");
+        assert!(!labels.contains_key("metrics_url"));
+
+        let mut labels = labels_of(&[
+            ("enable_metrics", "false"),
+            ("host", "0.0.0.0"),
+            ("port", "30000"),
+        ]);
+        derive_grpc_metrics_url(&mut labels, "grpc://host:30001");
+        assert!(!labels.contains_key("metrics_url"));
     }
 
     #[test]

--- a/model_gateway/tests/engine_metrics_grpc_test.rs
+++ b/model_gateway/tests/engine_metrics_grpc_test.rs
@@ -1,0 +1,202 @@
+//! Integration tests for `GET /engine_metrics` covering gRPC workers (W1).
+//!
+//! A gRPC worker has no HTTP base URL, so its scrape endpoint is carried in the
+//! `metrics_url` label (populated by metadata discovery). These tests stand up a
+//! stub HTTP `/metrics` server, register a gRPC-mode worker pointing at it, and
+//! assert the worker's series merge into the aggregated `/engine_metrics` output.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use axum::{response::IntoResponse, routing::get, Router};
+use smg::worker::{
+    manager::EngineMetricsResult, BasicWorkerBuilder, ConnectionMode, Worker, WorkerManager,
+    WorkerRegistry, WorkerType,
+};
+use tokio::sync::oneshot;
+
+/// Stub HTTP server exposing a fixed `/metrics` body. Returns its base URL and a
+/// shutdown handle.
+struct StubMetricsServer {
+    url: String,
+    hits: Arc<AtomicUsize>,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl StubMetricsServer {
+    #[expect(
+        clippy::expect_used,
+        clippy::disallowed_methods,
+        reason = "test infrastructure - panicking on setup failure is intentional"
+    )]
+    async fn start(body: &'static str) -> Self {
+        // Bind once and serve the same listener: reading the port and rebinding
+        // would race another process onto it between the two binds.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stub metrics server");
+        let port = listener.local_addr().expect("local addr").port();
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let route_hits = Arc::clone(&hits);
+        let app = Router::new().route(
+            "/metrics",
+            get(move || {
+                let route_hits = Arc::clone(&route_hits);
+                async move {
+                    route_hits.fetch_add(1, Ordering::Relaxed);
+                    body.into_response()
+                }
+            }),
+        );
+        let (tx, rx) = oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = rx.await;
+                })
+                .await
+                .expect("stub server");
+        });
+
+        Self {
+            url: format!("http://127.0.0.1:{port}"),
+            hits,
+            shutdown: Some(tx),
+            handle: Some(handle),
+        }
+    }
+
+    fn hits(&self) -> usize {
+        self.hits.load(Ordering::Relaxed)
+    }
+
+    async fn stop(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        }
+    }
+}
+
+fn grpc_worker(url: &str, labels: &[(&str, &str)]) -> Arc<dyn Worker> {
+    let labels: HashMap<String, String> = labels
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+    Arc::new(
+        BasicWorkerBuilder::new(url)
+            .worker_type(WorkerType::Regular)
+            .connection_mode(ConnectionMode::Grpc)
+            .labels(labels)
+            .build(),
+    )
+}
+
+const GRPC_METRICS: &str = "\
+# HELP sglang_num_running_reqs The number of running requests
+# TYPE sglang_num_running_reqs gauge
+sglang_num_running_reqs{model_name=\"m\"} 7
+";
+
+#[tokio::test]
+async fn grpc_worker_metrics_merge_into_engine_metrics() {
+    let stub = StubMetricsServer::start(GRPC_METRICS).await;
+    let metrics_url = format!("{}/metrics", stub.url);
+
+    let registry = WorkerRegistry::new();
+    registry
+        .register(grpc_worker(
+            "grpc://127.0.0.1:30001",
+            &[("metrics_url", metrics_url.as_str())],
+        ))
+        .expect("register grpc worker");
+
+    let client = reqwest::Client::new();
+    let result = WorkerManager::get_engine_metrics(&registry, &client).await;
+
+    let text = match result {
+        EngineMetricsResult::Ok(text) => text,
+        EngineMetricsResult::Err(msg) => panic!("expected Ok, got Err: {msg}"),
+    };
+
+    // The gRPC worker's series merged in, tagged with its gRPC identity.
+    assert!(
+        text.contains("sglang_num_running_reqs"),
+        "missing gRPC series:\n{text}"
+    );
+    assert!(
+        text.contains("grpc://127.0.0.1:30001"),
+        "missing worker_addr label:\n{text}"
+    );
+
+    stub.stop().await;
+}
+
+#[tokio::test]
+async fn grpc_workers_without_endpoint_are_skipped_not_failed() {
+    // An all-gRPC fleet with no discovered metrics endpoint must report the
+    // real cause ("no endpoint"), not the misleading "all backend requests
+    // failed" that the HTTP-only fetch used to produce.
+    let registry = WorkerRegistry::new();
+    registry
+        .register(grpc_worker("grpc://127.0.0.1:30001", &[]))
+        .expect("register grpc worker");
+
+    let client = reqwest::Client::new();
+    let result = WorkerManager::get_engine_metrics(&registry, &client).await;
+
+    match result {
+        EngineMetricsResult::Err(msg) => {
+            assert!(
+                msg.contains("metrics endpoint"),
+                "unexpected error message: {msg}"
+            );
+        }
+        EngineMetricsResult::Ok(text) => panic!("expected Err, got Ok:\n{text}"),
+    }
+}
+
+#[tokio::test]
+async fn dp_ranks_sharing_an_endpoint_are_scraped_once() {
+    // DP-aware backends register one worker per rank that share a single engine
+    // /metrics endpoint. The endpoint must be scraped once (not dp_size times),
+    // otherwise every summed series inflates by the number of ranks.
+    let stub = StubMetricsServer::start(GRPC_METRICS).await;
+    let metrics_url = format!("{}/metrics", stub.url);
+
+    let registry = WorkerRegistry::new();
+    for rank in 0..3 {
+        registry
+            .register(grpc_worker(
+                &format!("grpc://127.0.0.1:30001@{rank}"),
+                &[("metrics_url", metrics_url.as_str())],
+            ))
+            .expect("register grpc worker");
+    }
+
+    let client = reqwest::Client::new();
+    let result = WorkerManager::get_engine_metrics(&registry, &client).await;
+    let text = match result {
+        EngineMetricsResult::Ok(text) => text,
+        EngineMetricsResult::Err(msg) => panic!("expected Ok, got Err: {msg}"),
+    };
+
+    assert_eq!(stub.hits(), 1, "shared endpoint scraped more than once");
+    assert_eq!(
+        text.matches("sglang_num_running_reqs{").count(),
+        1,
+        "expected a single merged series, got:\n{text}"
+    );
+
+    stub.stop().await;
+}


### PR DESCRIPTION
Part of #1773. Closes #1774.

## What
`GET /engine_metrics` fanned out HTTP `GET {url}/metrics` to every worker; gRPC workers yielded `grpc://host:port/metrics`, failed, and were silently dropped (an all-gRPC fleet returned "All backend requests failed"). This makes the scrape transport-aware:

- Discover a gRPC worker's HTTP metrics endpoint from `GetServerInfo.server_args` during metadata discovery, stored as a `metrics_url` label. Precedence: explicit `metrics_url` → `prometheus_port` (+host) → derived `http://{host}:{port}/metrics`, only when `enable_metrics` is truthy (never a dark port). Kept out of `WorkerSpec` (protocols) per the iron law — it rides the label pipeline.
- `Worker::metrics_url()` accessor; `scrape_engine_metrics` branches per `connection_mode`. Workers with no known endpoint are **skipped and counted**, not dropped.
- New counter `smg_engine_metrics_scrape_total{connection_mode,result}` (success/failure/skipped); the blanket "All backend requests failed" is replaced when the real cause is "no endpoint known".
- Aggregation (`metrics_aggregator.rs`) unchanged.

Always-on (no flag). Works for upstream engines (e.g. SGLang) that already expose `/metrics`; SMG's own servicers gain it via W4 (#1777).

## Tests
Unit (server_args→metrics_url; per-mode URL selection) + integration (`engine_metrics_grpc_test.rs`: gRPC stub advertising `metrics_url` + stub `/metrics` merges into `/engine_metrics`). Verified green in an isolated target dir; **CI is authoritative**.

## Cross-workstream notes
- Shares `observability/metrics.rs` and `routers/grpc/client.rs` with W2 (#1775) / W3 (#1776) — additive edits; expect trivial merge conflicts when stacking.
- Integration seam with W4 (#1777): W4 advertises `metrics_port`/`metrics_url`; this PR allowlists `metrics_url`/`prometheus_port` in `SGLANG_GRPC_KEYS` only. The routable `metrics_url` path already matches end-to-end for SGLang. Follow-ups: allowlist a `metrics_port` alias and extend `TOKENSPEED_GRPC_KEYS`.
- Minor: `WorkerMetadata::grpc_metrics_url()`'s `prometheus_port` fallback derives the host from `bootstrap_host`, while discovery derives it from the gRPC URL — worth consolidating (discovery normalizes `prometheus_port`→`metrics_url`, so the fallback is effectively dead in prod).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added engine `/metrics` scraping observability with per-worker labeled outcomes (success, failure, skipped).
  * Enhanced automatic metrics endpoint discovery for HTTP and gRPC workers, including IPv6 handling, safer `metrics_url` precedence, and per-worker metrics URL support.

* **Bug Fixes**
  * Improved `get_engine_metrics` error reporting to clearly distinguish “all targets skipped (no endpoint)” from usable scrape failures.

* **Tests**
  * Added integration coverage for gRPC metrics scraping, endpoint-missing behavior, and de-duplication of shared scrape targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->