### PR TITLE
feat(tool_parser,reasoning_parser): add Step-3.5 tool and reasoning parsers

### DIFF
--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -8,7 +8,7 @@ use crate::{
     parsers::{
         BaseReasoningParser, CohereCmdParser, DeepSeekR1Parser, Glm45Parser, KimiParser,
         MiniMaxParser, NanoV3Parser, PassthroughParser, Qwen3Parser, QwenThinkingParser,
-        Step3Parser,
+        Step3Parser, Step3p5Parser,
     },
     traits::{ParserConfig, ReasoningParser, DEFAULT_MAX_BUFFER_SIZE},
 };
@@ -139,6 +139,7 @@ impl ParserFactory {
         // glm45/step3 mirror qwen3/deepseek_r1 respectively; kept separate for debugging.
         registry.register_parser("glm45", || Box::new(Glm45Parser::new()));
         registry.register_parser("step3", || Box::new(Step3Parser::new()));
+        registry.register_parser("step3p5", || Box::new(Step3p5Parser::new()));
 
         // appends <think> token at the beginning
         registry.register_parser("minimax", || Box::new(MiniMaxParser::new()));
@@ -194,6 +195,11 @@ impl ParserFactory {
         registry.register_pattern("kimi-k2-thinking", "kimi_thinking");
         registry.register_pattern("kimi-k2.5", "kimi_k25");
         registry.register_pattern("kimi", "kimi"); // legacy: Kimi-K2-Instruct with unicode tokens
+                                                   // Step-3.5 must be registered BEFORE step3: first substring match wins and
+                                                   // "step3.5"/"step3p5" both contain "step3".
+        registry.register_pattern("step3.5", "step3p5");
+        registry.register_pattern("step-3.5", "step3p5");
+        registry.register_pattern("step3p5", "step3p5");
         registry.register_pattern("step3", "step3");
         registry.register_pattern("minimax", "minimax");
         registry.register_pattern("minimax-m2", "minimax");
@@ -298,6 +304,25 @@ mod tests {
         let factory = ParserFactory::new();
         let step3 = factory.create("step3-model");
         assert_eq!(step3.model_type(), "step3");
+    }
+
+    #[test]
+    fn test_step3p5_model() {
+        let factory = ParserFactory::new();
+
+        // Step-3.5 IDs must route to step3p5, not step3.
+        let a = factory.create("step3.5-model");
+        assert_eq!(a.model_type(), "step3p5");
+
+        let b = factory.create("stepfun-ai/Step-3.5");
+        assert_eq!(b.model_type(), "step3p5");
+
+        let c = factory.create("Step3P5-chat");
+        assert_eq!(c.model_type(), "step3p5");
+
+        // Plain step3 IDs still resolve to step3.
+        let d = factory.create("step3-model");
+        assert_eq!(d.model_type(), "step3");
     }
 
     #[test]

--- a/crates/reasoning_parser/src/lib.rs
+++ b/crates/reasoning_parser/src/lib.rs
@@ -5,7 +5,7 @@ pub mod traits;
 pub use factory::{ParserFactory, ParserRegistry};
 pub use parsers::{
     BaseReasoningParser, CohereCmdParser, DeepSeekR1Parser, Glm45Parser, KimiParser, MiniMaxParser,
-    NanoV3Parser, PassthroughParser, Qwen3Parser, QwenThinkingParser, Step3Parser,
+    NanoV3Parser, PassthroughParser, Qwen3Parser, QwenThinkingParser, Step3Parser, Step3p5Parser,
 };
 pub use traits::{
     ParseError, ParserConfig, ParserResult, ReasoningParser, DEFAULT_MAX_BUFFER_SIZE,

--- a/crates/reasoning_parser/src/parsers/mod.rs
+++ b/crates/reasoning_parser/src/parsers/mod.rs
@@ -8,6 +8,7 @@ pub mod nano_v3;
 pub mod passthrough;
 pub mod qwen3;
 pub mod step3;
+pub mod step3p5;
 
 pub use base::BaseReasoningParser;
 pub use cohere_cmd::CohereCmdParser;
@@ -19,3 +20,4 @@ pub use nano_v3::NanoV3Parser;
 pub use passthrough::PassthroughParser;
 pub use qwen3::{Qwen3Parser, QwenThinkingParser};
 pub use step3::Step3Parser;
+pub use step3p5::Step3p5Parser;

--- a/crates/reasoning_parser/src/parsers/step3p5.rs
+++ b/crates/reasoning_parser/src/parsers/step3p5.rs
@@ -1,0 +1,165 @@
+// Step-3.5 specific reasoning parser.
+
+use crate::{
+    parsers::BaseReasoningParser,
+    traits::{ParseError, ParserConfig, ParserResult, ReasoningParser, DEFAULT_MAX_BUFFER_SIZE},
+};
+
+/// Step-3.5 reasoning parser.
+///
+/// Ported from vLLM's `Step3p5ReasoningParser`, which extends
+/// `BaseThinkingReasoningParser` with `<think>` / `</think>` tokens. Step-3.5
+/// emits reasoning at the start of generation (the template injects the thinking
+/// prefix), so output begins inside reasoning even when the literal `<think>`
+/// token is absent — modeled here with `always_in_reasoning: true`, matching the
+/// existing `step3` parser.
+pub struct Step3p5Parser {
+    base: BaseReasoningParser,
+}
+
+impl Step3p5Parser {
+    /// Create a new Step-3.5 parser.
+    pub fn new() -> Self {
+        let config = ParserConfig {
+            think_start_token: "<think>".to_string(),
+            think_end_token: "</think>".to_string(),
+            stream_reasoning: true,
+            max_buffer_size: DEFAULT_MAX_BUFFER_SIZE,
+            always_in_reasoning: true,
+        };
+
+        Self {
+            base: BaseReasoningParser::new(config).with_model_type("step3p5".to_string()),
+        }
+    }
+}
+
+impl Default for Step3p5Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReasoningParser for Step3p5Parser {
+    fn detect_and_parse_reasoning(&mut self, text: &str) -> Result<ParserResult, ParseError> {
+        self.base.detect_and_parse_reasoning(text)
+    }
+
+    fn parse_reasoning_streaming_incremental(
+        &mut self,
+        text: &str,
+    ) -> Result<ParserResult, ParseError> {
+        self.base.parse_reasoning_streaming_incremental(text)
+    }
+
+    fn reset(&mut self) {
+        self.base.reset();
+    }
+
+    fn model_type(&self) -> &str {
+        self.base.model_type()
+    }
+
+    fn is_in_reasoning(&self) -> bool {
+        self.base.is_in_reasoning()
+    }
+
+    fn mark_reasoning_started(&mut self) {
+        self.base.mark_reasoning_started();
+    }
+
+    fn mark_think_start_stripped(&mut self) {
+        self.base.mark_think_start_stripped();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_model_type() {
+        let parser = Step3p5Parser::new();
+        assert_eq!(parser.model_type(), "step3p5");
+    }
+
+    #[test]
+    fn test_initial_state_is_in_reasoning() {
+        let parser = Step3p5Parser::new();
+        // always_in_reasoning=true seeds in_reasoning on a fresh parser.
+        assert!(parser.is_in_reasoning());
+    }
+
+    #[test]
+    fn test_reasoning_without_start_token() {
+        let mut parser = Step3p5Parser::new();
+
+        // Output begins inside reasoning even without a leading <think>.
+        let result = parser
+            .detect_and_parse_reasoning("reasoning content</think>answer")
+            .unwrap();
+        assert_eq!(result.reasoning_text, "reasoning content");
+        assert_eq!(result.normal_text, "answer");
+    }
+
+    #[test]
+    fn test_reasoning_with_both_tokens() {
+        let mut parser = Step3p5Parser::new();
+
+        let result = parser
+            .detect_and_parse_reasoning("<think>thinking here</think>normal text")
+            .unwrap();
+        assert_eq!(result.reasoning_text, "thinking here");
+        assert_eq!(result.normal_text, "normal text");
+    }
+
+    #[test]
+    fn test_no_think_passthrough() {
+        let mut parser = Step3p5Parser::new();
+
+        // No end token: everything is reasoning (always_in_reasoning=true).
+        let result = parser
+            .detect_and_parse_reasoning("just reasoning, no end token")
+            .unwrap();
+        assert_eq!(result.reasoning_text, "just reasoning, no end token");
+        assert_eq!(result.normal_text, "");
+    }
+
+    #[test]
+    fn test_streaming_incremental() {
+        let mut parser = Step3p5Parser::new();
+
+        // First chunk - treated as reasoning.
+        let result1 = parser
+            .parse_reasoning_streaming_incremental("reasoning text ")
+            .unwrap();
+        assert_eq!(result1.normal_text, "");
+        assert_eq!(result1.reasoning_text, "reasoning text ");
+
+        // Second chunk - continues reasoning until end token, then content.
+        let result2 = parser
+            .parse_reasoning_streaming_incremental("more</think>answer")
+            .unwrap();
+        assert_eq!(result2.normal_text, "answer");
+        assert_eq!(result2.reasoning_text, "more");
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut parser = Step3p5Parser::new();
+
+        parser
+            .parse_reasoning_streaming_incremental("partial reasoning")
+            .unwrap();
+        parser.reset();
+
+        // After reset, in_reasoning is restored to the always_in_reasoning flag.
+        assert!(parser.is_in_reasoning());
+
+        let result = parser
+            .detect_and_parse_reasoning("fresh</think>content")
+            .unwrap();
+        assert_eq!(result.reasoning_text, "fresh");
+        assert_eq!(result.normal_text, "content");
+    }
+}

--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -11,7 +11,7 @@ use crate::{
     parsers::{
         CohereParser, DeepSeek31Parser, DeepSeekDsmlParser, DeepSeekParser, Glm4MoeParser,
         JsonParser, KimiK2Parser, LlamaParser, MinimaxM2Parser, MistralParser, PassthroughParser,
-        PythonicParser, QwenParser, QwenXmlParser, Step3Parser,
+        PythonicParser, QwenParser, QwenXmlParser, Step3Parser, Step3p5Parser,
     },
     traits::ToolParser,
 };
@@ -321,6 +321,7 @@ impl ParserFactory {
         registry.register_parser("glm45_moe", || Box::new(Glm4MoeParser::glm45()));
         registry.register_parser("glm47_moe", || Box::new(Glm4MoeParser::glm47()));
         registry.register_parser("step3", || Box::new(Step3Parser::new()));
+        registry.register_parser("step3p5", || Box::new(Step3p5Parser::new()));
         registry.register_parser_with_structural_tag(
             "kimik2",
             || Box::new(KimiK2Parser::new()),
@@ -395,6 +396,12 @@ impl ParserFactory {
         // Step3 models
         registry.map_model("step3*", "step3");
         registry.map_model("Step-3*", "step3");
+        // Step-3.5 models use XML framing (longer patterns take precedence over step3*)
+        registry.map_model("step3.5*", "step3p5");
+        registry.map_model("step-3.5*", "step3p5");
+        registry.map_model("Step-3.5*", "step3p5");
+        registry.map_model("stepfun-ai/step3.5*", "step3p5");
+        registry.map_model("stepfun-ai/Step-3.5*", "step3p5");
 
         // Kimi models
         registry.map_model("kimi-k2*", "kimik2");

--- a/crates/tool_parser/src/lib.rs
+++ b/crates/tool_parser/src/lib.rs
@@ -19,7 +19,7 @@ pub use factory::{ParserFactory, PooledParser, ToolConstraint};
 pub use parsers::{
     CohereParser, DeepSeek31Parser, DeepSeekDsmlParser, DeepSeekParser, Glm4MoeParser, JsonParser,
     KimiK2Parser, LlamaParser, MinimaxM2Parser, MistralParser, PythonicParser, QwenParser,
-    Step3Parser,
+    Step3Parser, Step3p5Parser,
 };
 pub use traits::ToolParser;
 pub use types::{FunctionCall, StreamingParseResult, ToolCall};

--- a/crates/tool_parser/src/parsers/mod.rs
+++ b/crates/tool_parser/src/parsers/mod.rs
@@ -18,6 +18,7 @@ pub mod pythonic;
 pub mod qwen;
 pub mod qwen_xml;
 pub mod step3;
+pub mod step3p5;
 
 // Shared helpers and utilities
 pub mod helpers;
@@ -38,3 +39,4 @@ pub use pythonic::PythonicParser;
 pub use qwen::QwenParser;
 pub use qwen_xml::QwenXmlParser;
 pub use step3::Step3Parser;
+pub use step3p5::Step3p5Parser;

--- a/crates/tool_parser/src/parsers/step3p5.rs
+++ b/crates/tool_parser/src/parsers/step3p5.rs
@@ -1,0 +1,564 @@
+use async_trait::async_trait;
+use openai_protocol::common::Tool;
+use regex::Regex;
+use serde_json::Value;
+
+use crate::{
+    errors::{ParserError, ParserResult},
+    parsers::helpers,
+    traits::ToolParser,
+    types::{FunctionCall, StreamingParseResult, ToolCall, ToolCallItem},
+};
+
+/// Step-3.5 XML format parser for tool calls.
+///
+/// Ported from vLLM's `step3p5_tool_parser.py` (`Step3p5ToolParser` /
+/// `StreamingXMLToolCallParser`). Step-3.5 wraps each call in `<tool_call>` …
+/// `</tool_call>`, declares the function with `<function=name>` … `</function>`,
+/// and emits each argument as `<parameter=key>value</parameter>`:
+///
+/// ```text
+/// <tool_call>
+/// <function=name>
+/// <parameter=key>value</parameter>
+/// </function>
+/// </tool_call>
+/// ```
+///
+/// The vLLM parser coerces each parameter value by its declared JSON-schema type
+/// (`_get_param_type` / `_convert_param_value`): `string`-family types stay verbatim,
+/// `int`/`num`/`float` parse to numbers, `bool` to booleans, and a literal `null`
+/// becomes JSON null. When no tool schema is available the value is inferred
+/// JSON-first, with a string fallback.
+pub struct Step3p5Parser {
+    /// Regex for extracting complete `<tool_call>…</tool_call>` blocks.
+    extractor: Regex,
+    /// Regex for extracting the `<function=name>` declaration.
+    xml_function_pattern: Regex,
+    /// Regex for extracting `<parameter=key>value</parameter>` pairs.
+    xml_param_pattern: Regex,
+
+    /// Buffer for accumulating incomplete patterns across chunks.
+    buffer: String,
+
+    /// Stores complete tool call info (name and arguments) for each tool being parsed.
+    prev_tool_call_arr: Vec<Value>,
+
+    /// Index of currently streaming tool call (-1 means no active tool).
+    current_tool_id: i32,
+
+    /// Flag for whether current tool's name has been sent to the client.
+    current_tool_name_sent: bool,
+
+    /// Tracks raw JSON string content streamed to client for each tool's arguments.
+    streamed_args_for_tool: Vec<String>,
+
+    /// Token configuration (exactly matching the vLLM source).
+    tool_call_start_token: &'static str,
+    tool_call_end_token: &'static str,
+
+    /// XML format streaming state.
+    in_tool_call: bool,
+    current_function_name: String,
+    current_parameters: serde_json::Map<String, Value>,
+}
+
+/// Coerce a raw parameter value by its declared JSON-schema type, mirroring vLLM's
+/// `_convert_param_value`. A literal `null` always maps to JSON null. Returns `None`
+/// when no declared type is known so the caller can fall back to inference.
+fn coerce_value(raw: &str, declared_type: Option<&str>) -> Option<Value> {
+    let trimmed = raw.trim();
+    if trimmed.eq_ignore_ascii_case("null") {
+        return Some(Value::Null);
+    }
+
+    let declared = declared_type?;
+    let ty = declared.trim().to_lowercase();
+
+    if ty == "string"
+        || ty == "str"
+        || ty == "text"
+        || ty == "varchar"
+        || ty == "char"
+        || ty == "enum"
+    {
+        return Some(Value::String(raw.to_string()));
+    }
+    if ty.starts_with("int")
+        || ty.starts_with("uint")
+        || ty.starts_with("long")
+        || ty.starts_with("short")
+        || ty.starts_with("unsigned")
+    {
+        if let Ok(n) = trimmed.parse::<i64>() {
+            return Some(Value::Number(n.into()));
+        }
+        // vLLM degrades to string on parse failure.
+        return Some(Value::String(raw.to_string()));
+    }
+    if ty.starts_with("num") || ty.starts_with("float") {
+        if let Ok(f) = trimmed.parse::<f64>() {
+            if f.fract() == 0.0 && f.is_finite() && f.abs() < (i64::MAX as f64) {
+                return Some(Value::Number((f as i64).into()));
+            }
+            if let Some(n) = serde_json::Number::from_f64(f) {
+                return Some(Value::Number(n));
+            }
+        }
+        return Some(Value::String(raw.to_string()));
+    }
+    if ty == "boolean" || ty == "bool" || ty == "binary" {
+        return Some(Value::Bool(trimmed.eq_ignore_ascii_case("true")));
+    }
+    if ty == "object"
+        || ty == "array"
+        || ty == "arr"
+        || ty == "sequence"
+        || ty.starts_with("dict")
+        || ty.starts_with("list")
+    {
+        if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
+            return Some(v);
+        }
+        return Some(Value::String(raw.to_string()));
+    }
+
+    // Unknown declared type: treat as string (vLLM's `repair_param_type` fallback).
+    Some(Value::String(raw.to_string()))
+}
+
+/// Infer a parameter value when no schema type is known. Tries JSON first
+/// (numbers, booleans, null, objects, arrays), then Python-style literals, and
+/// finally falls back to the trimmed string.
+fn infer_value(raw: &str) -> Value {
+    let trimmed = raw.trim();
+
+    if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
+        return v;
+    }
+
+    match trimmed {
+        "True" => return Value::Bool(true),
+        "False" => return Value::Bool(false),
+        "None" | "null" => return Value::Null,
+        _ => {}
+    }
+
+    Value::String(trimmed.to_string())
+}
+
+impl Step3p5Parser {
+    /// Create a new Step-3.5 XML parser.
+    #[expect(
+        clippy::expect_used,
+        reason = "regex patterns are compile-time string literals"
+    )]
+    pub fn new() -> Self {
+        let extractor = Regex::new(r"(?s)<tool_call>\s*(.*?)\s*</tool_call>")
+            .expect("Valid tool_call regex pattern");
+        let xml_function_pattern =
+            Regex::new(r"<function=([^>]+)>").expect("Valid XML function pattern");
+        let xml_param_pattern = Regex::new(r"(?s)<parameter=([^>]+)>(.*?)</parameter>")
+            .expect("Valid XML parameter pattern");
+
+        Self {
+            extractor,
+            xml_function_pattern,
+            xml_param_pattern,
+            buffer: String::new(),
+            prev_tool_call_arr: Vec::new(),
+            current_tool_id: -1,
+            current_tool_name_sent: false,
+            streamed_args_for_tool: Vec::new(),
+            tool_call_start_token: "<tool_call>",
+            tool_call_end_token: "</tool_call>",
+            in_tool_call: false,
+            current_function_name: String::new(),
+            current_parameters: serde_json::Map::new(),
+        }
+    }
+
+    /// Parse a single `<function=…>…</function>` block into a [`ToolCall`],
+    /// coercing each parameter by its declared schema type when available.
+    fn parse_xml_format(&self, content: &str, tools: &[Tool]) -> ParserResult<Option<ToolCall>> {
+        let function_captures = self
+            .xml_function_pattern
+            .captures(content)
+            .ok_or_else(|| ParserError::ParsingFailed("No function name found".to_string()))?;
+
+        let function_name = function_captures
+            .get(1)
+            .ok_or_else(|| ParserError::ParsingFailed("Function name capture failed".to_string()))?
+            .as_str()
+            .trim()
+            .to_string();
+
+        if function_name.is_empty() {
+            return Ok(None);
+        }
+
+        let param_types = helpers::param_types_for_function(tools, &function_name);
+
+        let mut parameters = serde_json::Map::new();
+        for cap in self.xml_param_pattern.captures_iter(content) {
+            if let (Some(key_match), Some(value_match)) = (cap.get(1), cap.get(2)) {
+                let key = key_match.as_str().trim().to_string();
+                let value = value_match.as_str();
+                let declared = param_types.get(&key).map(String::as_str);
+                let json_value =
+                    coerce_value(value, declared).unwrap_or_else(|| infer_value(value));
+                parameters.insert(key, json_value);
+            }
+        }
+
+        let arguments = serde_json::to_string(&parameters)
+            .map_err(|e| ParserError::ParsingFailed(e.to_string()))?;
+
+        Ok(Some(ToolCall {
+            function: FunctionCall {
+                name: function_name,
+                arguments,
+            },
+        }))
+    }
+
+    /// Extract all complete tool calls from `text` (shared by complete parsing
+    /// with and without schema information).
+    fn extract_all(&self, text: &str, tools: &[Tool]) -> (String, Vec<ToolCall>) {
+        let Some(idx) = text.find(self.tool_call_start_token) else {
+            return (text.to_string(), vec![]);
+        };
+        let normal_text = text[..idx].to_string();
+
+        let mut calls = Vec::new();
+        for captures in self.extractor.captures_iter(text) {
+            if let Some(content_str) = captures.get(1) {
+                let content = content_str.as_str().trim();
+                match self.parse_xml_format(content, tools) {
+                    Ok(Some(tool)) => calls.push(tool),
+                    Ok(None) => continue,
+                    Err(e) => {
+                        tracing::warn!("Failed to parse Step-3.5 tool call: {:?}", e);
+                        continue;
+                    }
+                }
+            }
+        }
+
+        if calls.is_empty() {
+            return (text.to_string(), vec![]);
+        }
+
+        (normal_text, calls)
+    }
+
+    /// Parse and stream complete parameters from the buffer, coercing by the
+    /// supplied schema types. Returns the tool call argument deltas to emit.
+    fn parse_and_stream_parameters(
+        &mut self,
+        param_types: &std::collections::HashMap<String, String>,
+    ) -> Vec<ToolCallItem> {
+        let mut calls: Vec<ToolCallItem> = vec![];
+
+        let mut new_params = serde_json::Map::new();
+        for cap in self.xml_param_pattern.captures_iter(&self.buffer) {
+            if let (Some(key_match), Some(value_match)) = (cap.get(1), cap.get(2)) {
+                let key = key_match.as_str().trim().to_string();
+                let value = value_match.as_str();
+                let declared = param_types.get(&key).map(String::as_str);
+                let json_value =
+                    coerce_value(value, declared).unwrap_or_else(|| infer_value(value));
+                new_params.insert(key, json_value);
+            }
+        }
+
+        if new_params != self.current_parameters {
+            let current_args = &mut self.streamed_args_for_tool[self.current_tool_id as usize];
+
+            if self.current_parameters.is_empty() {
+                let mut items = Vec::new();
+                for (key, value) in &new_params {
+                    let key_json =
+                        serde_json::to_string(key).unwrap_or_else(|_| format!("\"{key}\""));
+                    let value_json = serde_json::to_string(value).unwrap_or_default();
+                    items.push(format!("{key_json}: {value_json}"));
+                }
+                let json_fragment = format!("{{{}", items.join(", "));
+
+                calls.push(ToolCallItem {
+                    tool_index: self.current_tool_id as usize,
+                    name: None,
+                    parameters: json_fragment.clone(),
+                });
+                *current_args = json_fragment;
+            } else {
+                let new_keys: Vec<_> = new_params
+                    .keys()
+                    .filter(|k| !self.current_parameters.contains_key(*k))
+                    .collect();
+
+                if !new_keys.is_empty() {
+                    let mut continuation_parts = Vec::new();
+                    for key in new_keys {
+                        if let Some(value) = new_params.get(key) {
+                            let key_json =
+                                serde_json::to_string(key).unwrap_or_else(|_| format!("\"{key}\""));
+                            let value_json = serde_json::to_string(value).unwrap_or_default();
+                            continuation_parts.push(format!("{key_json}: {value_json}"));
+                        }
+                    }
+
+                    let json_fragment = format!(", {}", continuation_parts.join(", "));
+
+                    calls.push(ToolCallItem {
+                        tool_index: self.current_tool_id as usize,
+                        name: None,
+                        parameters: json_fragment.clone(),
+                    });
+                    current_args.push_str(&json_fragment);
+                }
+            }
+
+            self.current_parameters.clone_from(&new_params);
+            if let Some(tool_obj) =
+                self.prev_tool_call_arr[self.current_tool_id as usize].as_object_mut()
+            {
+                tool_obj.insert("arguments".to_string(), Value::Object(new_params));
+            }
+        }
+
+        calls
+    }
+
+    /// Reset streaming state for the next tool call.
+    fn reset_streaming_state(&mut self) {
+        self.in_tool_call = false;
+        self.current_tool_name_sent = false;
+        self.current_function_name.clear();
+        self.current_parameters.clear();
+    }
+}
+
+impl Default for Step3p5Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolParser for Step3p5Parser {
+    async fn parse_complete(&self, text: &str) -> ParserResult<(String, Vec<ToolCall>)> {
+        Ok(self.extract_all(text, &[]))
+    }
+
+    async fn parse_complete_with_tools(
+        &self,
+        text: &str,
+        tools: &[Tool],
+    ) -> ParserResult<(String, Vec<ToolCall>)> {
+        Ok(self.extract_all(text, tools))
+    }
+
+    async fn parse_incremental(
+        &mut self,
+        chunk: &str,
+        tools: &[Tool],
+    ) -> ParserResult<StreamingParseResult> {
+        self.buffer.push_str(chunk);
+
+        let mut normal_text = String::new();
+        let mut calls: Vec<ToolCallItem> = vec![];
+
+        let tool_indices = helpers::get_tool_indices(tools);
+
+        loop {
+            // Not in a tool call and no start token: flush as normal text.
+            if !self.in_tool_call && !self.buffer.contains(self.tool_call_start_token) {
+                if helpers::ends_with_partial_token(&self.buffer, self.tool_call_start_token)
+                    .is_none()
+                {
+                    normal_text.push_str(&self.buffer);
+                    self.buffer.clear();
+                }
+                break;
+            }
+
+            // Look for tool call start.
+            if !self.in_tool_call {
+                if let Some(s) = self.buffer.find(self.tool_call_start_token) {
+                    normal_text.push_str(&self.buffer[..s]);
+                    self.buffer = self.buffer[s + self.tool_call_start_token.len()..].to_string();
+                    self.in_tool_call = true;
+                    self.current_tool_name_sent = false;
+                    self.current_function_name.clear();
+                    self.current_parameters.clear();
+                    continue;
+                }
+                break;
+            }
+
+            // Parse function name if not sent yet.
+            if !self.current_tool_name_sent {
+                if let Some(captures) = self.xml_function_pattern.captures(&self.buffer) {
+                    if let Some(name_match) = captures.get(1) {
+                        let function_name = name_match.as_str().trim().to_string();
+
+                        if tool_indices.contains_key(&function_name) {
+                            self.current_function_name.clone_from(&function_name);
+                            self.current_tool_name_sent = true;
+
+                            if self.current_tool_id == -1 {
+                                self.current_tool_id = 0;
+                            }
+
+                            helpers::ensure_capacity(
+                                self.current_tool_id,
+                                &mut self.prev_tool_call_arr,
+                                &mut self.streamed_args_for_tool,
+                            );
+
+                            self.prev_tool_call_arr[self.current_tool_id as usize] = serde_json::json!({
+                                "name": function_name,
+                                "arguments": {}
+                            });
+
+                            calls.push(ToolCallItem {
+                                tool_index: self.current_tool_id as usize,
+                                name: Some(function_name),
+                                parameters: String::new(),
+                            });
+
+                            // Safe: group 0 is the entire match.
+                            self.buffer =
+                                self.buffer[captures.get(0).map_or(0, |m| m.end())..].to_string();
+                            continue;
+                        }
+
+                        tracing::warn!("Invalid function name: {}", function_name);
+                        self.reset_streaming_state();
+                        normal_text.push_str(&self.buffer);
+                        self.buffer.clear();
+                        break;
+                    }
+                }
+                // Function name not complete yet.
+                break;
+            }
+
+            // Parse parameters (only complete ones).
+            if self.current_tool_name_sent {
+                let param_types =
+                    helpers::param_types_for_function(tools, &self.current_function_name);
+                let param_calls = self.parse_and_stream_parameters(&param_types);
+                calls.extend(param_calls);
+
+                if let Some(end_pos) = self.buffer.find(self.tool_call_end_token) {
+                    let current_args = &self.streamed_args_for_tool[self.current_tool_id as usize];
+                    if !current_args.is_empty() {
+                        let open_braces = current_args.matches('{').count();
+                        let close_braces = current_args.matches('}').count();
+                        if open_braces > close_braces {
+                            calls.push(ToolCallItem {
+                                tool_index: self.current_tool_id as usize,
+                                name: None,
+                                parameters: "}".to_string(),
+                            });
+                            self.streamed_args_for_tool[self.current_tool_id as usize].push('}');
+                        }
+                    }
+
+                    self.buffer =
+                        self.buffer[end_pos + self.tool_call_end_token.len()..].to_string();
+                    self.reset_streaming_state();
+                    self.current_tool_id += 1;
+                    continue;
+                }
+                // Tool call not complete yet.
+                break;
+            }
+
+            break;
+        }
+
+        Ok(StreamingParseResult { normal_text, calls })
+    }
+
+    fn has_tool_markers(&self, text: &str) -> bool {
+        text.contains(self.tool_call_start_token)
+    }
+
+    fn get_unstreamed_tool_args(&self) -> Option<Vec<ToolCallItem>> {
+        helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
+    }
+
+    fn reset(&mut self) {
+        helpers::reset_parser_state(
+            &mut self.buffer,
+            &mut self.prev_tool_call_arr,
+            &mut self.current_tool_id,
+            &mut self.current_tool_name_sent,
+            &mut self.streamed_args_for_tool,
+        );
+        self.reset_streaming_state();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_coerce_value_string_keeps_numeric_text() {
+        assert_eq!(
+            coerce_value("42", Some("string")),
+            Some(Value::String("42".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_coerce_value_integer() {
+        assert_eq!(coerce_value("42", Some("integer")), Some(Value::from(42)));
+        assert_eq!(coerce_value(" 7 ", Some("int")), Some(Value::from(7)));
+    }
+
+    #[test]
+    fn test_coerce_value_number() {
+        assert_eq!(coerce_value("1.5", Some("number")), Some(Value::from(1.5)));
+        // Whole floats degrade to integers, matching vLLM.
+        assert_eq!(coerce_value("3.0", Some("number")), Some(Value::from(3)));
+    }
+
+    #[test]
+    fn test_coerce_value_boolean() {
+        assert_eq!(
+            coerce_value("true", Some("boolean")),
+            Some(Value::Bool(true))
+        );
+        assert_eq!(
+            coerce_value("False", Some("bool")),
+            Some(Value::Bool(false))
+        );
+    }
+
+    #[test]
+    fn test_coerce_value_null() {
+        assert_eq!(coerce_value("null", Some("string")), Some(Value::Null));
+        assert_eq!(coerce_value("NULL", None), Some(Value::Null));
+    }
+
+    #[test]
+    fn test_coerce_value_object() {
+        assert_eq!(
+            coerce_value(r#"{"a": 1}"#, Some("object")),
+            Some(serde_json::json!({"a": 1}))
+        );
+    }
+
+    #[test]
+    fn test_infer_value_fallbacks() {
+        assert_eq!(infer_value("42"), Value::from(42));
+        assert_eq!(infer_value("true"), Value::Bool(true));
+        assert_eq!(infer_value("None"), Value::Null);
+        assert_eq!(infer_value("hello"), Value::String("hello".to_string()));
+    }
+}

--- a/crates/tool_parser/tests/tool_parser_step3p5.rs
+++ b/crates/tool_parser/tests/tool_parser_step3p5.rs
@@ -1,0 +1,902 @@
+//! Step-3.5 Tool Parser Integration Tests
+//!
+//! Tests for the Step-3.5 XML tool parser, which handles the framing:
+//! <tool_call><function=name><parameter=key>value</parameter></function></tool_call>
+mod common;
+
+use common::create_test_tools;
+use tool_parser::{ParserFactory, Step3p5Parser, ToolParser};
+
+#[tokio::test]
+async fn test_step3p5_factory_routing() {
+    let factory = ParserFactory::new();
+    let registry = factory.registry();
+
+    assert!(factory.has_parser("step3p5"));
+
+    // Step-3.5 IDs route to step3p5 (longest trailing-* prefix wins).
+    for model in [
+        "step3.5",
+        "step3.5-large",
+        "step-3.5",
+        "Step-3.5",
+        "stepfun-ai/step3.5",
+        "stepfun-ai/Step-3.5-chat",
+    ] {
+        assert_eq!(
+            registry.resolve_model_to_parser(model).as_deref(),
+            Some("step3p5"),
+            "model {model} should resolve to step3p5"
+        );
+    }
+
+    // Plain Step3 IDs still resolve to step3.
+    for model in ["step3", "step3-model", "Step-3", "Step-3-large"] {
+        assert_eq!(
+            registry.resolve_model_to_parser(model).as_deref(),
+            Some("step3"),
+            "model {model} should resolve to step3"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_step3p5_single_tool() {
+    let parser = Step3p5Parser::new();
+    let input = r"<tool_call>
+<function=get_weather>
+<parameter=city>Beijing</parameter>
+<parameter=units>celsius</parameter>
+</function>
+</tool_call>";
+
+    let (_normal, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["city"], "Beijing");
+    assert_eq!(args["units"], "celsius");
+}
+
+#[tokio::test]
+async fn test_step3p5_normal_text_before_call() {
+    let parser = Step3p5Parser::new();
+    let input = r"Let me check that for you.
+<tool_call>
+<function=search>
+<parameter=query>rust async</parameter>
+</function>
+</tool_call>";
+
+    let (normal, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(normal, "Let me check that for you.\n");
+}
+
+#[tokio::test]
+async fn test_step3p5_parallel_tools() {
+    let parser = Step3p5Parser::new();
+    let input = r"<tool_call>
+<function=get_weather>
+<parameter=city>Tokyo</parameter>
+</function>
+</tool_call>
+<tool_call>
+<function=search>
+<parameter=query>weather forecast</parameter>
+</function>
+</tool_call>";
+
+    let (_normal, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "get_weather");
+    assert_eq!(tools[1].function.name, "search");
+}
+
+#[tokio::test]
+async fn test_step3p5_empty_parameters() {
+    let parser = Step3p5Parser::new();
+    let input = r"<tool_call>
+<function=get_time>
+</function>
+</tool_call>";
+
+    let (_normal, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_time");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args, serde_json::json!({}));
+}
+
+#[tokio::test]
+async fn test_step3p5_empty_parameter_value() {
+    let parser = Step3p5Parser::new();
+    let input = r"<tool_call>
+<function=process>
+<parameter=text></parameter>
+<parameter=count>5</parameter>
+</function>
+</tool_call>";
+
+    let (_normal, tools) = parser
+        .parse_complete_with_tools(input, &create_test_tools())
+        .await
+        .unwrap();
+    assert_eq!(tools.len(), 1);
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["text"], "");
+    // count is declared "number" in the test schema.
+    assert_eq!(args["count"], 5);
+}
+
+#[tokio::test]
+async fn test_step3p5_no_markers_passthrough() {
+    let parser = Step3p5Parser::new();
+    let input = "This is a plain response with no tool calls at all. \
+Even if it mentions get_weather or search, they are not calls.";
+
+    let (normal, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal, input);
+}
+
+#[tokio::test]
+async fn test_step3p5_format_detection() {
+    let parser = Step3p5Parser::new();
+    assert!(parser.has_tool_markers("<tool_call>"));
+    assert!(parser.has_tool_markers("hello <tool_call>"));
+    assert!(!parser.has_tool_markers("plain text"));
+    assert!(!parser.has_tool_markers("<function=test>"));
+}
+
+#[tokio::test]
+async fn test_step3p5_type_coercion_with_schema() {
+    let parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // `process` declares: count(number), rate(number), enabled(boolean),
+    // data(object), text(string).
+    let input = r#"<tool_call>
+<function=process>
+<parameter=count>42</parameter>
+<parameter=rate>1.5</parameter>
+<parameter=enabled>true</parameter>
+<parameter=data>{"k": [1, 2]}</parameter>
+<parameter=text>123</parameter>
+</function>
+</tool_call>"#;
+
+    let (_normal, calls) = parser
+        .parse_complete_with_tools(input, &tools)
+        .await
+        .unwrap();
+    assert_eq!(calls.len(), 1);
+
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert_eq!(args["count"], 42);
+    assert_eq!(args["rate"], 1.5);
+    assert_eq!(args["enabled"], true);
+    assert_eq!(args["data"], serde_json::json!({"k": [1, 2]}));
+    // Declared as string, so a numeric-looking value stays a string.
+    assert_eq!(args["text"], "123");
+}
+
+#[tokio::test]
+async fn test_step3p5_inference_without_schema() {
+    let parser = Step3p5Parser::new();
+
+    // No tools supplied: values are inferred JSON-first.
+    let input = r"<tool_call>
+<function=process>
+<parameter=count>42</parameter>
+<parameter=text>hello</parameter>
+</function>
+</tool_call>";
+
+    let (_normal, calls) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(calls.len(), 1);
+
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    // Inferred: numeric text parses as a number.
+    assert_eq!(args["count"], 42);
+    assert_eq!(args["text"], "hello");
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_basic() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    let chunks = vec![
+        "<tool_call>",
+        "<function=get_weather>",
+        "<parameter=city>Shanghai</parameter>",
+        "<parameter=units>celsius</parameter>",
+        "</function>",
+        "</tool_call>",
+    ];
+
+    let mut found_name = false;
+    let mut found_params = false;
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if let Some(name) = call.name {
+                assert_eq!(name, "get_weather");
+                found_name = true;
+            }
+            if !call.parameters.is_empty() {
+                found_params = true;
+            }
+        }
+    }
+
+    assert!(found_name, "Should have found tool name during streaming");
+    assert!(found_params, "Should have streamed parameters");
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_across_chunk_boundaries() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // Tags split mid-token across chunk boundaries.
+    let chunks = vec![
+        "<tool_c",
+        "all><function=",
+        "get_weather><param",
+        "eter=city>Bei",
+        "jing</parameter></func",
+        "tion></tool_call>",
+    ];
+
+    let mut found_name = false;
+    let mut streamed_args = String::new();
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if let Some(name) = call.name {
+                assert_eq!(name, "get_weather");
+                found_name = true;
+            }
+            streamed_args.push_str(&call.parameters);
+        }
+    }
+
+    assert!(found_name, "Should parse function name from partial chunks");
+    assert!(
+        streamed_args.contains("city"),
+        "Should stream the city parameter, got: {streamed_args}"
+    );
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_realistic_char_chunks() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    let input = r"<tool_call>
+<function=get_weather>
+<parameter=city>Tokyo</parameter>
+<parameter=units>celsius</parameter>
+</function>
+</tool_call>";
+
+    let mut got_tool_name = false;
+    for chunk in common::streaming_helpers::create_realistic_chunks(input) {
+        let result = parser.parse_incremental(&chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if let Some(name) = call.name {
+                assert_eq!(name, "get_weather");
+                got_tool_name = true;
+            }
+        }
+    }
+
+    assert!(
+        got_tool_name,
+        "Should parse tool name from char-level chunks"
+    );
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_no_markers_returns_text() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    let result = parser
+        .parse_incremental("just some normal text", &tools)
+        .await
+        .unwrap();
+    assert_eq!(result.normal_text, "just some normal text");
+    assert!(result.calls.is_empty());
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_parallel() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    let chunks = vec![
+        "<tool_call><function=get_weather><parameter=city>Tokyo</parameter></function></tool_call>",
+        "<tool_call><function=search><parameter=query>forecast</parameter></function></tool_call>",
+    ];
+
+    let mut tool_names = Vec::new();
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if let Some(name) = call.name {
+                tool_names.push(name);
+            }
+        }
+    }
+
+    assert_eq!(tool_names, vec!["get_weather", "search"]);
+}
+
+#[tokio::test]
+async fn test_step3p5_reset_between_requests() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // First request.
+    for chunk in [
+        "<tool_call><function=get_weather>",
+        "<parameter=city>London</parameter>",
+        "</function></tool_call>",
+    ] {
+        parser.parse_incremental(chunk, &tools).await.unwrap();
+    }
+
+    parser.reset();
+
+    // Second request after reset.
+    let mut second_tool_name = None;
+    for chunk in [
+        "<tool_call><function=search>",
+        "<parameter=query>rust</parameter>",
+        "</function></tool_call>",
+    ] {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if let Some(name) = call.name {
+                second_tool_name = Some(name);
+            }
+        }
+    }
+
+    assert_eq!(second_tool_name, Some("search".to_string()));
+}
+
+#[tokio::test]
+async fn test_step3p5_invalid_function_name_skipped() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    let chunks = vec![
+        "<tool_call>",
+        "<function=not_a_real_tool>",
+        "<parameter=x>1</parameter>",
+        "</function></tool_call>",
+    ];
+
+    let mut found_invalid = false;
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if call.name.as_deref() == Some("not_a_real_tool") {
+                found_invalid = true;
+            }
+        }
+    }
+
+    assert!(!found_invalid, "Invalid function should not be emitted");
+}
+
+// ============================================================================
+// Net-new robustness coverage (parallels qwen_xml / minimax_m2 suites).
+// ============================================================================
+
+#[tokio::test]
+async fn test_step3p5_text_before_and_after_call() {
+    let parser = Step3p5Parser::new();
+    let input = r"I'll analyze the weather for you now.
+<tool_call>
+<function=get_weather>
+<parameter=city>Boston</parameter>
+<parameter=units>celsius</parameter>
+</function>
+</tool_call>
+Based on the analysis, here's what I found.";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
+
+    // `extract_all` returns only the text preceding the first `<tool_call>`;
+    // trailing prose after the block is not part of normal_text.
+    assert!(normal_text.contains("I'll analyze the weather for you now."));
+    assert!(!normal_text.contains("Based on the analysis"));
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["city"], "Boston");
+    assert_eq!(args["units"], "celsius");
+}
+
+#[tokio::test]
+async fn test_step3p5_incomplete_tool_call_returns_text() {
+    let parser = Step3p5Parser::new();
+
+    // Open `<tool_call>` with no `</tool_call>`: the extractor regex requires a
+    // closing tag, so no call is produced and the input is returned verbatim.
+    let input = r"<tool_call>
+<function=get_weather>
+<parameter=city>Chicago</parameter>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(
+        tools.len(),
+        0,
+        "must not emit a bogus call for a truncated block"
+    );
+    assert_eq!(normal_text, input);
+}
+
+#[tokio::test]
+async fn test_step3p5_malformed_function_tag_unclosed() {
+    let parser = Step3p5Parser::new();
+
+    // `<function=get_weather` is never closed with its own `>`. REAL behavior:
+    // `xml_function_pattern` is `<function=([^>]+)>`, and `[^>]+` is greedy and
+    // matches across newlines, so it swallows everything up to the FIRST `>` it
+    // can find -- the one closing `<parameter=city>`. The captured "name" is thus
+    // the malformed blob `get_weather\n<parameter=city`, NOT a clean `get_weather`.
+    // The parser still emits one call (the name is non-empty), documenting that
+    // it does not silently drop a malformed-but-non-empty function tag.
+    let input = r"<tool_call>
+<function=get_weather
+<parameter=city>Miami</parameter>
+</function>
+</tool_call>";
+
+    let (_normal, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_ne!(
+        tools[0].function.name, "get_weather",
+        "the unclosed tag over-captures, so the name is not the clean value"
+    );
+    assert!(
+        tools[0].function.name.contains("get_weather"),
+        "over-captured name still contains the intended prefix, got: {}",
+        tools[0].function.name
+    );
+}
+
+#[tokio::test]
+async fn test_step3p5_missing_function_name() {
+    let parser = Step3p5Parser::new();
+
+    // `<function=>` has an empty name: the `[^>]+` group requires at least one
+    // char, so it does not match; the call is dropped.
+    let input = r"<tool_call>
+<function=>
+<parameter=city>Miami</parameter>
+</function>
+</tool_call>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input);
+}
+
+#[tokio::test]
+async fn test_step3p5_special_characters_in_values() {
+    let parser = Step3p5Parser::new();
+
+    // Note: `<`/`>`-like text inside a value works as long as it does not form a
+    // literal `</parameter>`; the non-greedy regex stops at the first close tag.
+    let input = r#"<tool_call>
+<function=process>
+<parameter=text>Special chars: @#$%^&*()</parameter>
+<parameter=emoji>🦀 Rust 🚀 你好</parameter>
+<parameter=quotes>"double" and 'single' quotes</parameter>
+<parameter=angles>a < b and c > d</parameter>
+</function>
+</tool_call>"#;
+
+    let (_normal, tools) = parser
+        .parse_complete_with_tools(input, &create_test_tools())
+        .await
+        .unwrap();
+    assert_eq!(tools.len(), 1);
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    // `text` is declared `string`, so it is kept verbatim.
+    assert_eq!(args["text"], "Special chars: @#$%^&*()");
+    assert_eq!(args["emoji"], "🦀 Rust 🚀 你好");
+    assert_eq!(args["quotes"], "\"double\" and 'single' quotes");
+    assert_eq!(args["angles"], "a < b and c > d");
+}
+
+#[tokio::test]
+async fn test_step3p5_whitespace_handling() {
+    let parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // Indented tags and padded values. `text` is a declared `string` so it is
+    // preserved verbatim (no trim); inferred values are trimmed before parsing.
+    let input = r"<tool_call>
+    <function=process>
+        <parameter=text>  spaces around  </parameter>
+        <parameter=count>  7  </parameter>
+    </function>
+</tool_call>";
+
+    let (_normal, tools) = parser
+        .parse_complete_with_tools(input, &tools)
+        .await
+        .unwrap();
+    assert_eq!(tools.len(), 1);
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    // string schema keeps surrounding whitespace verbatim.
+    assert_eq!(args["text"], "  spaces around  ");
+    // number schema trims before parsing.
+    assert_eq!(args["count"], 7);
+}
+
+#[tokio::test]
+async fn test_step3p5_many_parameters() {
+    let parser = Step3p5Parser::new();
+
+    let mut params_xml = String::new();
+    for i in 1..=10 {
+        params_xml.push_str(&format!("<parameter=param{i}>value{i}</parameter>\n"));
+    }
+    let input =
+        format!("<tool_call>\n<function=complex_func>\n{params_xml}</function>\n</tool_call>");
+
+    let (_normal, tools) = parser.parse_complete(&input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "complex_func");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    for i in 1..=10 {
+        assert_eq!(args[format!("param{i}")], format!("value{i}"));
+    }
+}
+
+#[tokio::test]
+async fn test_step3p5_unknown_function_complete_is_forwarded() {
+    let parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // REAL behavior: `parse_xml_format` (used by `extract_all` for complete
+    // parsing) only rejects an *empty* function name; it does NOT validate the
+    // name against the tool list. So an unknown function is FORWARDED as a call
+    // in complete parsing. (Contrast streaming `parse_incremental`, which checks
+    // `tool_indices` and drops unknown names — see
+    // `test_step3p5_invalid_function_name_skipped`.)
+    let input = r"<tool_call>
+<function=not_a_real_tool>
+<parameter=x>1</parameter>
+</function>
+</tool_call>";
+
+    let (_normal, calls) = parser
+        .parse_complete_with_tools(input, &tools)
+        .await
+        .unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.name, "not_a_real_tool");
+}
+
+#[tokio::test]
+async fn test_step3p5_empty_tools_slice_infers_json_first() {
+    let parser = Step3p5Parser::new();
+
+    // No schema: values are inferred JSON-first with a string fallback
+    // (`infer_value`): numbers/bools/null/objects/arrays parse, everything else
+    // stays a string.
+    let input = r#"<tool_call>
+<function=process>
+<parameter=int_val>42</parameter>
+<parameter=float_val>2.5</parameter>
+<parameter=bool_val>true</parameter>
+<parameter=null_val>null</parameter>
+<parameter=obj_val>{"a": 1}</parameter>
+<parameter=arr_val>[1, 2, 3]</parameter>
+<parameter=str_val>hello world</parameter>
+</function>
+</tool_call>"#;
+
+    let (_normal, calls) = parser.parse_complete_with_tools(input, &[]).await.unwrap();
+    assert_eq!(calls.len(), 1);
+
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert_eq!(args["int_val"], 42);
+    assert_eq!(args["float_val"], 2.5);
+    assert_eq!(args["bool_val"], true);
+    assert_eq!(args["null_val"], serde_json::Value::Null);
+    assert_eq!(args["obj_val"], serde_json::json!({"a": 1}));
+    assert_eq!(args["arr_val"], serde_json::json!([1, 2, 3]));
+    assert_eq!(args["str_val"], "hello world");
+}
+
+#[tokio::test]
+async fn test_step3p5_invalid_value_with_object_schema_falls_back_to_string() {
+    let parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // `data` is declared `object` in the `process` schema. An unparseable value
+    // must degrade gracefully to the raw string (vLLM's `repair_param_type`
+    // fallback in `coerce_value`), not error out the whole call.
+    let input = r"<tool_call>
+<function=process>
+<parameter=data>{not valid json at all</parameter>
+<parameter=text>ok</parameter>
+</function>
+</tool_call>";
+
+    let (_normal, calls) = parser
+        .parse_complete_with_tools(input, &tools)
+        .await
+        .unwrap();
+    assert_eq!(calls.len(), 1);
+
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert_eq!(args["data"], "{not valid json at all");
+    assert_eq!(args["text"], "ok");
+}
+
+#[tokio::test]
+async fn test_step3p5_multiline_parameter_values() {
+    let parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    let input = r"<tool_call>
+<function=process>
+<parameter=text>Line 1
+Line 2
+Line 3</parameter>
+</function>
+</tool_call>";
+
+    let (_normal, tools) = parser
+        .parse_complete_with_tools(input, &tools)
+        .await
+        .unwrap();
+    assert_eq!(tools.len(), 1);
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    // string schema preserves the embedded newlines verbatim.
+    assert_eq!(args["text"], "Line 1\nLine 2\nLine 3");
+}
+
+#[tokio::test]
+async fn test_step3p5_multiple_functions_in_one_block() {
+    let parser = Step3p5Parser::new();
+
+    // The grammar wraps one function per `<tool_call>` block. If a model emits
+    // two `<function=>` declarations inside a single block, `parse_xml_format`
+    // captures only the FIRST function name (`xml_function_pattern.captures`),
+    // but `captures_iter` over the parameter pattern collects EVERY parameter in
+    // the block. Documenting this real behavior.
+    let input = r"<tool_call>
+<function=get_weather>
+<parameter=city>Tokyo</parameter>
+</function>
+<function=search>
+<parameter=query>forecast</parameter>
+</function>
+</tool_call>";
+
+    let (_normal, calls) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(calls.len(), 1, "one tool_call block yields one call");
+    assert_eq!(calls[0].function.name, "get_weather");
+
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    // Both blocks' params are merged into the single emitted call.
+    assert_eq!(args["city"], "Tokyo");
+    assert_eq!(args["query"], "forecast");
+}
+
+#[tokio::test]
+async fn test_step3p5_back_to_back_blocks_streaming() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // Two complete blocks concatenated with no separator, fed in one chunk.
+    let chunk = "<tool_call><function=get_weather><parameter=city>Tokyo</parameter></function></tool_call><tool_call><function=search><parameter=query>rust</parameter></function></tool_call>";
+
+    let mut names = Vec::new();
+    let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+    for call in result.calls {
+        if let Some(name) = call.name {
+            names.push(name);
+        }
+    }
+    assert_eq!(names, vec!["get_weather", "search"]);
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_split_inside_function_tag() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // The split lands in the middle of `<function=get_weather>`.
+    let chunks = vec![
+        "<tool_call><function=get_w",
+        "eather><parameter=city>Berlin</parameter></function></tool_call>",
+    ];
+
+    let mut found_name = false;
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if let Some(name) = call.name {
+                assert_eq!(name, "get_weather");
+                found_name = true;
+            }
+        }
+    }
+    assert!(
+        found_name,
+        "name must resolve once the function tag completes"
+    );
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_split_inside_parameter_tag() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // The split lands in the middle of `<parameter=city>`.
+    let chunks = vec![
+        "<tool_call><function=get_weather><param",
+        "eter=city>Berlin</parameter></function></tool_call>",
+    ];
+
+    let mut streamed_args = String::new();
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            streamed_args.push_str(&call.parameters);
+        }
+    }
+    assert!(
+        streamed_args.contains("city"),
+        "city parameter must stream once the tag completes, got: {streamed_args}"
+    );
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_char_by_char_with_surrounding_text() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    let complete = "Let me help. <tool_call><function=get_weather><parameter=city>Seattle</parameter></function></tool_call> Done.";
+
+    let mut content = String::new();
+    let mut tool_name_found = false;
+    // Feed one byte at a time (ASCII-only input, so byte == char here).
+    for i in 0..complete.len() {
+        let delta = &complete[i..i + 1];
+        let result = parser.parse_incremental(delta, &tools).await.unwrap();
+        content.push_str(&result.normal_text);
+        for call in result.calls {
+            if let Some(name) = call.name {
+                assert_eq!(name, "get_weather");
+                tool_name_found = true;
+            }
+        }
+    }
+
+    assert!(
+        tool_name_found,
+        "name must be found under char-by-char streaming"
+    );
+    assert!(content.contains("Let me help."));
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_tiny_multibyte_bursts() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // Multi-byte value streamed via realistic 2-3 char chunks (the helper splits
+    // on char boundaries, so multi-byte chars are never torn).
+    let input = r"<tool_call>
+<function=get_weather>
+<parameter=city>北京市</parameter>
+</function>
+</tool_call>";
+
+    let mut found_name = false;
+    let mut streamed_args = String::new();
+    for chunk in common::streaming_helpers::create_realistic_chunks(input) {
+        let result = parser.parse_incremental(&chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if let Some(name) = call.name {
+                assert_eq!(name, "get_weather");
+                found_name = true;
+            }
+            streamed_args.push_str(&call.parameters);
+        }
+    }
+    assert!(found_name);
+    assert!(
+        streamed_args.contains("北京市"),
+        "multi-byte value must stream intact, got: {streamed_args}"
+    );
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_coercion_branches_with_schema() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // Drive every coercion branch end-to-end through streaming using the
+    // `process` schema (count/rate: number, enabled: boolean, text: string) plus
+    // a literal `null`. The float-with-whole-value branch (rate=2.0 -> 2) and the
+    // string-kept-verbatim branch (text="123") are both exercised here.
+    let chunks = vec![
+        "<tool_call><function=process>",
+        "<parameter=count>42</parameter>",
+        "<parameter=rate>2.0</parameter>",
+        "<parameter=enabled>true</parameter>",
+        "<parameter=text>123</parameter>",
+        "<parameter=data>null</parameter>",
+        "</function></tool_call>",
+    ];
+
+    let mut args_json = String::new();
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if call.name.is_none() {
+                args_json.push_str(&call.parameters);
+            }
+        }
+    }
+
+    let args: serde_json::Value = serde_json::from_str(&args_json).unwrap();
+    assert_eq!(args["count"], 42, "int branch");
+    assert_eq!(args["rate"], 2, "float->int when whole");
+    assert_eq!(args["enabled"], true, "bool branch");
+    assert_eq!(args["text"], "123", "string kept verbatim");
+    assert_eq!(args["data"], serde_json::Value::Null, "null literal branch");
+}
+
+#[tokio::test]
+async fn test_step3p5_streaming_float_kept_as_float() {
+    let mut parser = Step3p5Parser::new();
+    let tools = create_test_tools();
+
+    // Non-whole float must stay a float through streaming.
+    let chunks = vec![
+        "<tool_call><function=process>",
+        "<parameter=rate>1.5</parameter>",
+        "</function></tool_call>",
+    ];
+
+    let mut args_json = String::new();
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if call.name.is_none() {
+                args_json.push_str(&call.parameters);
+            }
+        }
+    }
+
+    let args: serde_json::Value = serde_json::from_str(&args_json).unwrap();
+    assert_eq!(args["rate"], 1.5);
+}


