### PR TITLE
fix(http): enforce streaming timeouts outside reqwest

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -486,6 +486,7 @@ struct Router {
     encode_policy: Option<PolicyType>,
     multimodal_tensor_transport: Option<String>,
     multimodal_shm_min_bytes: Option<usize>,
+    stream_idle_timeout_secs: u64,
 }
 
 impl Router {
@@ -740,6 +741,7 @@ impl Router {
             .connection_mode(self.connection_mode)
             .max_payload_size(self.max_payload_size)
             .request_timeout_secs(self.request_timeout_secs)
+            .stream_idle_timeout_secs(self.stream_idle_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
             .load_monitor_interval_secs(self.load_monitor_interval)
@@ -953,6 +955,7 @@ impl Router {
         encode_policy = None,
         multimodal_tensor_transport = None,
         multimodal_shm_min_bytes = None,
+        stream_idle_timeout_secs = 300,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1079,6 +1082,7 @@ impl Router {
         encode_policy: Option<PolicyType>,
         multimodal_tensor_transport: Option<String>,
         multimodal_shm_min_bytes: Option<usize>,
+        stream_idle_timeout_secs: u64,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1219,6 +1223,7 @@ impl Router {
             encode_policy,
             multimodal_tensor_transport,
             multimodal_shm_min_bytes,
+            stream_idle_timeout_secs,
         })
     }
 

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -214,6 +214,8 @@ class Router:
         bootstrap_port_annotation: Kubernetes annotation name for bootstrap port (PD
             mode). Default: 'sglang.ai/bootstrap-port'
         request_timeout_secs: Request timeout in seconds. Default: 600
+        stream_idle_timeout_secs: Maximum time a streaming response may go without
+            yielding a chunk. Default: 300
         max_concurrent_requests: Maximum number of concurrent requests allowed for
             rate limiting. Default: 256
         queue_size: Queue size for pending requests when max concurrent limit reached

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -103,8 +103,6 @@ class RouterArgs:
     storage_context_headers: dict[str, str] = dataclasses.field(default_factory=dict)
     # Request timeout in seconds
     request_timeout_secs: int = 1800
-    # Maximum time a streaming response may go without yielding a chunk
-    stream_idle_timeout_secs: int = 300
     # Grace period in seconds to wait for in-flight requests during shutdown
     shutdown_grace_period_secs: int = 180
     # Max concurrent requests for rate limiting (-1 to disable)
@@ -202,6 +200,9 @@ class RouterArgs:
     mesh_advertise_host: str | None = None
     mesh_port: int = 39527
     mesh_peer_urls: list[str] = dataclasses.field(default_factory=list)
+    # Maximum time a streaming response may go without yielding a chunk.
+    # Appended to preserve positional RouterArgs constructor compatibility.
+    stream_idle_timeout_secs: int = 300
 
     @staticmethod
     def add_cli_args(

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -103,6 +103,8 @@ class RouterArgs:
     storage_context_headers: dict[str, str] = dataclasses.field(default_factory=dict)
     # Request timeout in seconds
     request_timeout_secs: int = 1800
+    # Maximum time a streaming response may go without yielding a chunk
+    stream_idle_timeout_secs: int = 300
     # Grace period in seconds to wait for in-flight requests during shutdown
     shutdown_grace_period_secs: int = 180
     # Max concurrent requests for rate limiting (-1 to disable)
@@ -728,6 +730,12 @@ class RouterArgs:
             type=int,
             default=RouterArgs.request_timeout_secs,
             help="Request timeout in seconds",
+        )
+        request_group.add_argument(
+            f"--{prefix}stream-idle-timeout-secs",
+            type=int,
+            default=RouterArgs.stream_idle_timeout_secs,
+            help="Maximum time a streaming response may go without yielding a chunk",
         )
         request_group.add_argument(
             f"--{prefix}shutdown-grace-period-secs",

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -44,6 +44,7 @@ class TestRouterArgs:
         assert args.disable_retries is False
         assert args.disable_circuit_breaker is False
         assert args.mesh_advertise_host is None
+        assert args.stream_idle_timeout_secs == 300
 
     def test_parse_selector_valid(self):
         """Test parsing valid selector arguments."""
@@ -181,6 +182,7 @@ class TestRouterArgs:
             router_request_id_headers=["x-request-id", "x-trace-id"],
             router_storage_context_headers=["x-tenant-id=tenant_id", "x-user-id=user_id"],
             router_request_timeout_secs=1200,
+            router_stream_idle_timeout_secs=45,
             router_max_concurrent_requests=512,
             router_queue_size=200,
             router_queue_timeout_secs=120,
@@ -238,6 +240,7 @@ class TestRouterArgs:
             "x-user-id": "user_id",
         }
         assert router_args.request_timeout_secs == 1200
+        assert router_args.stream_idle_timeout_secs == 45
         assert router_args.max_concurrent_requests == 512
         assert router_args.queue_size == 200
         assert router_args.queue_timeout_secs == 120
@@ -313,6 +316,7 @@ class TestRouterArgs:
             router_request_id_headers=None,
             router_storage_context_headers=None,
             router_request_timeout_secs=1800,
+            router_stream_idle_timeout_secs=300,
             router_max_concurrent_requests=256,
             router_queue_size=100,
             router_queue_timeout_secs=60,

--- a/bindings/python/tests/test_router_config.py
+++ b/bindings/python/tests/test_router_config.py
@@ -136,11 +136,13 @@ class TestRouterConfigValidation:
             worker_startup_timeout_secs=600,
             worker_startup_check_interval=30,
             request_timeout_secs=1800,
+            stream_idle_timeout_secs=300,
             queue_timeout_secs=60,
         )
         assert args.worker_startup_timeout_secs == 600
         assert args.worker_startup_check_interval == 30
         assert args.request_timeout_secs == 1800
+        assert args.stream_idle_timeout_secs == 300
         assert args.queue_timeout_secs == 60
 
     def test_retry_config_validation(self):

--- a/bindings/python/tests/test_startup_sequence.py
+++ b/bindings/python/tests/test_startup_sequence.py
@@ -746,6 +746,7 @@ class TestStartupFlow:
             request_id_headers=["x-request-id", "x-trace-id"],
             storage_context_headers={"x-tenant-id": "tenant_id"},
             request_timeout_secs=1200,
+            stream_idle_timeout_secs=45,
             max_concurrent_requests=512,
             queue_size=200,
             queue_timeout_secs=120,
@@ -791,6 +792,7 @@ class TestStartupFlow:
                         request_id_headers=router_args.request_id_headers,
                         storage_context_headers=router_args.storage_context_headers,
                         request_timeout_secs=router_args.request_timeout_secs,
+                        stream_idle_timeout_secs=router_args.stream_idle_timeout_secs,
                         max_concurrent_requests=router_args.max_concurrent_requests,
                         queue_size=router_args.queue_size,
                         queue_timeout_secs=router_args.queue_timeout_secs,
@@ -840,6 +842,7 @@ class TestStartupFlow:
             assert captured_args["request_id_headers"] == ["x-request-id", "x-trace-id"]
             assert captured_args["storage_context_headers"] == {"x-tenant-id": "tenant_id"}
             assert captured_args["request_timeout_secs"] == 1200
+            assert captured_args["stream_idle_timeout_secs"] == 45
             assert captured_args["max_concurrent_requests"] == 512
             assert captured_args["queue_size"] == 200
             assert captured_args["queue_timeout_secs"] == 120

--- a/crates/multimodal/src/registry/llama4.rs
+++ b/crates/multimodal/src/registry/llama4.rs
@@ -58,7 +58,9 @@ impl Llama4Spec {
         {
             if shape.len() == 2 && shape[1] == 2 && data.len() == shape[0] * 2 {
                 return data
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|chunk| (chunk[0] as usize, chunk[1] as usize))
                     .collect();
             }

--- a/crates/multimodal/src/vision/processors/qwen_vl_base.rs
+++ b/crates/multimodal/src/vision/processors/qwen_vl_base.rs
@@ -947,7 +947,7 @@ impl QwenVLProcessorBase {
                                 let source_end = (row + patch_size) * 3;
                                 for (dst, pixel) in chunk[o..o + patch_size]
                                     .iter_mut()
-                                    .zip(raw[source_start..source_end].chunks_exact(3))
+                                    .zip(raw[source_start..source_end].as_chunks::<3>().0.iter())
                                 {
                                     *dst = lut_c[pixel[c] as usize];
                                 }

--- a/crates/multimodal/src/vision/transforms.rs
+++ b/crates/multimodal/src/vision/transforms.rs
@@ -515,7 +515,12 @@ fn pil_h_band_rgb(
             let mut blue = half;
             let source_start = source_x * 3;
             let source_end = (source_x + source_columns) * 3;
-            for (pixel, &coefficient) in row[source_start..source_end].chunks_exact(3).zip(kernel) {
+            for (pixel, &coefficient) in row[source_start..source_end]
+                .as_chunks::<3>()
+                .0
+                .iter()
+                .zip(kernel)
+            {
                 red += pixel[0] as i64 * coefficient;
                 green += pixel[1] as i64 * coefficient;
                 blue += pixel[2] as i64 * coefficient;

--- a/docs/concepts/reliability/rate-limiting.md
+++ b/docs/concepts/reliability/rate-limiting.md
@@ -111,6 +111,7 @@ smg \
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `--request-timeout-secs` | `1800` (30 min) | Maximum time for a request to complete |
+| `--stream-idle-timeout-secs` | `300` (5 min) | Maximum time a streaming response may go without yielding a chunk |
 | `--queue-timeout-secs` | `60` | Maximum time a request waits in queue |
 | `--worker-startup-timeout-secs` | `1800` (30 min) | Timeout for worker startup/model loading |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -452,6 +452,14 @@ smg \
 | Default | `1800` (30 minutes) |
 | Description | Maximum time for request processing |
 
+### Stream Idle Timeout
+
+| Option | `--stream-idle-timeout-secs` |
+|--------|------------------------------|
+| Environment | - |
+| Default | `300` (5 minutes) |
+| Description | Maximum time a streaming response may go without yielding a chunk |
+
 ### Shutdown Grace Period
 
 | Option | `--shutdown-grace-period-secs` |

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -50,6 +50,7 @@ impl std::error::Error for AppContextBuildError {}
 #[derive(Clone)]
 pub struct AppContext {
     pub client: Client,
+    pub streaming_client: Client,
     pub router_config: RouterConfig,
     pub rate_limiter: Option<Arc<TokenBucket>>,
     pub tokenizer_registry: Arc<TokenizerRegistry>,
@@ -90,6 +91,7 @@ impl std::fmt::Debug for AppContext {
 
 pub struct AppContextBuilder {
     client: Option<Client>,
+    streaming_client: Option<Client>,
     router_config: Option<RouterConfig>,
     rate_limiter: Option<Arc<TokenBucket>>,
     tokenizer_registry: Option<Arc<TokenizerRegistry>>,
@@ -143,6 +145,7 @@ impl AppContextBuilder {
     pub fn new() -> Self {
         Self {
             client: None,
+            streaming_client: None,
             router_config: None,
             rate_limiter: None,
             tokenizer_registry: None,
@@ -167,7 +170,15 @@ impl AppContextBuilder {
     }
 
     pub fn client(mut self, client: Client) -> Self {
+        if self.streaming_client.is_none() {
+            self.streaming_client = Some(client.clone());
+        }
         self.client = Some(client);
+        self
+    }
+
+    pub fn streaming_client(mut self, streaming_client: Client) -> Self {
+        self.streaming_client = Some(streaming_client);
         self
     }
 
@@ -336,6 +347,9 @@ impl AppContextBuilder {
             client: self
                 .client
                 .ok_or(AppContextBuildError::MissingField("client"))?,
+            streaming_client: self
+                .streaming_client
+                .ok_or(AppContextBuildError::MissingField("streaming_client"))?,
             router_config,
             rate_limiter: self.rate_limiter,
             tokenizer_registry: self
@@ -413,7 +427,7 @@ impl AppContextBuilder {
 
     /// Create HTTP client with TLS/mTLS configuration
     fn with_client(mut self, config: &RouterConfig, timeout_secs: u64) -> Result<Self, String> {
-        // FIXME: Current implementation creates a single HTTP client for all workers.
+        // FIXME: Current implementation creates shared HTTP clients for all workers.
         // This works well for single security domain deployments where all workers share
         // the same CA and can accept the same client certificate.
         //
@@ -429,15 +443,31 @@ impl AppContextBuilder {
         // Use rustls TLS backend when TLS/mTLS is configured (client cert or CA certs provided).
         // This ensures proper PKCS#8 key format support. For plain HTTP workers, use default
         // backend to avoid unnecessary TLS initialization overhead.
+        let client =
+            Self::build_worker_http_client(config, Some(Duration::from_secs(timeout_secs)))?;
+        let streaming_client = Self::build_worker_http_client(config, None)?;
+
+        self.client = Some(client);
+        self.streaming_client = Some(streaming_client);
+        Ok(self)
+    }
+
+    fn build_worker_http_client(
+        config: &RouterConfig,
+        total_timeout: Option<Duration>,
+    ) -> Result<Client, String> {
         let has_tls_config = config.client_identity.is_some() || !config.ca_certificates.is_empty();
 
         let mut client_builder = Client::builder()
             .pool_idle_timeout(Some(Duration::from_secs(50)))
             .pool_max_idle_per_host(500)
-            .timeout(Duration::from_secs(timeout_secs))
             .connect_timeout(Duration::from_secs(10))
             .tcp_nodelay(true)
             .tcp_keepalive(Some(Duration::from_secs(30)));
+
+        if let Some(total_timeout) = total_timeout {
+            client_builder = client_builder.timeout(total_timeout);
+        }
 
         // Force rustls backend when TLS is configured
         if has_tls_config {
@@ -466,12 +496,9 @@ impl AppContextBuilder {
             );
         }
 
-        let client = client_builder
+        client_builder
             .build()
-            .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
-
-        self.client = Some(client);
-        Ok(self)
+            .map_err(|e| format!("Failed to create HTTP client: {e}"))
     }
 
     /// Create rate limiter based on config
@@ -696,6 +723,14 @@ impl Default for AppContextBuilder {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
+    use bytes::Bytes;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+        time::{sleep, Duration},
+    };
+
     use super::*;
     use crate::config::types::PolicyConfig;
 
@@ -716,6 +751,86 @@ mod tests {
             .with_kv_event_monitor(&config)
             .kv_event_monitor
             .is_some()
+    }
+
+    #[expect(clippy::disallowed_methods, reason = "test infrastructure")]
+    async fn serve_slow_chunked_response(pause: Duration) -> Result<String> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept connection");
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await.expect("read request");
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ntransfer-encoding: chunked\r\n\r\n",
+                )
+                .await
+                .expect("write response headers");
+            socket
+                .write_all(b"6\r\nhello \r\n")
+                .await
+                .expect("write first response chunk");
+            sleep(pause).await;
+            socket
+                .write_all(b"5\r\nworld\r\n0\r\n\r\n")
+                .await
+                .expect("write final response chunk");
+        });
+        Ok(format!("http://{addr}/"))
+    }
+
+    #[tokio::test]
+    async fn streaming_client_has_no_total_body_timeout() -> Result<()> {
+        let config = RouterConfig::default();
+        let pause = Duration::from_millis(150);
+
+        let timed_url = serve_slow_chunked_response(pause).await?;
+        let timed_client =
+            AppContextBuilder::build_worker_http_client(&config, Some(Duration::from_millis(50)))
+                .map_err(anyhow::Error::msg)?;
+        let timed_response = timed_client.get(timed_url).send().await?;
+        let timed_error = timed_response
+            .bytes()
+            .await
+            .expect_err("client with total timeout should fail while reading body");
+        assert!(timed_error.is_timeout());
+
+        let streaming_url = serve_slow_chunked_response(pause).await?;
+        let streaming_client = AppContextBuilder::build_worker_http_client(&config, None)
+            .map_err(anyhow::Error::msg)?;
+        let body = streaming_client
+            .get(streaming_url)
+            .send()
+            .await?
+            .bytes()
+            .await?;
+        assert_eq!(body, Bytes::from_static(b"hello world"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn client_does_not_overwrite_explicit_streaming_client() -> Result<()> {
+        let config = RouterConfig::default();
+
+        let explicit_streaming_client = AppContextBuilder::build_worker_http_client(&config, None)
+            .map_err(anyhow::Error::msg)?;
+        let timeout_client =
+            AppContextBuilder::build_worker_http_client(&config, Some(Duration::from_millis(50)))
+                .map_err(anyhow::Error::msg)?;
+
+        let builder = AppContextBuilder::new()
+            .streaming_client(explicit_streaming_client)
+            .client(timeout_client);
+
+        let streaming_client = builder
+            .streaming_client
+            .expect("explicit streaming client should be preserved");
+        let url = serve_slow_chunked_response(Duration::from_millis(150)).await?;
+        let body = streaming_client.get(url).send().await?.bytes().await?;
+
+        assert_eq!(body, Bytes::from_static(b"hello world"));
+        Ok(())
     }
 
     /// The #1794-relevant guarantee: passthrough never starts the KV-event

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -194,6 +194,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn stream_idle_timeout_secs(mut self, timeout: u64) -> Self {
+        self.config.stream_idle_timeout_secs = timeout;
+        self
+    }
+
     pub fn worker_startup_timeout_secs(mut self, timeout: u64) -> Self {
         self.config.worker_startup_timeout_secs = timeout;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -35,6 +35,9 @@ pub struct RouterConfig {
     pub runtime_worker_threads: Option<usize>,
     pub max_payload_size: usize,
     pub request_timeout_secs: u64,
+    /// Maximum time a streaming response may go without yielding a chunk.
+    #[serde(default = "default_stream_idle_timeout_secs")]
+    pub stream_idle_timeout_secs: u64,
     pub worker_startup_timeout_secs: u64,
     pub worker_startup_check_interval_secs: u64,
     #[serde(default = "default_load_monitor_interval_secs")]
@@ -216,6 +219,10 @@ pub struct TokenizerCacheConfig {
 
 fn default_load_monitor_interval_secs() -> u64 {
     10
+}
+
+fn default_stream_idle_timeout_secs() -> u64 {
+    300
 }
 
 fn default_enable_l0() -> bool {
@@ -779,8 +786,9 @@ impl Default for RouterConfig {
             port: 3001,
             health_check_port: None,
             runtime_worker_threads: None,
-            max_payload_size: 536_870_912,     // 512MB
-            request_timeout_secs: 1800,        // 30 minutes
+            max_payload_size: 536_870_912, // 512MB
+            request_timeout_secs: 1800,    // 30 minutes
+            stream_idle_timeout_secs: default_stream_idle_timeout_secs(),
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading
             worker_startup_check_interval_secs: 30,
             load_monitor_interval_secs: 10,
@@ -925,6 +933,7 @@ mod tests {
         assert_eq!(config.port, 3001);
         assert_eq!(config.max_payload_size, 536_870_912);
         assert_eq!(config.request_timeout_secs, 1800);
+        assert_eq!(config.stream_idle_timeout_secs, 300);
         assert_eq!(config.worker_startup_timeout_secs, 1800);
         assert_eq!(config.worker_startup_check_interval_secs, 30);
         assert_eq!(config.load_monitor_interval_secs, 10);

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -576,6 +576,14 @@ impl ConfigValidator {
             });
         }
 
+        if config.stream_idle_timeout_secs == 0 {
+            return Err(ConfigError::InvalidValue {
+                field: "stream_idle_timeout_secs".to_string(),
+                value: config.stream_idle_timeout_secs.to_string(),
+                reason: "Must be > 0".to_string(),
+            });
+        }
+
         if config.queue_size > 0 && config.queue_timeout_secs == 0 {
             return Err(ConfigError::InvalidValue {
                 field: "queue_timeout_secs".to_string(),
@@ -1251,6 +1259,24 @@ mod tests {
         );
 
         assert!(ConfigValidator::validate(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_stream_idle_timeout() {
+        let mut config = RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker1:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        );
+        config.stream_idle_timeout_secs = 0;
+
+        let result = ConfigValidator::validate(&config);
+
+        assert!(matches!(
+            result,
+            Err(ConfigError::InvalidValue { ref field, .. }) if field == "stream_idle_timeout_secs"
+        ));
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -424,6 +424,10 @@ struct CliArgs {
     #[arg(long, default_value_t = 1800, help_heading = "Request Handling")]
     request_timeout_secs: u64,
 
+    /// Maximum time a streaming response may go without yielding a chunk
+    #[arg(long, default_value_t = 300, help_heading = "Request Handling")]
+    stream_idle_timeout_secs: u64,
+
     /// Grace period in seconds to wait for in-flight requests during shutdown
     #[arg(long, default_value_t = 180, help_heading = "Request Handling")]
     shutdown_grace_period_secs: u64,
@@ -1386,6 +1390,7 @@ impl CliArgs {
             .runtime_worker_threads(self.runtime_worker_threads)
             .max_payload_size(self.max_payload_size)
             .request_timeout_secs(self.request_timeout_secs)
+            .stream_idle_timeout_secs(self.stream_idle_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
             .load_monitor_interval_secs(self.load_monitor_interval)
@@ -1833,6 +1838,25 @@ mod tests {
             server_config.runtime_worker_threads,
             Some(3),
             "runtime_worker_threads must reach ServerConfig via to_server_config"
+        );
+    }
+
+    /// `--stream-idle-timeout-secs` must reach `RouterConfig` and survive nesting
+    /// into `ServerConfig.router_config`, matching the other router-level flags.
+    #[test]
+    fn stream_idle_timeout_secs_flows_into_both_configs() {
+        let cli = cli_args_from(&["--stream-idle-timeout-secs", "45"]);
+
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(
+            router_config.stream_idle_timeout_secs, 45,
+            "stream_idle_timeout_secs must reach RouterConfig via to_router_config"
+        );
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert_eq!(
+            server_config.router_config.stream_idle_timeout_secs, 45,
+            "stream_idle_timeout_secs must survive into ServerConfig via to_server_config"
         );
     }
 

--- a/model_gateway/src/routers/anthropic/context.rs
+++ b/model_gateway/src/routers/anthropic/context.rs
@@ -21,8 +21,10 @@ pub(crate) struct RouterContext {
     pub mcp_orchestrator: Arc<McpOrchestrator>,
     pub mcp_format_registry: FormatRegistry,
     pub http_client: reqwest::Client,
+    pub streaming_http_client: reqwest::Client,
     pub worker_registry: Arc<WorkerRegistry>,
     pub request_timeout: Duration,
+    pub stream_idle_timeout: Duration,
 }
 
 /// Per-request input that flows through handler functions.

--- a/model_gateway/src/routers/anthropic/non_streaming.rs
+++ b/model_gateway/src/routers/anthropic/non_streaming.rs
@@ -119,7 +119,7 @@ async fn send_one_request(
         &url,
         &req_headers,
         &req_ctx.request,
-        router.request_timeout,
+        Some(router.request_timeout),
     )
     .await?;
 

--- a/model_gateway/src/routers/anthropic/router.rs
+++ b/model_gateway/src/routers/anthropic/router.rs
@@ -54,6 +54,8 @@ impl fmt::Debug for AnthropicRouter {
 impl AnthropicRouter {
     pub fn new(context: Arc<AppContext>) -> Result<Self, String> {
         let request_timeout = Duration::from_secs(context.router_config.request_timeout_secs);
+        let stream_idle_timeout =
+            Duration::from_secs(context.router_config.stream_idle_timeout_secs);
         let mcp_orchestrator = context
             .mcp_orchestrator
             .get()
@@ -64,8 +66,10 @@ impl AnthropicRouter {
             mcp_orchestrator,
             mcp_format_registry: context.mcp_format_registry.clone(),
             http_client: context.client.clone(),
+            streaming_http_client: context.streaming_client.clone(),
             worker_registry: context.worker_registry.clone(),
             request_timeout,
+            stream_idle_timeout,
         };
 
         Ok(Self {

--- a/model_gateway/src/routers/anthropic/sse.rs
+++ b/model_gateway/src/routers/anthropic/sse.rs
@@ -11,7 +11,6 @@ use axum::{
     response::Response,
 };
 use bytes::Bytes;
-use futures::StreamExt;
 use openai_protocol::messages::{ContentBlock, MessageDeltaUsage, StopReason, ToolUseBlock};
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -19,7 +18,10 @@ use tracing::{debug, error, warn};
 
 use super::mcp::{IterationResult, McpToolCall};
 use crate::routers::{
-    common::sse::{SseDecodeError, SseDecoder, SseEncodeError, SseEncoder, SseFrame},
+    common::{
+        sse::{SseDecodeError, SseDecoder, SseEncodeError, SseEncoder, SseFrame},
+        stream_timeout::StreamDeadline,
+    },
     error::internal_error,
 };
 
@@ -224,6 +226,7 @@ pub(crate) async fn consume_and_forward<F>(
     response: reqwest::Response,
     global_index: &mut u32,
     is_first_iteration: bool,
+    stream_deadline: StreamDeadline,
     resolve_server_name: F,
 ) -> Result<StreamConsumeResult, String>
 where
@@ -238,8 +241,12 @@ where
         is_first_iteration,
         resolve_server_name,
     );
-
-    while let Some(chunk_result) = stream.next().await {
+    loop {
+        let chunk_result = match stream_deadline.next(&mut stream).await {
+            Ok(Some(chunk_result)) => chunk_result,
+            Ok(None) => break,
+            Err(timeout) => return Err(stream_deadline.message(timeout)),
+        };
         let chunk = chunk_result.map_err(|e| format!("Stream read error: {e}"))?;
 
         decoder.push(&chunk).map_err(|e| match e {

--- a/model_gateway/src/routers/anthropic/sse.rs
+++ b/model_gateway/src/routers/anthropic/sse.rs
@@ -260,6 +260,9 @@ where
             let frame = frame.map_err(|e| format!("Invalid UTF-8 in SSE frame: {e}"))?;
             if let Some((event_type, data)) = resolve_event(frame) {
                 processor.process(&event_type, &data).await?;
+                if processor.terminal_seen() {
+                    return Ok(processor.into_result());
+                }
             }
         }
         decoder.compact();
@@ -455,6 +458,7 @@ struct EventProcessor<'a, F> {
     result: IterationResult,
     usage: Option<MessageDeltaUsage>,
     upstream_blocks: Vec<BlockAccumulator>,
+    terminal_seen: bool,
 }
 
 impl<'a, F> EventProcessor<'a, F>
@@ -483,6 +487,7 @@ where
             },
             usage: None,
             upstream_blocks: Vec::new(),
+            terminal_seen: false,
         }
     }
 
@@ -492,6 +497,10 @@ where
             iteration: self.result,
             usage: self.usage,
         }
+    }
+
+    fn terminal_seen(&self) -> bool {
+        self.terminal_seen
     }
 
     /// Send an SSE event to the client, returning `Err` on disconnect.
@@ -517,7 +526,9 @@ where
             "content_block_delta" => self.handle_block_delta(&mut parsed).await?,
             "content_block_stop" => self.handle_block_stop(&parsed).await?,
             "message_delta" => self.handle_message_delta(&parsed),
-            "message_stop" => { /* Don't forward — we emit our own at the end */ }
+            "message_stop" => {
+                self.terminal_seen = true;
+            }
             "ping" => {
                 self.send("ping", &serde_json::json!({"type": "ping"}))
                     .await?;

--- a/model_gateway/src/routers/anthropic/sse.rs
+++ b/model_gateway/src/routers/anthropic/sse.rs
@@ -281,7 +281,11 @@ where
         }
     }
 
-    Ok(processor.into_result())
+    if processor.terminal_seen() {
+        Ok(processor.into_result())
+    } else {
+        Err("Upstream stream ended before message_stop".to_string())
+    }
 }
 
 // ============================================================================
@@ -829,6 +833,38 @@ mod tests {
 
         assert!(result.is_err_and(
             |error| error.starts_with("Streaming request exceeded configured total timeout")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_consume_and_forward_rejects_eof_before_message_stop() {
+        let upstream = http::Response::builder()
+            .status(StatusCode::OK)
+            .body("event: message_start\ndata: {\"type\":\"message_start\"}\n\n")
+            .unwrap();
+        let response = reqwest::Response::from(upstream);
+        let (tx, _rx) = mpsc::channel(2);
+        let mut encoder = SseEncoder::new();
+        let mut global_index = 0;
+        let deadline = StreamDeadline::new(
+            std::time::Duration::from_secs(1),
+            std::time::Duration::from_secs(1),
+        );
+
+        let result = consume_and_forward(
+            &tx,
+            &mut encoder,
+            response,
+            &mut global_index,
+            true,
+            deadline,
+            str::to_owned,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(error) if error == "Upstream stream ended before message_stop"
         ));
     }
 

--- a/model_gateway/src/routers/anthropic/sse.rs
+++ b/model_gateway/src/routers/anthropic/sse.rs
@@ -94,17 +94,21 @@ pub(crate) fn build_sse_response(
 // SSE event formatting and sending
 // ============================================================================
 
-/// Format and send an SSE event through the channel.
-///
-/// Returns `true` if the send succeeded, `false` if the receiver was dropped.
-pub(crate) async fn send_event(
+/// Format and send an SSE event without allowing downstream backpressure to
+/// outlive the configured total stream deadline.
+async fn send_event(
     tx: &mpsc::Sender<Result<Bytes, io::Error>>,
     enc: &mut SseEncoder,
     event_type: &str,
     data: &Value,
-) -> bool {
+    stream_deadline: StreamDeadline,
+) -> Result<(), String> {
     let bytes = format_sse_event(enc, event_type, data);
-    tx.send(Ok(bytes)).await.is_ok()
+    match stream_deadline.send_before_total(tx, Ok(bytes)).await {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(CLIENT_DISCONNECTED_ERROR.into()),
+        Err(timeout) => Err(stream_deadline.message(timeout)),
+    }
 }
 
 /// Format a `MessageStreamEvent` as SSE bytes: `event: <type>\ndata: <json>\n\n`
@@ -128,15 +132,6 @@ pub(crate) fn encode_error(enc: &mut SseEncoder, message: &str) -> Bytes {
     format_sse_event(enc, "error", &data)
 }
 
-/// Send an SSE error event.
-pub(crate) async fn send_error(
-    tx: &mpsc::Sender<Result<Bytes, io::Error>>,
-    enc: &mut SseEncoder,
-    message: &str,
-) -> bool {
-    tx.send(Ok(encode_error(enc, message))).await.is_ok()
-}
-
 /// Emit `content_block_start` + `content_block_stop` events for an
 /// `mcp_tool_result` block.
 pub(crate) async fn emit_mcp_tool_result(
@@ -144,7 +139,8 @@ pub(crate) async fn emit_mcp_tool_result(
     enc: &mut SseEncoder,
     call: &McpToolCall,
     global_index: &mut u32,
-) -> bool {
+    stream_deadline: StreamDeadline,
+) -> Result<(), String> {
     let index = *global_index;
 
     // content_block_start with mcp_tool_result
@@ -162,9 +158,14 @@ pub(crate) async fn emit_mcp_tool_result(
         }
     });
 
-    if !send_event(tx, enc, "content_block_start", &block_start).await {
-        return false;
-    }
+    send_event(
+        tx,
+        enc,
+        "content_block_start",
+        &block_start,
+        stream_deadline,
+    )
+    .await?;
 
     // content_block_stop
     let block_stop = serde_json::json!({
@@ -172,12 +173,10 @@ pub(crate) async fn emit_mcp_tool_result(
         "index": index
     });
 
-    if !send_event(tx, enc, "content_block_stop", &block_stop).await {
-        return false;
-    }
+    send_event(tx, enc, "content_block_stop", &block_stop, stream_deadline).await?;
 
     *global_index += 1;
-    true
+    Ok(())
 }
 
 /// Emit the final `message_delta` and `message_stop` events.
@@ -187,7 +186,8 @@ pub(crate) async fn emit_final(
     stop_reason: Option<&StopReason>,
     total_input_tokens: u32,
     total_output_tokens: u32,
-) {
+    stream_deadline: StreamDeadline,
+) -> Result<(), String> {
     let stop_reason_val = stop_reason
         .map(|r| serde_json::to_value(r).unwrap_or(Value::Null))
         .unwrap_or(Value::Null);
@@ -204,16 +204,12 @@ pub(crate) async fn emit_final(
         }
     });
 
-    if !send_event(tx, enc, "message_delta", &message_delta).await {
-        debug!("Failed to send final message_delta — channel closed");
-    }
+    send_event(tx, enc, "message_delta", &message_delta, stream_deadline).await?;
 
     let message_stop = serde_json::json!({
         "type": "message_stop"
     });
-    if !send_event(tx, enc, "message_stop", &message_stop).await {
-        debug!("Failed to send message_stop — channel closed");
-    }
+    send_event(tx, enc, "message_stop", &message_stop, stream_deadline).await
 }
 
 // ============================================================================
@@ -244,6 +240,7 @@ where
         enc,
         global_index,
         is_first_iteration,
+        stream_deadline,
         resolve_server_name,
     );
     loop {
@@ -464,6 +461,7 @@ struct EventProcessor<'a, F> {
     usage: Option<MessageDeltaUsage>,
     upstream_blocks: Vec<BlockAccumulator>,
     terminal_seen: bool,
+    stream_deadline: StreamDeadline,
 }
 
 impl<'a, F> EventProcessor<'a, F>
@@ -475,6 +473,7 @@ where
         enc: &'a mut SseEncoder,
         global_index: &'a mut u32,
         is_first_iteration: bool,
+        stream_deadline: StreamDeadline,
         resolve_server_name: F,
     ) -> Self {
         let index_base = *global_index;
@@ -493,6 +492,7 @@ where
             usage: None,
             upstream_blocks: Vec::new(),
             terminal_seen: false,
+            stream_deadline,
         }
     }
 
@@ -510,10 +510,7 @@ where
 
     /// Send an SSE event to the client, returning `Err` on disconnect.
     async fn send(&mut self, event_type: &str, data: &Value) -> Result<(), String> {
-        if !send_event(self.tx, self.enc, event_type, data).await {
-            return Err(CLIENT_DISCONNECTED_ERROR.into());
-        }
-        Ok(())
+        send_event(self.tx, self.enc, event_type, data, self.stream_deadline).await
     }
 
     /// Process a single SSE event from the upstream worker.
@@ -813,6 +810,26 @@ mod tests {
         let payload: Value = serde_json::from_str(&events[0].1).unwrap();
         assert_eq!(payload["type"], "error");
         assert_eq!(payload["error"]["message"], "deadline elapsed");
+    }
+
+    #[tokio::test]
+    async fn test_send_event_respects_total_deadline_when_channel_is_full() {
+        let deadline = StreamDeadline::new(
+            std::time::Duration::from_millis(10),
+            std::time::Duration::from_secs(1),
+        );
+        let (tx, _rx) = mpsc::channel(1);
+        let mut enc = SseEncoder::new();
+        let data = serde_json::json!({"type": "ping"});
+
+        send_event(&tx, &mut enc, "ping", &data, deadline)
+            .await
+            .unwrap();
+        let result = send_event(&tx, &mut enc, "ping", &data, deadline).await;
+
+        assert!(result.is_err_and(
+            |error| error.starts_with("Streaming request exceeded configured total timeout")
+        ));
     }
 
     #[test]

--- a/model_gateway/src/routers/anthropic/sse.rs
+++ b/model_gateway/src/routers/anthropic/sse.rs
@@ -116,12 +116,8 @@ fn format_sse_event(enc: &mut SseEncoder, event_type: &str, data: &Value) -> Byt
         })
 }
 
-/// Send an SSE error event.
-pub(crate) async fn send_error(
-    tx: &mpsc::Sender<Result<Bytes, io::Error>>,
-    enc: &mut SseEncoder,
-    message: &str,
-) -> bool {
+/// Format an SSE error event.
+pub(crate) fn encode_error(enc: &mut SseEncoder, message: &str) -> Bytes {
     let data = serde_json::json!({
         "type": "error",
         "error": {
@@ -129,7 +125,16 @@ pub(crate) async fn send_error(
             "message": message
         }
     });
-    send_event(tx, enc, "error", &data).await
+    format_sse_event(enc, "error", &data)
+}
+
+/// Send an SSE error event.
+pub(crate) async fn send_error(
+    tx: &mpsc::Sender<Result<Bytes, io::Error>>,
+    enc: &mut SseEncoder,
+    message: &str,
+) -> bool {
+    tx.send(Ok(encode_error(enc, message))).await.is_ok()
 }
 
 /// Emit `content_block_start` + `content_block_stop` events for an
@@ -795,6 +800,19 @@ mod tests {
         assert!(text.starts_with("event: ping\n"));
         assert!(text.contains("data: "));
         assert!(text.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn test_encode_error() {
+        let mut enc = SseEncoder::new();
+        let bytes = encode_error(&mut enc, "deadline elapsed");
+        let events = decode_events(&bytes);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "error");
+        let payload: Value = serde_json::from_str(&events[0].1).unwrap();
+        assert_eq!(payload["type"], "error");
+        assert_eq!(payload["error"]["message"], "deadline elapsed");
     }
 
     #[test]

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -3,7 +3,7 @@
 //! Handles both passthrough (no MCP) and MCP tool loop streaming paths,
 //! composing worker, sse, and mcp primitives.
 
-use std::{io, time::Instant};
+use std::{io, sync::Arc, time::Instant};
 
 use axum::{
     body::Body,
@@ -31,6 +31,7 @@ use crate::{
         },
         error::{self as router_error, extract_error_code_from_response},
     },
+    worker::Worker as WorkerTrait,
 };
 
 /// Channel buffer size for SSE events sent to the client.
@@ -80,12 +81,20 @@ async fn execute_passthrough(router: &RouterContext, req_ctx: &RequestContext) -
         }
     };
 
-    build_streaming_response(response, model_id, start_time, stream_deadline).await
+    build_streaming_response(
+        response,
+        req_ctx.worker.clone(),
+        model_id,
+        start_time,
+        stream_deadline,
+    )
+    .await
 }
 
 /// Build a streaming SSE response.
 async fn build_streaming_response(
     response: reqwest::Response,
+    worker: Arc<dyn WorkerTrait>,
     model_id: &str,
     start_time: Instant,
     stream_deadline: StreamDeadline,
@@ -113,6 +122,7 @@ async fn build_streaming_response(
         stream_deadline,
         model_id.to_string(),
         start_time,
+        Some(worker),
         true,
     ));
 
@@ -156,6 +166,24 @@ fn record_streaming_router_outcome(model_id: &str, start_time: Instant, status: 
     }
 }
 
+fn record_streaming_worker_outcome(worker: Option<&dyn WorkerTrait>, status: StatusCode) {
+    let Some(worker) = worker else {
+        return;
+    };
+    worker.record_outcome(status.as_u16());
+    if status.is_server_error() {
+        Metrics::record_worker_error(
+            metrics_labels::WORKER_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            if status == StatusCode::GATEWAY_TIMEOUT {
+                metrics_labels::ERROR_TIMEOUT
+            } else {
+                metrics_labels::ERROR_BACKEND
+            },
+        );
+    }
+}
+
 fn is_streaming_timeout_message(message: &str) -> bool {
     message.starts_with("Streaming request exceeded configured ")
 }
@@ -166,6 +194,7 @@ async fn relay_stream_with_deadline<S>(
     stream_deadline: StreamDeadline,
     model_id: String,
     start_time: Instant,
+    worker: Option<Arc<dyn WorkerTrait>>,
     record_router_outcome: bool,
 ) where
     S: Stream<Item = Result<Bytes, reqwest::Error>> + Unpin + Send + 'static,
@@ -209,12 +238,10 @@ async fn relay_stream_with_deadline<S>(
             }
         }
     }
+    let effective_status = stream_failure_status.unwrap_or(StatusCode::OK);
+    record_streaming_worker_outcome(worker.as_deref(), effective_status);
     if record_router_outcome {
-        record_streaming_router_outcome(
-            &model_id,
-            start_time,
-            stream_failure_status.unwrap_or(StatusCode::OK),
-        );
+        record_streaming_router_outcome(&model_id, start_time, effective_status);
     }
 }
 
@@ -270,6 +297,7 @@ async fn build_streaming_error_response(
             stream_deadline,
             model_id.to_string(),
             start_time,
+            None,
             false,
         ));
 

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -11,6 +11,7 @@ use axum::{
     response::Response,
 };
 use bytes::Bytes;
+use futures_util::Stream;
 use openai_protocol::messages::{InputContent, InputMessage, Role};
 use smg_mcp::McpToolSession;
 use tokio::sync::mpsc;
@@ -23,7 +24,11 @@ use super::{
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::{mcp_utils::DEFAULT_MAX_ITERATIONS, sse::SseEncoder},
+        common::{
+            mcp_utils::DEFAULT_MAX_ITERATIONS,
+            sse::{observe_event_type, update_event_boundary, SseDecoder, SseEncoder},
+            stream_timeout::{StreamDeadline, StreamTimeoutKind},
+        },
         error::{self as router_error, extract_error_code_from_response},
     },
 };
@@ -51,20 +56,31 @@ async fn execute_passthrough(router: &RouterContext, req_ctx: &RequestContext) -
 
     worker::record_router_request(model_id, true);
     let (url, req_headers) = worker::build_request(&*req_ctx.worker, req_ctx.headers.as_ref());
-    let response = match worker::send_request(
-        &router.http_client,
-        &url,
-        &req_headers,
-        &req_ctx.request,
-        router.request_timeout,
-    )
-    .await
+    let stream_deadline = StreamDeadline::new(router.request_timeout, router.stream_idle_timeout);
+    let response = match stream_deadline
+        .until_total(worker::send_request(
+            &router.streaming_http_client,
+            &url,
+            &req_headers,
+            &req_ctx.request,
+            None,
+        ))
+        .await
     {
-        Ok(r) => r,
-        Err(resp) => return resp,
+        Ok(result) => match result {
+            Ok(r) => r,
+            Err(resp) => return resp,
+        },
+        Err(_) => {
+            record_streaming_timeout_metrics(model_id, start_time);
+            return router_error::gateway_timeout(
+                "streaming_timeout",
+                stream_deadline.message(StreamTimeoutKind::Total),
+            );
+        }
     };
 
-    build_streaming_response(response, model_id, start_time).await
+    build_streaming_response(response, model_id, start_time, stream_deadline).await
 }
 
 /// Build a streaming SSE response.
@@ -72,11 +88,13 @@ async fn build_streaming_response(
     response: reqwest::Response,
     model_id: &str,
     start_time: Instant,
+    stream_deadline: StreamDeadline,
 ) -> Response {
     let status = response.status();
 
     if !status.is_success() {
-        return build_streaming_error_response(response, model_id, start_time).await;
+        return build_streaming_error_response(response, model_id, start_time, stream_deadline)
+            .await;
     }
 
     debug!(model = %model_id, status = %status, "Starting streaming response");
@@ -91,9 +109,91 @@ async fn build_streaming_response(
     );
 
     let headers = response.headers().clone();
-    let body = Body::from_stream(response.bytes_stream());
+    let upstream_stream = response.bytes_stream();
+    let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(SSE_CHANNEL_SIZE);
+
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "fire-and-forget stream relay; gateway shutdown need not wait for individual stream forwarding"
+    )]
+    tokio::spawn(relay_stream_with_deadline(
+        tx,
+        upstream_stream,
+        stream_deadline,
+        model_id.to_string(),
+        start_time,
+    ));
+
+    let body = Body::from_stream(tokio_stream::wrappers::ReceiverStream::new(rx));
 
     sse::build_sse_response(status, headers, body)
+}
+
+fn record_streaming_timeout_metrics(model_id: &str, start_time: Instant) {
+    Metrics::record_router_duration(
+        metrics_labels::ROUTER_HTTP,
+        metrics_labels::BACKEND_EXTERNAL,
+        metrics_labels::CONNECTION_HTTP,
+        model_id,
+        "messages",
+        start_time.elapsed(),
+    );
+    Metrics::record_router_error(
+        metrics_labels::ROUTER_HTTP,
+        metrics_labels::BACKEND_EXTERNAL,
+        metrics_labels::CONNECTION_HTTP,
+        model_id,
+        "messages",
+        "streaming_timeout",
+    );
+}
+
+async fn relay_stream_with_deadline<S>(
+    tx: mpsc::Sender<Result<Bytes, io::Error>>,
+    mut upstream_stream: S,
+    stream_deadline: StreamDeadline,
+    model_id: String,
+    start_time: Instant,
+) where
+    S: Stream<Item = Result<Bytes, reqwest::Error>> + Unpin + Send + 'static,
+{
+    let mut encoder = SseEncoder::new();
+    let mut boundary_tail = Vec::new();
+    let mut at_event_boundary = true;
+    let mut terminal_decoder = SseDecoder::new();
+    loop {
+        let chunk = match stream_deadline.next(&mut upstream_stream).await {
+            Ok(Some(chunk)) => chunk,
+            Ok(None) => break,
+            Err(timeout) => {
+                let message = stream_deadline.message(timeout);
+                record_streaming_timeout_metrics(&model_id, start_time);
+                if at_event_boundary {
+                    let _ = sse::send_error(&tx, &mut encoder, &message).await;
+                } else {
+                    let _ = tx.send(Err(io::Error::other(message))).await;
+                }
+                break;
+            }
+        };
+        match chunk {
+            Ok(bytes) => {
+                let stream_done =
+                    observe_event_type(&mut terminal_decoder, bytes.as_ref(), "message_stop");
+                at_event_boundary = update_event_boundary(&mut boundary_tail, bytes.as_ref());
+                if tx.send(Ok(bytes)).await.is_err() {
+                    break;
+                }
+                if stream_done {
+                    break;
+                }
+            }
+            Err(e) => {
+                let _ = tx.send(Err(io::Error::other(e))).await;
+                break;
+            }
+        }
+    }
 }
 
 /// Handle a non-success streaming response.
@@ -101,6 +201,7 @@ async fn build_streaming_error_response(
     response: reqwest::Response,
     model_id: &str,
     start_time: Instant,
+    stream_deadline: StreamDeadline,
 ) -> Response {
     let status = response.status();
     let content_type = response
@@ -134,13 +235,28 @@ async fn build_streaming_error_response(
         );
 
         let headers = response.headers().clone();
-        let body = Body::from_stream(response.bytes_stream());
+        let upstream_stream = response.bytes_stream();
+        let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(SSE_CHANNEL_SIZE);
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "fire-and-forget error stream relay; gateway shutdown need not wait for individual stream forwarding"
+        )]
+        tokio::spawn(relay_stream_with_deadline(
+            tx,
+            upstream_stream,
+            stream_deadline,
+            model_id.to_string(),
+            start_time,
+        ));
+
+        let body = Body::from_stream(tokio_stream::wrappers::ReceiverStream::new(rx));
 
         return sse::build_sse_response(status, headers, body);
     }
 
     // Non-SSE error: read the body and return a proper error response
-    worker::handle_error_response(response, model_id, start_time).await
+    worker::handle_streaming_error_response(response, model_id, start_time, stream_deadline).await
 }
 
 // ============================================================================
@@ -158,7 +274,7 @@ fn execute_mcp_streaming(router: &RouterContext, req_ctx: RequestContext) -> Res
         reason = "fire-and-forget streaming task; gateway shutdown need not wait for individual MCP tool loops"
     )]
     tokio::spawn(async move {
-        if let Err(e) = run_tool_loop(tx.clone(), router, req_ctx).await {
+        if let Err(e) = Box::pin(run_tool_loop(tx.clone(), router, req_ctx)).await {
             if e == sse::CLIENT_DISCONNECTED_ERROR {
                 debug!(error = %e, "Streaming tool loop ended: client disconnected");
                 return;
@@ -203,11 +319,20 @@ async fn run_tool_loop(
     let mut is_first_iteration = true;
     // Reusable SSE encoder shared across every event emitted for this stream.
     let mut encoder = SseEncoder::new();
+    let stream_deadline = StreamDeadline::new(router.request_timeout, router.stream_idle_timeout);
 
     for _iteration in 0..DEFAULT_MAX_ITERATIONS {
         Metrics::record_mcp_tool_iteration(&req_ctx.model_id);
 
-        let response = send_streaming_request(&router, &req_ctx).await?;
+        let iteration_start = Instant::now();
+        let response = send_streaming_request(
+            &router,
+            &req_ctx,
+            stream_deadline,
+            iteration_start,
+            is_first_iteration,
+        )
+        .await?;
 
         if !response.status().is_success() {
             return Err(format!(
@@ -223,6 +348,7 @@ async fn run_tool_loop(
             response,
             &mut global_index,
             is_first_iteration,
+            stream_deadline,
             |name| session.resolve_tool_server_label(name),
         )
         .await;
@@ -239,7 +365,20 @@ async fn run_tool_loop(
         }
 
         // Check if we should continue the tool loop
-        match mcp::process_iteration(&consumed.iteration, &session, &req_ctx.model_id).await {
+        let action = match Box::pin(stream_deadline.until_activity(mcp::process_iteration(
+            &consumed.iteration,
+            &session,
+            &req_ctx.model_id,
+        )))
+        .await
+        {
+            Ok(action) => action,
+            Err(timeout) => {
+                let _ = sse::send_error(&tx, &mut encoder, &stream_deadline.message(timeout)).await;
+                return Ok(());
+            }
+        };
+        match action {
             mcp::ToolLoopAction::Done => {
                 sse::emit_final(
                     &tx,
@@ -290,18 +429,29 @@ async fn run_tool_loop(
 async fn send_streaming_request(
     router: &RouterContext,
     req_ctx: &RequestContext,
+    stream_deadline: StreamDeadline,
+    start_time: Instant,
+    is_first_iteration: bool,
 ) -> Result<reqwest::Response, String> {
     worker::record_router_request(&req_ctx.model_id, true);
 
     let (url, req_headers) = worker::build_request(&*req_ctx.worker, req_ctx.headers.as_ref());
-    let response = worker::send_request(
-        &router.http_client,
+    let send_future = worker::send_request(
+        &router.streaming_http_client,
         &url,
         &req_headers,
         &req_ctx.request,
-        router.request_timeout,
-    )
-    .await
+        None,
+    );
+    let response = if is_first_iteration {
+        stream_deadline.until_total(send_future).await
+    } else {
+        stream_deadline.until_activity(send_future).await
+    }
+    .map_err(|timeout| {
+        record_streaming_timeout_metrics(&req_ctx.model_id, start_time);
+        stream_deadline.message(timeout)
+    })?
     .map_err(|e| {
         format!(
             "Failed to send request to worker ({})",

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -405,6 +405,7 @@ async fn run_tool_loop(
         {
             Ok(action) => action,
             Err(timeout) => {
+                record_streaming_timeout_metrics(&req_ctx.model_id, iteration_start);
                 let _ = sse::send_error(&tx, &mut encoder, &stream_deadline.message(timeout)).await;
                 return Ok(());
             }

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -413,6 +413,10 @@ async fn run_tool_loop(
             Err(err) => {
                 if is_streaming_timeout_message(&err) {
                     record_streaming_timeout_metrics(&req_ctx.model_id, iteration_start);
+                    record_streaming_worker_outcome(
+                        Some(req_ctx.worker.as_ref()),
+                        StatusCode::GATEWAY_TIMEOUT,
+                    );
                 }
                 return Err(err);
             }
@@ -514,6 +518,7 @@ async fn send_streaming_request(
     }
     .map_err(|timeout| {
         record_streaming_timeout_metrics(&req_ctx.model_id, start_time);
+        record_streaming_worker_outcome(Some(req_ctx.worker.as_ref()), StatusCode::GATEWAY_TIMEOUT);
         stream_deadline.message(timeout)
     })?
     .map_err(|e| {

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -106,8 +106,14 @@ async fn build_streaming_response(
     let status = response.status();
 
     if !status.is_success() {
-        return build_streaming_error_response(response, model_id, start_time, stream_deadline)
-            .await;
+        return build_streaming_error_response(
+            response,
+            worker.as_ref(),
+            model_id,
+            start_time,
+            stream_deadline,
+        )
+        .await;
     }
 
     debug!(model = %model_id, status = %status, "Starting streaming response");
@@ -174,18 +180,7 @@ fn record_streaming_worker_outcome(worker: Option<&dyn WorkerTrait>, status: Sta
     let Some(worker) = worker else {
         return;
     };
-    worker.record_outcome(status.as_u16());
-    if status.is_server_error() {
-        Metrics::record_worker_error(
-            metrics_labels::WORKER_REGULAR,
-            metrics_labels::CONNECTION_HTTP,
-            if status == StatusCode::GATEWAY_TIMEOUT {
-                metrics_labels::ERROR_TIMEOUT
-            } else {
-                metrics_labels::ERROR_BACKEND
-            },
-        );
-    }
+    worker::record_worker_outcome(worker, status);
 }
 
 fn is_streaming_timeout_message(message: &str) -> bool {
@@ -252,6 +247,7 @@ async fn relay_stream_with_deadline<S>(
 /// Handle a non-success streaming response.
 async fn build_streaming_error_response(
     response: reqwest::Response,
+    selected_worker: &dyn WorkerTrait,
     model_id: &str,
     start_time: Instant,
     stream_deadline: StreamDeadline,
@@ -286,6 +282,7 @@ async fn build_streaming_error_response(
             "messages",
             "streaming_error",
         );
+        worker::record_worker_outcome(selected_worker, status);
 
         let headers = response.headers().clone();
         let upstream_stream = response.bytes_stream();
@@ -311,7 +308,14 @@ async fn build_streaming_error_response(
     }
 
     // Non-SSE error: read the body and return a proper error response
-    worker::handle_streaming_error_response(response, model_id, start_time, stream_deadline).await
+    worker::handle_streaming_error_response(
+        response,
+        selected_worker,
+        model_id,
+        start_time,
+        stream_deadline,
+    )
+    .await
 }
 
 // ============================================================================

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -99,15 +99,6 @@ async fn build_streaming_response(
 
     debug!(model = %model_id, status = %status, "Starting streaming response");
 
-    Metrics::record_router_duration(
-        metrics_labels::ROUTER_HTTP,
-        metrics_labels::BACKEND_EXTERNAL,
-        metrics_labels::CONNECTION_HTTP,
-        model_id,
-        "messages",
-        start_time.elapsed(),
-    );
-
     let headers = response.headers().clone();
     let upstream_stream = response.bytes_stream();
     let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(SSE_CHANNEL_SIZE);
@@ -122,6 +113,7 @@ async fn build_streaming_response(
         stream_deadline,
         model_id.to_string(),
         start_time,
+        true,
     ));
 
     let body = Body::from_stream(tokio_stream::wrappers::ReceiverStream::new(rx));
@@ -129,23 +121,43 @@ async fn build_streaming_response(
     sse::build_sse_response(status, headers, body)
 }
 
-fn record_streaming_timeout_metrics(model_id: &str, start_time: Instant) {
-    Metrics::record_router_duration(
-        metrics_labels::ROUTER_HTTP,
-        metrics_labels::BACKEND_EXTERNAL,
-        metrics_labels::CONNECTION_HTTP,
-        model_id,
-        "messages",
-        start_time.elapsed(),
-    );
+fn record_streaming_error_metric(model_id: &str, error_type: &'static str) {
     Metrics::record_router_error(
         metrics_labels::ROUTER_HTTP,
         metrics_labels::BACKEND_EXTERNAL,
         metrics_labels::CONNECTION_HTTP,
         model_id,
         "messages",
-        "streaming_timeout",
+        error_type,
     );
+}
+
+fn record_streaming_timeout_metrics(model_id: &str, _start_time: Instant) {
+    record_streaming_error_metric(model_id, "streaming_timeout");
+}
+
+fn record_streaming_router_outcome(model_id: &str, start_time: Instant, status: StatusCode) {
+    if status.is_success() {
+        Metrics::record_router_duration(
+            metrics_labels::ROUTER_HTTP,
+            metrics_labels::BACKEND_EXTERNAL,
+            metrics_labels::CONNECTION_HTTP,
+            model_id,
+            "messages",
+            start_time.elapsed(),
+        );
+    } else {
+        let error_type = if status == StatusCode::GATEWAY_TIMEOUT {
+            "streaming_timeout"
+        } else {
+            metrics_labels::ERROR_BACKEND
+        };
+        record_streaming_error_metric(model_id, error_type);
+    }
+}
+
+fn is_streaming_timeout_message(message: &str) -> bool {
+    message.starts_with("Streaming request exceeded configured ")
 }
 
 async fn relay_stream_with_deadline<S>(
@@ -154,6 +166,7 @@ async fn relay_stream_with_deadline<S>(
     stream_deadline: StreamDeadline,
     model_id: String,
     start_time: Instant,
+    record_router_outcome: bool,
 ) where
     S: Stream<Item = Result<Bytes, reqwest::Error>> + Unpin + Send + 'static,
 {
@@ -161,13 +174,14 @@ async fn relay_stream_with_deadline<S>(
     let mut boundary_tail = Vec::new();
     let mut at_event_boundary = true;
     let mut terminal_decoder = SseDecoder::new();
+    let mut stream_failure_status = None;
     loop {
         let chunk = match stream_deadline.next(&mut upstream_stream).await {
             Ok(Some(chunk)) => chunk,
             Ok(None) => break,
             Err(timeout) => {
                 let message = stream_deadline.message(timeout);
-                record_streaming_timeout_metrics(&model_id, start_time);
+                stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                 if at_event_boundary {
                     let _ = sse::send_error(&tx, &mut encoder, &message).await;
                 } else {
@@ -189,10 +203,18 @@ async fn relay_stream_with_deadline<S>(
                 }
             }
             Err(e) => {
+                stream_failure_status = Some(StatusCode::BAD_GATEWAY);
                 let _ = tx.send(Err(io::Error::other(e))).await;
                 break;
             }
         }
+    }
+    if record_router_outcome {
+        record_streaming_router_outcome(
+            &model_id,
+            start_time,
+            stream_failure_status.unwrap_or(StatusCode::OK),
+        );
     }
 }
 
@@ -248,6 +270,7 @@ async fn build_streaming_error_response(
             stream_deadline,
             model_id.to_string(),
             start_time,
+            false,
         ));
 
         let body = Body::from_stream(tokio_stream::wrappers::ReceiverStream::new(rx));
@@ -353,7 +376,15 @@ async fn run_tool_loop(
         )
         .await;
 
-        let consumed = result?;
+        let consumed = match result {
+            Ok(consumed) => consumed,
+            Err(err) => {
+                if is_streaming_timeout_message(&err) {
+                    record_streaming_timeout_metrics(&req_ctx.model_id, iteration_start);
+                }
+                return Err(err);
+            }
+        };
         is_first_iteration = false;
 
         // Accumulate usage

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -74,6 +74,10 @@ async fn execute_passthrough(router: &RouterContext, req_ctx: &RequestContext) -
         },
         Err(_) => {
             record_streaming_timeout_metrics(model_id, start_time);
+            record_streaming_worker_outcome(
+                Some(req_ctx.worker.as_ref()),
+                StatusCode::GATEWAY_TIMEOUT,
+            );
             return router_error::gateway_timeout(
                 "streaming_timeout",
                 stream_deadline.message(StreamTimeoutKind::Total),

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -429,10 +429,10 @@ async fn run_tool_loop(
         .await?;
 
         if !response.status().is_success() {
-            return Err(format!(
-                "Worker returned error status: {}",
-                response.status()
-            ));
+            let status = response.status();
+            record_streaming_worker_outcome(Some(req_ctx.worker.as_ref()), status);
+            record_streaming_router_outcome(&req_ctx.model_id, iteration_start, status);
+            return Err(format!("Worker returned error status: {status}"));
         }
 
         // Consume the upstream SSE stream

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -453,13 +453,16 @@ async fn run_tool_loop(
                 consumed
             }
             Err(err) => {
-                if is_streaming_timeout_message(&err) {
-                    record_streaming_timeout_metrics(&req_ctx.model_id, iteration_start);
-                    record_streaming_worker_outcome(
-                        Some(req_ctx.worker.as_ref()),
-                        StatusCode::GATEWAY_TIMEOUT,
-                    );
+                if err == sse::CLIENT_DISCONNECTED_ERROR {
+                    return Err(err);
                 }
+                let status = if is_streaming_timeout_message(&err) {
+                    StatusCode::GATEWAY_TIMEOUT
+                } else {
+                    StatusCode::BAD_GATEWAY
+                };
+                record_streaming_router_outcome(&req_ctx.model_id, iteration_start, status);
+                record_streaming_worker_outcome(Some(req_ctx.worker.as_ref()), status);
                 return Err(err);
             }
         };

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -70,7 +70,12 @@ async fn execute_passthrough(router: &RouterContext, req_ctx: &RequestContext) -
     {
         Ok(result) => match result {
             Ok(r) => r,
-            Err(resp) => return resp,
+            Err(resp) => {
+                let status = resp.status();
+                record_streaming_worker_outcome(Some(req_ctx.worker.as_ref()), status);
+                record_streaming_router_outcome(model_id, start_time, status);
+                return resp;
+            }
         },
         Err(_) => {
             record_streaming_timeout_metrics(model_id, start_time);

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -506,6 +506,7 @@ async fn run_tool_loop(
                     stream_deadline,
                 )
                 .await?;
+                record_streaming_router_outcome(&req_ctx.model_id, iteration_start, StatusCode::OK);
                 return Ok(());
             }
             mcp::ToolLoopAction::Error(msg) => {

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -211,9 +211,13 @@ async fn relay_stream_with_deadline<S>(
                 let message = stream_deadline.message(timeout);
                 stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                 if at_event_boundary {
-                    let _ = sse::send_error(&tx, &mut encoder, &message).await;
+                    let _ = stream_deadline
+                        .until_total(sse::send_error(&tx, &mut encoder, &message))
+                        .await;
                 } else {
-                    let _ = tx.send(Err(io::Error::other(message))).await;
+                    let _ = stream_deadline
+                        .send_before_total(&tx, Err(io::Error::other(message)))
+                        .await;
                 }
                 break;
             }
@@ -223,8 +227,13 @@ async fn relay_stream_with_deadline<S>(
                 let stream_done =
                     observe_event_type(&mut terminal_decoder, bytes.as_ref(), "message_stop");
                 at_event_boundary = update_event_boundary(&mut boundary_tail, bytes.as_ref());
-                if tx.send(Ok(bytes)).await.is_err() {
-                    break;
+                match stream_deadline.send_before_total(&tx, Ok(bytes)).await {
+                    Ok(true) => {}
+                    Ok(false) => break,
+                    Err(_) => {
+                        stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
+                        break;
+                    }
                 }
                 if stream_done {
                     break;
@@ -232,7 +241,9 @@ async fn relay_stream_with_deadline<S>(
             }
             Err(e) => {
                 stream_failure_status = Some(StatusCode::BAD_GATEWAY);
-                let _ = tx.send(Err(io::Error::other(e))).await;
+                let _ = stream_deadline
+                    .send_before_total(&tx, Err(io::Error::other(e)))
+                    .await;
                 break;
             }
         }

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -203,21 +203,28 @@ async fn relay_stream_with_deadline<S>(
     let mut at_event_boundary = true;
     let mut terminal_observer = SseTerminalObserver::event_type("message_stop");
     let mut stream_failure_status = None;
+    let mut relay_send_timed_out = false;
+    let mut terminal_seen = false;
     loop {
         let chunk = match stream_deadline.next(&mut upstream_stream).await {
             Ok(Some(chunk)) => chunk,
-            Ok(None) => break,
+            Ok(None) => {
+                if record_router_outcome && !terminal_seen {
+                    stream_failure_status = Some(StatusCode::BAD_GATEWAY);
+                }
+                break;
+            }
             Err(timeout) => {
                 let message = stream_deadline.message(timeout);
                 stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                 if at_event_boundary {
                     let error_event = sse::encode_error(&mut encoder, &message);
                     let _ = stream_deadline
-                        .send_before_total(&tx, Ok(error_event))
+                        .send_terminal_before_total(&tx, Ok(error_event))
                         .await;
                 } else {
                     let _ = stream_deadline
-                        .send_before_total(&tx, Err(io::Error::other(message)))
+                        .send_terminal_before_total(&tx, Err(io::Error::other(message)))
                         .await;
                 }
                 break;
@@ -226,11 +233,13 @@ async fn relay_stream_with_deadline<S>(
         match chunk {
             Ok(bytes) => {
                 let stream_done = terminal_observer.observe(bytes.as_ref());
+                terminal_seen |= stream_done;
                 at_event_boundary = update_event_boundary(&mut boundary_tail, bytes.as_ref());
                 match stream_deadline.send_before_total(&tx, Ok(bytes)).await {
                     Ok(true) => {}
                     Ok(false) => break,
                     Err(_) => {
+                        relay_send_timed_out = true;
                         stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                         break;
                     }
@@ -242,14 +251,19 @@ async fn relay_stream_with_deadline<S>(
             Err(e) => {
                 stream_failure_status = Some(StatusCode::BAD_GATEWAY);
                 let _ = stream_deadline
-                    .send_before_total(&tx, Err(io::Error::other(e)))
+                    .send_terminal_before_total(&tx, Err(io::Error::other(e)))
                     .await;
                 break;
             }
         }
     }
     let effective_status = stream_failure_status.unwrap_or(StatusCode::OK);
-    record_streaming_worker_outcome(worker.as_deref(), effective_status);
+    let worker_status = if relay_send_timed_out {
+        StatusCode::OK
+    } else {
+        effective_status
+    };
+    record_streaming_worker_outcome(worker.as_deref(), worker_status);
     if record_router_outcome {
         record_streaming_router_outcome(&model_id, start_time, effective_status);
     }
@@ -355,7 +369,7 @@ fn execute_mcp_streaming(router: &RouterContext, req_ctx: RequestContext) -> Res
             let mut enc = SseEncoder::new();
             let error_event = sse::encode_error(&mut enc, &e);
             let _ = stream_deadline
-                .send_before_total(&tx, Ok(error_event))
+                .send_terminal_before_total(&tx, Ok(error_event))
                 .await;
         }
     });
@@ -465,7 +479,7 @@ async fn run_tool_loop(
                 let error_event =
                     sse::encode_error(&mut encoder, &stream_deadline.message(timeout));
                 let _ = stream_deadline
-                    .send_before_total(&tx, Ok(error_event))
+                    .send_terminal_before_total(&tx, Ok(error_event))
                     .await;
                 return Ok(());
             }
@@ -520,7 +534,7 @@ async fn run_tool_loop(
     let error_msg = format!("MCP tool loop exceeded maximum iterations ({DEFAULT_MAX_ITERATIONS})");
     let error_event = sse::encode_error(&mut encoder, &error_msg);
     let _ = stream_deadline
-        .send_before_total(&tx, Ok(error_event))
+        .send_terminal_before_total(&tx, Ok(error_event))
         .await;
     Ok(())
 }

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -443,7 +443,10 @@ async fn run_tool_loop(
         .await;
 
         let consumed = match result {
-            Ok(consumed) => consumed,
+            Ok(consumed) => {
+                record_streaming_worker_outcome(Some(req_ctx.worker.as_ref()), StatusCode::OK);
+                consumed
+            }
             Err(err) => {
                 if is_streaming_timeout_message(&err) {
                     record_streaming_timeout_metrics(&req_ctx.model_id, iteration_start);

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -336,6 +336,7 @@ async fn build_streaming_error_response(
 /// Spawn the MCP tool loop in a background task and return an SSE response.
 fn execute_mcp_streaming(router: &RouterContext, req_ctx: RequestContext) -> Response {
     let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(SSE_CHANNEL_SIZE);
+    let stream_deadline = StreamDeadline::new(router.request_timeout, router.stream_idle_timeout);
 
     let router = router.clone();
 
@@ -344,14 +345,18 @@ fn execute_mcp_streaming(router: &RouterContext, req_ctx: RequestContext) -> Res
         reason = "fire-and-forget streaming task; gateway shutdown need not wait for individual MCP tool loops"
     )]
     tokio::spawn(async move {
-        if let Err(e) = Box::pin(run_tool_loop(tx.clone(), router, req_ctx)).await {
+        if let Err(e) = Box::pin(run_tool_loop(tx.clone(), router, req_ctx, stream_deadline)).await
+        {
             if e == sse::CLIENT_DISCONNECTED_ERROR {
                 debug!(error = %e, "Streaming tool loop ended: client disconnected");
                 return;
             }
             warn!(error = %e, "Streaming tool loop failed");
             let mut enc = SseEncoder::new();
-            let _ = sse::send_error(&tx, &mut enc, &e).await;
+            let error_event = sse::encode_error(&mut enc, &e);
+            let _ = stream_deadline
+                .send_before_total(&tx, Ok(error_event))
+                .await;
         }
     });
 
@@ -375,6 +380,7 @@ async fn run_tool_loop(
     tx: mpsc::Sender<Result<Bytes, io::Error>>,
     router: RouterContext,
     mut req_ctx: RequestContext,
+    stream_deadline: StreamDeadline,
 ) -> Result<(), String> {
     let session_id = format!("msg_{}", uuid::Uuid::now_v7());
     let mcp_servers = req_ctx.mcp_servers.take().unwrap_or_default();
@@ -389,7 +395,6 @@ async fn run_tool_loop(
     let mut is_first_iteration = true;
     // Reusable SSE encoder shared across every event emitted for this stream.
     let mut encoder = SseEncoder::new();
-    let stream_deadline = StreamDeadline::new(router.request_timeout, router.stream_idle_timeout);
 
     for _iteration in 0..DEFAULT_MAX_ITERATIONS {
         Metrics::record_mcp_tool_iteration(&req_ctx.model_id);
@@ -473,8 +478,9 @@ async fn run_tool_loop(
                     consumed.iteration.stop_reason.as_ref(),
                     total_input_tokens,
                     total_output_tokens,
+                    stream_deadline,
                 )
-                .await;
+                .await?;
                 return Ok(());
             }
             mcp::ToolLoopAction::Error(msg) => {
@@ -483,10 +489,14 @@ async fn run_tool_loop(
             mcp::ToolLoopAction::Continue(cont) => {
                 // Emit mcp_tool_result events for each completed tool call
                 for call in &cont.mcp_calls {
-                    if !sse::emit_mcp_tool_result(&tx, &mut encoder, call, &mut global_index).await
-                    {
-                        return Ok(());
-                    }
+                    sse::emit_mcp_tool_result(
+                        &tx,
+                        &mut encoder,
+                        call,
+                        &mut global_index,
+                        stream_deadline,
+                    )
+                    .await?;
                 }
 
                 // Append assistant + tool_result messages for next iteration
@@ -508,7 +518,10 @@ async fn run_tool_loop(
         DEFAULT_MAX_ITERATIONS
     );
     let error_msg = format!("MCP tool loop exceeded maximum iterations ({DEFAULT_MAX_ITERATIONS})");
-    let _ = sse::send_error(&tx, &mut encoder, &error_msg).await;
+    let error_event = sse::encode_error(&mut encoder, &error_msg);
+    let _ = stream_deadline
+        .send_before_total(&tx, Ok(error_event))
+        .await;
     Ok(())
 }
 

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -26,7 +26,7 @@ use crate::{
     routers::{
         common::{
             mcp_utils::DEFAULT_MAX_ITERATIONS,
-            sse::{observe_event_type, update_event_boundary, SseDecoder, SseEncoder},
+            sse::{update_event_boundary, SseEncoder, SseTerminalObserver},
             stream_timeout::{StreamDeadline, StreamTimeoutKind},
         },
         error::{self as router_error, extract_error_code_from_response},
@@ -201,7 +201,7 @@ async fn relay_stream_with_deadline<S>(
     let mut encoder = SseEncoder::new();
     let mut boundary_tail = Vec::new();
     let mut at_event_boundary = true;
-    let mut terminal_decoder = SseDecoder::new();
+    let mut terminal_observer = SseTerminalObserver::event_type("message_stop");
     let mut stream_failure_status = None;
     loop {
         let chunk = match stream_deadline.next(&mut upstream_stream).await {
@@ -224,8 +224,7 @@ async fn relay_stream_with_deadline<S>(
         };
         match chunk {
             Ok(bytes) => {
-                let stream_done =
-                    observe_event_type(&mut terminal_decoder, bytes.as_ref(), "message_stop");
+                let stream_done = terminal_observer.observe(bytes.as_ref());
                 at_event_boundary = update_event_boundary(&mut boundary_tail, bytes.as_ref());
                 match stream_deadline.send_before_total(&tx, Ok(bytes)).await {
                     Ok(true) => {}

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -211,8 +211,9 @@ async fn relay_stream_with_deadline<S>(
                 let message = stream_deadline.message(timeout);
                 stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                 if at_event_boundary {
+                    let error_event = sse::encode_error(&mut encoder, &message);
                     let _ = stream_deadline
-                        .until_total(sse::send_error(&tx, &mut encoder, &message))
+                        .send_before_total(&tx, Ok(error_event))
                         .await;
                 } else {
                     let _ = stream_deadline
@@ -456,7 +457,11 @@ async fn run_tool_loop(
             Ok(action) => action,
             Err(timeout) => {
                 record_streaming_timeout_metrics(&req_ctx.model_id, iteration_start);
-                let _ = sse::send_error(&tx, &mut encoder, &stream_deadline.message(timeout)).await;
+                let error_event =
+                    sse::encode_error(&mut encoder, &stream_deadline.message(timeout));
+                let _ = stream_deadline
+                    .send_before_total(&tx, Ok(error_event))
+                    .await;
                 return Ok(());
             }
         };

--- a/model_gateway/src/routers/anthropic/worker.rs
+++ b/model_gateway/src/routers/anthropic/worker.rs
@@ -16,7 +16,10 @@ use tracing::{debug, error, info, warn};
 use super::utils::{read_response_body_limited, should_propagate_header, ReadBodyResult};
 use crate::{
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
-    routers::error,
+    routers::{
+        common::stream_timeout::{StreamBodyReadError, StreamDeadline, MAX_STREAM_ERROR_BODY_SIZE},
+        error,
+    },
     worker::Worker,
 };
 
@@ -47,11 +50,14 @@ pub(crate) async fn send_request(
     url: &str,
     headers: &HeaderMap,
     request: &CreateMessageRequest,
-    timeout: Duration,
+    timeout: Option<Duration>,
 ) -> Result<reqwest::Response, Response> {
     debug!(url = %url, "Sending request to worker");
 
-    let mut builder = http_client.post(url).json(request).timeout(timeout);
+    let mut builder = http_client.post(url).json(request);
+    if let Some(timeout) = timeout {
+        builder = builder.timeout(timeout);
+    }
     for (key, value) in headers {
         builder = builder.header(key, value);
     }
@@ -165,6 +171,58 @@ pub(crate) async fn handle_error_response(
         "Backend error"
     );
 
+    record_error_metrics(model_id, start_time, metrics_labels::ERROR_BACKEND);
+
+    (status, body).into_response()
+}
+
+/// Handle a non-success streaming response under the active streaming deadline.
+pub(crate) async fn handle_streaming_error_response(
+    response: reqwest::Response,
+    model_id: &str,
+    start_time: Instant,
+    stream_deadline: StreamDeadline,
+) -> Response {
+    let status = response.status();
+    let mut stream = response.bytes_stream();
+
+    let body = match stream_deadline
+        .read_text_limited(&mut stream, MAX_STREAM_ERROR_BODY_SIZE)
+        .await
+    {
+        Ok(body) if body.is_empty() => format!("Backend returned error: {status}"),
+        Ok(body) => body,
+        Err(StreamBodyReadError::Timeout(timeout)) => {
+            record_error_metrics(model_id, start_time, "streaming_timeout");
+            return error::gateway_timeout("streaming_timeout", stream_deadline.message(timeout));
+        }
+        Err(StreamBodyReadError::TooLarge { .. }) => {
+            warn!(
+                model = %model_id,
+                max_size = %MAX_STREAM_ERROR_BODY_SIZE,
+                "Error response body too large"
+            );
+            format!("Backend returned error: {status} (response too large)")
+        }
+        Err(err) => {
+            let message = stream_deadline.body_read_error_message(&err);
+            warn!(model = %model_id, error = %message, "Failed to read error response body");
+            format!("Backend returned error: {status}")
+        }
+    };
+
+    warn!(
+        model = %model_id,
+        status = %status,
+        body_preview = %body.chars().take(200).collect::<String>(),
+        "Backend error"
+    );
+
+    record_error_metrics(model_id, start_time, metrics_labels::ERROR_BACKEND);
+    (status, body).into_response()
+}
+
+fn record_error_metrics(model_id: &str, start_time: Instant, error_type: &'static str) {
     Metrics::record_router_duration(
         metrics_labels::ROUTER_HTTP,
         metrics_labels::BACKEND_EXTERNAL,
@@ -179,10 +237,8 @@ pub(crate) async fn handle_error_response(
         metrics_labels::CONNECTION_HTTP,
         model_id,
         "messages",
-        metrics_labels::ERROR_BACKEND,
+        error_type,
     );
-
-    (status, body).into_response()
 }
 
 // ============================================================================

--- a/model_gateway/src/routers/anthropic/worker.rs
+++ b/model_gateway/src/routers/anthropic/worker.rs
@@ -7,7 +7,7 @@
 use std::time::{Duration, Instant};
 
 use axum::{
-    http::HeaderMap,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
 use openai_protocol::messages::{CreateMessageRequest, Message};
@@ -179,6 +179,7 @@ pub(crate) async fn handle_error_response(
 /// Handle a non-success streaming response under the active streaming deadline.
 pub(crate) async fn handle_streaming_error_response(
     response: reqwest::Response,
+    worker: &dyn Worker,
     model_id: &str,
     start_time: Instant,
     stream_deadline: StreamDeadline,
@@ -194,6 +195,7 @@ pub(crate) async fn handle_streaming_error_response(
         Ok(body) => body,
         Err(StreamBodyReadError::Timeout(timeout)) => {
             record_error_metrics(model_id, start_time, "streaming_timeout");
+            record_worker_outcome(worker, StatusCode::GATEWAY_TIMEOUT);
             return error::gateway_timeout("streaming_timeout", stream_deadline.message(timeout));
         }
         Err(StreamBodyReadError::TooLarge { .. }) => {
@@ -219,7 +221,23 @@ pub(crate) async fn handle_streaming_error_response(
     );
 
     record_error_metrics(model_id, start_time, metrics_labels::ERROR_BACKEND);
+    record_worker_outcome(worker, status);
     (status, body).into_response()
+}
+
+pub(crate) fn record_worker_outcome(worker: &dyn Worker, status: StatusCode) {
+    worker.record_outcome(status.as_u16());
+    if status.is_server_error() {
+        Metrics::record_worker_error(
+            metrics_labels::WORKER_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            if status == StatusCode::GATEWAY_TIMEOUT {
+                metrics_labels::ERROR_TIMEOUT
+            } else {
+                metrics_labels::ERROR_BACKEND
+            },
+        );
+    }
 }
 
 fn record_error_metrics(model_id: &str, start_time: Instant, error_type: &'static str) {

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -29,4 +29,5 @@ pub mod persistence_utils;
 pub mod realtime;
 pub mod retry;
 pub mod sse;
+pub mod stream_timeout;
 pub mod worker_selection;

--- a/model_gateway/src/routers/common/sse.rs
+++ b/model_gateway/src/routers/common/sse.rs
@@ -289,6 +289,66 @@ pub fn parse_block(block: &str) -> Option<SseFrame<'_>> {
     parse_frame(block.trim_end_matches(['\r', '\n']))
 }
 
+/// Update a rolling tail of raw SSE bytes and return whether the stream is
+/// currently positioned at an event boundary.
+pub fn update_event_boundary(tail: &mut Vec<u8>, bytes: &[u8]) -> bool {
+    let suffix = if bytes.len() > 4 {
+        &bytes[bytes.len() - 4..]
+    } else {
+        bytes
+    };
+    let mut window = Vec::with_capacity(tail.len() + suffix.len());
+    window.extend_from_slice(tail);
+    window.extend_from_slice(suffix);
+
+    let start = window.len().saturating_sub(4);
+    tail.clear();
+    tail.extend_from_slice(&window[start..]);
+
+    let mut offset = 0;
+    let mut at_boundary = false;
+    while let Some((pos, len)) = find_frame_boundary(&window[offset..]) {
+        let end = offset + pos + len;
+        at_boundary = end == window.len();
+        offset = end;
+    }
+    at_boundary
+}
+
+/// Feed raw SSE bytes into a decoder and return whether a complete `[DONE]`
+/// sentinel was observed.
+pub fn observe_done_event(decoder: &mut SseDecoder, bytes: &[u8]) -> bool {
+    if decoder.push(bytes).is_err() {
+        return false;
+    }
+
+    let mut saw_done = false;
+    while let Some(frame) = decoder.next_frame() {
+        if frame.is_ok_and(|frame| frame.is_done()) {
+            saw_done = true;
+        }
+    }
+    decoder.compact();
+    saw_done
+}
+
+/// Feed raw SSE bytes into a decoder and return whether a complete event with
+/// the requested `event:` type was observed.
+pub fn observe_event_type(decoder: &mut SseDecoder, bytes: &[u8], event_type: &str) -> bool {
+    if decoder.push(bytes).is_err() {
+        return false;
+    }
+
+    let mut saw_event = false;
+    while let Some(frame) = decoder.next_frame() {
+        if frame.is_ok_and(|frame| frame.event_type.as_deref() == Some(event_type)) {
+            saw_event = true;
+        }
+    }
+    decoder.compact();
+    saw_event
+}
+
 // ============================================================================
 // Shared helpers
 // ============================================================================
@@ -532,6 +592,42 @@ mod tests {
         let json_str = serde_json::to_string(&val).unwrap();
         let expected = format!("event: content_block_start\ndata: {json_str}\n\n");
         assert_eq!(text, expected);
+    }
+
+    #[test]
+    fn update_event_boundary_detects_split_boundaries() {
+        let mut tail = Vec::new();
+
+        assert!(!update_event_boundary(&mut tail, b"data: he"));
+        assert!(!update_event_boundary(&mut tail, b"llo\n"));
+        assert!(update_event_boundary(&mut tail, b"\n"));
+
+        assert!(!update_event_boundary(&mut tail, b"data: next\r\n"));
+        assert!(update_event_boundary(&mut tail, b"\r\n"));
+    }
+
+    #[test]
+    fn observe_done_event_detects_split_done_frame() {
+        let mut decoder = SseDecoder::new();
+
+        assert!(!observe_done_event(&mut decoder, b"data: [DO"));
+        assert!(observe_done_event(&mut decoder, b"NE]\n\n"));
+    }
+
+    #[test]
+    fn observe_event_type_detects_split_terminal_event() {
+        let mut decoder = SseDecoder::new();
+
+        assert!(!observe_event_type(
+            &mut decoder,
+            b"event: message_stop\nda",
+            "message_stop"
+        ));
+        assert!(observe_event_type(
+            &mut decoder,
+            b"ta: {\"type\":\"message_stop\"}\n\n",
+            "message_stop"
+        ));
     }
 
     // --- SseDecoder tests ---

--- a/model_gateway/src/routers/common/sse.rs
+++ b/model_gateway/src/routers/common/sse.rs
@@ -315,38 +315,124 @@ pub fn update_event_boundary(tail: &mut Vec<u8>, bytes: &[u8]) -> bool {
     at_boundary
 }
 
-/// Feed raw SSE bytes into a decoder and return whether a complete `[DONE]`
-/// sentinel was observed.
-pub fn observe_done_event(decoder: &mut SseDecoder, bytes: &[u8]) -> bool {
-    if decoder.push(bytes).is_err() {
-        return false;
-    }
-
-    let mut saw_done = false;
-    while let Some(frame) = decoder.next_frame() {
-        if frame.is_ok_and(|frame| frame.is_done()) {
-            saw_done = true;
-        }
-    }
-    decoder.compact();
-    saw_done
+enum TerminalEvent {
+    Done,
+    EventType(Vec<u8>),
 }
 
-/// Feed raw SSE bytes into a decoder and return whether a complete event with
-/// the requested `event:` type was observed.
-pub fn observe_event_type(decoder: &mut SseDecoder, bytes: &[u8], event_type: &str) -> bool {
-    if decoder.push(bytes).is_err() {
-        return false;
+/// Incrementally observes terminal SSE events without buffering event payloads.
+///
+/// This is intentionally separate from [`SseDecoder`]: terminal tracking must
+/// recover after an oversized upstream event while the full decoder retains its
+/// strict buffer limit. Only enough bytes to match the configured terminal
+/// field are retained from each line.
+pub struct SseTerminalObserver {
+    target: TerminalEvent,
+    line: Vec<u8>,
+    max_line_len: usize,
+    line_truncated: bool,
+    skip_lf_after_cr: bool,
+    has_data: bool,
+    data_is_done: bool,
+    event_type_matches: bool,
+}
+
+impl SseTerminalObserver {
+    pub fn done() -> Self {
+        Self::new(TerminalEvent::Done, b"data: [DONE]".len())
     }
 
-    let mut saw_event = false;
-    while let Some(frame) = decoder.next_frame() {
-        if frame.is_ok_and(|frame| frame.event_type.as_deref() == Some(event_type)) {
-            saw_event = true;
+    pub fn event_type(event_type: &str) -> Self {
+        Self::new(
+            TerminalEvent::EventType(event_type.as_bytes().to_vec()),
+            b"event: ".len() + event_type.len(),
+        )
+    }
+
+    fn new(target: TerminalEvent, max_line_len: usize) -> Self {
+        Self {
+            target,
+            line: Vec::with_capacity(max_line_len),
+            max_line_len,
+            line_truncated: false,
+            skip_lf_after_cr: false,
+            has_data: false,
+            data_is_done: false,
+            event_type_matches: false,
         }
     }
-    decoder.compact();
-    saw_event
+
+    /// Feed raw SSE bytes and report whether a complete target event was seen.
+    pub fn observe(&mut self, bytes: &[u8]) -> bool {
+        let mut terminal_seen = false;
+        for &byte in bytes {
+            if self.skip_lf_after_cr {
+                self.skip_lf_after_cr = false;
+                if byte == b'\n' {
+                    continue;
+                }
+            }
+
+            match byte {
+                b'\r' => {
+                    terminal_seen |= self.finish_line();
+                    self.skip_lf_after_cr = true;
+                }
+                b'\n' => terminal_seen |= self.finish_line(),
+                _ if self.line.len() < self.max_line_len => self.line.push(byte),
+                _ => self.line_truncated = true,
+            }
+        }
+        terminal_seen
+    }
+
+    fn finish_line(&mut self) -> bool {
+        if self.line.is_empty() && !self.line_truncated {
+            let terminal_seen = self.has_data
+                && match &self.target {
+                    TerminalEvent::Done => self.data_is_done,
+                    TerminalEvent::EventType(_) => self.event_type_matches,
+                };
+            self.reset_event();
+            return terminal_seen;
+        }
+
+        let colon = self.line.iter().position(|&byte| byte == b':');
+        let (field, mut value) = match colon {
+            Some(index) => (&self.line[..index], &self.line[index + 1..]),
+            None => (self.line.as_slice(), &[][..]),
+        };
+        if value.first() == Some(&b' ') {
+            value = &value[1..];
+        }
+
+        match field {
+            b"data" => {
+                self.data_is_done = !self.has_data && !self.line_truncated && value == b"[DONE]";
+                self.has_data = true;
+            }
+            b"event" => {
+                self.event_type_matches = !self.line_truncated
+                    && match &self.target {
+                        TerminalEvent::Done => false,
+                        TerminalEvent::EventType(target) => value == target,
+                    };
+            }
+            _ => {}
+        }
+
+        self.line.clear();
+        self.line_truncated = false;
+        false
+    }
+
+    fn reset_event(&mut self) {
+        self.line.clear();
+        self.line_truncated = false;
+        self.has_data = false;
+        self.data_is_done = false;
+        self.event_type_matches = false;
+    }
 }
 
 // ============================================================================
@@ -608,26 +694,40 @@ mod tests {
 
     #[test]
     fn observe_done_event_detects_split_done_frame() {
-        let mut decoder = SseDecoder::new();
+        let mut observer = SseTerminalObserver::done();
 
-        assert!(!observe_done_event(&mut decoder, b"data: [DO"));
-        assert!(observe_done_event(&mut decoder, b"NE]\n\n"));
+        assert!(!observer.observe(b"data: [DO"));
+        assert!(observer.observe(b"NE]\n\n"));
     }
 
     #[test]
     fn observe_event_type_detects_split_terminal_event() {
-        let mut decoder = SseDecoder::new();
+        let mut observer = SseTerminalObserver::event_type("message_stop");
 
-        assert!(!observe_event_type(
-            &mut decoder,
-            b"event: message_stop\nda",
-            "message_stop"
+        assert!(!observer.observe(b"event: message_stop\nda"));
+        assert!(observer.observe(b"ta: {\"type\":\"message_stop\"}\n\n"));
+    }
+
+    #[test]
+    fn terminal_observer_recovers_after_oversized_event() {
+        let mut done_observer = SseTerminalObserver::done();
+        assert!(!done_observer.observe(b"data: an oversized payload that"));
+        assert!(!done_observer.observe(b" continues across chunks\n\n"));
+        assert!(done_observer.observe(b"data: [DONE]\n\n"));
+
+        let mut event_observer = SseTerminalObserver::event_type("message_stop");
+        assert!(event_observer.observe(
+            b"data: an oversized payload that exceeds the tracked line\n\n\
+              event: message_stop\ndata: {}\n\n"
         ));
-        assert!(observe_event_type(
-            &mut decoder,
-            b"ta: {\"type\":\"message_stop\"}\n\n",
-            "message_stop"
-        ));
+    }
+
+    #[test]
+    fn terminal_observer_does_not_match_done_line_inside_oversized_event() {
+        let mut observer = SseTerminalObserver::done();
+
+        assert!(!observer.observe(b"data: an oversized first line\ndata: [DONE]\n\n"));
+        assert!(observer.observe(b"data: [DONE]\n\n"));
     }
 
     // --- SseDecoder tests ---

--- a/model_gateway/src/routers/common/stream_timeout.rs
+++ b/model_gateway/src/routers/common/stream_timeout.rs
@@ -1,0 +1,221 @@
+//! Helpers for enforcing a wall-clock cap on long-lived streaming responses.
+
+use std::{fmt, future::Future, time::Duration};
+
+use bytes::Bytes;
+use futures_util::{Stream, StreamExt};
+use tokio::time::{self, Instant};
+
+pub const MAX_STREAM_ERROR_BODY_SIZE: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+pub struct StreamDeadline {
+    total_deadline: Instant,
+    total_timeout: Duration,
+    idle_timeout: Duration,
+}
+
+impl StreamDeadline {
+    pub fn new(total_timeout: Duration, idle_timeout: Duration) -> Self {
+        let now = Instant::now();
+        Self {
+            total_deadline: now.checked_add(total_timeout).unwrap_or(now),
+            total_timeout,
+            idle_timeout,
+        }
+    }
+
+    pub fn is_total_elapsed(&self) -> bool {
+        Instant::now() >= self.total_deadline
+    }
+
+    pub fn message(&self, timeout: StreamTimeoutKind) -> String {
+        match timeout {
+            StreamTimeoutKind::Total => format!(
+                "Streaming request exceeded configured total timeout of {} seconds",
+                self.total_timeout.as_secs()
+            ),
+            StreamTimeoutKind::Idle => format!(
+                "Streaming request exceeded configured idle timeout of {} seconds",
+                self.idle_timeout.as_secs()
+            ),
+        }
+    }
+
+    pub fn sse_error_event(&self, timeout: StreamTimeoutKind) -> Bytes {
+        let payload = serde_json::json!({
+            "error": {
+                "type": "timeout",
+                "code": "streaming_timeout",
+                "message": self.message(timeout),
+            }
+        });
+        Bytes::from(format!("event: error\ndata: {payload}\n\n"))
+    }
+
+    pub async fn until_total<F>(&self, future: F) -> Result<F::Output, StreamTimeoutKind>
+    where
+        F: Future,
+    {
+        time::timeout_at(self.total_deadline, future)
+            .await
+            .map_err(|_| StreamTimeoutKind::Total)
+    }
+
+    pub async fn until_activity<F>(&self, future: F) -> Result<F::Output, StreamTimeoutKind>
+    where
+        F: Future,
+    {
+        let (deadline, timeout) = self.activity_deadline()?;
+        time::timeout_at(deadline, future)
+            .await
+            .map_err(|_| timeout)
+    }
+
+    pub async fn next<S>(&self, stream: &mut S) -> Result<Option<S::Item>, StreamTimeoutKind>
+    where
+        S: Stream + Unpin,
+    {
+        let (next_deadline, timeout) = self.activity_deadline()?;
+        time::timeout_at(next_deadline, stream.next())
+            .await
+            .map_err(|_| timeout)
+    }
+
+    fn activity_deadline(&self) -> Result<(Instant, StreamTimeoutKind), StreamTimeoutKind> {
+        let now = Instant::now();
+        if now >= self.total_deadline {
+            return Err(StreamTimeoutKind::Total);
+        }
+
+        let idle_deadline = now.checked_add(self.idle_timeout).unwrap_or(now);
+        Ok(if idle_deadline < self.total_deadline {
+            (idle_deadline, StreamTimeoutKind::Idle)
+        } else {
+            (self.total_deadline, StreamTimeoutKind::Total)
+        })
+    }
+
+    pub async fn read_text_limited<S, E>(
+        &self,
+        stream: &mut S,
+        max_size: usize,
+    ) -> Result<String, StreamBodyReadError>
+    where
+        S: Stream<Item = Result<Bytes, E>> + Unpin,
+        E: fmt::Display,
+    {
+        let mut buf = Vec::new();
+        let mut total_size = 0;
+
+        loop {
+            let chunk = match self.next(stream).await {
+                Ok(Some(chunk)) => chunk,
+                Ok(None) => break,
+                Err(timeout) => return Err(StreamBodyReadError::Timeout(timeout)),
+            };
+
+            let chunk = chunk.map_err(|err| StreamBodyReadError::Read(err.to_string()))?;
+            total_size += chunk.len();
+            if total_size > max_size {
+                return Err(StreamBodyReadError::TooLarge { max_size });
+            }
+            buf.extend_from_slice(&chunk);
+        }
+
+        String::from_utf8(buf).map_err(|err| StreamBodyReadError::InvalidUtf8(err.to_string()))
+    }
+
+    pub fn body_read_error_message(&self, error: &StreamBodyReadError) -> String {
+        match error {
+            StreamBodyReadError::Timeout(timeout) => self.message(*timeout),
+            StreamBodyReadError::TooLarge { max_size } => {
+                format!("Streaming error body exceeded configured limit of {max_size} bytes")
+            }
+            StreamBodyReadError::Read(error) => {
+                format!("Failed to read upstream error body: {error}")
+            }
+            StreamBodyReadError::InvalidUtf8(error) => {
+                format!("Invalid UTF-8 in upstream error body: {error}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum StreamTimeoutKind {
+    Total,
+    Idle,
+}
+
+#[derive(Debug)]
+pub enum StreamBodyReadError {
+    Timeout(StreamTimeoutKind),
+    TooLarge { max_size: usize },
+    Read(String),
+    InvalidUtf8(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures_util::stream;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn next_reports_total_timeout() {
+        let deadline = StreamDeadline::new(Duration::from_millis(10), Duration::from_secs(1));
+        let mut stream = stream::pending::<()>();
+
+        let result = deadline.next(&mut stream).await;
+
+        assert!(matches!(result, Err(StreamTimeoutKind::Total)));
+    }
+
+    #[tokio::test]
+    async fn next_reports_idle_timeout() {
+        let deadline = StreamDeadline::new(Duration::from_secs(1), Duration::from_millis(10));
+        let mut stream = stream::pending::<()>();
+
+        let result = deadline.next(&mut stream).await;
+
+        assert!(matches!(result, Err(StreamTimeoutKind::Idle)));
+    }
+
+    #[tokio::test]
+    async fn until_activity_reports_idle_timeout() {
+        let deadline = StreamDeadline::new(Duration::from_secs(1), Duration::from_millis(10));
+
+        let result = deadline.until_activity(std::future::pending::<()>()).await;
+
+        assert!(matches!(result, Err(StreamTimeoutKind::Idle)));
+    }
+
+    #[tokio::test]
+    async fn read_text_limited_reports_idle_timeout() {
+        let deadline = StreamDeadline::new(Duration::from_secs(1), Duration::from_millis(10));
+        let mut stream = stream::pending::<Result<Bytes, std::io::Error>>();
+
+        let result = deadline.read_text_limited(&mut stream, 1024).await;
+
+        assert!(matches!(
+            result,
+            Err(StreamBodyReadError::Timeout(StreamTimeoutKind::Idle))
+        ));
+    }
+
+    #[tokio::test]
+    async fn read_text_limited_rejects_oversized_body() {
+        let deadline = StreamDeadline::new(Duration::from_secs(1), Duration::from_secs(1));
+        let mut stream = stream::iter([Ok::<_, std::io::Error>(Bytes::from_static(b"hello"))]);
+
+        let result = deadline.read_text_limited(&mut stream, 4).await;
+
+        assert!(matches!(
+            result,
+            Err(StreamBodyReadError::TooLarge { max_size: 4 })
+        ));
+    }
+}

--- a/model_gateway/src/routers/common/stream_timeout.rs
+++ b/model_gateway/src/routers/common/stream_timeout.rs
@@ -78,12 +78,32 @@ impl StreamDeadline {
     /// Send a relay item without allowing downstream backpressure to outlive
     /// the configured total stream deadline.
     ///
-    /// A ready send is attempted first so a terminal timeout item can still be
-    /// delivered after the deadline has elapsed. Returns `Ok(true)` when the
-    /// item was delivered, `Ok(false)` when the downstream receiver was
-    /// dropped, and `Err(Total)` when a full channel remained blocked until the
-    /// total deadline.
+    /// Returns `Ok(true)` when the item was delivered, `Ok(false)` when the
+    /// downstream receiver was dropped, and `Err(Total)` when the deadline
+    /// elapsed before delivery.
     pub async fn send_before_total<T>(
+        &self,
+        sender: &mpsc::Sender<T>,
+        item: T,
+    ) -> Result<bool, StreamTimeoutKind> {
+        if self.is_total_elapsed() {
+            return Err(StreamTimeoutKind::Total);
+        }
+
+        match sender.try_send(item) {
+            Ok(()) => Ok(true),
+            Err(mpsc::error::TrySendError::Closed(_)) => Ok(false),
+            Err(mpsc::error::TrySendError::Full(item)) => self
+                .until_total(sender.send(item))
+                .await
+                .map(|result| result.is_ok()),
+        }
+    }
+
+    /// Send a terminal relay item, allowing one ready nonblocking send after
+    /// the deadline so clients can receive the timeout reason. A full channel
+    /// is never awaited beyond the configured total deadline.
+    pub async fn send_terminal_before_total<T>(
         &self,
         sender: &mpsc::Sender<T>,
         item: T,
@@ -257,11 +277,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_before_total_delivers_ready_item_after_deadline() {
+    async fn send_before_total_rejects_ready_item_after_deadline() {
+        let deadline = StreamDeadline::new(Duration::ZERO, Duration::from_secs(1));
+        let (tx, _rx) = mpsc::channel(1);
+
+        assert!(matches!(
+            deadline.send_before_total(&tx, "ordinary").await,
+            Err(StreamTimeoutKind::Total)
+        ));
+    }
+
+    #[tokio::test]
+    async fn send_terminal_before_total_delivers_ready_item_after_deadline() {
         let deadline = StreamDeadline::new(Duration::ZERO, Duration::from_secs(1));
         let (tx, mut rx) = mpsc::channel(1);
 
-        assert!(deadline.send_before_total(&tx, "terminal").await.unwrap());
+        assert!(deadline
+            .send_terminal_before_total(&tx, "terminal")
+            .await
+            .unwrap());
         assert_eq!(rx.recv().await, Some("terminal"));
     }
 

--- a/model_gateway/src/routers/common/stream_timeout.rs
+++ b/model_gateway/src/routers/common/stream_timeout.rs
@@ -78,17 +78,24 @@ impl StreamDeadline {
     /// Send a relay item without allowing downstream backpressure to outlive
     /// the configured total stream deadline.
     ///
-    /// Returns `Ok(true)` when the item was delivered, `Ok(false)` when the
-    /// downstream receiver was dropped, and `Err(Total)` when a full channel
-    /// remained blocked until the total deadline.
+    /// A ready send is attempted first so a terminal timeout item can still be
+    /// delivered after the deadline has elapsed. Returns `Ok(true)` when the
+    /// item was delivered, `Ok(false)` when the downstream receiver was
+    /// dropped, and `Err(Total)` when a full channel remained blocked until the
+    /// total deadline.
     pub async fn send_before_total<T>(
         &self,
         sender: &mpsc::Sender<T>,
         item: T,
     ) -> Result<bool, StreamTimeoutKind> {
-        self.until_total(sender.send(item))
-            .await
-            .map(|result| result.is_ok())
+        match sender.try_send(item) {
+            Ok(()) => Ok(true),
+            Err(mpsc::error::TrySendError::Closed(_)) => Ok(false),
+            Err(mpsc::error::TrySendError::Full(item)) => self
+                .until_total(sender.send(item))
+                .await
+                .map(|result| result.is_ok()),
+        }
     }
 
     pub async fn next<S>(&self, stream: &mut S) -> Result<Option<S::Item>, StreamTimeoutKind>
@@ -247,6 +254,15 @@ mod tests {
         let result = deadline.send_before_total(&tx, "blocked").await;
 
         assert!(matches!(result, Err(StreamTimeoutKind::Total)));
+    }
+
+    #[tokio::test]
+    async fn send_before_total_delivers_ready_item_after_deadline() {
+        let deadline = StreamDeadline::new(Duration::ZERO, Duration::from_secs(1));
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(deadline.send_before_total(&tx, "terminal").await.unwrap());
+        assert_eq!(rx.recv().await, Some("terminal"));
     }
 
     #[tokio::test]

--- a/model_gateway/src/routers/common/stream_timeout.rs
+++ b/model_gateway/src/routers/common/stream_timeout.rs
@@ -4,7 +4,10 @@ use std::{fmt, future::Future, time::Duration};
 
 use bytes::Bytes;
 use futures_util::{Stream, StreamExt};
-use tokio::time::{self, Instant};
+use tokio::{
+    sync::mpsc,
+    time::{self, Instant},
+};
 
 pub const MAX_STREAM_ERROR_BODY_SIZE: usize = 1024 * 1024;
 
@@ -70,6 +73,22 @@ impl StreamDeadline {
         time::timeout_at(deadline, future)
             .await
             .map_err(|_| timeout)
+    }
+
+    /// Send a relay item without allowing downstream backpressure to outlive
+    /// the configured total stream deadline.
+    ///
+    /// Returns `Ok(true)` when the item was delivered, `Ok(false)` when the
+    /// downstream receiver was dropped, and `Err(Total)` when a full channel
+    /// remained blocked until the total deadline.
+    pub async fn send_before_total<T>(
+        &self,
+        sender: &mpsc::Sender<T>,
+        item: T,
+    ) -> Result<bool, StreamTimeoutKind> {
+        self.until_total(sender.send(item))
+            .await
+            .map(|result| result.is_ok())
     }
 
     pub async fn next<S>(&self, stream: &mut S) -> Result<Option<S::Item>, StreamTimeoutKind>
@@ -217,5 +236,25 @@ mod tests {
             result,
             Err(StreamBodyReadError::TooLarge { max_size: 4 })
         ));
+    }
+
+    #[tokio::test]
+    async fn send_before_total_times_out_when_channel_stays_full() {
+        let deadline = StreamDeadline::new(Duration::from_millis(10), Duration::from_secs(1));
+        let (tx, _rx) = mpsc::channel(1);
+
+        assert!(deadline.send_before_total(&tx, "first").await.unwrap());
+        let result = deadline.send_before_total(&tx, "blocked").await;
+
+        assert!(matches!(result, Err(StreamTimeoutKind::Total)));
+    }
+
+    #[tokio::test]
+    async fn send_before_total_reports_closed_receiver() {
+        let deadline = StreamDeadline::new(Duration::from_secs(1), Duration::from_secs(1));
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+
+        assert!(!deadline.send_before_total(&tx, "item").await.unwrap());
     }
 }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -76,6 +76,35 @@ struct PDRequestContext<'a> {
     headers: Option<HeaderMap>,
 }
 
+#[derive(Clone)]
+struct PDRouterStreamMetrics {
+    model_id: String,
+    endpoint: &'static str,
+    start_time: Instant,
+}
+
+fn record_pd_router_stream_outcome(metrics: &PDRouterStreamMetrics, status: StatusCode) {
+    if status.is_success() {
+        Metrics::record_router_duration(
+            metrics_labels::ROUTER_HTTP,
+            metrics_labels::BACKEND_PD,
+            metrics_labels::CONNECTION_HTTP,
+            &metrics.model_id,
+            metrics.endpoint,
+            metrics.start_time.elapsed(),
+        );
+    } else {
+        Metrics::record_router_error(
+            metrics_labels::ROUTER_HTTP,
+            metrics_labels::BACKEND_PD,
+            metrics_labels::CONNECTION_HTTP,
+            &metrics.model_id,
+            metrics.endpoint,
+            error_type_from_status(status),
+        );
+    }
+}
+
 enum PDDispatchError {
     Transport(String),
     StreamingTimeout(StreamTimeoutKind),
@@ -321,6 +350,7 @@ impl PDRouter {
         let model = canonical_model.as_deref().unwrap_or(context.model_id);
         context.model_id = model;
         let endpoint = route_to_endpoint(route);
+        let route_is_stream = context.is_stream;
 
         // Record request start (Layer 2)
         Metrics::record_router_request(
@@ -458,6 +488,7 @@ impl PDRouter {
                                 context,
                                 Arc::clone(&prefill),
                                 Arc::clone(&decode),
+                                start_time,
                             )
                             .await;
 
@@ -486,7 +517,7 @@ impl PDRouter {
 
         // Record Layer 2 metrics
         let duration = start_time.elapsed();
-        if response.status().is_success() {
+        if !route_is_stream && response.status().is_success() {
             Metrics::record_router_duration(
                 metrics_labels::ROUTER_HTTP,
                 metrics_labels::BACKEND_PD,
@@ -495,7 +526,7 @@ impl PDRouter {
                 endpoint,
                 duration,
             );
-        } else if !is_retryable_status(response.status()) {
+        } else if !response.status().is_success() && !is_retryable_status(response.status()) {
             Metrics::record_router_error(
                 metrics_labels::ROUTER_HTTP,
                 metrics_labels::BACKEND_PD,
@@ -562,6 +593,7 @@ impl PDRouter {
                 None,
                 load_guards,
                 stream_deadline,
+                None,
             )
         } else {
             // Handle non-streaming error response
@@ -636,6 +668,10 @@ impl PDRouter {
     }
 
     // Internal method that performs the actual dual dispatch (without retry logic)
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "PD dispatch must carry both leg payloads, selected workers, and router timing"
+    )]
     async fn execute_dual_dispatch_internal(
         &self,
         headers: Option<&HeaderMap>,
@@ -644,6 +680,7 @@ impl PDRouter {
         context: PDRequestContext<'_>,
         prefill: Arc<dyn Worker>,
         decode: Arc<dyn Worker>,
+        router_start: Instant,
     ) -> Response {
         let load_guards = vec![
             WorkerLoadGuard::new(prefill.clone(), headers),
@@ -828,6 +865,11 @@ impl PDRouter {
                 Some((prefill.clone(), decode.clone())),
                 load_guards,
                 stream_deadline,
+                Some(PDRouterStreamMetrics {
+                    model_id: context.model_id.to_string(),
+                    endpoint: route_to_endpoint(context.route),
+                    start_time: router_start,
+                }),
             )
         } else {
             // Non-streaming response
@@ -1023,6 +1065,7 @@ impl PDRouter {
         outcome_workers: Option<(Arc<dyn Worker>, Arc<dyn Worker>)>,
         load_guards: Vec<WorkerLoadGuard>,
         stream_deadline: StreamDeadline,
+        router_metrics: Option<PDRouterStreamMetrics>,
     ) -> Response {
         use crate::worker::AttachedBody;
 
@@ -1093,6 +1136,11 @@ impl PDRouter {
             if let Some((prefill, decode)) = outcome_workers {
                 let effective_status = stream_failure_status.unwrap_or(status);
                 record_pd_worker_outcome(prefill.as_ref(), decode.as_ref(), effective_status);
+                if status.is_success() {
+                    if let Some(metrics) = router_metrics.as_ref() {
+                        record_pd_router_stream_outcome(metrics, effective_status);
+                    }
+                }
             }
         });
 
@@ -1938,6 +1986,7 @@ mod tests {
                 None,
                 guards,
                 StreamDeadline::new(router.stream_timeout, router.stream_idle_timeout),
+                None,
             );
 
             // Guards are now attached to response body, so load should be 1

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -377,6 +377,7 @@ impl PDRouter {
         let retry_config = per_model_retry_config
             .as_ref()
             .unwrap_or(&self.retry_config);
+        let stream_deadline = StreamDeadline::new(self.stream_timeout, self.stream_idle_timeout);
 
         let response = RetryExecutor::execute_response_with_retry(
             retry_config,
@@ -496,6 +497,7 @@ impl PDRouter {
                                 Arc::clone(&prefill),
                                 Arc::clone(&decode),
                                 start_time,
+                                stream_deadline,
                             )
                             .await;
 
@@ -688,6 +690,7 @@ impl PDRouter {
         prefill: Arc<dyn Worker>,
         decode: Arc<dyn Worker>,
         router_start: Instant,
+        stream_deadline: StreamDeadline,
     ) -> Response {
         let load_guards = vec![
             WorkerLoadGuard::new(prefill.clone(), headers),
@@ -745,7 +748,6 @@ impl PDRouter {
         // decode head. Recorded on the success path only.
         let runtime = prefill.metadata().spec.runtime_type.as_str();
         let dispatch_start = Instant::now();
-        let stream_deadline = StreamDeadline::new(self.stream_timeout, self.stream_idle_timeout);
         let prefill_fut = async {
             let send_result = if context.is_stream {
                 stream_deadline

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1089,6 +1089,7 @@ impl PDRouter {
             let mut boundary_tail = Vec::new();
             let mut at_event_boundary = true;
             let mut stream_failure_status = None;
+            let mut relay_send_timed_out = false;
             loop {
                 let chunk_result = match stream_deadline.next(&mut stream).await {
                     Ok(Some(chunk_result)) => chunk_result,
@@ -1100,7 +1101,9 @@ impl PDRouter {
                         } else {
                             Err(stream_deadline.message(timeout))
                         };
-                        let _ = stream_deadline.send_before_total(&tx, timeout_item).await;
+                        let _ = stream_deadline
+                            .send_terminal_before_total(&tx, timeout_item)
+                            .await;
                         break;
                     }
                 };
@@ -1125,6 +1128,7 @@ impl PDRouter {
                             Ok(true) => {}
                             Ok(false) => break,
                             Err(_) => {
+                                relay_send_timed_out = true;
                                 stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                                 break;
                             }
@@ -1140,7 +1144,7 @@ impl PDRouter {
                         }
                         stream_failure_status = Some(StatusCode::BAD_GATEWAY);
                         let _ = stream_deadline
-                            .send_before_total(&tx, Err(format!("Stream error: {e}")))
+                            .send_terminal_before_total(&tx, Err(format!("Stream error: {e}")))
                             .await;
                         break;
                     }
@@ -1148,7 +1152,12 @@ impl PDRouter {
             }
             if let Some((prefill, decode)) = outcome_workers {
                 let effective_status = stream_failure_status.unwrap_or(status);
-                record_pd_worker_outcome(prefill.as_ref(), decode.as_ref(), effective_status);
+                let worker_status = if relay_send_timed_out {
+                    status
+                } else {
+                    effective_status
+                };
+                record_pd_worker_outcome(prefill.as_ref(), decode.as_ref(), worker_status);
                 if status.is_success() {
                     if let Some(metrics) = router_metrics.as_ref() {
                         record_pd_router_stream_outcome(metrics, effective_status);

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -861,7 +861,19 @@ impl PDRouter {
                                     return Self::first_decode_error_response(error, stream_deadline);
                                 }
                             };
-                        let prefill_body = match prefill_future.await {
+                        let prefill_result = match stream_deadline
+                            .until_activity(&mut prefill_future)
+                            .await
+                        {
+                            Ok(result) => result,
+                            Err(timeout) => {
+                                return Self::first_decode_error_response(
+                                    FirstDecodeChunkError::Timeout(timeout),
+                                    stream_deadline,
+                                );
+                            }
+                        };
+                        let prefill_body = match prefill_result {
                             Ok((_, body)) => body,
                             Err(error_response) => return error_response,
                         };
@@ -1227,12 +1239,21 @@ impl PDRouter {
             }
             if let Some((prefill, decode)) = outcome_workers {
                 let effective_status = stream_failure_status.unwrap_or(status);
-                let worker_status = if relay_send_timed_out {
+                let decode_status = if relay_send_timed_out {
                     status
                 } else {
                     effective_status
                 };
-                record_pd_worker_outcome(prefill.as_ref(), decode.as_ref(), worker_status);
+                record_pd_worker_outcome_for(
+                    prefill.as_ref(),
+                    metrics_labels::WORKER_PREFILL,
+                    status,
+                );
+                record_pd_worker_outcome_for(
+                    decode.as_ref(),
+                    metrics_labels::WORKER_DECODE,
+                    decode_status,
+                );
                 if status.is_success() {
                     if let Some(metrics) = router_metrics.as_ref() {
                         record_pd_router_stream_outcome(metrics, effective_status);
@@ -1575,21 +1596,20 @@ impl PDRouter {
 }
 
 fn record_pd_worker_outcome(prefill: &dyn Worker, decode: &dyn Worker, status: StatusCode) {
-    prefill.record_outcome(status.as_u16());
-    decode.record_outcome(status.as_u16());
+    record_pd_worker_outcome_for(prefill, metrics_labels::WORKER_PREFILL, status);
+    record_pd_worker_outcome_for(decode, metrics_labels::WORKER_DECODE, status);
+}
+
+fn record_pd_worker_outcome_for(
+    worker: &dyn Worker,
+    worker_type: &'static str,
+    status: StatusCode,
+) {
+    worker.record_outcome(status.as_u16());
 
     if status.is_server_error() {
         let error_type = error_type_from_status(status);
-        Metrics::record_worker_error(
-            metrics_labels::WORKER_PREFILL,
-            metrics_labels::CONNECTION_HTTP,
-            error_type,
-        );
-        Metrics::record_worker_error(
-            metrics_labels::WORKER_DECODE,
-            metrics_labels::CONNECTION_HTTP,
-            error_type,
-        );
+        Metrics::record_worker_error(worker_type, metrics_labels::CONNECTION_HTTP, error_type);
     }
 }
 

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1085,7 +1085,7 @@ impl PDRouter {
             futures_util::pin_mut!(stream);
             // Reusable SSE encoder for the logprob-merge re-encode path.
             let mut encoder = SseEncoder::new();
-            let mut done_decoder = sse::SseDecoder::new();
+            let mut done_observer = sse::SseTerminalObserver::done();
             let mut boundary_tail = Vec::new();
             let mut at_event_boundary = true;
             let mut stream_failure_status = None;
@@ -1106,7 +1106,7 @@ impl PDRouter {
                 };
                 match chunk_result {
                     Ok(chunk) => {
-                        let is_done = sse::observe_done_event(&mut done_decoder, chunk.as_ref());
+                        let is_done = done_observer.observe(chunk.as_ref());
 
                         let result = if return_logprob && prefill_logprobs.is_some() {
                             Self::merge_streaming_logprobs(

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -692,8 +692,13 @@ impl PDRouter {
         let headers = Some(&headers_with_trace);
 
         // Build both requests
+        let prefill_client = if context.is_stream {
+            &self.streaming_client
+        } else {
+            &self.client
+        };
         let prefill_request = self.build_post_with_headers(
-            &self.client,
+            prefill_client,
             prefill.as_ref(),
             context.route,
             &prefill_json_request,

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1,15 +1,19 @@
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
 use axum::{
     body::Body,
     extract::Request,
-    http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
+    http::{
+        header::{CONTENT_LENGTH, CONTENT_TYPE},
+        HeaderMap, HeaderValue, StatusCode,
+    },
     response::{IntoResponse, Response},
 };
 use bytes::Bytes;
-use futures_util::StreamExt;
-use memchr::memmem;
 use openai_protocol::{
     chat::ChatCompletionRequest,
     common::{GenerationRequest, InputIds, StringOrArray},
@@ -21,7 +25,7 @@ use reqwest::Client;
 use serde::Serialize;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, warn};
 
 use crate::{
@@ -37,7 +41,10 @@ use crate::{
         common::{
             header_utils,
             retry::{is_retryable_status, RetryExecutor},
-            sse::SseEncoder,
+            sse::{self, SseEncoder},
+            stream_timeout::{
+                StreamBodyReadError, StreamDeadline, StreamTimeoutKind, MAX_STREAM_ERROR_BODY_SIZE,
+            },
         },
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},
@@ -51,6 +58,9 @@ pub struct PDRouter {
     pub worker_registry: Arc<WorkerRegistry>,
     pub policy_registry: Arc<PolicyRegistry>,
     pub client: Client,
+    pub streaming_client: Client,
+    pub stream_timeout: Duration,
+    pub stream_idle_timeout: Duration,
     pub retry_config: RetryConfig,
     pub api_key: Option<String>,
 }
@@ -64,6 +74,16 @@ struct PDRequestContext<'a> {
     request_text: Option<String>,
     model_id: &'a str,
     headers: Option<HeaderMap>,
+}
+
+enum PDDispatchError {
+    Transport(String),
+    StreamingTimeout(StreamTimeoutKind),
+}
+
+enum PrefillBodyReadError {
+    Read(String),
+    Timeout(StreamTimeoutKind),
 }
 
 impl PDRouter {
@@ -167,6 +187,9 @@ impl PDRouter {
             worker_registry: Arc::clone(&ctx.worker_registry),
             policy_registry: Arc::clone(&ctx.policy_registry),
             client: ctx.client.clone(),
+            streaming_client: ctx.streaming_client.clone(),
+            stream_timeout: Duration::from_secs(ctx.router_config.request_timeout_secs),
+            stream_idle_timeout: Duration::from_secs(ctx.router_config.stream_idle_timeout_secs),
             retry_config: ctx.router_config.effective_retry_config(),
             api_key: ctx.router_config.api_key.clone(),
         })
@@ -426,6 +449,7 @@ impl PDRouter {
                             );
                         }
 
+                        let context_is_stream = context.is_stream;
                         let response = self
                             .execute_dual_dispatch_internal(
                                 headers,
@@ -438,22 +462,8 @@ impl PDRouter {
                             .await;
 
                         let status = response.status();
-                        prefill.record_outcome(status.as_u16());
-                        decode.record_outcome(status.as_u16());
-
-                        // Record worker errors for server errors (5xx)
-                        if status.is_server_error() {
-                            let error_type = error_type_from_status(status);
-                            Metrics::record_worker_error(
-                                metrics_labels::WORKER_PREFILL,
-                                metrics_labels::CONNECTION_HTTP,
-                                error_type,
-                            );
-                            Metrics::record_worker_error(
-                                metrics_labels::WORKER_DECODE,
-                                metrics_labels::CONNECTION_HTTP,
-                                error_type,
-                            );
+                        if !context_is_stream || !status.is_success() {
+                            record_pd_worker_outcome(prefill.as_ref(), decode.as_ref(), status);
                         }
 
                         response
@@ -505,22 +515,33 @@ impl PDRouter {
         context: &PDRequestContext<'_>,
         decode: Arc<dyn Worker>,
         load_guards: Vec<WorkerLoadGuard>,
+        stream_deadline: StreamDeadline,
     ) -> Response {
         let status = res.status();
 
         if context.is_stream {
             // Handle streaming error response
             let response_headers = header_utils::preserve_response_headers(res.headers());
-            let error_payload = match res.bytes().await {
+            let mut error_stream = res.bytes_stream();
+            let error_payload = match stream_deadline
+                .read_text_limited(&mut error_stream, MAX_STREAM_ERROR_BODY_SIZE)
+                .await
+            {
                 Ok(error_body) => {
-                    if let Ok(error_json) = serde_json::from_slice::<Value>(&error_body) {
+                    if let Ok(error_json) = serde_json::from_str::<Value>(&error_body) {
                         json!({ "message": error_json, "status": status.as_u16() })
                     } else {
-                        json!({ "message": String::from_utf8_lossy(&error_body).to_string(), "status": status.as_u16() })
+                        json!({ "message": error_body, "status": status.as_u16() })
                     }
                 }
-                Err(e) => {
-                    json!({ "message": format!("Decode server error: {}", e), "status": status.as_u16() })
+                Err(StreamBodyReadError::Timeout(timeout)) => {
+                    return error::gateway_timeout(
+                        "streaming_timeout",
+                        stream_deadline.message(timeout),
+                    );
+                }
+                Err(err) => {
+                    json!({ "message": format!("Decode server error: {}", stream_deadline.body_read_error_message(&err)), "status": status.as_u16() })
                 }
             };
 
@@ -531,14 +552,16 @@ impl PDRouter {
             let error_stream = tokio_stream::once(Ok(Bytes::from(sse_data)));
 
             let decode_url = decode.url().to_string();
-            self.create_streaming_response(
+            Self::create_streaming_response(
                 error_stream,
                 status,
                 None,
                 context.return_logprob,
                 Some(decode_url),
                 Some(response_headers),
+                None,
                 load_guards,
+                stream_deadline,
             )
         } else {
             // Handle non-streaming error response
@@ -640,8 +663,13 @@ impl PDRouter {
             headers,
             false,
         );
+        let decode_client = if context.is_stream {
+            &self.streaming_client
+        } else {
+            &self.client
+        };
         let decode_request = self.build_post_with_headers(
-            &self.client,
+            decode_client,
             decode.as_ref(),
             context.route,
             &decode_json_request,
@@ -668,13 +696,30 @@ impl PDRouter {
         // decode head. Recorded on the success path only.
         let runtime = prefill.metadata().spec.runtime_type.as_str();
         let dispatch_start = Instant::now();
+        let stream_deadline = StreamDeadline::new(self.stream_timeout, self.stream_idle_timeout);
         let prefill_fut = async {
-            let resp = prefill_request.send().await?;
-            Ok::<_, reqwest::Error>((dispatch_start.elapsed(), resp))
+            let send_result = if context.is_stream {
+                stream_deadline
+                    .until_total(prefill_request.send())
+                    .await
+                    .map_err(PDDispatchError::StreamingTimeout)?
+            } else {
+                prefill_request.send().await
+            };
+            let resp = send_result.map_err(|e| PDDispatchError::Transport(e.to_string()))?;
+            Ok::<_, PDDispatchError>((dispatch_start.elapsed(), resp))
         };
         let decode_fut = async {
-            let resp = decode_request.send().await?;
-            Ok::<_, reqwest::Error>((dispatch_start.elapsed(), resp))
+            let send_result = if context.is_stream {
+                stream_deadline
+                    .until_total(decode_request.send())
+                    .await
+                    .map_err(PDDispatchError::StreamingTimeout)?
+            } else {
+                decode_request.send().await
+            };
+            let resp = send_result.map_err(|e| PDDispatchError::Transport(e.to_string()))?;
+            Ok::<_, PDDispatchError>((dispatch_start.elapsed(), resp))
         };
         let pd_result = tokio::try_join!(prefill_fut, decode_fut);
 
@@ -683,7 +728,14 @@ impl PDRouter {
         let ((prefill_head_elapsed, prefill_response), (decode_head_elapsed, decode_response)) =
             match pd_result {
                 Ok(pair) => pair,
-                Err(e) => {
+                Err(PDDispatchError::StreamingTimeout(timeout)) => {
+                    error!("PD request exceeded streaming header timeout");
+                    return error::gateway_timeout(
+                        "streaming_timeout",
+                        stream_deadline.message(timeout),
+                    );
+                }
+                Err(PDDispatchError::Transport(e)) => {
                     error!("PD request transport error, both sides aborted: {e}");
                     // Don't record_outcome here — the caller (execute_dual_dispatch)
                     // records outcomes from the response status after we return.
@@ -707,7 +759,13 @@ impl PDRouter {
             );
 
             return self
-                .handle_decode_error_response(decode_response, &context, decode, load_guards)
+                .handle_decode_error_response(
+                    decode_response,
+                    &context,
+                    decode,
+                    load_guards,
+                    stream_deadline,
+                )
                 .await;
         }
 
@@ -725,7 +783,12 @@ impl PDRouter {
         // Process prefill response
         let prefill_drain_start = Instant::now();
         let prefill_body = match self
-            .process_prefill_response(prefill_response, prefill.url(), context.return_logprob)
+            .process_prefill_response(
+                prefill_response,
+                prefill.url(),
+                context.return_logprob,
+                context.is_stream.then_some(stream_deadline),
+            )
             .await
         {
             Ok((_, body)) => body,
@@ -755,14 +818,16 @@ impl PDRouter {
             let response_headers =
                 header_utils::preserve_response_headers(decode_response.headers());
 
-            self.create_streaming_response(
+            Self::create_streaming_response(
                 decode_response.bytes_stream(),
                 status,
                 prefill_logprobs,
                 context.return_logprob,
                 None,
                 Some(response_headers),
+                Some((prefill.clone(), decode.clone())),
                 load_guards,
+                stream_deadline,
             )
         } else {
             // Non-streaming response
@@ -948,23 +1013,21 @@ impl PDRouter {
     }
 
     #[expect(clippy::too_many_arguments)]
-    #[expect(
-        clippy::unused_self,
-        reason = "method on PDRouter for consistent API; may use self in future"
-    )]
     fn create_streaming_response(
-        &self,
         stream: impl futures_util::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
         status: StatusCode,
         prefill_logprobs: Option<Value>,
         return_logprob: bool,
         decode_url: Option<String>,
         headers: Option<HeaderMap>,
+        outcome_workers: Option<(Arc<dyn Worker>, Arc<dyn Worker>)>,
         load_guards: Vec<WorkerLoadGuard>,
+        stream_deadline: StreamDeadline,
     ) -> Response {
         use crate::worker::AttachedBody;
 
-        let (tx, rx) = mpsc::unbounded_channel();
+        const STREAM_RELAY_BUFFER: usize = 32;
+        let (tx, rx) = mpsc::channel(STREAM_RELAY_BUFFER);
 
         #[expect(
             clippy::disallowed_methods,
@@ -974,17 +1037,27 @@ impl PDRouter {
             futures_util::pin_mut!(stream);
             // Reusable SSE encoder for the logprob-merge re-encode path.
             let mut encoder = SseEncoder::new();
-            // Whether the next chunk begins at an SSE line boundary (i.e. the
-            // previous chunk ended with an EOL); used to anchor the [DONE]
-            // sentinel detection when the match sits at the start of a chunk.
-            let mut at_line_start = true;
-            while let Some(chunk_result) = stream.next().await {
+            let mut done_decoder = sse::SseDecoder::new();
+            let mut boundary_tail = Vec::new();
+            let mut at_event_boundary = true;
+            let mut stream_failure_status = None;
+            loop {
+                let chunk_result = match stream_deadline.next(&mut stream).await {
+                    Ok(Some(chunk_result)) => chunk_result,
+                    Ok(None) => break,
+                    Err(timeout) => {
+                        stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
+                        if at_event_boundary {
+                            let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout))).await;
+                        } else {
+                            let _ = tx.send(Err(stream_deadline.message(timeout))).await;
+                        }
+                        break;
+                    }
+                };
                 match chunk_result {
                     Ok(chunk) => {
-                        let is_done = Self::chunk_contains_done_event(&chunk, at_line_start);
-                        if let Some(&last) = chunk.last() {
-                            at_line_start = last == b'\n' || last == b'\r';
-                        }
+                        let is_done = sse::observe_done_event(&mut done_decoder, chunk.as_ref());
 
                         let result = if return_logprob && prefill_logprobs.is_some() {
                             Self::merge_streaming_logprobs(
@@ -997,7 +1070,9 @@ impl PDRouter {
                             chunk
                         };
 
-                        if tx.send(Ok(result)).is_err() {
+                        at_event_boundary =
+                            sse::update_event_boundary(&mut boundary_tail, result.as_ref());
+                        if tx.send(Ok(result)).await.is_err() {
                             break;
                         }
 
@@ -1009,20 +1084,26 @@ impl PDRouter {
                         if let Some(ref url) = decode_url {
                             error!("Stream error from decode server {}: {}", url, e);
                         }
-                        let _ = tx.send(Err(format!("Stream error: {e}")));
+                        stream_failure_status = Some(StatusCode::BAD_GATEWAY);
+                        let _ = tx.send(Err(format!("Stream error: {e}"))).await;
                         break;
                     }
                 }
             }
+            if let Some((prefill, decode)) = outcome_workers {
+                let effective_status = stream_failure_status.unwrap_or(status);
+                record_pd_worker_outcome(prefill.as_ref(), decode.as_ref(), effective_status);
+            }
         });
 
-        let stream = UnboundedReceiverStream::new(rx);
+        let stream = ReceiverStream::new(rx);
         let body = Body::from_stream(stream);
 
         let mut response = Response::new(body);
         *response.status_mut() = status;
 
         let mut response_headers = headers.unwrap_or_default();
+        response_headers.remove(CONTENT_LENGTH);
         response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
         *response.headers_mut() = response_headers;
 
@@ -1094,6 +1175,7 @@ impl PDRouter {
         prefill_response: reqwest::Response,
         prefill_url: &str,
         return_logprob: bool,
+        stream_deadline: Option<StreamDeadline>,
     ) -> Result<(StatusCode, Option<Bytes>), Response> {
         let prefill_status = StatusCode::from_u16(prefill_response.status().as_u16())
             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
@@ -1101,10 +1183,16 @@ impl PDRouter {
         // Check if prefill succeeded
         if !prefill_status.is_success() {
             // Get error body from prefill
-            let error_msg = prefill_response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown prefill error".to_string());
+            let error_msg = match Self::read_prefill_body(prefill_response, stream_deadline).await {
+                Ok(body) => String::from_utf8_lossy(&body).into_owned(),
+                Err(PrefillBodyReadError::Read(e)) => {
+                    warn!("Failed to read prefill error body: {}", e);
+                    "Unknown prefill error".to_string()
+                }
+                Err(PrefillBodyReadError::Timeout(timeout)) => {
+                    return Err(Self::prefill_timeout_response(stream_deadline, timeout));
+                }
+            };
 
             error!(
                 "Prefill server returned error status prefill_url={} status={} body={}",
@@ -1143,24 +1231,69 @@ impl PDRouter {
 
         // Read prefill body if needed for logprob merging
         let prefill_body = if return_logprob {
-            match prefill_response.bytes().await {
+            match Self::read_prefill_body(prefill_response, stream_deadline).await {
                 Ok(body) => Some(body),
-                Err(e) => {
+                Err(PrefillBodyReadError::Read(e)) => {
                     warn!("Failed to read prefill response body for logprobs: {}", e);
                     None
+                }
+                Err(PrefillBodyReadError::Timeout(timeout)) => {
+                    return Err(Self::prefill_timeout_response(stream_deadline, timeout));
                 }
             }
         } else {
             // For non-logprob requests, just consume the response without storing
             debug!("Consuming prefill response body (non-logprob request)");
-            match prefill_response.bytes().await {
+            match Self::read_prefill_body(prefill_response, stream_deadline).await {
                 Ok(_) => debug!("Prefill response consumed successfully"),
-                Err(e) => warn!("Error consuming prefill response: {}", e),
+                Err(PrefillBodyReadError::Read(e)) => {
+                    warn!("Error consuming prefill response: {}", e);
+                }
+                Err(PrefillBodyReadError::Timeout(timeout)) => {
+                    return Err(Self::prefill_timeout_response(stream_deadline, timeout));
+                }
             }
             None
         };
 
         Ok((prefill_status, prefill_body))
+    }
+
+    fn prefill_timeout_response(
+        stream_deadline: Option<StreamDeadline>,
+        timeout: StreamTimeoutKind,
+    ) -> Response {
+        let Some(stream_deadline) = stream_deadline else {
+            warn!("Prefill body read timed out without an active stream deadline");
+            return error::gateway_timeout(
+                "streaming_timeout",
+                "Streaming request exceeded configured timeout",
+            );
+        };
+        error::gateway_timeout("streaming_timeout", stream_deadline.message(timeout))
+    }
+
+    async fn read_prefill_body(
+        prefill_response: reqwest::Response,
+        stream_deadline: Option<StreamDeadline>,
+    ) -> Result<Bytes, PrefillBodyReadError> {
+        let Some(stream_deadline) = stream_deadline else {
+            return prefill_response
+                .bytes()
+                .await
+                .map_err(|e| PrefillBodyReadError::Read(e.to_string()));
+        };
+
+        let mut stream = prefill_response.bytes_stream();
+        let mut body = Vec::new();
+        loop {
+            match stream_deadline.next(&mut stream).await {
+                Ok(Some(Ok(chunk))) => body.extend_from_slice(&chunk),
+                Ok(Some(Err(e))) => return Err(PrefillBodyReadError::Read(e.to_string())),
+                Ok(None) => return Ok(Bytes::from(body)),
+                Err(timeout) => return Err(PrefillBodyReadError::Timeout(timeout)),
+            }
+        }
     }
 
     #[expect(
@@ -1221,50 +1354,6 @@ impl PDRouter {
         false
     }
 
-    /// Line-anchored detection of the SSE `data: [DONE]` terminal event in a
-    /// raw upstream chunk: a match must start at a line boundary and be
-    /// immediately followed by a complete empty-line event delimiter within
-    /// the same chunk. Payload text that merely contains those bytes never
-    /// qualifies — real EOL bytes cannot occur inside a `data:` payload
-    /// (JSON escapes them). Requiring the full delimiter also rejects
-    /// multi-line events like `data: [DONE]\ndata: x\n\n`, whose joined data
-    /// is not exactly `[DONE]`.
-    ///
-    /// `at_line_start` says whether `chunk` begins at a line boundary. A
-    /// sentinel or delimiter split across chunks is never treated as
-    /// terminal — every byte is still forwarded and the relay then ends via
-    /// upstream EOF, so deferring is always safe while a false positive
-    /// kills a live stream.
-    fn chunk_contains_done_event(chunk: &[u8], at_line_start: bool) -> bool {
-        const DONE_EVENT: &[u8] = b"data: [DONE]";
-        // Length of the EOL sequence at `bytes[pos..]`: 2 for \r\n, 1 for a
-        // bare \r or \n, 0 if none.
-        fn eol_len_at(bytes: &[u8], pos: usize) -> usize {
-            match bytes.get(pos) {
-                Some(b'\r') => 1 + usize::from(bytes.get(pos + 1) == Some(&b'\n')),
-                Some(b'\n') => 1,
-                _ => 0,
-            }
-        }
-        let mut from = 0;
-        while let Some(pos) = memmem::find(&chunk[from..], DONE_EVENT) {
-            let start = from + pos;
-            let anchored = match start.checked_sub(1) {
-                None => at_line_start,
-                Some(prev) => chunk[prev] == b'\n' || chunk[prev] == b'\r',
-            };
-            if anchored {
-                let line_end = start + DONE_EVENT.len();
-                let eol1 = eol_len_at(chunk, line_end);
-                if eol1 > 0 && eol_len_at(chunk, line_end + eol1) > 0 {
-                    return true;
-                }
-            }
-            from = start + 1;
-        }
-        false
-    }
-
     // Simple helper to merge logprobs in streaming responses
     // Optimized to reduce allocations in the merge path
     fn merge_streaming_logprobs(
@@ -1308,6 +1397,25 @@ impl PDRouter {
 
         // Re-serialize via the shared encoder (reuses its buffer across chunks).
         encoder.encode_data(&decode_json).map_err(|_| ())
+    }
+}
+
+fn record_pd_worker_outcome(prefill: &dyn Worker, decode: &dyn Worker, status: StatusCode) {
+    prefill.record_outcome(status.as_u16());
+    decode.record_outcome(status.as_u16());
+
+    if status.is_server_error() {
+        let error_type = error_type_from_status(status);
+        Metrics::record_worker_error(
+            metrics_labels::WORKER_PREFILL,
+            metrics_labels::CONNECTION_HTTP,
+            error_type,
+        );
+        Metrics::record_worker_error(
+            metrics_labels::WORKER_DECODE,
+            metrics_labels::CONNECTION_HTTP,
+            error_type,
+        );
     }
 }
 
@@ -1542,6 +1650,7 @@ impl RouterTrait for PDRouter {
 #[cfg(test)]
 mod tests {
     use openai_protocol::model_card::ModelCard;
+    use tokio_stream::wrappers::UnboundedReceiverStream;
 
     use super::*;
     use crate::{
@@ -1557,6 +1666,9 @@ mod tests {
             worker_registry,
             policy_registry,
             client: Client::new(),
+            streaming_client: Client::new(),
+            stream_timeout: Duration::from_secs(1800),
+            stream_idle_timeout: Duration::from_secs(300),
             retry_config: RetryConfig::default(),
             api_key: Some("test_api_key".to_string()),
         }
@@ -1573,64 +1685,6 @@ mod tests {
         };
         worker.set_status(status);
         Box::new(worker)
-    }
-
-    #[test]
-    fn test_done_event_detection() {
-        // Production-incident payload: a delta whose arguments contained the
-        // literal sentinel text; the old substring scan treated it as
-        // terminal and silently killed the stream.
-        let incident: &[u8] = b"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"function\":{\"arguments\":\"// data: [DONE]\"}}]}}]}\n\n";
-        // (chunk, chunk begins at a line boundary, expected, case)
-        let cases: &[(&[u8], bool, bool, &str)] = &[
-            (b"data: [DONE]\n\n", true, true, "standalone sentinel"),
-            (
-                b"data: {\"x\":1}\n\ndata: [DONE]\n\n",
-                true,
-                true,
-                "sentinel after a data event",
-            ),
-            (b"data: [DONE]\r\n\r\n", true, true, "CRLF endings"),
-            (
-                b"\ndata: [DONE]\n\n",
-                false,
-                true,
-                "line boundary inside the chunk",
-            ),
-            (incident, true, false, "sentinel text inside a JSON payload"),
-            (
-                b"data: [DONE]{\"x\":1}\n\n",
-                true,
-                false,
-                "line continues with payload",
-            ),
-            (b"data: [DONE]\n\n", false, false, "chunk starts mid-line"),
-            (
-                b"data: [DONE]",
-                true,
-                false,
-                "possibly a split payload line: defer",
-            ),
-            (
-                b"data: [DONE]\n",
-                true,
-                false,
-                "event delimiter incomplete: defer",
-            ),
-            (
-                b"data: [DONE]\ndata: x\n\n",
-                true,
-                false,
-                "one event, joined data is not [DONE]",
-            ),
-        ];
-        for (chunk, at_line_start, expected, case) in cases {
-            assert_eq!(
-                PDRouter::chunk_contains_done_event(chunk, *at_line_start),
-                *expected,
-                "{case}"
-            );
-        }
     }
 
     #[test]
@@ -1808,7 +1862,13 @@ mod tests {
         ];
 
         let response = router
-            .handle_decode_error_response(decode_response, &context, decode, load_guards)
+            .handle_decode_error_response(
+                decode_response,
+                &context,
+                decode,
+                load_guards,
+                StreamDeadline::new(router.stream_timeout, router.stream_idle_timeout),
+            )
             .await;
 
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
@@ -1868,14 +1928,16 @@ mod tests {
             assert_eq!(prefill_ref.load(), 1);
             assert_eq!(decode_ref.load(), 1);
 
-            let response = router.create_streaming_response(
+            let response = PDRouter::create_streaming_response(
                 stream.map(Ok),
                 StatusCode::OK,
                 None,
                 false,
                 None,
                 None,
+                None,
                 guards,
+                StreamDeadline::new(router.stream_timeout, router.stream_idle_timeout),
             );
 
             // Guards are now attached to response body, so load should be 1

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -14,6 +14,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use bytes::Bytes;
+use futures_util::{stream, StreamExt};
 use openai_protocol::{
     chat::ChatCompletionRequest,
     common::{GenerationRequest, InputIds, StringOrArray},
@@ -112,6 +113,12 @@ enum PDDispatchError {
 
 enum PrefillBodyReadError {
     Read(String),
+    Timeout(StreamTimeoutKind),
+}
+
+enum FirstDecodeChunkError {
+    Read(String),
+    PrematureEof,
     Timeout(StreamTimeoutKind),
 }
 
@@ -526,7 +533,7 @@ impl PDRouter {
                 endpoint,
                 duration,
             );
-        } else if !response.status().is_success() && !is_retryable_status(response.status()) {
+        } else if !response.status().is_success() {
             Metrics::record_router_error(
                 metrics_labels::ROUTER_HTTP,
                 metrics_labels::BACKEND_PD,
@@ -822,31 +829,64 @@ impl PDRouter {
             decode_head_elapsed,
         );
 
-        // Process prefill response
-        let prefill_drain_start = Instant::now();
-        let prefill_body = match self
-            .process_prefill_response(
-                prefill_response,
-                prefill.url(),
-                context.return_logprob,
-                context.is_stream.then_some(stream_deadline),
-            )
-            .await
-        {
-            Ok((_, body)) => body,
-            Err(error_response) => return error_response,
-        };
-
-        // Prefill RPC duration: prefill-head elapsed + body drain, independent
-        // of decode so a slower decode head never inflates it.
-        Metrics::record_pd_prefill_duration(
-            metrics_labels::BACKEND_PD,
-            context.model_id,
-            runtime,
-            prefill_head_elapsed + prefill_drain_start.elapsed(),
-        );
-
         if context.is_stream {
+            let response_headers =
+                header_utils::preserve_response_headers(decode_response.headers());
+            let mut decode_stream = decode_response.bytes_stream();
+            let prefill_drain_start = Instant::now();
+            let (prefill_body, first_decode_chunk) = {
+                let prefill_future = self.process_prefill_response(
+                    prefill_response,
+                    prefill.url(),
+                    context.return_logprob,
+                    Some(stream_deadline),
+                );
+                let first_decode_future = stream_deadline.next(&mut decode_stream);
+                tokio::pin!(prefill_future);
+                tokio::pin!(first_decode_future);
+
+                // Poll decode immediately so prefill activity cannot reset the
+                // decode stream's initial idle window.
+                tokio::select! {
+                    first_result = &mut first_decode_future => {
+                        let first_chunk =
+                            match Self::first_decode_chunk(first_result) {
+                                Ok(chunk) => chunk,
+                                Err(error) => {
+                                    return Self::first_decode_error_response(error, stream_deadline);
+                                }
+                            };
+                        let prefill_body = match prefill_future.await {
+                            Ok((_, body)) => body,
+                            Err(error_response) => return error_response,
+                        };
+                        (prefill_body, first_chunk)
+                    }
+                    prefill_result = &mut prefill_future => {
+                        let prefill_body = match prefill_result {
+                            Ok((_, body)) => body,
+                            Err(error_response) => return error_response,
+                        };
+                        let first_chunk = match Self::first_decode_chunk(first_decode_future.await) {
+                            Ok(chunk) => chunk,
+                            Err(error) => {
+                                return Self::first_decode_error_response(error, stream_deadline);
+                            }
+                        };
+                        (prefill_body, first_chunk)
+                    }
+                }
+            };
+
+            // Prefill RPC duration: prefill-head elapsed + body drain, independent
+            // of decode so a slower decode head never inflates it.
+            Metrics::record_pd_prefill_duration(
+                metrics_labels::BACKEND_PD,
+                context.model_id,
+                runtime,
+                prefill_head_elapsed + prefill_drain_start.elapsed(),
+            );
+
             // Streaming response
             let prefill_logprobs = if context.return_logprob {
                 prefill_body
@@ -857,11 +897,12 @@ impl PDRouter {
                 None
             };
 
-            let response_headers =
-                header_utils::preserve_response_headers(decode_response.headers());
+            let stream =
+                stream::once(async move { Ok::<Bytes, reqwest::Error>(first_decode_chunk) })
+                    .chain(decode_stream);
 
             Self::create_streaming_response(
-                decode_response.bytes_stream(),
+                stream,
                 status,
                 prefill_logprobs,
                 context.return_logprob,
@@ -877,6 +918,28 @@ impl PDRouter {
                 }),
             )
         } else {
+            // Process prefill response
+            let prefill_drain_start = Instant::now();
+            let prefill_body = match self
+                .process_prefill_response(
+                    prefill_response,
+                    prefill.url(),
+                    context.return_logprob,
+                    None,
+                )
+                .await
+            {
+                Ok((_, body)) => body,
+                Err(error_response) => return error_response,
+            };
+
+            Metrics::record_pd_prefill_duration(
+                metrics_labels::BACKEND_PD,
+                context.model_id,
+                runtime,
+                prefill_head_elapsed + prefill_drain_start.elapsed(),
+            );
+
             // Non-streaming response
             if context.return_logprob {
                 self.process_non_streaming_response(
@@ -1090,10 +1153,16 @@ impl PDRouter {
             let mut at_event_boundary = true;
             let mut stream_failure_status = None;
             let mut relay_send_timed_out = false;
+            let mut terminal_seen = false;
             loop {
                 let chunk_result = match stream_deadline.next(&mut stream).await {
                     Ok(Some(chunk_result)) => chunk_result,
-                    Ok(None) => break,
+                    Ok(None) => {
+                        if status.is_success() && !terminal_seen {
+                            stream_failure_status = Some(StatusCode::BAD_GATEWAY);
+                        }
+                        break;
+                    }
                     Err(timeout) => {
                         stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                         let timeout_item = if at_event_boundary {
@@ -1110,6 +1179,7 @@ impl PDRouter {
                 match chunk_result {
                     Ok(chunk) => {
                         let is_done = done_observer.observe(chunk.as_ref());
+                        terminal_seen |= is_done;
 
                         let result = if return_logprob && prefill_logprobs.is_some() {
                             Self::merge_streaming_logprobs(
@@ -1178,6 +1248,35 @@ impl PDRouter {
         *response.headers_mut() = response_headers;
 
         AttachedBody::wrap_response(response, load_guards)
+    }
+
+    fn first_decode_chunk(
+        result: Result<Option<Result<Bytes, reqwest::Error>>, StreamTimeoutKind>,
+    ) -> Result<Bytes, FirstDecodeChunkError> {
+        match result {
+            Ok(Some(Ok(chunk))) => Ok(chunk),
+            Ok(Some(Err(error))) => Err(FirstDecodeChunkError::Read(error.to_string())),
+            Ok(None) => Err(FirstDecodeChunkError::PrematureEof),
+            Err(timeout) => Err(FirstDecodeChunkError::Timeout(timeout)),
+        }
+    }
+
+    fn first_decode_error_response(
+        error: FirstDecodeChunkError,
+        stream_deadline: StreamDeadline,
+    ) -> Response {
+        match error {
+            FirstDecodeChunkError::Read(error) => error::bad_gateway(
+                "decode_stream_failed",
+                format!("Decode stream error: {error}"),
+            ),
+            FirstDecodeChunkError::PrematureEof => {
+                error::bad_gateway("premature_stream_eof", "Decode stream ended before [DONE]")
+            }
+            FirstDecodeChunkError::Timeout(timeout) => {
+                error::gateway_timeout("streaming_timeout", stream_deadline.message(timeout))
+            }
+        }
     }
 
     /// Build a non-streaming PD response with `Content-Type: application/json`.
@@ -2032,5 +2131,17 @@ mod tests {
         // Guards dropped when response dropped
         assert_eq!(prefill_ref.load(), 0);
         assert_eq!(decode_ref.load(), 0);
+    }
+
+    #[test]
+    fn test_first_decode_chunk_rejects_timeout_and_premature_eof() {
+        assert!(matches!(
+            PDRouter::first_decode_chunk(Ok(None)),
+            Err(FirstDecodeChunkError::PrematureEof)
+        ));
+        assert!(matches!(
+            PDRouter::first_decode_chunk(Err(StreamTimeoutKind::Idle)),
+            Err(FirstDecodeChunkError::Timeout(StreamTimeoutKind::Idle))
+        ));
     }
 }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1095,11 +1095,12 @@ impl PDRouter {
                     Ok(None) => break,
                     Err(timeout) => {
                         stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
-                        if at_event_boundary {
-                            let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout))).await;
+                        let timeout_item = if at_event_boundary {
+                            Ok(stream_deadline.sse_error_event(timeout))
                         } else {
-                            let _ = tx.send(Err(stream_deadline.message(timeout))).await;
-                        }
+                            Err(stream_deadline.message(timeout))
+                        };
+                        let _ = stream_deadline.send_before_total(&tx, timeout_item).await;
                         break;
                     }
                 };
@@ -1120,8 +1121,13 @@ impl PDRouter {
 
                         at_event_boundary =
                             sse::update_event_boundary(&mut boundary_tail, result.as_ref());
-                        if tx.send(Ok(result)).await.is_err() {
-                            break;
+                        match stream_deadline.send_before_total(&tx, Ok(result)).await {
+                            Ok(true) => {}
+                            Ok(false) => break,
+                            Err(_) => {
+                                stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
+                                break;
+                            }
                         }
 
                         if is_done {
@@ -1133,7 +1139,9 @@ impl PDRouter {
                             error!("Stream error from decode server {}: {}", url, e);
                         }
                         stream_failure_status = Some(StatusCode::BAD_GATEWAY);
-                        let _ = tx.send(Err(format!("Stream error: {e}"))).await;
+                        let _ = stream_deadline
+                            .send_before_total(&tx, Err(format!("Stream error: {e}")))
+                            .await;
                         break;
                     }
                 }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -510,7 +510,10 @@ impl PDRouter {
                     }
                 }
             },
-            |res, _attempt| is_retryable_status(res.status()),
+            |res, _attempt| {
+                is_retryable_status(res.status())
+                    && (!route_is_stream || !stream_deadline.is_total_elapsed())
+            },
             |delay, attempt| {
                 // Layer 3 worker metrics (PD mode uses both prefill and decode workers)
                 Metrics::record_worker_retry(metrics_labels::WORKER_PREFILL, endpoint);

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -876,13 +876,15 @@ impl Router {
                 let mut stream = stream;
                 let mut stream_failure_status = None;
                 let mut done_decoder = sse::SseDecoder::new();
+                let mut boundary_tail = Vec::new();
+                let mut at_event_boundary = true;
                 loop {
                     let chunk = match stream_deadline.next(&mut stream).await {
                         Ok(Some(chunk)) => chunk,
                         Ok(None) => break,
                         Err(timeout) => {
                             stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
-                            if stream_is_sse {
+                            if stream_is_sse && at_event_boundary {
                                 let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout))).await;
                             } else {
                                 let _ = tx.send(Err(stream_deadline.message(timeout))).await;
@@ -894,6 +896,8 @@ impl Router {
                         Ok(bytes) => {
                             let stream_done = stream_is_sse
                                 && sse::observe_done_event(&mut done_decoder, bytes.as_ref());
+                            at_event_boundary =
+                                sse::update_event_boundary(&mut boundary_tail, bytes.as_ref());
                             if tx.send(Ok(bytes)).await.is_err() {
                                 break;
                             }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -93,6 +93,20 @@ struct RouterStreamMetrics {
     start_time: Instant,
 }
 
+fn typed_stream_terminal_observers(route: &str) -> Vec<sse::SseTerminalObserver> {
+    match route {
+        "/generate" | "/v1/chat/completions" | "/v1/completions" => {
+            vec![sse::SseTerminalObserver::done()]
+        }
+        "/v1/messages" => vec![sse::SseTerminalObserver::event_type("message_stop")],
+        "/v1/responses" => vec![
+            sse::SseTerminalObserver::done(),
+            sse::SseTerminalObserver::event_type("response.completed"),
+        ],
+        _ => Vec::new(),
+    }
+}
+
 fn record_regular_router_stream_outcome(metrics: &RouterStreamMetrics, status: StatusCode) {
     if status.is_success() {
         Metrics::record_router_duration(
@@ -318,6 +332,7 @@ impl Router {
         let retry_config = per_model_retry_config
             .as_ref()
             .unwrap_or(&self.retry_config);
+        let stream_deadline = StreamDeadline::new(self.stream_timeout, self.stream_idle_timeout);
 
         let response = RetryExecutor::execute_response_with_retry(
             retry_config,
@@ -333,6 +348,7 @@ impl Router {
                         is_stream,
                         &text,
                         start,
+                        stream_deadline,
                     )
                     .await;
 
@@ -398,6 +414,7 @@ impl Router {
         is_stream: bool,
         text: &str,
         start_time: Instant,
+        stream_deadline: StreamDeadline,
     ) -> Response {
         let worker = match self.select_worker_for_model(model_id, Some(text), headers) {
             Some(w) => w,
@@ -452,6 +469,7 @@ impl Router {
                     endpoint: route_to_endpoint(route),
                     start_time,
                 },
+                stream_deadline,
             )
             .await;
 
@@ -1033,6 +1051,7 @@ impl Router {
         is_stream: bool,
         load_guard: Option<WorkerLoadGuard>,
         router_metrics: RouterStreamMetrics,
+        stream_deadline: StreamDeadline,
     ) -> Response {
         let api_key = worker.api_key().cloned();
         let endpoint_url = worker.endpoint_url(route);
@@ -1085,7 +1104,6 @@ impl Router {
             }
         }
 
-        let stream_deadline = StreamDeadline::new(self.stream_timeout, self.stream_idle_timeout);
         let send_result = if is_stream {
             match stream_deadline.until_total(request_builder.send()).await {
                 Ok(result) => result,
@@ -1138,6 +1156,7 @@ impl Router {
             let (tx, rx) = mpsc::channel(STREAM_RELAY_BUFFER);
             let worker_for_stream = worker.clone();
             let stream_router_metrics = router_metrics.clone();
+            let terminal_observers = typed_stream_terminal_observers(route);
 
             // Spawn task to forward stream
             #[expect(
@@ -1150,11 +1169,18 @@ impl Router {
                 let mut relay_send_timed_out = false;
                 let mut boundary_tail = Vec::new();
                 let mut at_event_boundary = true;
-                let mut done_observer = sse::SseTerminalObserver::done();
+                let requires_terminal = !terminal_observers.is_empty();
+                let mut terminal_observers = terminal_observers;
+                let mut terminal_seen = false;
                 loop {
                     let chunk = match stream_deadline.next(&mut stream).await {
                         Ok(Some(chunk)) => chunk,
-                        Ok(None) => break,
+                        Ok(None) => {
+                            if requires_terminal && !terminal_seen {
+                                stream_failure_status = Some(StatusCode::BAD_GATEWAY);
+                            }
+                            break;
+                        }
                         Err(timeout) => {
                             stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                             let timeout_item = if at_event_boundary {
@@ -1170,7 +1196,10 @@ impl Router {
                     };
                     match chunk {
                         Ok(bytes) => {
-                            let stream_done = done_observer.observe(bytes.as_ref());
+                            let stream_done = terminal_observers
+                                .iter_mut()
+                                .any(|observer| observer.observe(bytes.as_ref()));
+                            terminal_seen |= stream_done;
                             at_event_boundary =
                                 sse::update_event_boundary(&mut boundary_tail, bytes.as_ref());
                             match stream_deadline.send_before_total(&tx, Ok(bytes)).await {
@@ -1765,5 +1794,21 @@ mod tests {
 
         let worker = router.worker_registry.get_by_url(&url).unwrap();
         assert!(worker.is_healthy());
+    }
+
+    #[test]
+    fn typed_stream_routes_require_protocol_specific_terminal_events() {
+        let mut chat = typed_stream_terminal_observers("/v1/chat/completions");
+        assert!(chat[0].observe(b"data: [DONE]\n\n"));
+
+        let mut messages = typed_stream_terminal_observers("/v1/messages");
+        assert!(messages[0].observe(b"event: message_stop\ndata: {}\n\n"));
+
+        let mut responses = typed_stream_terminal_observers("/v1/responses");
+        assert!(responses
+            .iter_mut()
+            .any(|observer| observer.observe(b"event: response.completed\ndata: {}\n\n")));
+
+        assert!(typed_stream_terminal_observers("/v1/embeddings").is_empty());
     }
 }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -875,6 +875,7 @@ impl Router {
             tokio::spawn(async move {
                 let mut stream = stream;
                 let mut stream_failure_status = None;
+                let mut relay_send_timed_out = false;
                 let mut done_observer = sse::SseTerminalObserver::done();
                 let mut boundary_tail = Vec::new();
                 let mut at_event_boundary = true;
@@ -889,7 +890,9 @@ impl Router {
                             } else {
                                 Err(stream_deadline.message(timeout))
                             };
-                            let _ = stream_deadline.send_before_total(&tx, timeout_item).await;
+                            let _ = stream_deadline
+                                .send_terminal_before_total(&tx, timeout_item)
+                                .await;
                             break;
                         }
                     };
@@ -903,6 +906,7 @@ impl Router {
                                 Ok(true) => {}
                                 Ok(false) => break,
                                 Err(_) => {
+                                    relay_send_timed_out = true;
                                     stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                                     break;
                                 }
@@ -914,7 +918,7 @@ impl Router {
                         Err(e) => {
                             stream_failure_status = Some(StatusCode::BAD_GATEWAY);
                             let _ = stream_deadline
-                                .send_before_total(&tx, Err(format!("Stream error: {e}")))
+                                .send_terminal_before_total(&tx, Err(format!("Stream error: {e}")))
                                 .await;
                             break;
                         }
@@ -927,7 +931,12 @@ impl Router {
                 // the failed worker immediately.
                 let effective_status = stream_failure_status.unwrap_or(stream_header_status);
                 if stream_header_status.is_success() {
-                    record_regular_worker_outcome(worker_for_stream.as_ref(), effective_status);
+                    let worker_status = if relay_send_timed_out {
+                        stream_header_status
+                    } else {
+                        effective_status
+                    };
+                    record_regular_worker_outcome(worker_for_stream.as_ref(), worker_status);
                 }
                 if effective_status.is_success() {
                     Metrics::record_router_duration(
@@ -1138,6 +1147,7 @@ impl Router {
             tokio::spawn(async move {
                 let mut stream = stream;
                 let mut stream_failure_status = None;
+                let mut relay_send_timed_out = false;
                 let mut boundary_tail = Vec::new();
                 let mut at_event_boundary = true;
                 let mut done_observer = sse::SseTerminalObserver::done();
@@ -1152,7 +1162,9 @@ impl Router {
                             } else {
                                 Err(stream_deadline.message(timeout))
                             };
-                            let _ = stream_deadline.send_before_total(&tx, timeout_item).await;
+                            let _ = stream_deadline
+                                .send_terminal_before_total(&tx, timeout_item)
+                                .await;
                             break;
                         }
                     };
@@ -1165,6 +1177,7 @@ impl Router {
                                 Ok(true) => {}
                                 Ok(false) => break,
                                 Err(_) => {
+                                    relay_send_timed_out = true;
                                     stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                                     break;
                                 }
@@ -1176,7 +1189,7 @@ impl Router {
                         Err(e) => {
                             stream_failure_status = Some(StatusCode::BAD_GATEWAY);
                             let _ = stream_deadline
-                                .send_before_total(&tx, Err(format!("Stream error: {e}")))
+                                .send_terminal_before_total(&tx, Err(format!("Stream error: {e}")))
                                 .await;
                             break;
                         }
@@ -1184,7 +1197,12 @@ impl Router {
                 }
                 let effective_status = stream_failure_status.unwrap_or(status);
                 if status.is_success() {
-                    record_regular_worker_outcome(worker_for_stream.as_ref(), effective_status);
+                    let worker_status = if relay_send_timed_out {
+                        status
+                    } else {
+                        effective_status
+                    };
+                    record_regular_worker_outcome(worker_for_stream.as_ref(), worker_status);
                     record_regular_router_stream_outcome(&stream_router_metrics, effective_status);
                 }
             });

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -875,7 +875,7 @@ impl Router {
             tokio::spawn(async move {
                 let mut stream = stream;
                 let mut stream_failure_status = None;
-                let mut done_decoder = sse::SseDecoder::new();
+                let mut done_observer = sse::SseTerminalObserver::done();
                 let mut boundary_tail = Vec::new();
                 let mut at_event_boundary = true;
                 loop {
@@ -895,8 +895,8 @@ impl Router {
                     };
                     match chunk {
                         Ok(bytes) => {
-                            let stream_done = stream_is_sse
-                                && sse::observe_done_event(&mut done_decoder, bytes.as_ref());
+                            let stream_done =
+                                stream_is_sse && done_observer.observe(bytes.as_ref());
                             at_event_boundary =
                                 sse::update_event_boundary(&mut boundary_tail, bytes.as_ref());
                             match stream_deadline.send_before_total(&tx, Ok(bytes)).await {
@@ -1140,7 +1140,7 @@ impl Router {
                 let mut stream_failure_status = None;
                 let mut boundary_tail = Vec::new();
                 let mut at_event_boundary = true;
-                let mut done_decoder = sse::SseDecoder::new();
+                let mut done_observer = sse::SseTerminalObserver::done();
                 loop {
                     let chunk = match stream_deadline.next(&mut stream).await {
                         Ok(Some(chunk)) => chunk,
@@ -1158,8 +1158,7 @@ impl Router {
                     };
                     match chunk {
                         Ok(bytes) => {
-                            let stream_done =
-                                sse::observe_done_event(&mut done_decoder, bytes.as_ref());
+                            let stream_done = done_observer.observe(bytes.as_ref());
                             at_event_boundary =
                                 sse::update_event_boundary(&mut boundary_tail, bytes.as_ref());
                             match stream_deadline.send_before_total(&tx, Ok(bytes)).await {

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -1,9 +1,16 @@
-use std::{error::Error as _, sync::Arc, time::Instant};
+use std::{
+    error::Error as _,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use axum::{
     body::{to_bytes, Body},
     extract::Request,
-    http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, Method, StatusCode},
+    http::{
+        header::{CONTENT_LENGTH, CONTENT_TYPE},
+        HeaderMap, HeaderValue, Method, StatusCode,
+    },
     response::{IntoResponse, Response},
     Json,
 };
@@ -29,7 +36,7 @@ use reqwest::{
     Client,
 };
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::error;
 
 use crate::{
@@ -50,6 +57,8 @@ use crate::{
                 ws::handle_realtime_ws, RealtimeLabels, RealtimeRegistry,
             },
             retry::{is_retryable_status, RetryExecutor},
+            sse,
+            stream_timeout::{StreamDeadline, StreamTimeoutKind},
             worker_selection::{SelectWorkerRequest, WorkerSelector},
         },
         error::{self, extract_error_code_from_response},
@@ -68,6 +77,9 @@ pub struct Router {
     worker_registry: Arc<WorkerRegistry>,
     policy_registry: Arc<PolicyRegistry>,
     client: Client,
+    streaming_client: Client,
+    stream_timeout: Duration,
+    stream_idle_timeout: Duration,
     retry_config: RetryConfig,
     realtime_registry: Arc<RealtimeRegistry>,
     webrtc_bind_addr: Option<std::net::IpAddr>,
@@ -80,6 +92,9 @@ impl std::fmt::Debug for Router {
             .field("worker_registry", &self.worker_registry)
             .field("policy_registry", &self.policy_registry)
             .field("client", &self.client)
+            .field("streaming_client", &self.streaming_client)
+            .field("stream_timeout", &self.stream_timeout)
+            .field("stream_idle_timeout", &self.stream_idle_timeout)
             .field("retry_config", &self.retry_config)
             .finish_non_exhaustive()
     }
@@ -96,6 +111,9 @@ impl Router {
             worker_registry: ctx.worker_registry.clone(),
             policy_registry: ctx.policy_registry.clone(),
             client: ctx.client.clone(),
+            streaming_client: ctx.streaming_client.clone(),
+            stream_timeout: Duration::from_secs(ctx.router_config.request_timeout_secs),
+            stream_idle_timeout: Duration::from_secs(ctx.router_config.stream_idle_timeout_secs),
             retry_config: ctx.router_config.effective_retry_config(),
             realtime_registry: ctx.realtime_registry.clone(),
             webrtc_bind_addr: ctx.webrtc_bind_addr,
@@ -395,7 +413,7 @@ impl Router {
                 typed_req,
                 route,
                 canonical_model,
-                worker.as_ref(),
+                worker.clone(),
                 is_stream,
                 load_guard,
             )
@@ -403,16 +421,9 @@ impl Router {
 
         events::RequestReceivedEvent {}.emit();
 
-        let status = response.status();
-        worker.record_outcome(status.as_u16());
-
-        // Record worker errors for server errors (5xx)
-        if status.is_server_error() {
-            Metrics::record_worker_error(
-                metrics_labels::WORKER_REGULAR,
-                metrics_labels::CONNECTION_HTTP,
-                error_type_from_status(status),
-            );
+        if !is_stream {
+            let status = response.status();
+            record_regular_worker_outcome(worker.as_ref(), status);
         }
 
         response
@@ -685,7 +696,12 @@ impl Router {
         };
 
         let endpoint_url = worker.endpoint_url(route);
-        let mut request_builder = self.client.post(&endpoint_url).multipart(form);
+        let client = if is_stream {
+            &self.streaming_client
+        } else {
+            &self.client
+        };
+        let mut request_builder = client.post(&endpoint_url).multipart(form);
 
         if let Some(key) = worker.api_key().cloned() {
             let mut auth_header = String::with_capacity(7 + key.len());
@@ -710,7 +726,38 @@ impl Router {
             }
         }
 
-        let res = match request_builder.send().await {
+        let stream_deadline = StreamDeadline::new(self.stream_timeout, self.stream_idle_timeout);
+        let send_result = if is_stream {
+            match stream_deadline.until_total(request_builder.send()).await {
+                Ok(result) => result,
+                Err(_) => {
+                    let err_resp = error::gateway_timeout(
+                        "streaming_timeout",
+                        stream_deadline.message(StreamTimeoutKind::Total),
+                    );
+                    let err_status = err_resp.status();
+                    record_regular_worker_outcome(worker.as_ref(), err_status);
+                    Metrics::record_router_upstream_response(
+                        metrics_labels::ROUTER_HTTP,
+                        err_status.as_u16(),
+                        extract_error_code_from_response(&err_resp),
+                    );
+                    Metrics::record_router_error(
+                        metrics_labels::ROUTER_HTTP,
+                        metrics_labels::BACKEND_REGULAR,
+                        metrics_labels::CONNECTION_HTTP,
+                        model_id,
+                        endpoint,
+                        error_type_from_status(err_status),
+                    );
+                    return err_resp;
+                }
+            }
+        } else {
+            request_builder.send().await
+        };
+
+        let res = match send_result {
             Ok(res) => res,
             Err(e) => {
                 error!(
@@ -725,14 +772,7 @@ impl Router {
                 // and worker-error metric; transport failures (timeouts,
                 // connect errors) must be visible to health tracking so the
                 // same bad worker isn't picked repeatedly.
-                worker.record_outcome(err_status.as_u16());
-                if err_status.is_server_error() {
-                    Metrics::record_worker_error(
-                        metrics_labels::WORKER_REGULAR,
-                        metrics_labels::CONNECTION_HTTP,
-                        error_type_from_status(err_status),
-                    );
-                }
+                record_regular_worker_outcome(worker.as_ref(), err_status);
                 Metrics::record_router_upstream_response(
                     metrics_labels::ROUTER_HTTP,
                     err_status.as_u16(),
@@ -766,7 +806,15 @@ impl Router {
             // JSON body (success or 4xx error). Don't relabel non-SSE
             // responses as SSE; leave that judgment to whatever the worker
             // set.
-            let response_headers = header_utils::preserve_response_headers(res.headers());
+            let mut response_headers = header_utils::preserve_response_headers(res.headers());
+            response_headers.remove(CONTENT_LENGTH);
+            if !status.is_success() {
+                record_regular_worker_outcome(worker.as_ref(), status);
+            }
+            let stream_is_sse = response_headers
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.to_ascii_lowercase().contains("text/event-stream"));
             let stream = res.bytes_stream();
             // Bounded channel applies backpressure: if the downstream client
             // is slow, the upstream relay awaits on `send` rather than piling
@@ -790,8 +838,21 @@ impl Router {
             )]
             tokio::spawn(async move {
                 let mut stream = stream;
-                let mut stream_failed = false;
-                while let Some(chunk) = stream.next().await {
+                let mut stream_failure_status = None;
+                loop {
+                    let chunk = match stream_deadline.next(&mut stream).await {
+                        Ok(Some(chunk)) => chunk,
+                        Ok(None) => break,
+                        Err(timeout) => {
+                            stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
+                            if stream_is_sse {
+                                let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout))).await;
+                            } else {
+                                let _ = tx.send(Err(stream_deadline.message(timeout))).await;
+                            }
+                            break;
+                        }
+                    };
                     match chunk {
                         Ok(bytes) => {
                             if tx.send(Ok(bytes)).await.is_err() {
@@ -799,27 +860,20 @@ impl Router {
                             }
                         }
                         Err(e) => {
-                            stream_failed = true;
+                            stream_failure_status = Some(StatusCode::BAD_GATEWAY);
                             let _ = tx.send(Err(format!("Stream error: {e}"))).await;
                             break;
                         }
                     }
                 }
-                // Effective status = BAD_GATEWAY if the relay failed, else the
-                // worker's header status. Covers both "5xx header returned
-                // while stream=true" and "200 header then mid-stream break".
-                let effective_status = if stream_failed {
-                    StatusCode::BAD_GATEWAY
-                } else {
-                    stream_header_status
-                };
-                worker_for_stream.record_outcome(effective_status.as_u16());
-                if effective_status.is_server_error() {
-                    Metrics::record_worker_error(
-                        metrics_labels::WORKER_REGULAR,
-                        metrics_labels::CONNECTION_HTTP,
-                        error_type_from_status(effective_status),
-                    );
+                // For successful stream headers, delay worker/router outcome
+                // accounting until the body relay finishes so mid-stream
+                // failures are visible. Non-success headers were recorded
+                // before returning the response so retry selection can see
+                // the failed worker immediately.
+                let effective_status = stream_failure_status.unwrap_or(stream_header_status);
+                if stream_header_status.is_success() {
+                    record_regular_worker_outcome(worker_for_stream.as_ref(), effective_status);
                 }
                 if effective_status.is_success() {
                     Metrics::record_router_duration(
@@ -872,14 +926,7 @@ impl Router {
         // that. Streaming outcomes are owned by the relay task above.
         if !is_stream {
             let final_status = response.status();
-            worker.record_outcome(final_status.as_u16());
-            if final_status.is_server_error() {
-                Metrics::record_worker_error(
-                    metrics_labels::WORKER_REGULAR,
-                    metrics_labels::CONNECTION_HTTP,
-                    error_type_from_status(final_status),
-                );
-            }
+            record_regular_worker_outcome(worker.as_ref(), final_status);
             if final_status.is_success() {
                 Metrics::record_router_duration(
                     metrics_labels::ROUTER_HTTP,
@@ -919,7 +966,7 @@ impl Router {
         typed_req: &T,
         route: &'static str,
         canonical_model: Option<&str>,
-        worker: &dyn Worker,
+        worker: Arc<dyn Worker>,
         is_stream: bool,
         load_guard: Option<WorkerLoadGuard>,
     ) -> Response {
@@ -951,7 +998,12 @@ impl Router {
         };
         strip_default_sglang_fields(&mut json_val);
 
-        let mut request_builder = self.client.post(&endpoint_url).json(&json_val);
+        let client = if is_stream {
+            &self.streaming_client
+        } else {
+            &self.client
+        };
+        let mut request_builder = client.post(&endpoint_url).json(&json_val);
 
         if let Some(key) = api_key {
             // Pre-allocate string with capacity to avoid reallocation
@@ -969,7 +1021,24 @@ impl Router {
             }
         }
 
-        let res = match request_builder.send().await {
+        let stream_deadline = StreamDeadline::new(self.stream_timeout, self.stream_idle_timeout);
+        let send_result = if is_stream {
+            match stream_deadline.until_total(request_builder.send()).await {
+                Ok(result) => result,
+                Err(_) => {
+                    let response = error::gateway_timeout(
+                        "streaming_timeout",
+                        stream_deadline.message(StreamTimeoutKind::Total),
+                    );
+                    record_regular_worker_outcome(worker.as_ref(), response.status());
+                    return response;
+                }
+            }
+        } else {
+            request_builder.send().await
+        };
+
+        let res = match send_result {
             Ok(res) => res,
             Err(e) => {
                 error!(
@@ -979,7 +1048,11 @@ impl Router {
                     e
                 );
 
-                return convert_reqwest_error(e);
+                let response = convert_reqwest_error(e);
+                if is_stream {
+                    record_regular_worker_outcome(worker.as_ref(), response.status());
+                }
+                return response;
             }
         };
 
@@ -989,11 +1062,17 @@ impl Router {
         if is_stream {
             // Preserve headers for streaming response
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
+            response_headers.remove(CONTENT_LENGTH);
+            if !status.is_success() {
+                record_regular_worker_outcome(worker.as_ref(), status);
+            }
             // Ensure we set the correct content-type for SSE
             response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
 
             let stream = res.bytes_stream();
-            let (tx, rx) = mpsc::unbounded_channel();
+            const STREAM_RELAY_BUFFER: usize = 32;
+            let (tx, rx) = mpsc::channel(STREAM_RELAY_BUFFER);
+            let worker_for_stream = worker.clone();
 
             // Spawn task to forward stream
             #[expect(
@@ -1002,22 +1081,51 @@ impl Router {
             )]
             tokio::spawn(async move {
                 let mut stream = stream;
-                while let Some(chunk) = stream.next().await {
+                let mut stream_failure_status = None;
+                let mut boundary_tail = Vec::new();
+                let mut at_event_boundary = true;
+                let mut done_decoder = sse::SseDecoder::new();
+                loop {
+                    let chunk = match stream_deadline.next(&mut stream).await {
+                        Ok(Some(chunk)) => chunk,
+                        Ok(None) => break,
+                        Err(timeout) => {
+                            stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
+                            if at_event_boundary {
+                                let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout))).await;
+                            } else {
+                                let _ = tx.send(Err(stream_deadline.message(timeout))).await;
+                            }
+                            break;
+                        }
+                    };
                     match chunk {
                         Ok(bytes) => {
-                            if tx.send(Ok(bytes)).is_err() {
+                            let stream_done =
+                                sse::observe_done_event(&mut done_decoder, bytes.as_ref());
+                            at_event_boundary =
+                                sse::update_event_boundary(&mut boundary_tail, bytes.as_ref());
+                            if tx.send(Ok(bytes)).await.is_err() {
+                                break;
+                            }
+                            if stream_done {
                                 break;
                             }
                         }
                         Err(e) => {
-                            let _ = tx.send(Err(format!("Stream error: {e}")));
+                            stream_failure_status = Some(StatusCode::BAD_GATEWAY);
+                            let _ = tx.send(Err(format!("Stream error: {e}"))).await;
                             break;
                         }
                     }
                 }
+                let effective_status = stream_failure_status.unwrap_or(status);
+                if status.is_success() {
+                    record_regular_worker_outcome(worker_for_stream.as_ref(), effective_status);
+                }
             });
 
-            let stream = UnboundedReceiverStream::new(rx);
+            let stream = ReceiverStream::new(rx);
             let body = Body::from_stream(stream);
 
             let mut response = Response::new(body);
@@ -1077,6 +1185,17 @@ impl Router {
             rerank_response.drop_documents();
         }
         Ok(Json(rerank_response).into_response())
+    }
+}
+
+fn record_regular_worker_outcome(worker: &dyn Worker, status: StatusCode) {
+    worker.record_outcome(status.as_u16());
+    if status.is_server_error() {
+        Metrics::record_worker_error(
+            metrics_labels::WORKER_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            error_type_from_status(status),
+        );
     }
 }
 
@@ -1515,6 +1634,9 @@ mod tests {
             worker_registry,
             policy_registry,
             client: Client::new(),
+            streaming_client: Client::new(),
+            stream_timeout: Duration::from_secs(1800),
+            stream_idle_timeout: Duration::from_secs(300),
             retry_config: RetryConfig::default(),
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -86,6 +86,35 @@ pub struct Router {
     webrtc_stun_server: Option<String>,
 }
 
+#[derive(Clone)]
+struct RouterStreamMetrics {
+    model_id: String,
+    endpoint: &'static str,
+    start_time: Instant,
+}
+
+fn record_regular_router_stream_outcome(metrics: &RouterStreamMetrics, status: StatusCode) {
+    if status.is_success() {
+        Metrics::record_router_duration(
+            metrics_labels::ROUTER_HTTP,
+            metrics_labels::BACKEND_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            &metrics.model_id,
+            metrics.endpoint,
+            metrics.start_time.elapsed(),
+        );
+    } else {
+        Metrics::record_router_error(
+            metrics_labels::ROUTER_HTTP,
+            metrics_labels::BACKEND_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            &metrics.model_id,
+            metrics.endpoint,
+            error_type_from_status(status),
+        );
+    }
+}
+
 impl std::fmt::Debug for Router {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Router")
@@ -303,6 +332,7 @@ impl Router {
                         canonical_model.as_deref(),
                         is_stream,
                         &text,
+                        start,
                     )
                     .await;
 
@@ -330,7 +360,7 @@ impl Router {
         )
         .await;
 
-        if response.status().is_success() {
+        if !is_stream && response.status().is_success() {
             let duration = start.elapsed();
             Metrics::record_router_duration(
                 metrics_labels::ROUTER_HTTP,
@@ -340,7 +370,7 @@ impl Router {
                 endpoint,
                 duration,
             );
-        } else if !is_retryable_status(response.status()) {
+        } else if !response.status().is_success() && !is_retryable_status(response.status()) {
             Metrics::record_router_error(
                 metrics_labels::ROUTER_HTTP,
                 metrics_labels::BACKEND_REGULAR,
@@ -356,7 +386,7 @@ impl Router {
 
     #[expect(
         clippy::too_many_arguments,
-        reason = "per-attempt state threaded from route_typed_request; a struct would only move the arity"
+        reason = "typed retry attempts pass alias, route, and stream metric context explicitly"
     )]
     async fn route_typed_request_once<T: GenerationRequest + serde::Serialize + Clone>(
         &self,
@@ -367,6 +397,7 @@ impl Router {
         canonical_model: Option<&str>,
         is_stream: bool,
         text: &str,
+        start_time: Instant,
     ) -> Response {
         let worker = match self.select_worker_for_model(model_id, Some(text), headers) {
             Some(w) => w,
@@ -416,6 +447,11 @@ impl Router {
                 worker.clone(),
                 is_stream,
                 load_guard,
+                RouterStreamMetrics {
+                    model_id: model_id.to_string(),
+                    endpoint: route_to_endpoint(route),
+                    start_time,
+                },
             )
             .await;
 
@@ -958,7 +994,7 @@ impl Router {
     // heard of the alias, so the body it receives carries the canonical name.
     #[expect(
         clippy::too_many_arguments,
-        reason = "per-request state threaded from route_typed_request_once; a struct would only move the arity"
+        reason = "request forwarding needs alias, worker, load guard, stream mode, and metric context"
     )]
     async fn send_typed_request<T: serde::Serialize>(
         &self,
@@ -969,6 +1005,7 @@ impl Router {
         worker: Arc<dyn Worker>,
         is_stream: bool,
         load_guard: Option<WorkerLoadGuard>,
+        router_metrics: RouterStreamMetrics,
     ) -> Response {
         let api_key = worker.api_key().cloned();
         let endpoint_url = worker.endpoint_url(route);
@@ -1073,6 +1110,7 @@ impl Router {
             const STREAM_RELAY_BUFFER: usize = 32;
             let (tx, rx) = mpsc::channel(STREAM_RELAY_BUFFER);
             let worker_for_stream = worker.clone();
+            let stream_router_metrics = router_metrics.clone();
 
             // Spawn task to forward stream
             #[expect(
@@ -1122,6 +1160,7 @@ impl Router {
                 let effective_status = stream_failure_status.unwrap_or(status);
                 if status.is_success() {
                     record_regular_worker_outcome(worker_for_stream.as_ref(), effective_status);
+                    record_regular_router_stream_outcome(&stream_router_metrics, effective_status);
                 }
             });
 

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -362,7 +362,10 @@ impl Router {
                 res
             },
             // should_retry predicate
-            |res, _attempt| is_retryable_status(res.status()),
+            |res, _attempt| {
+                is_retryable_status(res.status())
+                    && (!is_stream || !stream_deadline.is_total_elapsed())
+            },
             // on_backoff hook
             |delay, attempt| {
                 // Layer 3 worker metrics
@@ -1157,6 +1160,8 @@ impl Router {
             let worker_for_stream = worker.clone();
             let stream_router_metrics = router_metrics.clone();
             let terminal_observers = typed_stream_terminal_observers(route);
+            let response_error_observer = (route == "/v1/responses")
+                .then(|| sse::SseTerminalObserver::event_type("response.error"));
 
             // Spawn task to forward stream
             #[expect(
@@ -1171,6 +1176,7 @@ impl Router {
                 let mut at_event_boundary = true;
                 let requires_terminal = !terminal_observers.is_empty();
                 let mut terminal_observers = terminal_observers;
+                let mut response_error_observer = response_error_observer;
                 let mut terminal_seen = false;
                 loop {
                     let chunk = match stream_deadline.next(&mut stream).await {
@@ -1196,6 +1202,12 @@ impl Router {
                     };
                     match chunk {
                         Ok(bytes) => {
+                            if response_error_observer
+                                .as_mut()
+                                .is_some_and(|observer| observer.observe(bytes.as_ref()))
+                            {
+                                stream_failure_status = Some(StatusCode::BAD_GATEWAY);
+                            }
                             let stream_done = terminal_observers
                                 .iter_mut()
                                 .any(|observer| observer.observe(bytes.as_ref()));

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -884,11 +884,12 @@ impl Router {
                         Ok(None) => break,
                         Err(timeout) => {
                             stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
-                            if stream_is_sse && at_event_boundary {
-                                let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout))).await;
+                            let timeout_item = if stream_is_sse && at_event_boundary {
+                                Ok(stream_deadline.sse_error_event(timeout))
                             } else {
-                                let _ = tx.send(Err(stream_deadline.message(timeout))).await;
-                            }
+                                Err(stream_deadline.message(timeout))
+                            };
+                            let _ = stream_deadline.send_before_total(&tx, timeout_item).await;
                             break;
                         }
                     };
@@ -898,8 +899,13 @@ impl Router {
                                 && sse::observe_done_event(&mut done_decoder, bytes.as_ref());
                             at_event_boundary =
                                 sse::update_event_boundary(&mut boundary_tail, bytes.as_ref());
-                            if tx.send(Ok(bytes)).await.is_err() {
-                                break;
+                            match stream_deadline.send_before_total(&tx, Ok(bytes)).await {
+                                Ok(true) => {}
+                                Ok(false) => break,
+                                Err(_) => {
+                                    stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
+                                    break;
+                                }
                             }
                             if stream_done {
                                 break;
@@ -907,7 +913,9 @@ impl Router {
                         }
                         Err(e) => {
                             stream_failure_status = Some(StatusCode::BAD_GATEWAY);
-                            let _ = tx.send(Err(format!("Stream error: {e}"))).await;
+                            let _ = stream_deadline
+                                .send_before_total(&tx, Err(format!("Stream error: {e}")))
+                                .await;
                             break;
                         }
                     }
@@ -1139,11 +1147,12 @@ impl Router {
                         Ok(None) => break,
                         Err(timeout) => {
                             stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
-                            if at_event_boundary {
-                                let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout))).await;
+                            let timeout_item = if at_event_boundary {
+                                Ok(stream_deadline.sse_error_event(timeout))
                             } else {
-                                let _ = tx.send(Err(stream_deadline.message(timeout))).await;
-                            }
+                                Err(stream_deadline.message(timeout))
+                            };
+                            let _ = stream_deadline.send_before_total(&tx, timeout_item).await;
                             break;
                         }
                     };
@@ -1153,8 +1162,13 @@ impl Router {
                                 sse::observe_done_event(&mut done_decoder, bytes.as_ref());
                             at_event_boundary =
                                 sse::update_event_boundary(&mut boundary_tail, bytes.as_ref());
-                            if tx.send(Ok(bytes)).await.is_err() {
-                                break;
+                            match stream_deadline.send_before_total(&tx, Ok(bytes)).await {
+                                Ok(true) => {}
+                                Ok(false) => break,
+                                Err(_) => {
+                                    stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
+                                    break;
+                                }
                             }
                             if stream_done {
                                 break;
@@ -1162,7 +1176,9 @@ impl Router {
                         }
                         Err(e) => {
                             stream_failure_status = Some(StatusCode::BAD_GATEWAY);
-                            let _ = tx.send(Err(format!("Stream error: {e}"))).await;
+                            let _ = stream_deadline
+                                .send_before_total(&tx, Err(format!("Stream error: {e}")))
+                                .await;
                             break;
                         }
                     }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -370,7 +370,7 @@ impl Router {
                 endpoint,
                 duration,
             );
-        } else if !response.status().is_success() && !is_retryable_status(response.status()) {
+        } else if !response.status().is_success() {
             Metrics::record_router_error(
                 metrics_labels::ROUTER_HTTP,
                 metrics_labels::BACKEND_REGULAR,

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -875,6 +875,7 @@ impl Router {
             tokio::spawn(async move {
                 let mut stream = stream;
                 let mut stream_failure_status = None;
+                let mut done_decoder = sse::SseDecoder::new();
                 loop {
                     let chunk = match stream_deadline.next(&mut stream).await {
                         Ok(Some(chunk)) => chunk,
@@ -891,7 +892,12 @@ impl Router {
                     };
                     match chunk {
                         Ok(bytes) => {
+                            let stream_done = stream_is_sse
+                                && sse::observe_done_event(&mut done_decoder, bytes.as_ref());
                             if tx.send(Ok(bytes)).await.is_err() {
+                                break;
+                            }
+                            if stream_done {
                                 break;
                             }
                         }

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -1,13 +1,15 @@
 //! Chat completion routing for the OpenAI router.
 
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use axum::{
     body::Body,
     http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
     response::Response,
 };
-use futures_util::StreamExt;
 use openai_protocol::chat::ChatCompletionRequest;
 use serde_json::to_value;
 use tokio::sync::mpsc;
@@ -26,11 +28,14 @@ use crate::{
         common::{
             header_utils::{apply_provider_headers, extract_auth_header},
             retry::{is_retryable_status, RetryExecutor},
+            sse,
+            stream_timeout::{StreamDeadline, StreamTimeoutKind},
             worker_selection::{SelectWorkerRequest, WorkerSelector},
         },
         error,
+        grpc::utils::error_type_from_status,
     },
-    worker::{Endpoint, ProviderType, WorkerRegistry},
+    worker::{Endpoint, ProviderType, Worker, WorkerRegistry},
 };
 
 /// Shared context passed to chat routing functions.
@@ -39,6 +44,17 @@ pub(super) struct ChatRouterContext<'a> {
     pub provider_registry: &'a ProviderRegistry,
     pub shared_components: &'a Arc<SharedComponents>,
     pub retry_config: &'a RetryConfig,
+}
+
+fn record_regular_worker_outcome(worker: &dyn Worker, status: StatusCode) {
+    worker.record_outcome(status.as_u16());
+    if status.is_server_error() {
+        Metrics::record_worker_error(
+            metrics_labels::WORKER_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            error_type_from_status(status),
+        );
+    }
 }
 
 /// Route a chat completion request to the appropriate upstream worker.
@@ -146,10 +162,21 @@ pub(super) async fn route_chat(
     )]
     let payload_ref = ctx.payload().expect("Payload not prepared");
     let payload_json = Arc::new(payload_ref.json.clone());
-    let client = ctx.components.client().clone();
     let headers_cloned = Arc::new(ctx.headers().cloned());
     let worker_api_key = Arc::new(worker.api_key().cloned());
     let is_streaming = ctx.is_streaming();
+    let stream_timeout =
+        Duration::from_secs(deps.shared_components.router_config.request_timeout_secs);
+    let stream_idle_timeout = Duration::from_secs(
+        deps.shared_components
+            .router_config
+            .stream_idle_timeout_secs,
+    );
+    let client = if is_streaming {
+        ctx.components.streaming_client().clone()
+    } else {
+        ctx.components.client().clone()
+    };
 
     let response = RetryExecutor::execute_response_with_retry(
         deps.retry_config,
@@ -171,44 +198,94 @@ pub(super) async fn route_chat(
                     req = req.header("Accept", "text/event-stream");
                 }
 
-                let resp = match req.send().await {
-                    Ok(r) => r,
-                    Err(e) => {
-                        worker.record_outcome(503);
-                        return error::service_unavailable(
-                            "upstream_error",
-                            format!("Failed to contact upstream: {e}"),
-                        );
+                let stream_deadline = StreamDeadline::new(stream_timeout, stream_idle_timeout);
+                let resp = if is_streaming {
+                    match stream_deadline.until_total(req.send()).await {
+                        Ok(Ok(r)) => r,
+                        Ok(Err(e)) => {
+                            record_regular_worker_outcome(worker.as_ref(), StatusCode::SERVICE_UNAVAILABLE);
+                            return error::service_unavailable(
+                                "upstream_error",
+                                format!("Failed to contact upstream: {e}"),
+                            );
+                        }
+                        Err(_) => {
+                            record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+                            let message = stream_deadline.message(StreamTimeoutKind::Total);
+                            return error::gateway_timeout("streaming_timeout", message);
+                        }
+                    }
+                } else {
+                    match req.send().await {
+                        Ok(r) => r,
+                        Err(e) => {
+                            record_regular_worker_outcome(worker.as_ref(), StatusCode::SERVICE_UNAVAILABLE);
+                            return error::service_unavailable(
+                                "upstream_error",
+                                format!("Failed to contact upstream: {e}"),
+                            );
+                        }
                     }
                 };
 
                 let status = StatusCode::from_u16(resp.status().as_u16())
                     .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
-                // Record CB outcome based on HTTP status.
-                // For streaming: status is known upfront (200 = success).
-                // For non-streaming: we record here too — body read errors
-                // are connection issues, not worker health issues.
-                worker.record_outcome(status.as_u16());
+                // Non-streaming outcomes are final after headers/body handling here.
+                // Streaming outcomes are recorded by the relay task, which can see
+                // post-header body timeouts and transport errors.
+                if !is_streaming || !status.is_success() {
+                    record_regular_worker_outcome(worker.as_ref(), status);
+                }
 
                 if is_streaming {
                     let stream = resp.bytes_stream();
                     let (tx, rx) = mpsc::unbounded_channel();
+                    let worker_for_stream = worker.clone();
                     #[expect(clippy::disallowed_methods, reason = "fire-and-forget stream relay; gateway shutdown need not wait for individual stream forwarding")]
                     tokio::spawn(async move {
                         let mut s = stream;
-                        while let Some(chunk) = s.next().await {
+                        let mut stream_failure_status = None;
+                        let mut boundary_tail = Vec::new();
+                        let mut at_event_boundary = true;
+                        let mut done_decoder = sse::SseDecoder::new();
+                        loop {
+                            let chunk = match stream_deadline.next(&mut s).await {
+                                Ok(Some(chunk)) => chunk,
+                                Ok(None) => break,
+                                Err(timeout) => {
+                                    stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
+                                    if at_event_boundary {
+                                        let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
+                                    } else {
+                                        let _ = tx.send(Err(stream_deadline.message(timeout)));
+                                    }
+                                    break;
+                                }
+                            };
                             match chunk {
                                 Ok(bytes) => {
+                                    let stream_done =
+                                        sse::observe_done_event(&mut done_decoder, bytes.as_ref());
+                                    at_event_boundary =
+                                        sse::update_event_boundary(&mut boundary_tail, bytes.as_ref());
                                     if tx.send(Ok(bytes)).is_err() {
+                                        break;
+                                    }
+                                    if stream_done {
                                         break;
                                     }
                                 }
                                 Err(e) => {
+                                    stream_failure_status = Some(StatusCode::BAD_GATEWAY);
                                     let _ = tx.send(Err(format!("Stream error: {e}")));
                                     break;
                                 }
                             }
+                        }
+                        let effective_status = stream_failure_status.unwrap_or(status);
+                        if status.is_success() {
+                            record_regular_worker_outcome(worker_for_stream.as_ref(), effective_status);
                         }
                     });
                     let mut response =

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -371,7 +371,7 @@ pub(super) async fn route_chat(
             metrics_labels::ENDPOINT_CHAT,
             start.elapsed(),
         );
-    } else {
+    } else if !response.status().is_success() {
         Metrics::record_router_error(
             metrics_labels::ROUTER_OPENAI,
             metrics_labels::BACKEND_EXTERNAL,

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -57,6 +57,28 @@ fn record_regular_worker_outcome(worker: &dyn Worker, status: StatusCode) {
     }
 }
 
+fn record_chat_router_stream_outcome(model_id: &str, start_time: Instant, status: StatusCode) {
+    if status.is_success() {
+        Metrics::record_router_duration(
+            metrics_labels::ROUTER_OPENAI,
+            metrics_labels::BACKEND_EXTERNAL,
+            metrics_labels::CONNECTION_HTTP,
+            model_id,
+            metrics_labels::ENDPOINT_CHAT,
+            start_time.elapsed(),
+        );
+    } else {
+        Metrics::record_router_error(
+            metrics_labels::ROUTER_OPENAI,
+            metrics_labels::BACKEND_EXTERNAL,
+            metrics_labels::CONNECTION_HTTP,
+            model_id,
+            metrics_labels::ENDPOINT_CHAT,
+            error_type_from_status(status),
+        );
+    }
+}
+
 /// Route a chat completion request to the appropriate upstream worker.
 pub(super) async fn route_chat(
     deps: &ChatRouterContext<'_>,
@@ -242,6 +264,8 @@ pub(super) async fn route_chat(
                     let stream = resp.bytes_stream();
                     let (tx, rx) = mpsc::unbounded_channel();
                     let worker_for_stream = worker.clone();
+                    let stream_model_id = model.to_string();
+                    let stream_start = start;
                     #[expect(clippy::disallowed_methods, reason = "fire-and-forget stream relay; gateway shutdown need not wait for individual stream forwarding")]
                     tokio::spawn(async move {
                         let mut s = stream;
@@ -286,6 +310,11 @@ pub(super) async fn route_chat(
                         let effective_status = stream_failure_status.unwrap_or(status);
                         if status.is_success() {
                             record_regular_worker_outcome(worker_for_stream.as_ref(), effective_status);
+                            record_chat_router_stream_outcome(
+                                &stream_model_id,
+                                stream_start,
+                                effective_status,
+                            );
                         }
                     });
                     let mut response =
@@ -333,7 +362,7 @@ pub(super) async fn route_chat(
     )
     .await;
 
-    if response.status().is_success() {
+    if !streaming && response.status().is_success() {
         Metrics::record_router_duration(
             metrics_labels::ROUTER_OPENAI,
             metrics_labels::BACKEND_EXTERNAL,

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -199,6 +199,7 @@ pub(super) async fn route_chat(
     } else {
         ctx.components.client().clone()
     };
+    let stream_deadline = StreamDeadline::new(stream_timeout, stream_idle_timeout);
 
     let response = RetryExecutor::execute_response_with_retry(
         deps.retry_config,
@@ -220,7 +221,6 @@ pub(super) async fn route_chat(
                     req = req.header("Accept", "text/event-stream");
                 }
 
-                let stream_deadline = StreamDeadline::new(stream_timeout, stream_idle_timeout);
                 let resp = if is_streaming {
                     match stream_deadline.until_total(req.send()).await {
                         Ok(Ok(r)) => r,

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -273,10 +273,16 @@ pub(super) async fn route_chat(
                         let mut boundary_tail = Vec::new();
                         let mut at_event_boundary = true;
                         let mut done_observer = sse::SseTerminalObserver::done();
+                        let mut terminal_seen = false;
                         loop {
                             let chunk = match stream_deadline.next(&mut s).await {
                                 Ok(Some(chunk)) => chunk,
-                                Ok(None) => break,
+                                Ok(None) => {
+                                    if status.is_success() && !terminal_seen {
+                                        stream_failure_status = Some(StatusCode::BAD_GATEWAY);
+                                    }
+                                    break;
+                                }
                                 Err(timeout) => {
                                     stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
                                     if at_event_boundary {
@@ -290,6 +296,7 @@ pub(super) async fn route_chat(
                             match chunk {
                                 Ok(bytes) => {
                                     let stream_done = done_observer.observe(bytes.as_ref());
+                                    terminal_seen |= stream_done;
                                     at_event_boundary =
                                         sse::update_event_boundary(&mut boundary_tail, bytes.as_ref());
                                     if tx.send(Ok(bytes)).is_err() {

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -351,7 +351,10 @@ pub(super) async fn route_chat(
                 }
             }
         },
-        |res, _attempt| is_retryable_status(res.status()),
+        |res, _attempt| {
+            is_retryable_status(res.status())
+                && (!is_streaming || !stream_deadline.is_total_elapsed())
+        },
         |delay, attempt| {
             Metrics::record_worker_retry(
                 metrics_labels::BACKEND_EXTERNAL,

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -272,7 +272,7 @@ pub(super) async fn route_chat(
                         let mut stream_failure_status = None;
                         let mut boundary_tail = Vec::new();
                         let mut at_event_boundary = true;
-                        let mut done_decoder = sse::SseDecoder::new();
+                        let mut done_observer = sse::SseTerminalObserver::done();
                         loop {
                             let chunk = match stream_deadline.next(&mut s).await {
                                 Ok(Some(chunk)) => chunk,
@@ -289,8 +289,7 @@ pub(super) async fn route_chat(
                             };
                             match chunk {
                                 Ok(bytes) => {
-                                    let stream_done =
-                                        sse::observe_done_event(&mut done_decoder, bytes.as_ref());
+                                    let stream_done = done_observer.observe(bytes.as_ref());
                                     at_event_boundary =
                                         sse::update_event_boundary(&mut boundary_tail, bytes.as_ref());
                                     if tx.send(Ok(bytes)).is_err() {

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -1,6 +1,6 @@
 //! Request context types for OpenAI router pipeline.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use axum::http::HeaderMap;
 use openai_protocol::{chat::ChatCompletionRequest, responses::ResponsesRequest};
@@ -40,6 +40,7 @@ pub enum RequestType {
 #[derive(Clone)]
 pub struct SharedComponents {
     pub client: reqwest::Client,
+    pub streaming_client: reqwest::Client,
     pub router_config: Arc<RouterConfig>,
 }
 
@@ -62,6 +63,13 @@ impl ComponentRefs {
         match self {
             ComponentRefs::Shared(s) => &s.client,
             ComponentRefs::Responses(r) => &r.shared.client,
+        }
+    }
+
+    pub fn streaming_client(&self) -> &reqwest::Client {
+        match self {
+            ComponentRefs::Shared(s) => &s.streaming_client,
+            ComponentRefs::Responses(r) => &r.shared.streaming_client,
         }
     }
 
@@ -238,6 +246,8 @@ pub struct OwnedStreamingContext {
     pub original_body: ResponsesRequest,
     pub previous_response_id: Option<String>,
     pub existing_mcp_list_tools_labels: Vec<String>,
+    pub stream_timeout: Duration,
+    pub stream_idle_timeout: Duration,
     pub storage: StorageHandles,
 }
 
@@ -264,6 +274,10 @@ impl RequestContext {
             .conversation_item_storage()
             .ok_or("Conversation item storage required")?
             .clone();
+        let stream_timeout =
+            Duration::from_secs(self.components.router_config().request_timeout_secs);
+        let stream_idle_timeout =
+            Duration::from_secs(self.components.router_config().stream_idle_timeout_secs);
 
         Ok(OwnedStreamingContext {
             url: payload_state.url,
@@ -271,6 +285,8 @@ impl RequestContext {
             original_body,
             previous_response_id: responses_payload_state.previous_response_id,
             existing_mcp_list_tools_labels: responses_payload_state.existing_mcp_list_tools_labels,
+            stream_timeout,
+            stream_idle_timeout,
             storage: StorageHandles {
                 response,
                 conversation,

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -32,6 +32,7 @@ use crate::{
                 self, extract_embedded_openai_responses, mcp_response_item_id, FormatRegistry,
                 ResponseFormat, ResponseTransformer,
             },
+            stream_timeout::{StreamDeadline, StreamTimeoutKind},
         },
         error,
         openai::responses::utils,
@@ -177,7 +178,8 @@ pub(crate) async fn execute_streaming_tool_calls(
     model_id: &str,
     request_tools: &[ResponseTool],
     request_user: Option<&str>,
-) -> bool {
+    stream_deadline: StreamDeadline,
+) -> Result<bool, StreamTimeoutKind> {
     for call in pending_calls {
         if call.name.is_empty() {
             warn!(
@@ -229,7 +231,7 @@ pub(crate) async fn execute_streaming_tool_calls(
                     response_format,
                     sequence_number,
                 ) {
-                    return false;
+                    return Ok(false);
                 }
                 state.record_call(
                     session.is_builtin_tool(&call.name),
@@ -244,7 +246,7 @@ pub(crate) async fn execute_streaming_tool_calls(
         };
 
         if !send_tool_call_intermediate_event(tx, &call, response_format, sequence_number) {
-            return false;
+            return Ok(false);
         }
 
         // Coerce non-object payloads to `{}` before merging overrides — the
@@ -262,13 +264,14 @@ pub(crate) async fn execute_streaming_tool_calls(
         // Log the effective (post-merge) args so the log reflects what the
         // MCP server actually receives, not the pre-merge string from the model.
         debug!("Calling MCP tool '{}' with args: {}", call.name, arguments);
-        let tool_output = session
-            .execute_tool(ToolExecutionInput {
+        let tool_output = Box::pin(stream_deadline.until_activity(session.execute_tool(
+            ToolExecutionInput {
                 call_id: call.call_id.clone(),
                 tool_name: call.name.clone(),
                 arguments,
-            })
-            .await;
+            },
+        )))
+        .await?;
 
         Metrics::record_mcp_tool_duration(model_id, &tool_output.tool_name, tool_output.duration);
         Metrics::record_mcp_tool_call(
@@ -304,7 +307,7 @@ pub(crate) async fn execute_streaming_tool_calls(
             response_format,
             sequence_number,
         ) {
-            return false;
+            return Ok(false);
         }
 
         state.record_call(
@@ -316,7 +319,7 @@ pub(crate) async fn execute_streaming_tool_calls(
             mcp_call_item,
         );
     }
-    true
+    Ok(true)
 }
 
 /// Transform payload to replace MCP/builtin tools with function tools.

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -25,10 +25,7 @@ use crate::{
     middleware::TenantRequestMeta,
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     routers::{
-        common::{
-            mcp_utils::request_uses_mcp_routing,
-            worker_selection::{SelectWorkerRequest, WorkerSelector},
-        },
+        common::worker_selection::{SelectWorkerRequest, WorkerSelector},
         error,
     },
     worker::{Endpoint, ProviderType, WorkerRegistry},
@@ -52,8 +49,6 @@ pub(in crate::routers::openai) async fn route_responses(
     let start = Instant::now();
     let model = model_id;
     let streaming = body.stream.unwrap_or(false);
-    let streaming_uses_mcp =
-        streaming && body.tools.as_deref().is_some_and(request_uses_mcp_routing);
 
     Metrics::record_router_request(
         metrics_labels::ROUTER_OPENAI,
@@ -195,7 +190,7 @@ pub(in crate::routers::openai) async fn route_responses(
         handle_non_streaming_response(ctx).await
     };
 
-    if response.status().is_success() && (!streaming || streaming_uses_mcp) {
+    if response.status().is_success() && !streaming {
         Metrics::record_router_duration(
             metrics_labels::ROUTER_OPENAI,
             metrics_labels::BACKEND_EXTERNAL,

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -25,7 +25,10 @@ use crate::{
     middleware::TenantRequestMeta,
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     routers::{
-        common::worker_selection::{SelectWorkerRequest, WorkerSelector},
+        common::{
+            mcp_utils::request_uses_mcp_routing,
+            worker_selection::{SelectWorkerRequest, WorkerSelector},
+        },
         error,
     },
     worker::{Endpoint, ProviderType, WorkerRegistry},
@@ -49,6 +52,8 @@ pub(in crate::routers::openai) async fn route_responses(
     let start = Instant::now();
     let model = model_id;
     let streaming = body.stream.unwrap_or(false);
+    let streaming_uses_mcp =
+        streaming && body.tools.as_deref().is_some_and(request_uses_mcp_routing);
 
     Metrics::record_router_request(
         metrics_labels::ROUTER_OPENAI,
@@ -185,12 +190,12 @@ pub(in crate::routers::openai) async fn route_responses(
     });
 
     let response = if ctx.is_streaming() {
-        handle_streaming_response(ctx).await
+        handle_streaming_response(ctx, start).await
     } else {
         handle_non_streaming_response(ctx).await
     };
 
-    if response.status().is_success() {
+    if response.status().is_success() && (!streaming || streaming_uses_mcp) {
         Metrics::record_router_duration(
             metrics_labels::ROUTER_OPENAI,
             metrics_labels::BACKEND_EXTERNAL,

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -794,11 +794,16 @@ pub(super) async fn handle_simple_streaming_passthrough(
 }
 
 /// Handle streaming WITH MCP tool call interception and execution
+#[expect(
+    clippy::too_many_arguments,
+    reason = "MCP streaming needs client, worker, request context, orchestrator, format registry, and router timing"
+)]
 pub(super) fn handle_streaming_with_tool_interception(
     client: &reqwest::Client,
     worker: Arc<dyn Worker>,
     headers: Option<&HeaderMap>,
     req: StreamingRequest,
+    router_start: Instant,
     orchestrator: &Arc<McpOrchestrator>,
     format_registry: openai_bridge::FormatRegistry,
     mcp_servers: Vec<McpServerBinding>,
@@ -811,6 +816,7 @@ pub(super) fn handle_streaming_with_tool_interception(
     let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
     let should_store = req.original_body.store.unwrap_or(true);
     let original_request = req.original_body;
+    let stream_model_id = original_request.model.clone();
     let previous_response_id = req.previous_response_id;
     let existing_mcp_list_tools_labels = req.existing_mcp_list_tools_labels;
     let url = req.url;
@@ -828,6 +834,12 @@ pub(super) fn handle_streaming_with_tool_interception(
         reason = "fire-and-forget MCP tool loop; gateway shutdown need not wait for individual tool loops"
     )]
     tokio::spawn(async move {
+        macro_rules! record_router_outcome {
+            ($status:expr) => {
+                record_responses_router_stream_outcome(&stream_model_id, router_start, $status);
+            };
+        }
+
         let mut state = ToolLoopState::new(
             original_request.input.clone(),
             existing_mcp_list_tools_labels,
@@ -871,6 +883,7 @@ pub(super) fn handle_streaming_with_tool_interception(
         loop {
             if stream_deadline.is_total_elapsed() {
                 let _ = tx.send(Ok(stream_deadline.sse_error_event(StreamTimeoutKind::Total)));
+                record_router_outcome!(StatusCode::GATEWAY_TIMEOUT);
                 return;
             }
 
@@ -888,6 +901,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => {
                     record_regular_worker_outcome(worker.as_ref(), StatusCode::BAD_GATEWAY);
+                    record_router_outcome!(StatusCode::BAD_GATEWAY);
                     let _ = send_sse_event(
                         &tx,
                         &mut sse_encoder,
@@ -899,6 +913,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                 Err(timeout) => {
                     let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
                     record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+                    record_router_outcome!(StatusCode::GATEWAY_TIMEOUT);
                     return;
                 }
             };
@@ -916,11 +931,13 @@ pub(super) fn handle_streaming_with_tool_interception(
                     Err(StreamBodyReadError::Timeout(timeout)) => {
                         let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
                         record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+                        record_router_outcome!(StatusCode::GATEWAY_TIMEOUT);
                         return;
                     }
                     Err(err) => stream_deadline.body_read_error_message(&err),
                 };
                 record_regular_worker_outcome(worker.as_ref(), status_code);
+                record_router_outcome!(status_code);
                 let body = error::sanitize_error_body(&body);
                 let _ = send_sse_event(
                     &tx,
@@ -942,13 +959,14 @@ pub(super) fn handle_streaming_with_tool_interception(
             let mut tool_calls_detected = false;
             let mut seen_in_progress = false;
 
-            'model_stream: loop {
+            loop {
                 let chunk_result = match stream_deadline.next(&mut upstream_stream).await {
                     Ok(Some(chunk_result)) => chunk_result,
                     Ok(None) => break,
                     Err(timeout) => {
                         let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
                         record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+                        record_router_outcome!(StatusCode::GATEWAY_TIMEOUT);
                         return;
                     }
                 };
@@ -969,7 +987,9 @@ pub(super) fn handle_streaming_with_tool_interception(
                                 if tx.send(Ok(Bytes::from(done_block))).is_err() {
                                     return;
                                 }
-                                break 'model_stream;
+                                record_regular_worker_outcome(worker.as_ref(), status);
+                                record_router_outcome!(status);
+                                return;
                             }
 
                             // Process through handler
@@ -1101,6 +1121,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                     }
                     Err(e) => {
                         record_regular_worker_outcome(worker.as_ref(), StatusCode::BAD_GATEWAY);
+                        record_router_outcome!(StatusCode::BAD_GATEWAY);
                         let _ = send_sse_event(
                             &tx,
                             &mut sse_encoder,
@@ -1120,6 +1141,7 @@ pub(super) fn handle_streaming_with_tool_interception(
             // If no tool calls, we're done - stream is complete
             if !tool_calls_detected {
                 record_regular_worker_outcome(worker.as_ref(), status);
+                record_router_outcome!(status);
                 if !send_final_response_event(
                     &handler,
                     &tx,
@@ -1196,6 +1218,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                     "Reached tool call limit during streaming: {}",
                     effective_limit
                 );
+                record_router_outcome!(StatusCode::BAD_GATEWAY);
                 send_sse_event(
                     &tx,
                     &mut sse_encoder,
@@ -1228,11 +1251,13 @@ pub(super) fn handle_streaming_with_tool_interception(
                 Ok(should_continue) => should_continue,
                 Err(timeout) => {
                     let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
+                    record_router_outcome!(StatusCode::GATEWAY_TIMEOUT);
                     return;
                 }
             };
 
             if !should_continue {
+                record_router_outcome!(status);
                 return;
             }
 
@@ -1249,6 +1274,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                     is_first_iteration = false;
                 }
                 Err(e) => {
+                    record_router_outcome!(StatusCode::BAD_GATEWAY);
                     send_sse_event(
                         &tx,
                         &mut sse_encoder,
@@ -1337,6 +1363,7 @@ pub async fn handle_streaming_response(ctx: RequestContext, router_start: Instan
         worker.clone(),
         headers.as_ref(),
         req,
+        router_start,
         &mcp_orchestrator,
         mcp_format_registry,
         mcp_servers,

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -11,11 +11,13 @@ use std::{borrow::Cow, io, sync::Arc};
 
 use axum::{
     body::Body,
-    http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
+    http::{
+        header::{CONTENT_LENGTH, CONTENT_TYPE},
+        HeaderMap, HeaderValue, StatusCode,
+    },
     response::{IntoResponse, Response},
 };
 use bytes::Bytes;
-use futures_util::StreamExt;
 use openai_protocol::{
     event_types::{
         is_function_call_type, is_response_event, FunctionCallEvent, ItemType, McpEvent,
@@ -37,11 +39,16 @@ use super::{
         rewrite_streaming_block,
     },
 };
-use crate::routers::common::openai_bridge::{self, mcp_response_item_id, ResponseFormat};
+use crate::routers::common::{
+    openai_bridge::{self, mcp_response_item_id, ResponseFormat},
+    stream_timeout::{
+        StreamBodyReadError, StreamDeadline, StreamTimeoutKind, MAX_STREAM_ERROR_BODY_SIZE,
+    },
+};
 const SSE_DONE: &str = "data: [DONE]\n\n";
 
 use crate::{
-    observability::metrics::Metrics,
+    observability::metrics::{metrics_labels, Metrics},
     routers::{
         common::{
             header_utils::{
@@ -52,6 +59,7 @@ use crate::{
             sse::SseEncoder,
         },
         error,
+        grpc::utils::error_type_from_status,
         openai::{
             context::{RequestContext, StreamingEventContext, StreamingRequest},
             mcp::{
@@ -61,7 +69,19 @@ use crate::{
             },
         },
     },
+    worker::Worker,
 };
+
+fn record_regular_worker_outcome(worker: &dyn Worker, status: StatusCode) {
+    worker.record_outcome(status.as_u16());
+    if status.is_server_error() {
+        Metrics::record_worker_error(
+            metrics_labels::WORKER_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            error_type_from_status(status),
+        );
+    }
+}
 
 /// Apply all transformations to event data in-place (rewrite + transform)
 /// Optimized to parse JSON only once instead of multiple times
@@ -529,10 +549,12 @@ pub(super) fn send_final_response_event(
 /// Simple pass-through streaming without MCP interception
 pub(super) async fn handle_simple_streaming_passthrough(
     client: &reqwest::Client,
-    worker: &Arc<dyn crate::worker::Worker>,
+    worker: &Arc<dyn Worker>,
     headers: Option<&HeaderMap>,
     req: StreamingRequest,
 ) -> Response {
+    let stream_timeout = req.stream_timeout;
+    let stream_idle_timeout = req.stream_idle_timeout;
     let mut request_builder = client.post(&req.url).json(&req.payload);
     let provider = ApiProvider::from_url(&req.url);
     let auth_header = provider.extract_auth_header(headers, worker.api_key());
@@ -540,13 +562,22 @@ pub(super) async fn handle_simple_streaming_passthrough(
 
     request_builder = request_builder.header("Accept", "text/event-stream");
 
-    let response = match request_builder.send().await {
-        Ok(resp) => resp,
-        Err(err) => {
-            worker.record_outcome(502);
+    let stream_deadline = StreamDeadline::new(stream_timeout, stream_idle_timeout);
+    let response = match stream_deadline.until_total(request_builder.send()).await {
+        Ok(Ok(resp)) => resp,
+        Ok(Err(err)) => {
+            record_regular_worker_outcome(worker.as_ref(), StatusCode::BAD_GATEWAY);
             return (
                 StatusCode::BAD_GATEWAY,
                 format!("Failed to forward request to OpenAI: {err}"),
+            )
+                .into_response();
+        }
+        Err(_) => {
+            record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+            return (
+                StatusCode::GATEWAY_TIMEOUT,
+                stream_deadline.message(StreamTimeoutKind::Total),
             )
                 .into_response();
         }
@@ -556,18 +587,35 @@ pub(super) async fn handle_simple_streaming_passthrough(
     let status_code =
         StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
-    worker.record_outcome(status.as_u16());
-
     if !status.is_success() {
-        let error_body = response
-            .text()
+        let mut error_stream = response.bytes_stream();
+        let error_body = match stream_deadline
+            .read_text_limited(&mut error_stream, MAX_STREAM_ERROR_BODY_SIZE)
             .await
-            .unwrap_or_else(|err| format!("Failed to read upstream error body: {err}"));
+        {
+            Ok(body) => {
+                record_regular_worker_outcome(worker.as_ref(), status_code);
+                body
+            }
+            Err(StreamBodyReadError::Timeout(timeout)) => {
+                record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+                return (
+                    StatusCode::GATEWAY_TIMEOUT,
+                    stream_deadline.message(timeout),
+                )
+                    .into_response();
+            }
+            Err(err) => {
+                record_regular_worker_outcome(worker.as_ref(), status_code);
+                stream_deadline.body_read_error_message(&err)
+            }
+        };
         let error_body = error::sanitize_error_body(&error_body);
         return (status_code, error_body).into_response();
     }
 
-    let preserved_headers = preserve_response_headers(response.headers());
+    let mut preserved_headers = preserve_response_headers(response.headers());
+    preserved_headers.remove(CONTENT_LENGTH);
     let mut upstream_stream = response.bytes_stream();
 
     let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
@@ -576,6 +624,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
     let original_request = req.original_body;
     let previous_response_id = req.previous_response_id;
     let storage = req.storage;
+    let worker_for_stream = worker.clone();
 
     #[expect(
         clippy::disallowed_methods,
@@ -583,16 +632,27 @@ pub(super) async fn handle_simple_streaming_passthrough(
     )]
     tokio::spawn(async move {
         let mut accumulator = StreamingResponseAccumulator::new();
-        let mut upstream_failed = false;
+        let mut stream_failure_status = None;
         let mut receiver_connected = true;
         let mut chunk_processor = ChunkProcessor::new();
 
-        while let Some(chunk_result) = upstream_stream.next().await {
+        'stream_loop: loop {
+            let chunk_result = match stream_deadline.next(&mut upstream_stream).await {
+                Ok(Some(chunk_result)) => chunk_result,
+                Ok(None) => break,
+                Err(timeout) => {
+                    let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
+                    stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
+                    break;
+                }
+            };
             match chunk_result {
                 Ok(chunk) => {
                     chunk_processor.push_chunk(&chunk);
 
                     while let Some(raw_block) = chunk_processor.next_block() {
+                        let (_, raw_data) = parse_sse_block(&raw_block);
+                        let is_done = raw_data.as_ref() == "[DONE]";
                         let block_cow = match rewrite_streaming_block(
                             &raw_block,
                             &original_request,
@@ -602,7 +662,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
                             None => Cow::Borrowed(raw_block.as_str()),
                         };
 
-                        if should_store {
+                        if should_store && !is_done {
                             accumulator.ingest_block(&block_cow);
                         }
 
@@ -616,6 +676,9 @@ pub(super) async fn handle_simple_streaming_passthrough(
                         if !receiver_connected && !should_store {
                             break;
                         }
+                        if is_done {
+                            break 'stream_loop;
+                        }
                     }
 
                     if !receiver_connected && !should_store {
@@ -623,7 +686,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
                     }
                 }
                 Err(err) => {
-                    upstream_failed = true;
+                    stream_failure_status = Some(StatusCode::BAD_GATEWAY);
                     let io_err = io::Error::other(err);
                     let _ = tx.send(Err(io_err));
                     break;
@@ -631,7 +694,10 @@ pub(super) async fn handle_simple_streaming_passthrough(
             }
         }
 
-        if should_store && !upstream_failed {
+        let effective_status = stream_failure_status.unwrap_or(status_code);
+        record_regular_worker_outcome(worker_for_stream.as_ref(), effective_status);
+
+        if should_store && stream_failure_status.is_none() {
             if chunk_processor.has_remaining() {
                 accumulator.ingest_block(&chunk_processor.take_remaining());
             }
@@ -683,14 +749,17 @@ pub(super) async fn handle_simple_streaming_passthrough(
 /// Handle streaming WITH MCP tool call interception and execution
 pub(super) fn handle_streaming_with_tool_interception(
     client: &reqwest::Client,
-    worker_api_key: Option<String>,
+    worker: Arc<dyn Worker>,
     headers: Option<&HeaderMap>,
     req: StreamingRequest,
     orchestrator: &Arc<McpOrchestrator>,
     format_registry: openai_bridge::FormatRegistry,
     mcp_servers: Vec<McpServerBinding>,
 ) -> Response {
+    let stream_timeout = req.stream_timeout;
+    let stream_idle_timeout = req.stream_idle_timeout;
     let payload = req.payload;
+    let worker_api_key = worker.api_key().cloned();
 
     let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
     let should_store = req.original_body.store.unwrap_or(true);
@@ -736,6 +805,7 @@ pub(super) fn handle_streaming_with_tool_interception(
         let mut sse_encoder = SseEncoder::new();
         let mut next_output_index: usize = 0;
         let mut preserved_response_id: Option<String> = None;
+        let stream_deadline = StreamDeadline::new(stream_timeout, stream_idle_timeout);
         let list_tools_bindings = mcp_list_tools_bindings_to_emit(
             &state.existing_mcp_list_tools_labels,
             session.mcp_servers(),
@@ -752,14 +822,25 @@ pub(super) fn handle_streaming_with_tool_interception(
             provider.extract_auth_header(headers_opt.as_ref(), worker_api_key.as_ref());
 
         loop {
+            if stream_deadline.is_total_elapsed() {
+                let _ = tx.send(Ok(stream_deadline.sse_error_event(StreamTimeoutKind::Total)));
+                return;
+            }
+
             // Make streaming request
             let mut request_builder = client_clone.post(&url_clone).json(&current_payload);
             request_builder = provider.apply_headers(request_builder, auth_header.as_ref());
             request_builder = request_builder.header("Accept", "text/event-stream");
 
-            let response = match request_builder.send().await {
-                Ok(r) => r,
-                Err(e) => {
+            let response_result = if is_first_iteration {
+                stream_deadline.until_total(request_builder.send()).await
+            } else {
+                stream_deadline.until_activity(request_builder.send()).await
+            };
+            let response = match response_result {
+                Ok(Ok(r)) => r,
+                Ok(Err(e)) => {
+                    record_regular_worker_outcome(worker.as_ref(), StatusCode::BAD_GATEWAY);
                     let _ = send_sse_event(
                         &tx,
                         &mut sse_encoder,
@@ -768,11 +849,31 @@ pub(super) fn handle_streaming_with_tool_interception(
                     );
                     return;
                 }
+                Err(timeout) => {
+                    let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
+                    record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+                    return;
+                }
             };
 
             if !response.status().is_success() {
                 let status = response.status();
-                let body = response.text().await.unwrap_or_default();
+                let status_code = StatusCode::from_u16(status.as_u16())
+                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                let mut error_stream = response.bytes_stream();
+                let body = match stream_deadline
+                    .read_text_limited(&mut error_stream, MAX_STREAM_ERROR_BODY_SIZE)
+                    .await
+                {
+                    Ok(body) => body,
+                    Err(StreamBodyReadError::Timeout(timeout)) => {
+                        let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
+                        record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+                        return;
+                    }
+                    Err(err) => stream_deadline.body_read_error_message(&err),
+                };
+                record_regular_worker_outcome(worker.as_ref(), status_code);
                 let body = error::sanitize_error_body(&body);
                 let _ = send_sse_event(
                     &tx,
@@ -783,6 +884,8 @@ pub(super) fn handle_streaming_with_tool_interception(
                 return;
             }
 
+            let status = StatusCode::from_u16(response.status().as_u16())
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
             let mut upstream_stream = response.bytes_stream();
             let mut handler = StreamingToolHandler::with_starting_index(next_output_index);
             if let Some(ref id) = preserved_response_id {
@@ -792,7 +895,16 @@ pub(super) fn handle_streaming_with_tool_interception(
             let mut tool_calls_detected = false;
             let mut seen_in_progress = false;
 
-            while let Some(chunk_result) = upstream_stream.next().await {
+            'model_stream: loop {
+                let chunk_result = match stream_deadline.next(&mut upstream_stream).await {
+                    Ok(Some(chunk_result)) => chunk_result,
+                    Ok(None) => break,
+                    Err(timeout) => {
+                        let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
+                        record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+                        return;
+                    }
+                };
                 match chunk_result {
                     Ok(chunk) => {
                         chunk_processor.push_chunk(&chunk);
@@ -803,6 +915,14 @@ pub(super) fn handle_streaming_with_tool_interception(
 
                             if data.is_empty() {
                                 continue;
+                            }
+
+                            if data.as_ref() == "[DONE]" {
+                                let done_block = format!("{raw_block}\n\n");
+                                if tx.send(Ok(Bytes::from(done_block))).is_err() {
+                                    return;
+                                }
+                                break 'model_stream;
                             }
 
                             // Process through handler
@@ -933,6 +1053,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                         }
                     }
                     Err(e) => {
+                        record_regular_worker_outcome(worker.as_ref(), StatusCode::BAD_GATEWAY);
                         let _ = send_sse_event(
                             &tx,
                             &mut sse_encoder,
@@ -951,6 +1072,7 @@ pub(super) fn handle_streaming_with_tool_interception(
 
             // If no tool calls, we're done - stream is complete
             if !tool_calls_detected {
+                record_regular_worker_outcome(worker.as_ref(), status);
                 if !send_final_response_event(
                     &handler,
                     &tx,
@@ -1005,6 +1127,8 @@ pub(super) fn handle_streaming_with_tool_interception(
                 return;
             }
 
+            record_regular_worker_outcome(worker.as_ref(), status);
+
             // Execute tools
             let pending_calls = handler.take_pending_calls();
 
@@ -1039,7 +1163,7 @@ pub(super) fn handle_streaming_with_tool_interception(
             // hosted-tool overrides (e.g. image_generation size/quality) are
             // merged into dispatch args before MCP execution. The request-level
             // `user` is also forwarded into hosted-tool dispatch args.
-            if !execute_streaming_tool_calls(
+            let tool_execution_result = Box::pin(execute_streaming_tool_calls(
                 pending_calls,
                 &session,
                 &format_registry,
@@ -1049,9 +1173,19 @@ pub(super) fn handle_streaming_with_tool_interception(
                 &original_request.model,
                 original_request.tools.as_deref().unwrap_or(&[]),
                 original_request.user.as_deref(),
-            )
-            .await
-            {
+                stream_deadline,
+            ))
+            .await;
+
+            let should_continue = match tool_execution_result {
+                Ok(should_continue) => should_continue,
+                Err(timeout) => {
+                    let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
+                    return;
+                }
+            };
+
+            if !should_continue {
                 return;
             }
 
@@ -1132,7 +1266,7 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
         _ => None,
     };
 
-    let client = ctx.components.client().clone();
+    let client = ctx.components.streaming_client().clone();
     let req = match ctx.into_streaming_context() {
         Ok(r) => r,
         Err(msg) => {
@@ -1146,7 +1280,7 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
 
     handle_streaming_with_tool_interception(
         &client,
-        worker.api_key().cloned(),
+        worker.clone(),
         headers.as_ref(),
         req,
         &mcp_orchestrator,

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -7,7 +7,7 @@
 //! - MCP tool execution loops within streaming responses
 //! - Event transformation and output index remapping
 
-use std::{borrow::Cow, io, sync::Arc};
+use std::{borrow::Cow, io, sync::Arc, time::Instant};
 
 use axum::{
     body::Body,
@@ -78,6 +78,28 @@ fn record_regular_worker_outcome(worker: &dyn Worker, status: StatusCode) {
         Metrics::record_worker_error(
             metrics_labels::WORKER_REGULAR,
             metrics_labels::CONNECTION_HTTP,
+            error_type_from_status(status),
+        );
+    }
+}
+
+fn record_responses_router_stream_outcome(model_id: &str, start_time: Instant, status: StatusCode) {
+    if status.is_success() {
+        Metrics::record_router_duration(
+            metrics_labels::ROUTER_OPENAI,
+            metrics_labels::BACKEND_EXTERNAL,
+            metrics_labels::CONNECTION_HTTP,
+            model_id,
+            metrics_labels::ENDPOINT_RESPONSES,
+            start_time.elapsed(),
+        );
+    } else {
+        Metrics::record_router_error(
+            metrics_labels::ROUTER_OPENAI,
+            metrics_labels::BACKEND_EXTERNAL,
+            metrics_labels::CONNECTION_HTTP,
+            model_id,
+            metrics_labels::ENDPOINT_RESPONSES,
             error_type_from_status(status),
         );
     }
@@ -552,9 +574,11 @@ pub(super) async fn handle_simple_streaming_passthrough(
     worker: &Arc<dyn Worker>,
     headers: Option<&HeaderMap>,
     req: StreamingRequest,
+    router_start: Instant,
 ) -> Response {
     let stream_timeout = req.stream_timeout;
     let stream_idle_timeout = req.stream_idle_timeout;
+    let stream_model_id = req.original_body.model.clone();
     let mut request_builder = client.post(&req.url).json(&req.payload);
     let provider = ApiProvider::from_url(&req.url);
     let auth_header = provider.extract_auth_header(headers, worker.api_key());
@@ -567,6 +591,11 @@ pub(super) async fn handle_simple_streaming_passthrough(
         Ok(Ok(resp)) => resp,
         Ok(Err(err)) => {
             record_regular_worker_outcome(worker.as_ref(), StatusCode::BAD_GATEWAY);
+            record_responses_router_stream_outcome(
+                &stream_model_id,
+                router_start,
+                StatusCode::BAD_GATEWAY,
+            );
             return (
                 StatusCode::BAD_GATEWAY,
                 format!("Failed to forward request to OpenAI: {err}"),
@@ -575,6 +604,11 @@ pub(super) async fn handle_simple_streaming_passthrough(
         }
         Err(_) => {
             record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+            record_responses_router_stream_outcome(
+                &stream_model_id,
+                router_start,
+                StatusCode::GATEWAY_TIMEOUT,
+            );
             return (
                 StatusCode::GATEWAY_TIMEOUT,
                 stream_deadline.message(StreamTimeoutKind::Total),
@@ -595,10 +629,16 @@ pub(super) async fn handle_simple_streaming_passthrough(
         {
             Ok(body) => {
                 record_regular_worker_outcome(worker.as_ref(), status_code);
+                record_responses_router_stream_outcome(&stream_model_id, router_start, status_code);
                 body
             }
             Err(StreamBodyReadError::Timeout(timeout)) => {
                 record_regular_worker_outcome(worker.as_ref(), StatusCode::GATEWAY_TIMEOUT);
+                record_responses_router_stream_outcome(
+                    &stream_model_id,
+                    router_start,
+                    StatusCode::GATEWAY_TIMEOUT,
+                );
                 return (
                     StatusCode::GATEWAY_TIMEOUT,
                     stream_deadline.message(timeout),
@@ -607,6 +647,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
             }
             Err(err) => {
                 record_regular_worker_outcome(worker.as_ref(), status_code);
+                record_responses_router_stream_outcome(&stream_model_id, router_start, status_code);
                 stream_deadline.body_read_error_message(&err)
             }
         };
@@ -625,6 +666,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
     let previous_response_id = req.previous_response_id;
     let storage = req.storage;
     let worker_for_stream = worker.clone();
+    let stream_model_id_for_relay = stream_model_id.clone();
 
     #[expect(
         clippy::disallowed_methods,
@@ -696,6 +738,11 @@ pub(super) async fn handle_simple_streaming_passthrough(
 
         let effective_status = stream_failure_status.unwrap_or(status_code);
         record_regular_worker_outcome(worker_for_stream.as_ref(), effective_status);
+        record_responses_router_stream_outcome(
+            &stream_model_id_for_relay,
+            router_start,
+            effective_status,
+        );
 
         if should_store && stream_failure_status.is_none() {
             if chunk_processor.has_remaining() {
@@ -1225,7 +1272,7 @@ pub(super) fn handle_streaming_with_tool_interception(
 }
 
 /// Main entry point for streaming responses
-pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
+pub async fn handle_streaming_response(ctx: RequestContext, router_start: Instant) -> Response {
     use crate::routers::common::mcp_utils::{ensure_request_mcp_client, request_uses_mcp_routing};
 
     let worker = match ctx.worker() {
@@ -1275,7 +1322,14 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
     };
 
     let Some((mcp_servers, mcp_orchestrator, mcp_format_registry)) = mcp_routing else {
-        return handle_simple_streaming_passthrough(&client, &worker, headers.as_ref(), req).await;
+        return handle_simple_streaming_passthrough(
+            &client,
+            &worker,
+            headers.as_ref(),
+            req,
+            router_start,
+        )
+        .await;
     };
 
     handle_streaming_with_tool_interception(

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -61,7 +61,7 @@ use crate::{
         error,
         grpc::utils::error_type_from_status,
         openai::{
-            context::{RequestContext, StreamingEventContext, StreamingRequest},
+            context::{RequestContext, StorageHandles, StreamingEventContext, StreamingRequest},
             mcp::{
                 build_resume_payload, execute_streaming_tool_calls, inject_mcp_metadata_streaming,
                 mcp_list_tools_bindings_to_emit, prepare_mcp_tools_as_functions,
@@ -568,6 +568,46 @@ pub(super) fn send_final_response_event(
     }
 }
 
+async fn persist_mcp_streaming_response(
+    mut response_json: Value,
+    preserved_response_id: Option<&str>,
+    state: &ToolLoopState,
+    session: &McpToolSession<'_>,
+    original_request: &ResponsesRequest,
+    previous_response_id: Option<&str>,
+    storage: &StorageHandles,
+) {
+    if let Some(id) = preserved_response_id {
+        if let Some(obj) = response_json.as_object_mut() {
+            obj.insert("id".to_string(), Value::String(id.to_string()));
+        }
+    }
+    inject_mcp_metadata_streaming(&mut response_json, state, session);
+
+    restore_original_tools(&mut response_json, original_request, Some(session));
+    patch_response_with_request_metadata(
+        &mut response_json,
+        original_request,
+        previous_response_id,
+    );
+
+    if let Err(err) = persist_conversation_items(
+        storage.conversation.clone(),
+        storage.conversation_item.clone(),
+        storage.response.clone(),
+        &response_json,
+        original_request,
+        storage.request_context.clone(),
+    )
+    .await
+    {
+        warn!(
+            "Failed to persist conversation items (stream + MCP): {}",
+            err
+        );
+    }
+}
+
 /// Simple pass-through streaming without MCP interception
 pub(super) async fn handle_simple_streaming_passthrough(
     client: &reqwest::Client,
@@ -984,11 +1024,32 @@ pub(super) fn handle_streaming_with_tool_interception(
 
                             if data.as_ref() == "[DONE]" {
                                 let done_block = format!("{raw_block}\n\n");
-                                if tx.send(Ok(Bytes::from(done_block))).is_err() {
-                                    return;
+                                let done_sent = tx.send(Ok(Bytes::from(done_block))).is_ok();
+                                let current_response_id = handler
+                                    .original_response_id()
+                                    .map(str::to_string)
+                                    .or_else(|| preserved_response_id.clone());
+                                if should_store {
+                                    if let Some(response_json) =
+                                        handler.accumulator.into_final_response()
+                                    {
+                                        persist_mcp_streaming_response(
+                                            response_json,
+                                            current_response_id.as_deref(),
+                                            &state,
+                                            &session,
+                                            &original_request,
+                                            previous_response_id.as_deref(),
+                                            &storage,
+                                        )
+                                        .await;
+                                    }
                                 }
                                 record_regular_worker_outcome(worker.as_ref(), status);
                                 record_router_outcome!(status);
+                                if !done_sent {
+                                    return;
+                                }
                                 return;
                             }
 
@@ -1159,37 +1220,17 @@ pub(super) fn handle_streaming_with_tool_interception(
                     None
                 };
 
-                if let Some(mut response_json) = final_response_json {
-                    if let Some(ref id) = preserved_response_id {
-                        if let Some(obj) = response_json.as_object_mut() {
-                            obj.insert("id".to_string(), Value::String(id.clone()));
-                        }
-                    }
-                    inject_mcp_metadata_streaming(&mut response_json, &state, &session);
-
-                    restore_original_tools(&mut response_json, &original_request, Some(&session));
-                    patch_response_with_request_metadata(
-                        &mut response_json,
+                if let Some(response_json) = final_response_json {
+                    persist_mcp_streaming_response(
+                        response_json,
+                        preserved_response_id.as_deref(),
+                        &state,
+                        &session,
                         &original_request,
                         previous_response_id.as_deref(),
-                    );
-
-                    // Always persist conversation items and response (even without conversation)
-                    if let Err(err) = persist_conversation_items(
-                        storage.conversation.clone(),
-                        storage.conversation_item.clone(),
-                        storage.response.clone(),
-                        &response_json,
-                        &original_request,
-                        storage.request_context.clone(),
+                        &storage,
                     )
-                    .await
-                    {
-                        warn!(
-                            "Failed to persist conversation items (stream + MCP): {}",
-                            err
-                        );
-                    }
+                    .await;
                 }
 
                 let _ = tx.send(Ok(Bytes::from_static(SSE_DONE.as_bytes())));

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -47,6 +47,15 @@ use crate::routers::common::{
 };
 const SSE_DONE: &str = "data: [DONE]\n\n";
 
+fn stream_event_matches(event_name: Option<&str>, raw_data: &str, expected: &str) -> bool {
+    event_name == Some(expected)
+        || serde_json::from_str::<Value>(raw_data)
+            .ok()
+            .and_then(|value| value.get("type").and_then(Value::as_str).map(str::to_owned))
+            .as_deref()
+            == Some(expected)
+}
+
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
@@ -717,11 +726,17 @@ pub(super) async fn handle_simple_streaming_passthrough(
         let mut stream_failure_status = None;
         let mut receiver_connected = true;
         let mut chunk_processor = ChunkProcessor::new();
+        let mut terminal_seen = false;
 
         'stream_loop: loop {
             let chunk_result = match stream_deadline.next(&mut upstream_stream).await {
                 Ok(Some(chunk_result)) => chunk_result,
-                Ok(None) => break,
+                Ok(None) => {
+                    if !terminal_seen {
+                        stream_failure_status = Some(StatusCode::BAD_GATEWAY);
+                    }
+                    break;
+                }
                 Err(timeout) => {
                     let _ = tx.send(Ok(stream_deadline.sse_error_event(timeout)));
                     stream_failure_status = Some(StatusCode::GATEWAY_TIMEOUT);
@@ -733,8 +748,18 @@ pub(super) async fn handle_simple_streaming_passthrough(
                     chunk_processor.push_chunk(&chunk);
 
                     while let Some(raw_block) = chunk_processor.next_block() {
-                        let (_, raw_data) = parse_sse_block(&raw_block);
+                        let (event_name, raw_data) = parse_sse_block(&raw_block);
                         let is_done = raw_data.as_ref() == "[DONE]";
+                        let is_completed = stream_event_matches(
+                            event_name,
+                            raw_data.as_ref(),
+                            ResponseEvent::COMPLETED,
+                        );
+                        if stream_event_matches(event_name, raw_data.as_ref(), "response.error") {
+                            stream_failure_status = Some(StatusCode::BAD_GATEWAY);
+                        }
+                        let is_terminal = is_done || is_completed;
+                        terminal_seen |= is_terminal;
                         let block_cow = match rewrite_streaming_block(
                             &raw_block,
                             &original_request,
@@ -758,7 +783,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
                         if !receiver_connected && !should_store {
                             break;
                         }
-                        if is_done {
+                        if is_terminal {
                             break 'stream_loop;
                         }
                     }
@@ -1409,4 +1434,28 @@ pub async fn handle_streaming_response(ctx: RequestContext, router_start: Instan
         mcp_format_registry,
         mcp_servers,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stream_event_matches;
+
+    #[test]
+    fn stream_event_matches_event_field_or_payload_type() {
+        assert!(stream_event_matches(
+            Some("response.completed"),
+            "{}",
+            "response.completed"
+        ));
+        assert!(stream_event_matches(
+            None,
+            r#"{"type":"response.error"}"#,
+            "response.error"
+        ));
+        assert!(!stream_event_matches(
+            Some("response.output_text.delta"),
+            r#"{"type":"response.output_text.delta"}"#,
+            "response.completed"
+        ));
+    }
 }

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -56,6 +56,10 @@ fn stream_event_matches(event_name: Option<&str>, raw_data: &str, expected: &str
             == Some(expected)
 }
 
+fn mcp_iteration_can_advance(tool_calls_detected: bool, terminal_seen: bool) -> bool {
+    tool_calls_detected || terminal_seen
+}
+
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
@@ -1023,6 +1027,7 @@ pub(super) fn handle_streaming_with_tool_interception(
             let mut chunk_processor = ChunkProcessor::new();
             let mut tool_calls_detected = false;
             let mut seen_in_progress = false;
+            let mut terminal_seen = false;
 
             loop {
                 let chunk_result = match stream_deadline.next(&mut upstream_stream).await {
@@ -1076,6 +1081,22 @@ pub(super) fn handle_streaming_with_tool_interception(
                                     return;
                                 }
                                 return;
+                            }
+
+                            let is_completed = stream_event_matches(
+                                event_name,
+                                data.as_ref(),
+                                ResponseEvent::COMPLETED,
+                            );
+                            let is_response_error =
+                                stream_event_matches(event_name, data.as_ref(), "response.error");
+                            terminal_seen |= is_completed;
+                            if is_response_error {
+                                record_regular_worker_outcome(
+                                    worker.as_ref(),
+                                    StatusCode::BAD_GATEWAY,
+                                );
+                                record_router_outcome!(StatusCode::BAD_GATEWAY);
                             }
 
                             // Process through handler
@@ -1199,9 +1220,13 @@ pub(super) fn handle_streaming_with_tool_interception(
                                     break; // Exit stream processing to execute tools
                                 }
                             }
+
+                            if is_response_error {
+                                return;
+                            }
                         }
 
-                        if tool_calls_detected {
+                        if tool_calls_detected || terminal_seen {
                             break;
                         }
                     }
@@ -1217,6 +1242,22 @@ pub(super) fn handle_streaming_with_tool_interception(
                         return;
                     }
                 }
+            }
+
+            if !mcp_iteration_can_advance(tool_calls_detected, terminal_seen) {
+                record_regular_worker_outcome(worker.as_ref(), StatusCode::BAD_GATEWAY);
+                record_router_outcome!(StatusCode::BAD_GATEWAY);
+                let _ = send_sse_event(
+                    &tx,
+                    &mut sse_encoder,
+                    "error",
+                    &json!({
+                        "error": {
+                            "message": "Upstream stream ended before response.completed or [DONE]"
+                        }
+                    }),
+                );
+                return;
             }
 
             next_output_index = handler.next_output_index();
@@ -1438,7 +1479,7 @@ pub async fn handle_streaming_response(ctx: RequestContext, router_start: Instan
 
 #[cfg(test)]
 mod tests {
-    use super::stream_event_matches;
+    use super::{mcp_iteration_can_advance, stream_event_matches};
 
     #[test]
     fn stream_event_matches_event_field_or_payload_type() {
@@ -1457,5 +1498,12 @@ mod tests {
             r#"{"type":"response.output_text.delta"}"#,
             "response.completed"
         ));
+    }
+
+    #[test]
+    fn mcp_iteration_requires_tool_dispatch_or_terminal_event() {
+        assert!(mcp_iteration_can_advance(true, false));
+        assert!(mcp_iteration_can_advance(false, true));
+        assert!(!mcp_iteration_can_advance(false, false));
     }
 }

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -100,6 +100,7 @@ impl OpenAIRouter {
 
         let shared_components = Arc::new(SharedComponents {
             client: ctx.client.clone(),
+            streaming_client: ctx.streaming_client.clone(),
             router_config: Arc::new(ctx.router_config.clone()),
         });
 

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1319,6 +1319,7 @@ mod tests {
         // Jobs submitted during tests will queue but not be processed
         Arc::new(AppContext {
             client: reqwest::Client::new(),
+            streaming_client: reqwest::Client::new(),
             router_config: router_config.clone(),
             rate_limiter: Some(Arc::new(TokenBucket::new(1000, 1000))),
             worker_registry: worker_registry.clone(),

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -739,10 +739,7 @@ async fn run_event_loop(
                 }
             }
             Ok(WorkerEvent::StatusChanged {
-                worker,
-                new_status,
-                old_status: _,
-                ..
+                worker, new_status, ..
             }) => {
                 if new_status != WorkerStatus::Ready {
                     monitor.evict_worker_loads(&worker);

--- a/model_gateway/src/workflow/steps/local/drain_workers.rs
+++ b/model_gateway/src/workflow/steps/local/drain_workers.rs
@@ -147,6 +147,7 @@ mod tests {
 
         Arc::new(AppContext {
             client: reqwest::Client::new(),
+            streaming_client: reqwest::Client::new(),
             router_config: router_config.clone(),
             rate_limiter: Some(Arc::new(TokenBucket::new(1000, 1000))),
             worker_registry: Arc::clone(&registry),


### PR DESCRIPTION
## Problem

Streaming routes currently use a reqwest client configured with `request_timeout_secs`. Reqwest applies that timeout while reading the response body, so a long generation that hits the cap gets cut off as an incomplete chunked read instead of a controlled SMG timeout.

## Fix

Use a separate worker HTTP client for streaming requests without reqwest's total body timeout, and enforce streaming deadlines in SMG instead:

- `request_timeout_secs` remains the total wall-clock cap, from upstream send through body relay.
- `stream_idle_timeout_secs` caps gaps between streamed chunks, defaulting to 300s.
- Streaming error bodies and SSE error streams use the same deadlines.

Non-streaming requests still use the existing timeout-bearing client. The idle timeout is exposed as `--stream-idle-timeout-secs` for CLI users.

## Test Plan

- Added coverage for total vs idle streaming timeout classification.
- Added slow chunked-response regressions for the streaming client and builder override behavior.
- Ran focused SMG Rust checks locally; CI covers the full PR suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--stream-idle-timeout-secs` (default `300`) to configure the maximum idle gap between streamed chunks, including wiring into server and router behavior.

* **Bug Fixes**
  * Improved streaming reliability with deadline-aware forwarding, timeout handling, and clearer SSE timeout error events.
  * Limited and deadline-bound streaming error-body reads to prevent unbounded buffering.

* **Documentation**
  * Documented the new “Stream Idle Timeout” configuration option in reliability and configuration references.

* **Tests**
  * Extended coverage for total-vs-idle timeout behavior, SSE event boundary detection, and preservation of the dedicated streaming client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->