### PR TITLE
fix(grpc): router-authoritative string stop sequences for SGLang skip_tokenizer_init workers

### DIFF
--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use llm_tokenizer::traits::Tokenizer;
 use rand::RngExt;
 use smg_grpc_client::{
     mlx_proto,
@@ -291,6 +292,102 @@ fn apply_tokenspeed_sampling_defaults(
     apply_opt!(repetition_penalty);
 }
 
+/// Resolve string `stop` sequences for SGLang gRPC workers.
+///
+/// SMG's SGLang workers run with `skip_tokenizer_init=True` (the router owns
+/// the tokenizer). Upstream SGLang's `SamplingParams.verify()` rejects string
+/// `stop` sequences in that mode — it needs a tokenizer to decode generated
+/// tokens back to text for matching — and returns
+/// `stop=[...] is unavailable when skip_tokenizer_init=True`, which surfaces to
+/// the caller as a 400. That breaks OpenAI API compatibility for any request
+/// carrying the (documented, first-class) `stop` parameter (see issue #227).
+///
+/// The router already matches string stops itself via `StopSequenceDecoder`
+/// (it detokenizes worker output and trims the stop text), so the worker never
+/// needs the raw strings. This helper therefore:
+///   1. Clears the string `stop` list on the SGLang request so the worker stops
+///      rejecting it — this alone fixes the 400 and preserves correct output
+///      because the router-side decoder still trims the text; and
+///   2. As an optimization, encodes any stop string that maps to a *single*
+///      token into `stop_token_ids` so the worker can still halt generation
+///      early for the common case (e.g. `["."]`, `["\n"]`). The proto
+///      `stop_token_ids` field is a flat list of single token IDs, so a
+///      multi-token stop string cannot be represented there — pushing its
+///      sub-tokens would stop generation far too eagerly (on any one of them).
+///      Multi-token (and empty) stops are left entirely to the router-side
+///      decoder: the worker generates until EOS/max_tokens and the router
+///      truncates the text at the stop.
+///
+/// Only SGLang is affected: the vLLM servicer forces `detokenize=bool(stop)`,
+/// TRT-LLM tokenizes stop words server-side, and the MLX proto has no
+/// string-`stop` field. Non-SGLang requests are left untouched.
+pub(crate) fn resolve_sglang_string_stops(
+    request: &mut ProtoGenerateRequest,
+    tokenizer: Option<&Arc<dyn Tokenizer>>,
+) {
+    let ProtoGenerateRequest::Sglang(req) = request else {
+        return;
+    };
+    let Some(params) = req.sampling_params.as_mut() else {
+        return;
+    };
+    if params.stop.is_empty() {
+        return;
+    }
+
+    // Always drop the string stops from the SGLang request: the worker cannot
+    // handle them under skip_tokenizer_init and the router-side decoder is the
+    // source of truth for string-stop matching/trimming.
+    let stop_strings = std::mem::take(&mut params.stop);
+
+    // Without a tokenizer we cannot encode (not expected on the gRPC path,
+    // which always resolves one to tokenize the prompt). Still safe: the
+    // strings are dropped above so the worker no longer 400s.
+    let Some(tokenizer) = tokenizer else {
+        warn!(
+            "No tokenizer available to encode SGLang stop sequences; \
+             relying on router-side stop decoder only"
+        );
+        return;
+    };
+
+    for stop in stop_strings {
+        if stop.is_empty() {
+            continue;
+        }
+        // add_special_tokens=false: we want the literal token(s) for the stop
+        // string, not a BOS/EOS-wrapped encoding.
+        match tokenizer.encode(&stop, false) {
+            Ok(encoding) => {
+                let ids = encoding.token_ids();
+                if ids.len() == 1 {
+                    let id = ids[0];
+                    if !params.stop_token_ids.contains(&id) {
+                        params.stop_token_ids.push(id);
+                    }
+                } else {
+                    // 0 tokens (unknown/whitespace-only) or multi-token: the
+                    // router-side StopSequenceDecoder handles these.
+                    debug!(
+                        stop = %stop,
+                        token_count = ids.len(),
+                        "SGLang stop sequence not single-token; \
+                         handled by router-side stop decoder"
+                    );
+                }
+            }
+            Err(e) => {
+                warn!(
+                    stop = %stop,
+                    error = %e,
+                    "Failed to encode SGLang stop sequence; \
+                     relying on router-side stop decoder"
+                );
+            }
+        }
+    }
+}
+
 /// Inject PD bootstrap metadata for SGLang if needed.
 ///
 /// SGLang uses DisaggregatedParams with bootstrap host/port/room.
@@ -432,5 +529,152 @@ mod request_id_tests {
 
         let id = resolve_request_id(&request_type, Some(&meta), "chatcmpl-", false);
         assert!(id.starts_with("chatcmpl-"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use llm_tokenizer::{mock::MockTokenizer, traits::Tokenizer};
+    use smg_grpc_client::{sglang_proto, vllm_proto};
+
+    use super::{resolve_sglang_string_stops, ProtoGenerateRequest};
+
+    fn mock_tokenizer() -> Arc<dyn Tokenizer> {
+        // MockTokenizer vocab: "." => 6, "Hello" => 1, "world" => 2, ...
+        // Its `encode` splits on whitespace and looks up each known word, so
+        // "." => [6] (single-token) and "Hello world" => [1, 2] (multi-token).
+        Arc::new(MockTokenizer::new())
+    }
+
+    fn sglang_request_with_stops(
+        stop: Vec<&str>,
+        stop_token_ids: Vec<u32>,
+    ) -> ProtoGenerateRequest {
+        ProtoGenerateRequest::Sglang(Box::new(sglang_proto::GenerateRequest {
+            sampling_params: Some(sglang_proto::SamplingParams {
+                stop: stop.into_iter().map(str::to_string).collect(),
+                stop_token_ids,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+    }
+
+    fn sglang_params(req: &ProtoGenerateRequest) -> &sglang_proto::SamplingParams {
+        match req {
+            ProtoGenerateRequest::Sglang(r) => r.sampling_params.as_ref().unwrap(),
+            _ => panic!("expected SGLang request"),
+        }
+    }
+
+    #[test]
+    fn resolve_sglang_stops_single_token_becomes_stop_token_id() {
+        let mut req = sglang_request_with_stops(vec!["."], vec![]);
+        resolve_sglang_string_stops(&mut req, Some(&mock_tokenizer()));
+
+        let params = sglang_params(&req);
+        // String stop dropped so the worker (skip_tokenizer_init) won't 400.
+        assert!(params.stop.is_empty(), "string stop should be cleared");
+        // "." (token 6) forwarded as a stop token id for early worker stopping.
+        assert_eq!(params.stop_token_ids, vec![6]);
+    }
+
+    #[test]
+    fn resolve_sglang_stops_multi_token_relies_on_router_decoder() {
+        // "Hello world" => [1, 2]: multi-token can't be a flat stop_token_id,
+        // so it must NOT be forwarded (would over-eagerly stop on any subtoken).
+        let mut req = sglang_request_with_stops(vec!["Hello world"], vec![]);
+        resolve_sglang_string_stops(&mut req, Some(&mock_tokenizer()));
+
+        let params = sglang_params(&req);
+        assert!(params.stop.is_empty(), "string stop should be cleared");
+        assert!(
+            params.stop_token_ids.is_empty(),
+            "multi-token stop must not be forwarded as stop_token_ids"
+        );
+    }
+
+    #[test]
+    fn resolve_sglang_stops_mixed_only_single_token_forwarded() {
+        let mut req = sglang_request_with_stops(vec![".", "Hello world"], vec![]);
+        resolve_sglang_string_stops(&mut req, Some(&mock_tokenizer()));
+
+        let params = sglang_params(&req);
+        assert!(params.stop.is_empty());
+        assert_eq!(params.stop_token_ids, vec![6]);
+    }
+
+    #[test]
+    fn resolve_sglang_stops_preserves_existing_stop_token_ids_and_dedups() {
+        // Pre-existing stop_token_ids must be preserved; "." (6) already present
+        // must not be duplicated.
+        let mut req = sglang_request_with_stops(vec!["."], vec![6, 42]);
+        resolve_sglang_string_stops(&mut req, Some(&mock_tokenizer()));
+
+        let params = sglang_params(&req);
+        assert!(params.stop.is_empty());
+        assert_eq!(
+            params.stop_token_ids,
+            vec![6, 42],
+            "no duplicate for existing id"
+        );
+    }
+
+    #[test]
+    fn resolve_sglang_stops_empty_and_unknown_strings_add_nothing() {
+        // "" is skipped; "unknowntoken" encodes to [] under the mock vocab.
+        let mut req = sglang_request_with_stops(vec!["", "unknowntoken"], vec![]);
+        resolve_sglang_string_stops(&mut req, Some(&mock_tokenizer()));
+
+        let params = sglang_params(&req);
+        assert!(params.stop.is_empty(), "string stops still cleared");
+        assert!(params.stop_token_ids.is_empty());
+    }
+
+    #[test]
+    fn resolve_sglang_stops_without_tokenizer_still_clears_strings() {
+        // No tokenizer: cannot encode, but the string stops must still be
+        // dropped so the worker does not 400.
+        let mut req = sglang_request_with_stops(vec!["."], vec![]);
+        resolve_sglang_string_stops(&mut req, None);
+
+        let params = sglang_params(&req);
+        assert!(params.stop.is_empty());
+        assert!(params.stop_token_ids.is_empty());
+    }
+
+    #[test]
+    fn resolve_sglang_stops_noop_when_no_string_stops() {
+        let mut req = sglang_request_with_stops(vec![], vec![7]);
+        resolve_sglang_string_stops(&mut req, Some(&mock_tokenizer()));
+
+        let params = sglang_params(&req);
+        assert!(params.stop.is_empty());
+        assert_eq!(params.stop_token_ids, vec![7], "unrelated ids untouched");
+    }
+
+    #[test]
+    fn resolve_sglang_stops_leaves_non_sglang_untouched() {
+        // vLLM handles string stops fine (detokenize=bool(stop)) — must not be
+        // mutated by the SGLang-specific fix.
+        let mut req = ProtoGenerateRequest::Vllm(Box::new(vllm_proto::GenerateRequest {
+            sampling_params: Some(vllm_proto::SamplingParams {
+                stop: vec![".".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+        resolve_sglang_string_stops(&mut req, Some(&mock_tokenizer()));
+
+        match &req {
+            ProtoGenerateRequest::Vllm(r) => {
+                let params = r.sampling_params.as_ref().unwrap();
+                assert_eq!(params.stop, vec![".".to_string()], "vLLM stop preserved");
+                assert!(params.stop_token_ids.is_empty());
+            }
+            _ => panic!("expected vLLM request"),
+        }
     }
 }

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -147,6 +147,12 @@ impl PipelineStage for ChatRequestBuildingStage {
             ctx.state.workers.as_ref(),
         );
 
+        // issue #227: SGLang gRPC workers run with skip_tokenizer_init and
+        // reject string `stop` sequences. Resolve them router-side (drop the
+        // strings, convert single-token stops to stop_token_ids) before
+        // dispatch; the router-side StopSequenceDecoder handles text trimming.
+        helpers::resolve_sglang_string_stops(&mut proto_request, ctx.tokenizer_arc().as_ref());
+
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {
                 helpers::maybe_inject_pd_metadata(&mut proto_request, workers);

--- a/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
@@ -141,6 +141,7 @@ impl PipelineStage for CompletionRequestBuildingStage {
         let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
         let request_type = &ctx.input.request_type;
         let workers = ctx.state.workers.as_ref();
+        let tokenizer = ctx.tokenizer_arc();
 
         let plan = match items.as_slice() {
             [] => {
@@ -149,9 +150,8 @@ impl PipelineStage for CompletionRequestBuildingStage {
                     "No prompts prepared",
                 ))
             }
-            [item] => ExecutionPlan::generate(
-                self.plan_kind,
-                self.build_proto_request(
+            [item] => {
+                let mut proto_request = self.build_proto_request(
                     builder_client,
                     helpers::resolve_request_id(
                         request_type,
@@ -163,8 +163,15 @@ impl PipelineStage for CompletionRequestBuildingStage {
                     &completion_request,
                     request_type,
                     workers,
-                )?,
-            ),
+                )?;
+                // issue #227: SGLang gRPC workers run with skip_tokenizer_init
+                // and reject string `stop` sequences. Resolve them router-side
+                // (drop the strings, convert single-token stops to
+                // stop_token_ids) before dispatch; the router-side
+                // StopSequenceDecoder handles text trimming.
+                helpers::resolve_sglang_string_stops(&mut proto_request, tokenizer.as_ref());
+                ExecutionPlan::generate(self.plan_kind, proto_request)
+            }
             batch_items => {
                 // The shared id (client rid or middleware request id) stays
                 // clean for the response; per-sub engine ids get a uniqueness
@@ -186,14 +193,19 @@ impl PipelineStage for CompletionRequestBuildingStage {
                     } else {
                         format!("{shared_request_id}-p{i}")
                     };
-                    requests.push(self.build_proto_request(
+                    let mut proto_request = self.build_proto_request(
                         builder_client,
                         sub_request_id,
                         item,
                         &completion_request,
                         request_type,
                         workers,
-                    )?);
+                    )?;
+                    // issue #227: SGLang gRPC workers reject string `stop`
+                    // sequences under skip_tokenizer_init; resolve them
+                    // router-side before dispatch (see single-item branch).
+                    helpers::resolve_sglang_string_stops(&mut proto_request, tokenizer.as_ref());
+                    requests.push(proto_request);
                 }
                 ExecutionPlan::Batch {
                     kind: self.plan_kind,

--- a/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
@@ -86,6 +86,12 @@ impl PipelineStage for GenerateRequestBuildingStage {
             ctx.state.workers.as_ref(),
         );
 
+        // issue #227: SGLang gRPC workers run with skip_tokenizer_init and
+        // reject string `stop` sequences. Resolve them router-side (drop the
+        // strings, convert single-token stops to stop_token_ids) before
+        // dispatch; the router-side StopSequenceDecoder handles text trimming.
+        helpers::resolve_sglang_string_stops(&mut proto_request, ctx.tokenizer_arc().as_ref());
+
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {
                 helpers::maybe_inject_pd_metadata(&mut proto_request, workers);

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -148,6 +148,12 @@ impl PipelineStage for MessageRequestBuildingStage {
             ctx.state.workers.as_ref(),
         );
 
+        // issue #227: SGLang gRPC workers run with skip_tokenizer_init and
+        // reject string `stop` sequences. Resolve them router-side (drop the
+        // strings, convert single-token stops to stop_token_ids) before
+        // dispatch; the router-side StopSequenceDecoder handles text trimming.
+        helpers::resolve_sglang_string_stops(&mut proto_request, ctx.tokenizer_arc().as_ref());
+
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {
                 helpers::maybe_inject_pd_metadata(&mut proto_request, workers);


### PR DESCRIPTION
## Summary

SGLang gRPC workers run with `skip_tokenizer_init=True` (the router owns the tokenizer). The router forwards string `stop` sequences as-is into the gRPC `SamplingParams`, and SGLang's `SamplingParams.verify()` **rejects** them in that mode:

```
stop=['.'] is unavailable when skip_tokenizer_init=True
(requires tokenizer to decode tokens to text for matching).
```

So any request carrying the OpenAI-compatible `stop` parameter against an SGLang gRPC worker gets a **400**. This PR makes the **router authoritative for string stops** end to end: the 400 is gone, output text is trimmed correctly, `finish_reason` / `matched_stop` / Anthropic `stop_reason`+`stop_sequence` match what vLLM reports for the same request, and streaming requests **abort the worker** when the router matches a stop — so multi-token stops no longer over-generate to `max_tokens` (no inflated `usage.completion_tokens`, no wasted GPU time).

SGLang-specific: the vLLM servicer forces `detokenize=bool(stop)`, TRT-LLM tokenizes stop words server-side, MLX has no string-`stop` field.

## Design

The router already decodes worker output through a `StopSequenceDecoder` per request. This PR completes that into full ownership of string stops:

**1. Drain string stops from SGLang requests** (`resolve_sglang_string_stops` in `common/stages/helpers.rs`), called from the chat / completions / messages request-building stages — exactly the paths whose streaming *and* non-streaming handlers both run a trimming decoder. As an optimization, a stop string that encodes to a **single token** is forwarded as a `stop_token_ids` entry so the worker halts immediately (skipped when `ignore_eos=true`, where SGLang skips all `stop_token_ids` matching — see `Req._check_token_based_finish`).

**2. Record what matched** — `StopSequenceDecoder` now tracks `MatchedStop::Sequence(String) | TokenId(u32)` when it stops.

**3. Refine response metadata** (`utils::refine_stop_metadata`, applied at all six response sites: chat/completions/messages × streaming/non-streaming):
   - decoder matched a string stop → `finish_reason="stop"`, `matched_stop` = the original stop string (was: `"length"` + null);
   - worker halted on a *converted* single-token stop and reported a numeric token id → mapped back to the user's stop string;
   - EOS and user-provided `stop_token_ids` pass through unchanged.
   Also gates the streaming Messages `stop_reason` on an actual string match (a numeric matched_stop is `end_turn`, not `stop_sequence` with a null sequence), and removes the completions endpoint's stream-vs-non-stream `finish_reason` divergence.

**4. Streaming early termination** — when the router decoder matches a string stop on an SGLang stream (n=1), the loop records usage from the chunk's cumulative counters, emits the final chunks, and breaks **without** `mark_completed()`; dropping the stream sends the Abort RPC (`AbortOnDropStream`). Gated to SGLang streams and actual `Sequence` matches — vLLM/TRT-LLM paths are untouched.

### Deliberately not drained (documented `NOTE`s at the call sites)

- **Harmony (gpt-oss)**: no router-side decoder exists there, and injecting a user stop token can truncate before `<|return|>`/`<|call|>`, corrupting Harmony parsing. Keeps the pre-existing 400.
- **Native `/generate`**: its streaming path has no decoder, so a cleared stop would stream untrimmed text. Keeps the pre-existing 400.

### Known remaining limitations (in the helper docstring)

- Non-streaming multi-token stops: `finish_reason`/`matched_stop` are correct, but the worker still generates to EOS/`max_tokens` before the response is assembled. Needs early abort in `response_collection` — follow-up.
- SentencePiece leading-space tokenization can keep the single-token optimization from firing mid-sentence; correctness holds via the decoder.

## Tests

- `resolve_sglang_string_stops`: 12 unit tests (single/multi-token, mixed, dedup, empty/unknown, whitespace single-token via a wrapper tokenizer, two distinct single tokens, `ignore_eos`, missing `sampling_params`, no tokenizer, non-SGLang untouched)
- `refine_stop_metadata`: 5 unit tests
- `StopSequenceDecoder::matched_stop`: 2 unit tests
- Full `smg` lib suite green; clippy/fmt clean

## End-to-end verification (B200, real SGLang gRPC worker)

Same host, same engine image and weights, only the router build swapped:

- `stop=["."]` (non-stream) → 200, `finish_reason="stop"`, `matched_stop="."` (the string, not a token id), text trimmed at the stop
- multi-token stop (non-stream) → `finish_reason="stop"`, `matched_stop=<stop string>`, text trimmed exactly before the stop
- multi-token stop (**streaming**) → stream terminates at the match with `usage.completion_tokens=3` vs **488** for the identical request non-streamed (worker log shows `Receive abort request: ...`), confirming the Abort path works

This is the same change merged in our production deployment after review and e2e validation.