### PR DESCRIPTION
## Description

### Problem

SMG has no parser for Step-3.5, so its XML-framed tool calls and `<think>` reasoning are not extracted.

### Solution

Add Step-3.5 tool and reasoning parsers, registered so Step-3.5 model IDs route to them ahead of the broad `step3` patterns (first substring match wins, and `step3.5`/`step3p5` both contain `step3`).

## Changes

- **Tool parser** (`crates/tool_parser/src/parsers/step3p5.rs`): XML framing — `<tool_call><function=name><parameter=key>value</parameter></function></tool_call>` — with schema-typed value coercion (`string`/`int`/`num`/`bool`/`object` families, literal `null`) and a JSON-first inference fallback when no schema is available; incremental streaming with partial-token hold-back. The single `.expect()` is on compile-time regex literals (`#[expect(reason=…)]`).
- **Reasoning parser** (`crates/reasoning_parser/src/parsers/step3p5.rs`): `<think>` / `</think>` via `BaseReasoningParser` with `always_in_reasoning=true` (the template prefills the think prefix, matching `step3`).
- **Registration**: both factories register `step3p5` and route `step3.5` / `step-3.5` / `Step-3.5*` / `stepfun-ai/Step-3.5*` to it, before the broad `step3` match.

## Test Plan

- `cargo +nightly fmt --all` — clean
- `cargo clippy -p tool-parser -p reasoning-parser --all-targets -- -D warnings` — clean
- `cargo test -p tool-parser -p reasoning-parser` — all pass, incl. the new `tool_parser_step3p5` suite (36 cases: single/parallel/multiple-function blocks, schema coercion + inference branches, streaming across chunk/char/multibyte boundaries and split inside function/parameter tags, malformed/incomplete/invalid input, reset, factory routing step3.5 → step3p5 not step3).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (parser crates; default features)
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full support for Step-3.5 model variants with automatic model ID recognition and routing.
  * Step-3.5 reasoning parser now available for processing thinking and reasoning blocks with proper token handling.
  * Step-3.5 tool parser now available for extracting tool calls and parameters from Step-3.5 model outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->