### PR TITLE
fix(reasoning): auto-select kimi_k25 for Kimi-K2.6/K2.7

### DIFF
--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -194,6 +194,8 @@ impl ParserFactory {
         registry.register_pattern("glm-5", "glm45"); // GLM-5.x reuse glm45 reasoning format
         registry.register_pattern("kimi-k2-thinking", "kimi_thinking");
         registry.register_pattern("kimi-k2.5", "kimi_k25");
+        registry.register_pattern("kimi-k2.6", "kimi_k25"); // K2.6/K2.7 share the K2.5 <think> template
+        registry.register_pattern("kimi-k2.7", "kimi_k25");
         registry.register_pattern("kimi", "kimi"); // legacy: Kimi-K2-Instruct with unicode tokens
         registry.register_pattern("step3", "step3");
         registry.register_pattern("minimax", "minimax");
@@ -273,6 +275,31 @@ mod tests {
         let factory = ParserFactory::new();
         let parser = factory.create("kimi-chat");
         assert_eq!(parser.model_type(), "kimi");
+    }
+
+    #[test]
+    fn test_kimi_k2_family_automap() {
+        let factory = ParserFactory::new();
+        assert_eq!(
+            factory.create("moonshotai/Kimi-K2.5").model_type(),
+            "kimi_k25"
+        );
+        assert_eq!(
+            factory.create("moonshotai/Kimi-K2.6").model_type(),
+            "kimi_k25"
+        );
+        assert_eq!(
+            factory.create("moonshotai/Kimi-K2.7-Code").model_type(),
+            "kimi_k25"
+        );
+        assert_eq!(
+            factory.create("moonshotai/Kimi-K2-Thinking").model_type(),
+            "kimi_thinking"
+        );
+        assert_eq!(
+            factory.create("moonshotai/Kimi-K2-Instruct").model_type(),
+            "kimi"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

`Kimi-K2.6` and `Kimi-K2.7` have no reasoning-parser auto-select pattern. Reasoning-parser auto-selection matches the model id against registered patterns with a **first-match substring** check, so these SKUs fell through to the generic `kimi` entry — the **legacy Kimi-K2-Instruct** parser that expects unicode `◁think▷` / `◁/think▷` delimiters.

K2.6/K2.7 actually use `<think>` / `</think>` (the same chat-template family as K2.5, with `<think>` prefilled into the generation prompt when thinking is on). So for any deployment relying on `--reasoning-parser` auto-detection, K2.6/K2.7 reasoning was mis-split into `content`.

### Solution

Add explicit `kimi-k2.6` / `kimi-k2.7` → `kimi_k25` patterns, matching the existing `kimi-k2.5` mapping (all three share the same template). The `.`-versioned patterns do not match `kimi-k2-instruct`, which stays on the legacy unicode parser; `kimi-k2-thinking` continues to map to `kimi_thinking`.

Note: this only affects **name-based auto-selection**. Deployments that pass `--reasoning-parser` explicitly (e.g. the nightly A/B) are unaffected.

## Changes

- `crates/reasoning_parser/src/factory.rs`: register `kimi-k2.6` and `kimi-k2.7` → `kimi_k25`.
- Add `test_kimi_k2_family_automap` locking the full K2 family mapping.

## Test Plan

`factory.create(model).model_type()` for the auto-select path:

| model id | before | after |
|---|---|---|
| `moonshotai/Kimi-K2.5` | `kimi_k25` | `kimi_k25` |
| `moonshotai/Kimi-K2.6` | **`kimi`** (legacy ◁think▷) | **`kimi_k25`** |
| `moonshotai/Kimi-K2.7-Code` | **`kimi`** (legacy ◁think▷) | **`kimi_k25`** |
| `moonshotai/Kimi-K2-Thinking` | `kimi_thinking` | `kimi_thinking` |
| `moonshotai/Kimi-K2-Instruct` | `kimi` | `kimi` |

```
cargo test -p reasoning-parser --lib factory::tests::test_kimi_k2_family_automap
# test result: ok. 1 passed
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic recognition and routing for the Kimi K2 model family, including K2.6 and K2.7-Code.
  * Enhanced model-pattern handling so Kimi K2.5, K2.6, K2.7-Code, K2-Thinking, and legacy Kimi K2 variants resolve to the correct reasoning parser behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->