### PR TITLE
feat(router): add per-worker PD Prefill admission

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -169,6 +169,14 @@ impl Worker for GrpcWorker {
         self.load.fetch_add(1, Ordering::Relaxed);
     }
 
+    fn try_increment_load(&self, max: usize) -> bool {
+        self.load
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1).filter(|next| *next <= max)
+            })
+            .is_ok()
+    }
+
     fn decrement_load(&self) {
         self.load.fetch_sub(1, Ordering::Relaxed);
     }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -487,6 +487,9 @@ struct Router {
     multimodal_tensor_transport: Option<String>,
     multimodal_shm_min_bytes: Option<usize>,
     model_aliases: HashMap<String, String>,
+    prefill_max_inflight_requests_per_worker: i32,
+    prefill_queue_size: Option<usize>,
+    prefill_queue_timeout_secs: Option<u64>,
 }
 
 impl Router {
@@ -747,6 +750,9 @@ impl Router {
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
             .queue_timeout_secs(self.queue_timeout_secs)
+            .prefill_max_inflight_requests_per_worker(self.prefill_max_inflight_requests_per_worker)
+            .prefill_queue_size(self.prefill_queue_size)
+            .prefill_queue_timeout_secs(self.prefill_queue_timeout_secs)
             .cors_allowed_origins(self.cors_allowed_origins.clone())
             .retry_config(config::RetryConfig {
                 max_retries: self.retry_max_retries,
@@ -956,6 +962,9 @@ impl Router {
         multimodal_tensor_transport = None,
         multimodal_shm_min_bytes = None,
         model_aliases = HashMap::new(),
+        prefill_max_inflight_requests_per_worker = -1,
+        prefill_queue_size = None,
+        prefill_queue_timeout_secs = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1083,6 +1092,9 @@ impl Router {
         multimodal_tensor_transport: Option<String>,
         multimodal_shm_min_bytes: Option<usize>,
         model_aliases: HashMap<String, String>,
+        prefill_max_inflight_requests_per_worker: i32,
+        prefill_queue_size: Option<usize>,
+        prefill_queue_timeout_secs: Option<u64>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1224,6 +1236,9 @@ impl Router {
             multimodal_tensor_transport,
             multimodal_shm_min_bytes,
             model_aliases,
+            prefill_max_inflight_requests_per_worker,
+            prefill_queue_size,
+            prefill_queue_timeout_secs,
         })
     }
 

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -205,6 +205,15 @@ class Router:
             only). If not specified, uses the main policy. Default: None
         decode_policy: Specific load balancing policy for decode nodes (PD mode only).
             If not specified, uses the main policy. Default: None
+        prefill_max_inflight_requests_per_worker: Maximum in-flight Prefill requests
+            per worker in PD or EPD mode. A non-positive value disables the limit.
+            Default: -1
+        prefill_queue_size: Maximum number of requests waiting for Prefill admission.
+            Defaults to 100 when Prefill admission is enabled. Set to 0 to disable
+            waiting. Default: None
+        prefill_queue_timeout_secs: Maximum time in seconds a request may wait for
+            Prefill admission. Defaults to 60 when Prefill admission is enabled.
+            Default: None
         request_id_headers: List of HTTP headers to check for request IDs. If not
             specified, uses common defaults: ['x-request-id', 'x-correlation-id',
             'x-trace-id', 'request-id']. Example: ['x-my-request-id',

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -202,6 +202,9 @@ class RouterArgs:
     mesh_peer_urls: list[str] = dataclasses.field(default_factory=list)
     # Append new fields here to preserve positional callers.
     model_aliases: dict[str, str] = dataclasses.field(default_factory=dict)
+    prefill_max_inflight_requests_per_worker: int = -1
+    prefill_queue_size: int | None = None
+    prefill_queue_timeout_secs: int | None = None
 
     @staticmethod
     def add_cli_args(
@@ -544,6 +547,33 @@ class RouterArgs:
             action="append",
             metavar=("URL",),
             help="Decode server URL. Can be specified multiple times.",
+        )
+        pd_group.add_argument(
+            f"--{prefix}prefill-max-inflight-requests-per-worker",
+            type=int,
+            default=RouterArgs.prefill_max_inflight_requests_per_worker,
+            help=(
+                "Maximum in-flight Prefill requests per worker in PD or EPD mode."
+                " A non-positive value disables the limit (default: -1)."
+            ),
+        )
+        pd_group.add_argument(
+            f"--{prefix}prefill-queue-size",
+            type=int,
+            default=RouterArgs.prefill_queue_size,
+            help=(
+                "Maximum number of requests waiting for Prefill admission."
+                " Defaults to 100 when Prefill admission is enabled; 0 disables waiting."
+            ),
+        )
+        pd_group.add_argument(
+            f"--{prefix}prefill-queue-timeout-secs",
+            type=int,
+            default=RouterArgs.prefill_queue_timeout_secs,
+            help=(
+                "Maximum time in seconds a request may wait for Prefill admission."
+                " Defaults to 60 when Prefill admission is enabled."
+            ),
         )
         pd_group.add_argument(
             f"--{prefix}worker-startup-timeout-secs",

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -562,6 +562,29 @@ class TestParseRouterArgs:
         assert router_args.prefill_policy == "power_of_two"
         assert router_args.decode_policy == "round_robin"
 
+    def test_parse_pd_prefill_admission_args(self):
+        """Test parsing explicit Prefill admission options."""
+        args = [
+            "--pd-disaggregation",
+            "--prefill",
+            "http://prefill1:8000",
+            "none",
+            "--decode",
+            "http://decode1:8001",
+            "--prefill-max-inflight-requests-per-worker",
+            "7",
+            "--prefill-queue-size",
+            "13",
+            "--prefill-queue-timeout-secs",
+            "17",
+        ]
+
+        router_args = parse_router_args(args)
+
+        assert router_args.prefill_max_inflight_requests_per_worker == 7
+        assert router_args.prefill_queue_size == 13
+        assert router_args.prefill_queue_timeout_secs == 17
+
     def test_parse_epd_args(self):
         """Test parsing EPD disaggregated mode arguments."""
         args = [

--- a/bindings/python/tests/test_startup_sequence.py
+++ b/bindings/python/tests/test_startup_sequence.py
@@ -655,6 +655,9 @@ def test_router_defaults_and_start(monkeypatch):
         prefill_selector=None,
         decode_selector=None,
         cors_allowed_origins=None,
+        prefill_max_inflight_requests_per_worker=7,
+        prefill_queue_size=13,
+        prefill_queue_timeout_secs=17,
     )
 
     r = Router.from_args(args)
@@ -665,6 +668,9 @@ def test_router_defaults_and_start(monkeypatch):
     assert captured["decode_selector"] is None
     assert captured["cors_allowed_origins"] is None
     assert captured["worker_urls"] == ["http://w1:8000"]
+    assert captured["prefill_max_inflight_requests_per_worker"] == 7
+    assert captured["prefill_queue_size"] == 13
+    assert captured["prefill_queue_timeout_secs"] == 17
     from smg.smg_rs import PolicyType
 
     assert captured["policy"] == PolicyType.RoundRobin

--- a/docs/concepts/routing/pd-disaggregation.md
+++ b/docs/concepts/routing/pd-disaggregation.md
@@ -172,6 +172,33 @@ smg \
 | `--decode` | Decode worker URLs |
 | `--prefill-policy` | Routing policy for prefill workers |
 | `--decode-policy` | Routing policy for decode workers |
+| `--prefill-max-inflight-requests-per-worker` | Maximum in-flight Prefill requests per worker; non-positive disables it (default: `-1`) |
+| `--prefill-queue-size` | Maximum requests waiting for Prefill admission (default: `100` when enabled; `0` disables waiting) |
+| `--prefill-queue-timeout-secs` | Maximum Prefill admission wait (default: `60`) |
+
+Each SMG process applies the Prefill limit independently to each registered
+Prefill worker. One client request occupies one slot from worker selection until
+the Prefill response reaches EOF. Batch inputs and parallel samples requested
+through `n` still occupy one slot. With `--dp-aware`, every registered rank is a
+separate worker and therefore has its own limit.
+
+When every eligible Prefill worker is full, the request joins one Router-wide
+FIFO queue. Queued requests do not bind to a worker. At the head of the queue,
+SMG reads the current worker health, capacity, and cache state before running the
+Prefill policy. The head also re-checks once per second, so a worker that becomes
+usable again without reporting a state change is still picked up. A full queue
+and an expired queue wait both return `429` with different error codes. Decode
+workers keep their normal load tracking but have no admission limit. Prefill
+admission cannot be enabled together with the priority scheduler.
+
+With the `consistent_hashing` policy, `X-SMG-Target-Worker` remains strict: a
+request waits for the selected Prefill worker and is never moved to another
+worker when that target is full.
+
+SMG exports `smg_pd_prefill_admission_inflight` per worker,
+`smg_pd_prefill_admission_queued`, `smg_pd_prefill_admission_wait_seconds`, and
+`smg_pd_prefill_admission_rejections_total` by rejection reason. These metrics
+measure Router admission, not the queue inside the inference engine.
 
 ### Per-Phase Policies
 

--- a/docs/getting-started/pd-disaggregation.md
+++ b/docs/getting-started/pd-disaggregation.md
@@ -58,9 +58,19 @@ smg \
   --pd-disaggregation \
   --prefill http://prefill:8000 9001 \
   --decode http://decode:8001 \
+  --prefill-max-inflight-requests-per-worker 32 \
+  --prefill-queue-size 32 \
+  --prefill-queue-timeout-secs 30 \
   --host 0.0.0.0 \
   --port 30000
 ```
+
+Each SMG process applies the optional limit independently to each registered
+Prefill worker. One client request occupies one slot until Prefill reaches EOF.
+When every eligible worker is full, requests wait in one Router-wide FIFO queue.
+SMG selects a worker only when the request reaches the head and capacity is
+available. Queue full and queue timeout responses use HTTP `429`. Decode remains
+unlimited by this feature.
 
 ### Multiple Workers
 
@@ -124,6 +134,9 @@ smg \
   --prefill grpc://prefill:50051 \
   --decode grpc://decode:50052 \
   --model-path /path/to/model \
+  --prefill-max-inflight-requests-per-worker 32 \
+  --prefill-queue-size 32 \
+  --prefill-queue-timeout-secs 30 \
   --host 0.0.0.0 \
   --port 30000
 ```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -177,6 +177,36 @@ Prefill-Decode disaggregated mode separates prefill and decode operations across
 | `--prefill-policy` | Specific policy for prefill nodes | Uses main `--policy` |
 | `--decode-policy` | Specific policy for decode nodes | Uses main `--policy` |
 
+### PD/EPD Prefill Admission
+
+Prefill admission bounds requests assigned by one SMG process to each registered
+Prefill worker. One client request occupies one slot until Prefill reaches EOF,
+fails, or is cancelled. Batch inputs and parallel samples requested through `n`
+still occupy one slot.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--prefill-max-inflight-requests-per-worker` | Maximum in-flight Prefill requests per worker; non-positive disables the limit | `-1` |
+| `--prefill-queue-size` | Router-wide FIFO queue depth; `0` disables waiting | `100` when enabled |
+| `--prefill-queue-timeout-secs` | Maximum time waiting for Prefill capacity | `60` when enabled |
+
+Queued requests do not bind to a worker. The queue head re-evaluates worker
+health, capacity, and cache state before selecting a Prefill worker. New requests
+cannot bypass existing waiters. Queue full returns `429` with
+`pd_prefill_queue_full`; queue timeout returns `429` with
+`pd_prefill_queue_timeout`. Local admission errors are not retried by SMG.
+
+The limit and queue are local to each SMG process. With `--dp-aware`, each rank
+is a separate worker and receives its own limit. Decode workers retain load
+tracking but have no admission limit. Prefill admission cannot be combined with
+`--priority-scheduler-enabled`. Queue options without a positive Prefill limit
+are rejected at startup.
+
+Prometheus exposes `smg_pd_prefill_admission_inflight` per worker,
+`smg_pd_prefill_admission_queued`, `smg_pd_prefill_admission_wait_seconds`, and
+`smg_pd_prefill_admission_rejections_total`. These are SMG admission metrics;
+engine queue metrics remain separate.
+
 ### Worker Startup Configuration
 
 | Option | Description | Default |

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -267,6 +267,20 @@ HTTP responses from upstream workers.
 
 ---
 
+### PD Prefill Admission Metrics
+
+Router-local Prefill admission state for PD and EPD routing. These metrics do
+not include queues inside the inference engine.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `smg_pd_prefill_admission_inflight` | Gauge | `worker` | Admitted requests whose Prefill phase has not finished |
+| `smg_pd_prefill_admission_queued` | Gauge | None | Requests waiting for Prefill capacity |
+| `smg_pd_prefill_admission_wait_seconds` | Histogram | None | Time spent waiting for Prefill capacity |
+| `smg_pd_prefill_admission_rejections_total` | Counter | `reason` | Rejections grouped by `queue_full`, `queue_timeout`, or `unavailable` |
+
+---
+
 ## Layer 3: Worker Metrics
 
 Metrics for worker pool management and resilience.

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -11,6 +11,7 @@ use smg_data_connector::{
     StorageFactoryConfig,
 };
 use smg_mcp::McpOrchestrator;
+use tokio::sync::broadcast::error::RecvError;
 use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::debug;
 
@@ -26,7 +27,7 @@ use crate::{
         router_manager::RouterManager,
     },
     wasm::{config::WasmRuntimeConfig, module_manager::WasmModuleManager},
-    worker::{KvEventMonitor, WorkerMonitor, WorkerRegistry, WorkerService},
+    worker::{KvEventMonitor, PrefillAdmission, WorkerMonitor, WorkerRegistry, WorkerService},
     workflow::{JobQueue, WorkflowEngines},
 };
 
@@ -59,6 +60,7 @@ pub struct AppContext {
     pub reasoning_parser_factory: Option<ReasoningParserFactory>,
     pub tool_parser_factory: Option<ToolParserFactory>,
     pub worker_registry: Arc<WorkerRegistry>,
+    pub prefill_admission: Option<Arc<PrefillAdmission>>,
     pub policy_registry: Arc<PolicyRegistry>,
     pub router_manager: Option<Arc<RouterManager>>,
     pub response_storage: Arc<dyn ResponseStorage>,
@@ -88,6 +90,28 @@ impl std::fmt::Debug for AppContext {
             .field("router_config", &self.router_config)
             .finish_non_exhaustive()
     }
+}
+
+fn start_prefill_admission_notifier(
+    worker_registry: &WorkerRegistry,
+    admission: &Arc<PrefillAdmission>,
+) -> Result<(), AppContextBuildError> {
+    let mut events = worker_registry.subscribe_events();
+    let admission = Arc::downgrade(admission);
+    let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
+        AppContextBuildError::InvalidConfig(format!(
+            "Prefill admission requires a Tokio runtime: {error}"
+        ))
+    })?;
+    runtime.spawn(async move {
+        while let Ok(_) | Err(RecvError::Lagged(_)) = events.recv().await {
+            let Some(admission) = admission.upgrade() else {
+                break;
+            };
+            admission.notify_capacity_changed();
+        }
+    });
+    Ok(())
 }
 
 pub struct AppContextBuilder {
@@ -335,9 +359,53 @@ impl AppContextBuilder {
         let worker_registry = self
             .worker_registry
             .ok_or(AppContextBuildError::MissingField("worker_registry"))?;
+        let client = self
+            .client
+            .ok_or(AppContextBuildError::MissingField("client"))?;
+        let tokenizer_registry = self
+            .tokenizer_registry
+            .ok_or(AppContextBuildError::MissingField("tokenizer_registry"))?;
+        let policy_registry = self
+            .policy_registry
+            .ok_or(AppContextBuildError::MissingField("policy_registry"))?;
+        let response_storage = self
+            .response_storage
+            .ok_or(AppContextBuildError::MissingField("response_storage"))?;
+        let conversation_storage = self
+            .conversation_storage
+            .ok_or(AppContextBuildError::MissingField("conversation_storage"))?;
+        let conversation_item_storage =
+            self.conversation_item_storage
+                .ok_or(AppContextBuildError::MissingField(
+                    "conversation_item_storage",
+                ))?;
         let worker_job_queue = self
             .worker_job_queue
             .ok_or(AppContextBuildError::MissingField("worker_job_queue"))?;
+        let workflow_engines = self
+            .workflow_engines
+            .ok_or(AppContextBuildError::MissingField("workflow_engines"))?;
+        let mcp_orchestrator = self
+            .mcp_orchestrator
+            .ok_or(AppContextBuildError::MissingField("mcp_orchestrator"))?;
+
+        let prefill_admission =
+            usize::try_from(router_config.prefill_max_inflight_requests_per_worker)
+                .ok()
+                .filter(|max| *max > 0)
+                .map(|max| {
+                    Arc::new(PrefillAdmission::new(
+                        max,
+                        router_config.effective_prefill_queue_size(),
+                        Duration::from_secs(router_config.effective_prefill_queue_timeout_secs()),
+                    ))
+                });
+        if let Some(admission) = prefill_admission
+            .as_ref()
+            .filter(|_| router_config.effective_prefill_queue_size() > 0)
+        {
+            start_prefill_admission_notifier(&worker_registry, admission)?;
+        }
 
         // Create WorkerService from the already-built components
         let worker_service = Arc::new(WorkerService::new(
@@ -347,42 +415,27 @@ impl AppContextBuilder {
         ));
 
         Ok(AppContext {
-            client: self
-                .client
-                .ok_or(AppContextBuildError::MissingField("client"))?,
+            client,
             router_config,
             rate_limiter: self.rate_limiter,
             rate_limit_manager: self.rate_limit_manager,
-            tokenizer_registry: self
-                .tokenizer_registry
-                .ok_or(AppContextBuildError::MissingField("tokenizer_registry"))?,
+            tokenizer_registry,
             multimodal_config_registry: Arc::new(MultimodalConfigRegistry::new()),
             reasoning_parser_factory: self.reasoning_parser_factory,
             tool_parser_factory: self.tool_parser_factory,
             worker_registry,
-            policy_registry: self
-                .policy_registry
-                .ok_or(AppContextBuildError::MissingField("policy_registry"))?,
+            prefill_admission,
+            policy_registry,
             router_manager: self.router_manager,
-            response_storage: self
-                .response_storage
-                .ok_or(AppContextBuildError::MissingField("response_storage"))?,
-            conversation_storage: self
-                .conversation_storage
-                .ok_or(AppContextBuildError::MissingField("conversation_storage"))?,
-            conversation_item_storage: self.conversation_item_storage.ok_or(
-                AppContextBuildError::MissingField("conversation_item_storage"),
-            )?,
+            response_storage,
+            conversation_storage,
+            conversation_item_storage,
             worker_monitor: self.worker_monitor,
             configured_reasoning_parser,
             configured_tool_parser,
             worker_job_queue,
-            workflow_engines: self
-                .workflow_engines
-                .ok_or(AppContextBuildError::MissingField("workflow_engines"))?,
-            mcp_orchestrator: self
-                .mcp_orchestrator
-                .ok_or(AppContextBuildError::MissingField("mcp_orchestrator"))?,
+            workflow_engines,
+            mcp_orchestrator,
             mcp_format_registry: self.mcp_format_registry.unwrap_or_default(),
             wasm_manager: self.wasm_manager,
             worker_service,
@@ -712,8 +765,15 @@ impl Default for AppContextBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
+
     use super::*;
-    use crate::config::types::PolicyConfig;
+    use crate::{
+        config::types::PolicyConfig,
+        worker::{BasicWorkerBuilder, PrefillAdmissionAttempt, Worker, WorkerType},
+    };
 
     fn config_with_policy(policy: PolicyConfig) -> RouterConfig {
         RouterConfig {
@@ -789,5 +849,96 @@ mod tests {
         let result = AppContextBuilder::new().maybe_rate_limit_manager(&config);
         assert!(result.is_ok());
         assert!(result.unwrap().rate_limit_manager.is_some());
+    }
+
+    fn prefill_worker(url: &str) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(WorkerType::Prefill)
+                .health_config(HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        )
+    }
+
+    #[tokio::test]
+    async fn worker_status_change_wakes_prefill_admission() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let admission = Arc::new(PrefillAdmission::new(1, 1, Duration::from_secs(1)));
+        start_prefill_admission_notifier(&registry, &admission).unwrap();
+
+        let first = prefill_worker("http://prefill-1:8000");
+        registry.register(Arc::clone(&first)).unwrap();
+        let occupied = admission
+            .admit(None, {
+                let first = Arc::clone(&first);
+                move |capacity| capacity.select(Arc::clone(&first), ())
+            })
+            .await
+            .unwrap();
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter must run concurrently with worker status changes"
+        )]
+        let waiting = tokio::spawn({
+            let admission = Arc::clone(&admission);
+            let registry = Arc::clone(&registry);
+            let attempts = Arc::clone(&attempts);
+            async move {
+                admission
+                    .admit(None, |capacity| {
+                        attempts.fetch_add(1, Ordering::Relaxed);
+                        let workers = registry.get_by_type(WorkerType::Prefill);
+                        if workers.is_empty() {
+                            return PrefillAdmissionAttempt::Unavailable;
+                        }
+                        workers
+                            .iter()
+                            .find(|worker| worker.is_available() && capacity.has_capacity(worker))
+                            .map_or(PrefillAdmissionAttempt::AtCapacity, |worker| {
+                                capacity.select(Arc::clone(worker), Arc::clone(worker))
+                            })
+                    })
+                    .await
+            }
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while admission.queued_requests() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let second: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://prefill-2:8000")
+                .worker_type(WorkerType::Prefill)
+                .build(),
+        );
+        let second_id = registry.register(Arc::clone(&second)).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while attempts.load(Ordering::Relaxed) < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(admission.queued_requests(), 1);
+
+        registry.transition_status(&second_id, WorkerStatus::Ready);
+        let selected = tokio::time::timeout(Duration::from_secs(1), waiting)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(selected.selected.url(), second.url());
+        drop(selected);
+        drop(occupied);
     }
 }

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -248,6 +248,21 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn prefill_max_inflight_requests_per_worker(mut self, max: i32) -> Self {
+        self.config.prefill_max_inflight_requests_per_worker = max;
+        self
+    }
+
+    pub fn prefill_queue_size(mut self, size: Option<usize>) -> Self {
+        self.config.prefill_queue_size = size;
+        self
+    }
+
+    pub fn prefill_queue_timeout_secs(mut self, timeout: Option<u64>) -> Self {
+        self.config.prefill_queue_timeout_secs = timeout;
+        self
+    }
+
     pub fn rate_limit_tokens_per_second(mut self, tokens: i32) -> Self {
         self.config.rate_limit_tokens_per_second = Some(tokens);
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -76,6 +76,18 @@ pub struct RouterConfig {
     pub max_concurrent_requests: i32,
     pub queue_size: usize,
     pub queue_timeout_secs: u64,
+    /// Maximum in-flight Prefill requests per worker in PD or EPD mode.
+    /// A non-positive value disables the limit.
+    #[serde(default = "default_disabled_limit")]
+    pub prefill_max_inflight_requests_per_worker: i32,
+    /// Maximum number of PD requests waiting for Prefill admission.
+    /// `None` applies the built-in default when admission is enabled.
+    #[serde(default)]
+    pub prefill_queue_size: Option<usize>,
+    /// Maximum time a PD request may wait for Prefill admission.
+    /// `None` applies the built-in default when admission is enabled.
+    #[serde(default)]
+    pub prefill_queue_timeout_secs: Option<u64>,
     /// If not set, defaults to max_concurrent_requests
     pub rate_limit_tokens_per_second: Option<i32>,
     /// Enable the priority-aware admission scheduler. When false (default),
@@ -225,6 +237,13 @@ pub struct TokenizerCacheConfig {
 fn default_load_monitor_interval_secs() -> u64 {
     10
 }
+
+const fn default_disabled_limit() -> i32 {
+    -1
+}
+
+pub const DEFAULT_PREFILL_QUEUE_SIZE: usize = 100;
+pub const DEFAULT_PREFILL_QUEUE_TIMEOUT_SECS: u64 = 60;
 
 fn default_enable_l0() -> bool {
     false
@@ -810,6 +829,9 @@ impl Default for RouterConfig {
             max_concurrent_requests: -1,
             queue_size: 100,
             queue_timeout_secs: 60,
+            prefill_max_inflight_requests_per_worker: default_disabled_limit(),
+            prefill_queue_size: None,
+            prefill_queue_timeout_secs: None,
             rate_limit_tokens_per_second: None,
             priority_scheduler_enabled: false,
             priority_scheduler_default_max_class: default_priority_scheduler_max_class(),
@@ -892,6 +914,16 @@ impl RouterConfig {
             Some(trace_config) => trace_config.enable_trace,
             None => false,
         }
+    }
+
+    pub fn effective_prefill_queue_size(&self) -> usize {
+        self.prefill_queue_size
+            .unwrap_or(DEFAULT_PREFILL_QUEUE_SIZE)
+    }
+
+    pub fn effective_prefill_queue_timeout_secs(&self) -> u64 {
+        self.prefill_queue_timeout_secs
+            .unwrap_or(DEFAULT_PREFILL_QUEUE_TIMEOUT_SECS)
     }
 
     /// Compute the effective retry config considering disable flag

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -84,6 +84,7 @@ impl ConfigValidator {
         Self::validate_tenant_resolution(config)?;
         Self::validate_tenant_api_keys(config)?;
         Self::validate_model_aliases(config)?;
+        Self::validate_prefill_admission(config)?;
         if let Some(discovery) = &config.discovery {
             Self::validate_discovery(discovery, &config.mode)?;
         }
@@ -115,6 +116,45 @@ impl ConfigValidator {
         }
 
         Self::validate_tokenizer_cache(&config.tokenizer_cache)?;
+
+        Ok(())
+    }
+
+    fn validate_prefill_admission(config: &RouterConfig) -> ConfigResult<()> {
+        if config.prefill_max_inflight_requests_per_worker <= 0 {
+            if config.prefill_queue_size.is_some() || config.prefill_queue_timeout_secs.is_some() {
+                return Err(ConfigError::IncompatibleConfig {
+                    reason: "Prefill queue options require --prefill-max-inflight-requests-per-worker to be positive".to_string(),
+                });
+            }
+            return Ok(());
+        }
+
+        if !matches!(
+            config.mode,
+            RoutingMode::PrefillDecode { .. } | RoutingMode::EncodePrefillDecode { .. }
+        ) {
+            return Err(ConfigError::IncompatibleConfig {
+                reason: "Prefill admission is only supported in PD or EPD mode".to_string(),
+            });
+        }
+
+        if config.priority_scheduler_enabled {
+            return Err(ConfigError::IncompatibleConfig {
+                reason: "Prefill admission cannot be combined with --priority-scheduler-enabled"
+                    .to_string(),
+            });
+        }
+
+        if config.effective_prefill_queue_size() > 0
+            && config.effective_prefill_queue_timeout_secs() == 0
+        {
+            return Err(ConfigError::InvalidValue {
+                field: "prefill_queue_timeout_secs".to_string(),
+                value: "0".to_string(),
+                reason: "Must be > 0 when the Prefill queue is enabled".to_string(),
+            });
+        }
 
         Ok(())
     }
@@ -1158,6 +1198,65 @@ mod tests {
             },
             PolicyConfig::Random,
         )
+    }
+
+    fn pd_mode_config() -> RouterConfig {
+        RouterConfig::new(
+            RoutingMode::PrefillDecode {
+                prefill_urls: vec![("http://prefill:8000".to_string(), None)],
+                decode_urls: vec!["http://decode:8000".to_string()],
+                prefill_policy: None,
+                decode_policy: None,
+            },
+            PolicyConfig::Random,
+        )
+    }
+
+    #[test]
+    fn prefill_queue_options_require_admission() {
+        let mut config = pd_mode_config();
+        config.prefill_queue_size = Some(1);
+
+        assert!(matches!(
+            ConfigValidator::validate(&config),
+            Err(ConfigError::IncompatibleConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn prefill_admission_rejects_priority_scheduler() {
+        let mut config = pd_mode_config();
+        config.prefill_max_inflight_requests_per_worker = 1;
+        config.priority_scheduler_enabled = true;
+
+        assert!(matches!(
+            ConfigValidator::validate(&config),
+            Err(ConfigError::IncompatibleConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn enabled_prefill_queue_requires_nonzero_timeout() {
+        let mut config = pd_mode_config();
+        config.prefill_max_inflight_requests_per_worker = 1;
+        config.prefill_queue_size = Some(1);
+        config.prefill_queue_timeout_secs = Some(0);
+
+        assert!(matches!(
+            ConfigValidator::validate(&config),
+            Err(ConfigError::InvalidValue { ref field, .. })
+                if field == "prefill_queue_timeout_secs"
+        ));
+    }
+
+    #[test]
+    fn zero_size_prefill_queue_does_not_require_timeout() {
+        let mut config = pd_mode_config();
+        config.prefill_max_inflight_requests_per_worker = 1;
+        config.prefill_queue_size = Some(0);
+        config.prefill_queue_timeout_secs = Some(0);
+
+        assert!(ConfigValidator::validate(&config).is_ok());
     }
 
     #[test]

--- a/model_gateway/src/health.rs
+++ b/model_gateway/src/health.rs
@@ -20,8 +20,7 @@
 //!    maintainer recomputes on every `WorkerEvent` (bursts coalesced) and on
 //!    a short checkpoint interval. The checkpoint covers the status
 //!    mutations that bypass the registry broadcast — `set_status()` called
-//!    directly by `ActivateWorkersStep`, the mesh inbound health refresh in
-//!    `WorkerRegistry::on_remote_worker_state`, FFI bindings — and tokenizer
+//!    directly by `ActivateWorkersStep`, FFI bindings — and tokenizer
 //!    registrations, which emit no worker event at all.
 //!
 //! 2. **Dedicated probe listener.** When `--health-check-port` (config

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -295,6 +295,18 @@ struct CliArgs {
     #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "least_load", "prefix_hash", "consistent_hashing", "manual", "bucket"], help_heading = "PD Disaggregation")]
     decode_policy: Option<String>,
 
+    /// Maximum in-flight Prefill requests per worker in PD or EPD mode (non-positive to disable)
+    #[arg(long, default_value_t = -1, help_heading = "PD Disaggregation")]
+    prefill_max_inflight_requests_per_worker: i32,
+
+    /// Maximum number of requests waiting for Prefill admission (default: 100 when enabled)
+    #[arg(long, help_heading = "PD Disaggregation")]
+    prefill_queue_size: Option<usize>,
+
+    /// Maximum time in seconds a request may wait for Prefill admission (default: 60 when enabled)
+    #[arg(long, help_heading = "PD Disaggregation")]
+    prefill_queue_timeout_secs: Option<u64>,
+
     /// Specific policy for encode nodes in EPD mode. Defaults to consistent_hashing.
     #[arg(long, value_parser = ["random", "round_robin", "consistent_hashing"], help_heading = "PD Disaggregation")]
     encode_policy: Option<String>,
@@ -1457,6 +1469,9 @@ impl CliArgs {
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
             .queue_timeout_secs(self.queue_timeout_secs)
+            .prefill_max_inflight_requests_per_worker(self.prefill_max_inflight_requests_per_worker)
+            .prefill_queue_size(self.prefill_queue_size)
+            .prefill_queue_timeout_secs(self.prefill_queue_timeout_secs)
             .priority_scheduler_enabled(self.priority_scheduler_enabled)
             .priority_scheduler_default_max_class(self.priority_scheduler_default_max_class.clone())
             .priority_scheduler_config(self.priority_scheduler_config.clone())

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -227,7 +227,22 @@ pub(crate) fn init_metrics() {
         "smg_pd_kv_transfer_failures_total",
         "PD KV-transfer failures (missing connector params at decode handoff)"
     );
-
+    describe_gauge!(
+        "smg_pd_prefill_admission_inflight",
+        "Prefill requests admitted by SMG per worker"
+    );
+    describe_gauge!(
+        "smg_pd_prefill_admission_queued",
+        "Requests waiting in the SMG Prefill admission queue"
+    );
+    describe_histogram!(
+        "smg_pd_prefill_admission_wait_seconds",
+        "Time spent waiting in the SMG Prefill admission queue"
+    );
+    describe_counter!(
+        "smg_pd_prefill_admission_rejections_total",
+        "Prefill admission rejections by reason"
+    );
     // Layer 3: Worker metrics
     describe_gauge!(
         "smg_worker_pool_size",
@@ -1017,6 +1032,31 @@ impl Metrics {
     /// Record a PD KV-transfer failure (missing connector params at handoff).
     pub fn record_pd_kv_transfer_failure() {
         counter!("smg_pd_kv_transfer_failures_total").increment(1);
+    }
+
+    pub fn set_pd_prefill_admission_inflight(worker_url: &str, count: usize) {
+        let worker = intern_string(worker_url);
+        gauge!(
+            "smg_pd_prefill_admission_inflight",
+            "worker" => worker
+        )
+        .set(count as f64);
+    }
+
+    pub fn set_pd_prefill_admission_queued(depth: usize) {
+        gauge!("smg_pd_prefill_admission_queued").set(depth as f64);
+    }
+
+    pub fn record_pd_prefill_admission_wait(duration: Duration) {
+        histogram!("smg_pd_prefill_admission_wait_seconds").record(duration.as_secs_f64());
+    }
+
+    pub fn record_pd_prefill_admission_rejection(reason: &'static str) {
+        counter!(
+            "smg_pd_prefill_admission_rejections_total",
+            "reason" => reason
+        )
+        .increment(1);
     }
 
     // ========================================================================

--- a/model_gateway/src/routers/grpc/common/response_collection.rs
+++ b/model_gateway/src/routers/grpc/common/response_collection.rs
@@ -9,8 +9,8 @@ use tracing::error as trace_error;
 use crate::routers::{
     error,
     grpc::{
-        context::ExecutionResult,
-        proto_wrapper::{ProtoGenerateComplete, ProtoResponseVariant, ProtoStream},
+        context::{ExecutionResult, ExecutionStream},
+        proto_wrapper::{ProtoGenerateComplete, ProtoResponseVariant},
         utils::tonic_ext::TonicStatusExt,
     },
 };
@@ -41,17 +41,14 @@ pub(crate) async fn collect_responses(
             decode,
             ..
         } => {
-            // Collect prefill for input_logprobs (don't mark completed yet)
+            // Release capacity at EOF, but keep abort-on-drop armed until Decode succeeds.
             let prefill_responses = collect_stream_responses(&mut prefill, "Prefill").await?;
-
-            // Collect decode for actual output (don't mark completed yet)
+            // Collect decode for actual output.
             let mut decode_stream = *decode;
             let mut decode_responses =
                 collect_stream_responses(&mut decode_stream, "Decode").await?;
-
-            // Mark both streams as completed now that both succeeded
-            prefill.mark_completed();
             decode_stream.mark_completed();
+            prefill.mark_completed();
 
             // Merge prefill input_logprobs if requested
             if merge_logprobs {
@@ -112,7 +109,7 @@ fn merge_prefill_logprobs(
 
 /// Collect all complete responses from a gRPC stream, discarding chunks.
 async fn collect_stream_responses(
-    stream: &mut ProtoStream,
+    stream: &mut ExecutionStream,
     worker_name: &str,
 ) -> Result<Vec<ProtoGenerateComplete>, Response> {
     let mut all_responses = Vec::new();

--- a/model_gateway/src/routers/grpc/common/stages/mod.rs
+++ b/model_gateway/src/routers/grpc/common/stages/mod.rs
@@ -22,6 +22,13 @@ pub trait PipelineStage: Send + Sync {
     /// - `Err(response)` - Error occurred, return this error response
     async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response>;
 
+    /// Whether this stage starts backend work. Streaming adapters commit their
+    /// HTTP response immediately before this boundary so earlier failures can
+    /// still preserve their HTTP status and error body.
+    fn begins_backend_dispatch(&self) -> bool {
+        false
+    }
+
     /// Stage name for logging
     fn name(&self) -> &'static str;
 

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -15,8 +15,9 @@ use crate::{
         grpc::{
             common::stages::encode::EncodeDispatchPlan,
             context::{
-                ClientSelection, ExecutionPlan, ExecutionPlanKind, ExecutionResult, LoadGuards,
-                PdTiming, RequestContext, WorkerSelection,
+                ClientSelection, ExecutionPlan, ExecutionPlanKind, ExecutionResult,
+                ExecutionStream, LoadGuards, PdLoadGuards, PdTiming, RequestContext,
+                WorkerSelection,
             },
             proto_wrapper::{
                 ProtoEmbedRequest, ProtoGenerateRequest, ProtoRequest, ProtoResponseVariant,
@@ -121,12 +122,6 @@ fn mooncake_decode_params(transfer_id: &str, engine_id: &str, host: &str, port: 
 /// Request execution stage: execute the plan produced by request building.
 pub(crate) struct RequestExecutionStage;
 
-impl RequestExecutionStage {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
 #[async_trait]
 impl PipelineStage for RequestExecutionStage {
     async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
@@ -142,17 +137,7 @@ impl PipelineStage for RequestExecutionStage {
         // jobs' SHM Drop guards here: dispatch consumes them, while an early
         // error before dispatch drops them and reclaims the SHM.
         let encode_dispatch = ctx.state.encode_outputs.take().map(|o| o.dispatch);
-
-        let clients = ctx.state.clients.as_mut().ok_or_else(|| {
-            error!(
-                function = "RequestExecutionStage::execute",
-                "Client acquisition not completed"
-            );
-            error::internal_error(
-                "client_acquisition_not_completed",
-                "Client acquisition not completed",
-            )
-        })?;
+        let mut pd_load_guards = ctx.state.pd_load_guards.take();
 
         // Create load guards for worker load tracking (increment load when created)
         // They will be automatically dropped (and decrement load) when RequestContext is dropped
@@ -171,11 +156,39 @@ impl PipelineStage for RequestExecutionStage {
             ExecutionPlan::Batch { requests, .. } => requests.len(),
             _ => 1,
         };
-        ctx.state.load_guards = Some(LoadGuards::scaled(
-            workers,
-            ctx.input.headers.as_ref(),
-            sub_requests,
-        ));
+        match workers {
+            WorkerSelection::Single { worker } => {
+                if pd_load_guards.is_some() {
+                    return Err(error::internal_error(
+                        "unexpected_pd_load_reservation",
+                        "Single-worker execution received PD load reservations",
+                    ));
+                }
+                ctx.state.load_guards = Some(LoadGuards::scaled(
+                    worker,
+                    ctx.input.headers.as_ref(),
+                    sub_requests,
+                ));
+            }
+            WorkerSelection::Disaggregated { .. } if pd_load_guards.is_none() => {
+                return Err(error::internal_error(
+                    "pd_load_reservation_missing",
+                    "PD execution has no worker load reservations",
+                ));
+            }
+            WorkerSelection::Disaggregated { .. } => {}
+        }
+
+        let clients = ctx.state.clients.as_mut().ok_or_else(|| {
+            error!(
+                function = "RequestExecutionStage::execute",
+                "Client acquisition not completed"
+            );
+            error::internal_error(
+                "client_acquisition_not_completed",
+                "Client acquisition not completed",
+            )
+        })?;
 
         // Extract dispatch metadata for tracing span
         let dispatch = ctx.state.dispatch.as_ref();
@@ -203,18 +216,45 @@ impl PipelineStage for RequestExecutionStage {
                     }
                 },
                 ExecutionPlan::PrefillDecode(req) => {
-                    self.execute_pd_dispatch(req, clients, workers, model).await
+                    let guards = pd_load_guards.take().ok_or_else(|| {
+                        error::internal_error(
+                            "pd_load_reservation_missing",
+                            "PD execution has no worker load reservations",
+                        )
+                    })?;
+                    self.execute_pd_dispatch(req, clients, workers, model, guards)
+                        .await
                 }
                 ExecutionPlan::EncodePrefillDecode { request } => {
                     // Bootstrap info was injected into the prefill request during
                     // request building; dispatch the encode jobs with the
                     // prefill+decode leg.
-                    self.execute_epd_dispatch(request, clients, workers, model, encode_dispatch)
-                        .await
+                    let guards = pd_load_guards.take().ok_or_else(|| {
+                        error::internal_error(
+                            "pd_load_reservation_missing",
+                            "EPD execution has no worker load reservations",
+                        )
+                    })?;
+                    self.execute_epd_dispatch(
+                        request,
+                        clients,
+                        workers,
+                        model,
+                        encode_dispatch,
+                        guards,
+                    )
+                    .await
                 }
                 ExecutionPlan::Batch { kind, requests, .. } => {
-                    self.execute_batch_dispatch(kind, requests, clients, workers, model)
-                        .await
+                    self.execute_batch_dispatch(
+                        kind,
+                        requests,
+                        clients,
+                        workers,
+                        model,
+                        pd_load_guards,
+                    )
+                    .await
                 }
             }
         }
@@ -224,6 +264,10 @@ impl PipelineStage for RequestExecutionStage {
         // Store result in context for ResponseProcessingStage
         ctx.state.response.execution_result = Some(result);
         Ok(None)
+    }
+
+    fn begins_backend_dispatch(&self) -> bool {
+        true
     }
 
     fn name(&self) -> &'static str {
@@ -238,6 +282,7 @@ impl RequestExecutionStage {
         clients: &mut ClientSelection,
         workers: &WorkerSelection,
         model: &str,
+        guards: PdLoadGuards,
     ) -> Result<ExecutionResult, Response> {
         // Dispatch based on runtime type:
         // - SGLang: parallel prefill/decode dispatch with bootstrap metadata
@@ -245,13 +290,13 @@ impl RequestExecutionStage {
         let runtime_type = workers.disaggregated_runtime_type();
         match runtime_type {
             Some(RuntimeType::Vllm) => {
-                self.execute_sequential_pd(proto_request, clients, workers, model)
+                self.execute_sequential_pd(proto_request, clients, workers, model, guards)
                     .await
             }
             Some(RuntimeType::Sglang) | Some(RuntimeType::TokenSpeed) => {
                 // These runtimes carry bootstrap rendezvous in the request
                 // and use parallel prefill/decode dispatch.
-                self.execute_parallel_pd(proto_request, clients, workers)
+                self.execute_parallel_pd(proto_request, clients, workers, guards)
                     .await
             }
             Some(RuntimeType::Trtllm)
@@ -288,12 +333,13 @@ impl RequestExecutionStage {
         workers: &WorkerSelection,
         model: &str,
         encode_dispatch: Option<EncodeDispatchPlan>,
+        guards: PdLoadGuards,
     ) -> Result<ExecutionResult, Response> {
         if let Some(encode_dispatch) = encode_dispatch {
             Self::spawn_encode_dispatch(encode_dispatch);
         }
         proto_request.clear_mm_pixel_values();
-        self.execute_pd_dispatch(proto_request, clients, workers, model)
+        self.execute_pd_dispatch(proto_request, clients, workers, model, guards)
             .await
     }
 
@@ -351,24 +397,57 @@ impl RequestExecutionStage {
         clients: &ClientSelection,
         workers: &WorkerSelection,
         model: &str,
+        pd_load_guards: Option<PdLoadGuards>,
     ) -> Result<ExecutionResult, Response> {
-        let dispatches = requests.into_iter().map(|request| {
-            let mut clients = clients.clone();
-            async move {
-                match kind {
-                    ExecutionPlanKind::Single => {
-                        self.execute_single(request, &mut clients, workers).await
-                    }
-                    // Completion EPD carries no encode jobs; sub-requests dispatch as PD.
-                    ExecutionPlanKind::PrefillDecode | ExecutionPlanKind::EncodePrefillDecode => {
-                        self.execute_pd_dispatch(request, &mut clients, workers, model)
-                            .await
-                    }
+        let results = match kind {
+            ExecutionPlanKind::Single => {
+                if pd_load_guards.is_some() {
+                    return Err(error::internal_error(
+                        "unexpected_pd_load_reservation",
+                        "Single-worker batch received PD load reservations",
+                    ));
                 }
+                try_join_all(requests.into_iter().map(|request| {
+                    let mut clients = clients.clone();
+                    async move { self.execute_single(request, &mut clients, workers).await }
+                }))
+                .await?
             }
-        });
-
-        let results = try_join_all(dispatches).await?;
+            // Completion EPD carries no encode jobs; sub-requests dispatch as PD.
+            ExecutionPlanKind::PrefillDecode | ExecutionPlanKind::EncodePrefillDecode => {
+                let guards = pd_load_guards.ok_or_else(|| {
+                    error::internal_error(
+                        "pd_load_reservation_missing",
+                        "PD batch has no worker load reservations",
+                    )
+                })?;
+                let guard_sets = guards.share_across(requests.len()).ok_or_else(|| {
+                    error::internal_error(
+                        "pd_batch_load_reservation_mismatch",
+                        "PD batch load reservation does not match its prompt count",
+                    )
+                })?;
+                try_join_all(
+                    requests
+                        .into_iter()
+                        .zip(guard_sets)
+                        .map(|(request, guards)| {
+                            let mut clients = clients.clone();
+                            async move {
+                                self.execute_pd_dispatch(
+                                    request,
+                                    &mut clients,
+                                    workers,
+                                    model,
+                                    guards,
+                                )
+                                .await
+                            }
+                        }),
+                )
+                .await?
+            }
+        };
         Ok(ExecutionResult::Batch { results })
     }
 
@@ -404,7 +483,9 @@ impl RequestExecutionStage {
             )
         })?;
 
-        Ok(ExecutionResult::Single { stream })
+        Ok(ExecutionResult::Single {
+            stream: ExecutionStream::untracked(stream),
+        })
     }
 
     async fn execute_single_embed(
@@ -443,7 +524,12 @@ impl RequestExecutionStage {
         proto_request: ProtoGenerateRequest,
         clients: &mut ClientSelection,
         workers: &WorkerSelection,
+        guards: PdLoadGuards,
     ) -> Result<ExecutionResult, Response> {
+        let PdLoadGuards {
+            prefill: prefill_guard,
+            decode: decode_guard,
+        } = guards;
         let runtime = workers
             .disaggregated_runtime_type()
             .map(|r| r.as_str())
@@ -474,9 +560,9 @@ impl RequestExecutionStage {
             decode_request.set_data_parallel_rank(rank as i32);
         }
 
-        // `generate` only establishes the prefill stream here (SMG does not drain
-        // it on this path), so prefill duration cannot be measured — only TTFT,
-        // recorded at the first decode token in streaming. prefill_start anchors it.
+        // `generate` only establishes the Prefill stream here. Downstream response
+        // handling drains it, so this stage cannot measure the full Prefill duration.
+        // `prefill_start` anchors TTFT at the first Decode token.
         let prefill_start = Instant::now();
         let (prefill_result, decode_result): (StreamResult, StreamResult) = tokio::join!(
             prefill_client.generate(prefill_request),
@@ -518,8 +604,8 @@ impl RequestExecutionStage {
         })?;
 
         Ok(ExecutionResult::PrefillDecode {
-            prefill: prefill_stream,
-            decode: Box::new(decode_stream),
+            prefill: ExecutionStream::tracked_prefill(prefill_stream, prefill_guard),
+            decode: Box::new(ExecutionStream::tracked_decode(decode_stream, decode_guard)),
             pd_timing: PdTiming {
                 prefill_start,
                 runtime,
@@ -539,7 +625,12 @@ impl RequestExecutionStage {
         clients: &mut ClientSelection,
         workers: &WorkerSelection,
         model: &str,
+        guards: PdLoadGuards,
     ) -> Result<ExecutionResult, Response> {
+        let PdLoadGuards {
+            prefill: prefill_guard,
+            decode: decode_guard,
+        } = guards;
         let runtime = workers
             .disaggregated_runtime_type()
             .map(|r| r.as_str())
@@ -649,7 +740,7 @@ impl RequestExecutionStage {
 
         // Send to prefill, wait for completion
         let prefill_start = Instant::now();
-        let mut prefill_stream = prefill_client
+        let prefill_stream = prefill_client
             .generate(prefill_request)
             .await
             .map_err(|e| {
@@ -662,6 +753,7 @@ impl RequestExecutionStage {
                 error!(function = "execute_sequential_pd", error = %e, "Prefill worker failed to start");
                 e.to_http_error("prefill_worker_failed_to_start", format!("Prefill worker failed to start: {}", e.message()))
             })?;
+        let mut prefill_stream = ExecutionStream::tracked_prefill(prefill_stream, prefill_guard);
 
         // Drain prefill response, harvesting connector params from the Complete frame
         let mut prefill_kv_params: Option<String> = None;
@@ -689,7 +781,6 @@ impl RequestExecutionStage {
                 }
             }
         }
-        prefill_stream.mark_completed();
         workers.record_outcome_prefill(200);
         // Captured at drain; recorded below only once decode is established.
         let prefill_duration = prefill_start.elapsed();
@@ -779,6 +870,10 @@ impl RequestExecutionStage {
             )
         })?;
 
+        // Prefill EOF releases its capacity, but keep abort-on-drop armed until
+        // Decode accepts the handoff. A failed Decode start must reclaim the
+        // Prefill request and any KV state left for that handoff.
+        prefill_stream.mark_completed();
         workers.record_outcome_decode(200);
         // Decode established: record the success-only PD metrics here.
         Metrics::record_pd_kv_connector_mode(kv_connector_label);
@@ -796,7 +891,7 @@ impl RequestExecutionStage {
         );
 
         Ok(ExecutionResult::Single {
-            stream: decode_stream,
+            stream: ExecutionStream::tracked_decode(decode_stream, decode_guard),
         })
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -14,33 +14,120 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo, WorkerLeg},
     routers::{
+        common::header_utils,
         error,
         grpc::{
-            context::{EncodeWorkerAssignment, RequestContext, WorkerSelection},
+            context::{EncodeWorkerAssignment, PdLoadGuards, RequestContext, WorkerSelection},
             multimodal,
         },
+        PD_PREFILL_QUEUE_FULL, PD_PREFILL_QUEUE_TIMEOUT,
     },
     worker::{
-        ConnectionMode, HashRing, RuntimeType, Worker, WorkerRegistry, WorkerType, UNKNOWN_MODEL_ID,
+        acquire_prefill, ConnectionMode, HashRing, PrefillAcquireError, PrefillAdmission,
+        PrefillAdmissionRejection, PrefillCandidateError, PrefillSelectionContext, RuntimeType,
+        Worker, WorkerLoadGuard, WorkerRegistry, WorkerType, UNKNOWN_MODEL_ID,
     },
 };
 
-/// Result type for PD worker pair selection: (prefill, decode, runtime_type)
-type PdWorkerPair = (Arc<dyn Worker>, Arc<dyn Worker>, RuntimeType);
+type PdWorkerPair = (Arc<dyn Worker>, Arc<dyn Worker>, RuntimeType, PdLoadGuards);
 
-/// Result type for EPD worker selection: (encode assignments, prefill, decode, runtime_type).
 type EncodePrefillDecodeWorkerSelection = (
     Vec<EncodeWorkerAssignment>,
     Arc<dyn Worker>,
     Arc<dyn Worker>,
     RuntimeType,
+    PdLoadGuards,
 );
+
+struct PdCandidate {
+    prefill: Arc<dyn Worker>,
+    decode: Arc<dyn Worker>,
+    runtime_type: RuntimeType,
+}
+
+struct EncodePrefillDecodeCandidate {
+    encode_assignments: Vec<EncodeWorkerAssignment>,
+    prefill: Arc<dyn Worker>,
+    decode: Arc<dyn Worker>,
+    runtime_type: RuntimeType,
+}
+
+struct PdSelectionContext<'a> {
+    request_text: Option<&'a str>,
+    tokens: Option<&'a [u32]>,
+    headers: Option<&'a HeaderMap>,
+    hash_ring: Option<Arc<HashRing>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PdSelectionError {
+    Unavailable,
+    QueueFull,
+    QueueTimeout,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PdCandidateError {
+    Unavailable,
+    PrefillAtCapacity,
+}
+
+impl PdSelectionError {
+    fn into_response(self, model_id: &str) -> Response {
+        match self {
+            Self::Unavailable => error::model_not_found(model_id),
+            Self::QueueFull => error::too_many_requests(
+                PD_PREFILL_QUEUE_FULL,
+                "The Prefill admission queue is full",
+            ),
+            Self::QueueTimeout => error::too_many_requests(
+                PD_PREFILL_QUEUE_TIMEOUT,
+                "Timed out waiting for Prefill admission",
+            ),
+        }
+    }
+}
+
+impl From<PdCandidateError> for PdSelectionError {
+    fn from(value: PdCandidateError) -> Self {
+        match value {
+            PdCandidateError::Unavailable => Self::Unavailable,
+            PdCandidateError::PrefillAtCapacity => Self::QueueFull,
+        }
+    }
+}
+
+impl From<PrefillAdmissionRejection> for PdSelectionError {
+    fn from(value: PrefillAdmissionRejection) -> Self {
+        match value {
+            PrefillAdmissionRejection::QueueFull => Self::QueueFull,
+            PrefillAdmissionRejection::QueueTimeout => Self::QueueTimeout,
+            PrefillAdmissionRejection::Unavailable => Self::Unavailable,
+        }
+    }
+}
+
+impl From<PrefillAcquireError<PdCandidateError>> for PdSelectionError {
+    fn from(value: PrefillAcquireError<PdCandidateError>) -> Self {
+        match value {
+            PrefillAcquireError::Candidate(error) => error.into(),
+            PrefillAcquireError::Rejected(rejection) => rejection.into(),
+        }
+    }
+}
+
+impl PrefillCandidateError for PdCandidateError {
+    fn is_at_capacity(&self) -> bool {
+        matches!(self, Self::PrefillAtCapacity)
+    }
+}
 
 /// Worker selection stage: Select appropriate worker(s) based on routing mode
 pub(crate) struct WorkerSelectionStage {
     worker_registry: Arc<WorkerRegistry>,
     policy_registry: Arc<PolicyRegistry>,
     mode: WorkerSelectionMode,
+    prefill_admission: Option<Arc<PrefillAdmission>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -58,11 +145,13 @@ impl WorkerSelectionStage {
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
         mode: WorkerSelectionMode,
+        prefill_admission: Option<Arc<PrefillAdmission>>,
     ) -> Self {
         Self {
             worker_registry,
             policy_registry,
             mode,
+            prefill_admission,
         }
     }
 }
@@ -92,10 +181,11 @@ impl PipelineStage for WorkerSelectionStage {
         let headers = ctx.input.headers.as_ref();
 
         let model_id = ctx.input.model_id.as_str();
-        let workers = match self.mode {
+
+        let (workers, pd_load_guards) = match self.mode {
             WorkerSelectionMode::Regular => {
                 match self.select_single_worker(model_id, text, tokens, headers) {
-                    Some(w) => WorkerSelection::Single { worker: w },
+                    Some(w) => (WorkerSelection::Single { worker: w }, None),
                     None => {
                         error!(
                             function = "WorkerSelectionStage::execute",
@@ -108,21 +198,25 @@ impl PipelineStage for WorkerSelectionStage {
                 }
             }
             WorkerSelectionMode::PrefillDecode => {
-                match self.select_pd_pair(model_id, text, tokens, headers) {
-                    Some((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
-                        encode_assignments: None,
-                        prefill,
-                        decode,
-                        runtime_type,
-                    },
-                    None => {
+                match self.select_pd_pair(model_id, text, tokens, headers).await {
+                    Ok((prefill, decode, runtime_type, guards)) => (
+                        WorkerSelection::Disaggregated {
+                            encode_assignments: None,
+                            prefill,
+                            decode,
+                            runtime_type,
+                        },
+                        Some(guards),
+                    ),
+                    Err(selection_error) => {
                         error!(
                             function = "WorkerSelectionStage::execute",
                             mode = "PrefillDecode",
                             model_id = %model_id,
-                            "No available PD worker pairs for model"
+                            error = ?selection_error,
+                            "Failed to reserve a PD worker pair"
                         );
-                        return Err(error::model_not_found(model_id));
+                        return Err(selection_error.into_response(model_id));
                     }
                 }
             }
@@ -141,14 +235,17 @@ impl PipelineStage for WorkerSelectionStage {
                         ));
                     }
                 };
-                match self.select_encode_prefill_decode_workers(
-                    model_id,
-                    text,
-                    tokens,
-                    headers,
-                    &encode_item_hashes,
-                ) {
-                    Some((encode_assignments, prefill, decode, runtime_type)) => {
+                match self
+                    .select_encode_prefill_decode_workers(
+                        model_id,
+                        text,
+                        tokens,
+                        headers,
+                        &encode_item_hashes,
+                    )
+                    .await
+                {
+                    Ok((encode_assignments, prefill, decode, runtime_type, guards)) => (
                         WorkerSelection::Disaggregated {
                             encode_assignments: if encode_assignments.is_empty() {
                                 None
@@ -158,16 +255,18 @@ impl PipelineStage for WorkerSelectionStage {
                             prefill,
                             decode,
                             runtime_type,
-                        }
-                    }
-                    None => {
+                        },
+                        Some(guards),
+                    ),
+                    Err(selection_error) => {
                         error!(
                             function = "WorkerSelectionStage::execute",
                             mode = "EncodePrefillDecode",
                             model_id = %model_id,
-                            "No available encode/prefill/decode worker set for model"
+                            error = ?selection_error,
+                            "Failed to reserve an encode/prefill/decode worker set"
                         );
-                        return Err(error::model_not_found(model_id));
+                        return Err(selection_error.into_response(model_id));
                     }
                 }
             }
@@ -191,6 +290,7 @@ impl PipelineStage for WorkerSelectionStage {
         }
 
         ctx.state.workers = Some(workers);
+        ctx.state.pd_load_guards = pd_load_guards;
         Ok(None)
     }
 
@@ -277,13 +377,41 @@ impl WorkerSelectionStage {
         Some(selected)
     }
 
-    fn select_pd_pair(
+    async fn select_pd_pair(
         &self,
         model_id: &str,
         text: Option<&str>,
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
-    ) -> Option<PdWorkerPair> {
+    ) -> Result<PdWorkerPair, PdSelectionError> {
+        let (candidate, prefill_guard) = acquire_prefill(
+            self.prefill_admission.as_deref(),
+            headers,
+            |candidate: &PdCandidate| &candidate.prefill,
+            |capacity| self.select_pd_candidate(model_id, text, tokens, headers, capacity),
+        )
+        .await?;
+        let decode_guard = WorkerLoadGuard::new(Arc::clone(&candidate.decode), headers);
+
+        Ok((
+            candidate.prefill,
+            candidate.decode,
+            candidate.runtime_type,
+            PdLoadGuards {
+                prefill: prefill_guard,
+                decode: decode_guard,
+            },
+        ))
+    }
+
+    fn select_pd_candidate(
+        &self,
+        model_id: &str,
+        text: Option<&str>,
+        tokens: Option<&[u32]>,
+        headers: Option<&HeaderMap>,
+        capacity: Option<&PrefillSelectionContext<'_>>,
+    ) -> Result<PdCandidate, PdCandidateError> {
         // Treat "unknown" model as wildcard (match any worker)
         let model_filter = if model_id == UNKNOWN_MODEL_ID {
             None
@@ -299,7 +427,7 @@ impl WorkerSelectionStage {
             false,
         );
 
-        let (all_prefill, all_decode): (Vec<_>, Vec<_>) =
+        let (mut all_prefill, all_decode): (Vec<_>, Vec<_>) =
             all_workers
                 .into_iter()
                 .fold((Vec::new(), Vec::new()), |mut acc, w| {
@@ -318,37 +446,55 @@ impl WorkerSelectionStage {
 
         if all_prefill.is_empty() {
             warn!("No available prefill workers");
-            return None;
+            return Err(PdCandidateError::Unavailable);
         }
 
         if all_decode.is_empty() {
             warn!("No available decode workers");
-            return None;
+            return Err(PdCandidateError::Unavailable);
         }
 
-        // Determine the runtime type from prefill workers.
-        // All workers in a PD pair must use the same runtime.
-        let first_runtime = all_prefill.first()?.metadata().spec.runtime_type;
+        let prefill_policy = self.policy_registry.get_prefill_policy();
+        let decode_policy = self.policy_registry.get_decode_policy();
+        let targeted = prefill_policy.name() == "consistent_hashing"
+            && header_utils::extract_target_worker(headers).is_some();
+
+        all_prefill.retain(|prefill| {
+            all_decode.iter().any(|decode| {
+                decode.metadata().spec.runtime_type == prefill.metadata().spec.runtime_type
+            })
+        });
+        if all_prefill.is_empty() {
+            warn!("No available PD worker pair with a shared runtime");
+            return Err(PdCandidateError::Unavailable);
+        }
+        if let Some(capacity) = capacity {
+            if !targeted {
+                all_prefill.retain(|worker| capacity.has_capacity(worker));
+                if all_prefill.is_empty() {
+                    return Err(PdCandidateError::PrefillAtCapacity);
+                }
+            }
+        }
+
+        let target_runtime = all_prefill[0].metadata().spec.runtime_type;
 
         // Check for mixed runtimes in both prefill and decode pools
         let prefill_mixed = all_prefill
             .iter()
-            .skip(1)
-            .any(|w| w.metadata().spec.runtime_type != first_runtime);
+            .any(|w| w.metadata().spec.runtime_type != target_runtime);
         let decode_mixed = all_decode
             .iter()
-            .any(|w| w.metadata().spec.runtime_type != first_runtime);
+            .any(|w| w.metadata().spec.runtime_type != target_runtime);
 
         if prefill_mixed || decode_mixed {
             warn!(
                 "Mixed runtime types in PD workers (prefill_mixed={}, decode_mixed={}). Using {:?}.",
                 prefill_mixed,
                 decode_mixed,
-                first_runtime
+                target_runtime
             );
         }
-
-        let target_runtime = first_runtime;
 
         // Filter both pools to the target runtime
         let available_prefill: Vec<_> = all_prefill
@@ -362,70 +508,112 @@ impl WorkerSelectionStage {
 
         if available_prefill.is_empty() || available_decode.is_empty() {
             warn!("No available PD pair for runtime {:?}", target_runtime);
-            return None;
+            return Err(PdCandidateError::Unavailable);
         }
-
-        // Select using policies
-        let policy = self.policy_registry.get_policy_or_default(model_id);
+        if targeted {
+            let target = header_utils::extract_target_worker(headers)
+                .and_then(|value| value.parse::<usize>().ok())
+                .and_then(|index| available_prefill.get(index))
+                .ok_or(PdCandidateError::Unavailable)?;
+            if capacity.is_some_and(|capacity| !capacity.has_capacity(target)) {
+                return Err(PdCandidateError::PrefillAtCapacity);
+            }
+        }
 
         // Get cached hash ring for consistent hashing (O(log n) lookup)
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
 
         // Prefill and decode are separate pools; tag each leg so the routing-key
         // override keys its sticky map per leg (a key sticks independently).
-        let mut info = SelectWorkerInfo {
+        let selection = PdSelectionContext {
             request_text: text,
             tokens,
             headers,
             hash_ring,
-            leg: WorkerLeg::Prefill,
         };
-        let prefill_idx = self
-            .policy_registry
-            .select_worker(&policy, &available_prefill, &info)?;
-        info.leg = WorkerLeg::Decode;
-        let decode_idx = self
-            .policy_registry
-            .select_worker(&policy, &available_decode, &info)?;
-
+        let prefill = self.select_disaggregated_worker(
+            &available_prefill,
+            &prefill_policy,
+            &selection,
+            WorkerLeg::Prefill,
+        )?;
+        let decode = self.select_disaggregated_worker(
+            &available_decode,
+            &decode_policy,
+            &selection,
+            WorkerLeg::Decode,
+        )?;
         let model = model_id;
-        let policy_name = policy.name();
 
         // Record worker selection metrics for both prefill and decode
         Metrics::record_worker_selection(
             metrics_labels::WORKER_PREFILL,
             metrics_labels::CONNECTION_GRPC,
             model,
-            policy_name,
+            prefill_policy.name(),
         );
         Metrics::record_worker_selection(
             metrics_labels::WORKER_DECODE,
             metrics_labels::CONNECTION_GRPC,
             model,
-            policy_name,
+            decode_policy.name(),
         );
 
-        Some((
-            available_prefill[prefill_idx].clone(),
-            available_decode[decode_idx].clone(),
-            target_runtime,
-        ))
+        Ok(PdCandidate {
+            prefill,
+            decode,
+            runtime_type: target_runtime,
+        })
     }
 
-    /// Select per-item encode workers + a prefill/decode pair for EPD routing.
-    ///
-    /// Mirrors `select_pd_pair` but also assigns each multimodal item to an
-    /// encode worker. prefill+decode are selected as a normal PD pair. All pools
-    /// are filtered to a runtime shared by the selected encode/prefill/decode
-    /// legs.
-    fn select_encode_prefill_decode_workers(
+    async fn select_encode_prefill_decode_workers(
         &self,
         model_id: &str,
         text: Option<&str>,
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
         encode_item_hashes: &[Vec<u8>],
-    ) -> Option<EncodePrefillDecodeWorkerSelection> {
+    ) -> Result<EncodePrefillDecodeWorkerSelection, PdSelectionError> {
+        let (candidate, prefill_guard) = acquire_prefill(
+            self.prefill_admission.as_deref(),
+            headers,
+            |candidate: &EncodePrefillDecodeCandidate| &candidate.prefill,
+            |capacity| {
+                self.select_encode_prefill_decode_candidate(
+                    model_id,
+                    text,
+                    tokens,
+                    headers,
+                    encode_item_hashes,
+                    capacity,
+                )
+            },
+        )
+        .await?;
+        let decode_guard = WorkerLoadGuard::new(Arc::clone(&candidate.decode), headers);
+
+        Ok((
+            candidate.encode_assignments,
+            candidate.prefill,
+            candidate.decode,
+            candidate.runtime_type,
+            PdLoadGuards {
+                prefill: prefill_guard,
+                decode: decode_guard,
+            },
+        ))
+    }
+
+    /// Select per-item Encode workers and one Prefill/Decode pair for EPD.
+    fn select_encode_prefill_decode_candidate(
+        &self,
+        model_id: &str,
+        text: Option<&str>,
+        tokens: Option<&[u32]>,
+        headers: Option<&HeaderMap>,
+        encode_item_hashes: &[Vec<u8>],
+        capacity: Option<&PrefillSelectionContext<'_>>,
+    ) -> Result<EncodePrefillDecodeCandidate, PdCandidateError> {
         // Treat "unknown" model as wildcard (match any worker)
         let model_filter = if model_id == UNKNOWN_MODEL_ID {
             None
@@ -441,7 +629,7 @@ impl WorkerSelectionStage {
             false,
         );
 
-        let (all_encode, all_prefill, all_decode): (Vec<_>, Vec<_>, Vec<_>) = all_workers
+        let (all_encode, mut all_prefill, all_decode): (Vec<_>, Vec<_>, Vec<_>) = all_workers
             .into_iter()
             .fold((Vec::new(), Vec::new(), Vec::new()), |mut acc, w| {
                 if w.is_available() {
@@ -458,40 +646,52 @@ impl WorkerSelectionStage {
         let needs_encode = !encode_item_hashes.is_empty();
         if needs_encode && all_encode.is_empty() {
             warn!("No available encode workers");
-            return None;
+            return Err(PdCandidateError::Unavailable);
         }
         if all_prefill.is_empty() {
             warn!("No available prefill workers");
-            return None;
+            return Err(PdCandidateError::Unavailable);
         }
         if all_decode.is_empty() {
             warn!("No available decode workers");
-            return None;
+            return Err(PdCandidateError::Unavailable);
+        }
+
+        let encode_policy = self.policy_registry.get_encode_policy();
+        let prefill_policy = self.policy_registry.get_prefill_policy();
+        let decode_policy = self.policy_registry.get_decode_policy();
+        let targeted = prefill_policy.name() == "consistent_hashing"
+            && header_utils::extract_target_worker(headers).is_some();
+
+        // Multimodal EPD currently supports TokenSpeed only.
+        all_prefill.retain(|prefill| {
+            let runtime = prefill.metadata().spec.runtime_type;
+            (!needs_encode || runtime == RuntimeType::TokenSpeed)
+                && all_decode
+                    .iter()
+                    .any(|decode| decode.metadata().spec.runtime_type == runtime)
+                && (!needs_encode
+                    || all_encode
+                        .iter()
+                        .any(|encode| encode.metadata().spec.runtime_type == runtime))
+        });
+        if all_prefill.is_empty() {
+            warn!("No available encode/prefill/decode worker set with a shared runtime");
+            return Err(PdCandidateError::Unavailable);
+        }
+        if let Some(capacity) = capacity {
+            if !targeted {
+                all_prefill.retain(|worker| capacity.has_capacity(worker));
+                if all_prefill.is_empty() {
+                    return Err(PdCandidateError::PrefillAtCapacity);
+                }
+            }
         }
 
         // Disaggregated legs must share a runtime. Pick a runtime that has at
         // least one available worker in every required EPD pool instead of
         // blindly using the first prefill runtime.
-        let Some(target_runtime) = all_prefill
-            .iter()
-            .map(|w| w.metadata().spec.runtime_type)
-            .find(|runtime| {
-                // The current EPD multimodal encoder adapter is TokenSpeed-
-                // specific. Do not select a shared SGLang/vLLM runtime only to
-                // reject it later during request building.
-                (!needs_encode || *runtime == RuntimeType::TokenSpeed)
-                    && all_decode
-                        .iter()
-                        .any(|w| w.metadata().spec.runtime_type == *runtime)
-                    && (!needs_encode
-                        || all_encode
-                            .iter()
-                            .any(|w| w.metadata().spec.runtime_type == *runtime))
-            })
-        else {
-            warn!("No available encode/prefill/decode worker set with a shared runtime");
-            return None;
-        };
+        let target_runtime = all_prefill[0].metadata().spec.runtime_type;
 
         let mixed = all_prefill
             .iter()
@@ -530,33 +730,20 @@ impl WorkerSelectionStage {
                 "No available encode/prefill/decode worker set for runtime {:?}",
                 target_runtime
             );
-            return None;
+            return Err(PdCandidateError::Unavailable);
         }
-
-        // Select encode, prefill, and decode via their per-role policies. Encode
-        // defaults to consistent hashing over each item's content hash; prefill
-        // and decode fall back to the main policy when unset.
-        let encode_policy = self.policy_registry.get_encode_policy();
-        let prefill_policy = self.policy_registry.get_prefill_policy();
-        let decode_policy = self.policy_registry.get_decode_policy();
+        if targeted {
+            let target = header_utils::extract_target_worker(headers)
+                .and_then(|value| value.parse::<usize>().ok())
+                .and_then(|index| available_prefill.get(index))
+                .ok_or(PdCandidateError::Unavailable)?;
+            if capacity.is_some_and(|capacity| !capacity.has_capacity(target)) {
+                return Err(PdCandidateError::PrefillAtCapacity);
+            }
+        }
 
         // Get cached hash ring for consistent hashing (O(log n) lookup)
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
-
-        let mut info = SelectWorkerInfo {
-            request_text: text,
-            tokens,
-            headers,
-            hash_ring: hash_ring.clone(),
-            leg: WorkerLeg::Prefill,
-        };
-        let prefill_idx =
-            self.policy_registry
-                .select_worker(&prefill_policy, &available_prefill, &info)?;
-        info.leg = WorkerLeg::Decode;
-        let decode_idx =
-            self.policy_registry
-                .select_worker(&decode_policy, &available_decode, &info)?;
 
         let encode_assignments = assign_encode_workers(
             &available_encode,
@@ -564,8 +751,27 @@ impl WorkerSelectionStage {
             model_id,
             encode_policy.as_ref(),
             hash_ring.clone(),
-        )?;
+        )
+        .ok_or(PdCandidateError::Unavailable)?;
 
+        let selection = PdSelectionContext {
+            request_text: text,
+            tokens,
+            headers,
+            hash_ring,
+        };
+        let prefill = self.select_disaggregated_worker(
+            &available_prefill,
+            &prefill_policy,
+            &selection,
+            WorkerLeg::Prefill,
+        )?;
+        let decode = self.select_disaggregated_worker(
+            &available_decode,
+            &decode_policy,
+            &selection,
+            WorkerLeg::Decode,
+        )?;
         // Record worker selection metrics for prefill and decode, each tagged
         // with the policy that picked it. Encode item assignment metrics are
         // recorded in assign_encode_workers.
@@ -582,12 +788,42 @@ impl WorkerSelectionStage {
             decode_policy.name(),
         );
 
-        Some((
+        Ok(EncodePrefillDecodeCandidate {
             encode_assignments,
-            available_prefill[prefill_idx].clone(),
-            available_decode[decode_idx].clone(),
-            target_runtime,
-        ))
+            prefill,
+            decode,
+            runtime_type: target_runtime,
+        })
+    }
+
+    fn select_disaggregated_worker(
+        &self,
+        candidates: &[Arc<dyn Worker>],
+        policy: &Arc<dyn LoadBalancingPolicy>,
+        request: &PdSelectionContext<'_>,
+        leg: WorkerLeg,
+    ) -> Result<Arc<dyn Worker>, PdCandidateError> {
+        if candidates.is_empty() {
+            return Err(PdCandidateError::Unavailable);
+        }
+
+        let selected_idx = self
+            .policy_registry
+            .select_worker(
+                policy,
+                candidates,
+                &SelectWorkerInfo {
+                    request_text: request.request_text,
+                    tokens: request.tokens,
+                    headers: request.headers,
+                    hash_ring: request.hash_ring.clone(),
+                    leg,
+                },
+            )
+            .filter(|index| *index < candidates.len())
+            .ok_or(PdCandidateError::Unavailable)?;
+
+        Ok(Arc::clone(&candidates[selected_idx]))
     }
 }
 
@@ -653,4 +889,432 @@ fn hex_encode(bytes: &[u8]) -> String {
         out.push(HEX[(byte & 0x0f) as usize] as char);
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use openai_protocol::{model_card::ModelCard, worker::HealthCheckConfig};
+
+    use super::*;
+    use crate::{
+        config::types::PolicyConfig,
+        mesh::adapters::tree_sync::RepairEntry,
+        policies::{CacheAwareConfig, CacheAwarePolicy, TreeHandle, TreeKind},
+        worker::BasicWorkerBuilder,
+    };
+
+    fn worker_with_runtime(
+        url: &str,
+        worker_type: WorkerType,
+        runtime_type: RuntimeType,
+    ) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(worker_type)
+                .connection_mode(ConnectionMode::Grpc)
+                .runtime_type(runtime_type)
+                .health_config(HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        )
+    }
+
+    fn worker(url: &str, worker_type: WorkerType) -> Arc<dyn Worker> {
+        worker_with_runtime(url, worker_type, RuntimeType::Sglang)
+    }
+
+    fn modeled_worker(
+        url: &str,
+        model_id: &str,
+        worker_type: WorkerType,
+        runtime_type: RuntimeType,
+    ) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .model(ModelCard::new(model_id))
+                .worker_type(worker_type)
+                .connection_mode(ConnectionMode::Grpc)
+                .runtime_type(runtime_type)
+                .health_config(HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        )
+    }
+
+    fn stage(
+        worker_registry: Arc<WorkerRegistry>,
+        policy: PolicyConfig,
+        prefill_admission: Option<Arc<PrefillAdmission>>,
+    ) -> WorkerSelectionStage {
+        WorkerSelectionStage::new(
+            worker_registry,
+            Arc::new(PolicyRegistry::new(policy)),
+            WorkerSelectionMode::PrefillDecode,
+            prefill_admission,
+        )
+    }
+
+    fn token_tree_has_tenant(policy: &CacheAwarePolicy, tokens: &[u32], worker_url: &str) -> bool {
+        policy
+            .open_repair_stream(UNKNOWN_MODEL_ID, TreeKind::Token)
+            .expect("token tree should be initialized")
+            .any(|entry| {
+                matches!(
+                    entry,
+                    RepairEntry::Token {
+                        tokens: path,
+                        tenants,
+                    } if path == tokens
+                        && tenants
+                            .iter()
+                            .any(|(tenant, _)| tenant.as_ref() == worker_url)
+                )
+            })
+    }
+
+    #[tokio::test]
+    async fn admission_filters_full_prefill_before_policy_selection() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let full = worker("grpc://prefill-full:30000", WorkerType::Prefill);
+        let available = worker("grpc://prefill-available:30000", WorkerType::Prefill);
+        let decode = worker("grpc://decode:30000", WorkerType::Decode);
+        for worker in [&full, &available, &decode] {
+            registry.register(Arc::clone(worker)).unwrap();
+        }
+
+        let admission = Arc::new(PrefillAdmission::new(1, 0, Duration::from_secs(1)));
+        let occupied = admission
+            .admit(None, {
+                let full = Arc::clone(&full);
+                move |capacity| capacity.select(Arc::clone(&full), ())
+            })
+            .await
+            .unwrap();
+        let stage = stage(
+            registry,
+            PolicyConfig::RoundRobin,
+            Some(Arc::clone(&admission)),
+        );
+
+        let (prefill, selected_decode, _, guards) = stage
+            .select_pd_pair(UNKNOWN_MODEL_ID, None, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(prefill.url(), available.url());
+        assert_eq!(selected_decode.url(), decode.url());
+        assert_eq!(full.load(), 1);
+        assert_eq!(available.load(), 1);
+        assert_eq!(decode.load(), 1);
+        drop(guards);
+        drop(occupied);
+        assert_eq!(full.load(), 0);
+        assert_eq!(available.load(), 0);
+        assert_eq!(decode.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn admission_selects_an_available_compatible_runtime() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let full_prefill = worker("grpc://sglang-prefill:30000", WorkerType::Prefill);
+        let sglang_decode = worker("grpc://sglang-decode:30000", WorkerType::Decode);
+        let available_prefill = worker_with_runtime(
+            "grpc://vllm-prefill:30000",
+            WorkerType::Prefill,
+            RuntimeType::Vllm,
+        );
+        let vllm_decode = worker_with_runtime(
+            "grpc://vllm-decode:30000",
+            WorkerType::Decode,
+            RuntimeType::Vllm,
+        );
+        for worker in [
+            &full_prefill,
+            &sglang_decode,
+            &available_prefill,
+            &vllm_decode,
+        ] {
+            registry.register(Arc::clone(worker)).unwrap();
+        }
+
+        let admission = Arc::new(PrefillAdmission::new(1, 0, Duration::from_secs(1)));
+        let occupied = admission
+            .admit(None, {
+                let full_prefill = Arc::clone(&full_prefill);
+                move |capacity| capacity.select(Arc::clone(&full_prefill), ())
+            })
+            .await
+            .unwrap();
+        let stage = stage(
+            registry,
+            PolicyConfig::RoundRobin,
+            Some(Arc::clone(&admission)),
+        );
+
+        let (prefill, decode, runtime, guards) = stage
+            .select_pd_pair(UNKNOWN_MODEL_ID, None, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(prefill.url(), available_prefill.url());
+        assert_eq!(decode.url(), vllm_decode.url());
+        assert_eq!(runtime, RuntimeType::Vllm);
+        assert_eq!(full_prefill.load(), 1);
+        assert_eq!(sglang_decode.load(), 0);
+        assert_eq!(available_prefill.load(), 1);
+        assert_eq!(vllm_decode.load(), 1);
+
+        drop(guards);
+        drop(occupied);
+        assert_eq!(full_prefill.load(), 0);
+        assert_eq!(available_prefill.load(), 0);
+        assert_eq!(vllm_decode.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn unpaired_capacity_does_not_hide_a_full_pairable_prefill() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let pairable_prefill = worker("grpc://sglang-prefill:30000", WorkerType::Prefill);
+        let decode = worker("grpc://sglang-decode:30000", WorkerType::Decode);
+        let unpaired_prefill = worker_with_runtime(
+            "grpc://vllm-prefill:30000",
+            WorkerType::Prefill,
+            RuntimeType::Vllm,
+        );
+        for worker in [&pairable_prefill, &decode, &unpaired_prefill] {
+            registry.register(Arc::clone(worker)).unwrap();
+        }
+
+        let admission = Arc::new(PrefillAdmission::new(1, 0, Duration::from_secs(1)));
+        let occupied = admission
+            .admit(None, {
+                let pairable_prefill = Arc::clone(&pairable_prefill);
+                move |capacity| capacity.select(Arc::clone(&pairable_prefill), ())
+            })
+            .await
+            .unwrap();
+        let stage = stage(
+            registry,
+            PolicyConfig::RoundRobin,
+            Some(Arc::clone(&admission)),
+        );
+
+        let result = stage
+            .select_pd_pair(UNKNOWN_MODEL_ID, None, None, None)
+            .await;
+
+        assert!(matches!(result, Err(PdSelectionError::QueueFull)));
+        assert_eq!(pairable_prefill.load(), 1);
+        assert_eq!(unpaired_prefill.load(), 0);
+        assert_eq!(decode.load(), 0);
+        drop(occupied);
+    }
+
+    #[tokio::test]
+    async fn explicit_target_indexes_the_runtime_filtered_prefill_pool() {
+        const MODEL_ID: &str = "mixed-runtime-model";
+
+        let registry = Arc::new(WorkerRegistry::new());
+        let first = modeled_worker(
+            "grpc://sglang-prefill-1:30000",
+            MODEL_ID,
+            WorkerType::Prefill,
+            RuntimeType::Sglang,
+        );
+        let other_runtime = modeled_worker(
+            "grpc://vllm-prefill:30000",
+            MODEL_ID,
+            WorkerType::Prefill,
+            RuntimeType::Vllm,
+        );
+        let target = modeled_worker(
+            "grpc://sglang-prefill-2:30000",
+            MODEL_ID,
+            WorkerType::Prefill,
+            RuntimeType::Sglang,
+        );
+        let sglang_decode_first = modeled_worker(
+            "grpc://sglang-decode-1:30000",
+            MODEL_ID,
+            WorkerType::Decode,
+            RuntimeType::Sglang,
+        );
+        let sglang_decode_target = modeled_worker(
+            "grpc://sglang-decode-2:30000",
+            MODEL_ID,
+            WorkerType::Decode,
+            RuntimeType::Sglang,
+        );
+        let vllm_decode = modeled_worker(
+            "grpc://vllm-decode:30000",
+            MODEL_ID,
+            WorkerType::Decode,
+            RuntimeType::Vllm,
+        );
+        for worker in [
+            &first,
+            &other_runtime,
+            &target,
+            &sglang_decode_first,
+            &sglang_decode_target,
+            &vllm_decode,
+        ] {
+            registry.register(Arc::clone(worker)).unwrap();
+        }
+
+        let admission = Arc::new(PrefillAdmission::new(1, 0, Duration::from_secs(1)));
+        let stage = stage(registry, PolicyConfig::ConsistentHashing, Some(admission));
+        let mut headers = HeaderMap::new();
+        headers.insert("x-smg-target-worker", "1".parse().unwrap());
+
+        let (prefill, decode, runtime, guards) = stage
+            .select_pd_pair(MODEL_ID, None, None, Some(&headers))
+            .await
+            .unwrap();
+
+        assert_eq!(prefill.url(), target.url());
+        assert_eq!(decode.url(), sglang_decode_target.url());
+        assert_eq!(runtime, RuntimeType::Sglang);
+        assert_eq!(first.load(), 0);
+        assert_eq!(other_runtime.load(), 0);
+        assert_eq!(target.load(), 1);
+        drop(guards);
+    }
+
+    #[tokio::test]
+    async fn queued_cache_aware_request_commits_only_after_final_worker_selection() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let first = worker("grpc://prefill-cache-1:30000", WorkerType::Prefill);
+        let second = worker("grpc://prefill-cache-2:30000", WorkerType::Prefill);
+        let decode = worker("grpc://decode-cache:30000", WorkerType::Decode);
+        for worker in [&first, &second, &decode] {
+            registry.register(Arc::clone(worker)).unwrap();
+        }
+
+        let cache_policy = Arc::new(CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        }));
+        cache_policy.init_workers(&[Arc::clone(&first), Arc::clone(&second)]);
+        let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin));
+        policy_registry.set_prefill_policy(cache_policy.clone());
+
+        let admission = Arc::new(PrefillAdmission::new(1, 1, Duration::from_secs(5)));
+        let occupied_first = admission
+            .admit(None, {
+                let first = Arc::clone(&first);
+                move |capacity| capacity.select(Arc::clone(&first), ())
+            })
+            .await
+            .unwrap();
+        let occupied_second = admission
+            .admit(None, {
+                let second = Arc::clone(&second);
+                move |capacity| capacity.select(Arc::clone(&second), ())
+            })
+            .await
+            .unwrap();
+        let stage = Arc::new(WorkerSelectionStage::new(
+            registry,
+            policy_registry,
+            WorkerSelectionMode::PrefillDecode,
+            Some(Arc::clone(&admission)),
+        ));
+        let tokens: Vec<u32> = (1..=16).collect();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let queued = tokio::spawn({
+            let stage = Arc::clone(&stage);
+            let tokens = tokens.clone();
+            async move {
+                stage
+                    .select_pd_pair(UNKNOWN_MODEL_ID, None, Some(&tokens), None)
+                    .await
+            }
+        });
+        for _ in 0..1_000 {
+            if admission.queued_requests() == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(admission.queued_requests(), 1);
+        assert_eq!(first.processed_requests(), 0);
+        assert_eq!(second.processed_requests(), 0);
+        assert!(!token_tree_has_tenant(&cache_policy, &tokens, first.url()));
+        assert!(!token_tree_has_tenant(&cache_policy, &tokens, second.url()));
+
+        drop(occupied_second);
+        let (selected_prefill, _, _, guards) = queued.await.unwrap().unwrap();
+
+        assert_eq!(selected_prefill.url(), second.url());
+        assert_eq!(first.processed_requests(), 0);
+        assert_eq!(second.processed_requests(), 1);
+        assert!(!token_tree_has_tenant(&cache_policy, &tokens, first.url()));
+        assert!(token_tree_has_tenant(&cache_policy, &tokens, second.url()));
+
+        drop(guards);
+        drop(occupied_first);
+    }
+
+    #[tokio::test]
+    async fn admission_does_not_reassign_a_full_explicit_target() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let first = worker("grpc://prefill-1:30000", WorkerType::Prefill);
+        let second = worker("grpc://prefill-2:30000", WorkerType::Prefill);
+        let decode = worker("grpc://decode:30000", WorkerType::Decode);
+        for worker in [&first, &second, &decode] {
+            registry.register(Arc::clone(worker)).unwrap();
+        }
+
+        let ordered_prefill: Vec<_> = registry
+            .get_workers_filtered(
+                None,
+                Some(WorkerType::Prefill),
+                Some(ConnectionMode::Grpc),
+                Some(RuntimeType::Sglang),
+                false,
+            )
+            .into_iter()
+            .filter(|worker| worker.is_available())
+            .collect();
+        assert_eq!(ordered_prefill.len(), 2);
+        let target = Arc::clone(&ordered_prefill[0]);
+        let alternative = Arc::clone(&ordered_prefill[1]);
+
+        let admission = Arc::new(PrefillAdmission::new(1, 0, Duration::from_secs(1)));
+        let occupied = admission
+            .admit(None, {
+                let target = Arc::clone(&target);
+                move |capacity| capacity.select(Arc::clone(&target), ())
+            })
+            .await
+            .unwrap();
+        let stage = stage(
+            registry,
+            PolicyConfig::ConsistentHashing,
+            Some(Arc::clone(&admission)),
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert("x-smg-target-worker", "0".parse().unwrap());
+
+        let result = stage
+            .select_pd_pair(UNKNOWN_MODEL_ID, None, None, Some(&headers))
+            .await;
+
+        assert!(matches!(result, Err(PdSelectionError::QueueFull)));
+        assert_eq!(target.load(), 1);
+        assert_eq!(alternative.load(), 0);
+        assert_eq!(decode.load(), 0);
+        drop(occupied);
+    }
 }

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -18,6 +18,7 @@ use openai_protocol::{
     responses::ResponsesRequest,
 };
 use reasoning_parser::ParserFactory as ReasoningParserFactory;
+use tokio::sync::mpsc::UnboundedSender;
 use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::debug;
 
@@ -32,7 +33,7 @@ use super::{
 };
 use crate::{
     middleware::TenantRequestMeta,
-    worker::{RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry},
+    worker::{PrefillLoadGuard, RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry},
 };
 
 /// Main request processing context
@@ -181,6 +182,10 @@ pub(crate) struct ProcessingState {
 
     // Load guard for worker load tracking (created at execution stage)
     pub load_guards: Option<LoadGuards>,
+
+    // PD load reservations are acquired with worker selection, before clients
+    // or EPD encode work are created.
+    pub pd_load_guards: Option<PdLoadGuards>,
 
     // Stage 6: Response processing state
     pub response: ResponseState,
@@ -405,49 +410,130 @@ pub(crate) struct DispatchMetadata {
     pub weight_version: Option<String>,
 }
 
-/// Load guards for worker load tracking
-/// Automatically decrements load when dropped
+/// Regular-mode load tracking. Streaming response stages attach these guards
+/// to the client response body, preserving the existing lifecycle.
 pub(crate) enum LoadGuards {
-    Single {
-        _guard: WorkerLoadGuard,
-    },
-    /// Disaggregated guards cover the prefill+decode pair. EPD encode workers are
-    /// assigned per item; their fire-and-supervise RPCs do not hold load guards.
-    Disaggregated {
-        _prefill: WorkerLoadGuard,
-        _decode: WorkerLoadGuard,
-    },
-    /// Batched completion fan-out: one guard set per sub-request so load-aware
-    /// policies see the real backend concurrency.
-    Batch {
-        _guards: Vec<LoadGuards>,
-    },
+    Single { _guard: WorkerLoadGuard },
+    Batch { _guards: Vec<LoadGuards> },
 }
 
 impl LoadGuards {
-    pub fn new(selection: &WorkerSelection, headers: Option<&HeaderMap>) -> Self {
-        match selection {
-            WorkerSelection::Single { worker } => LoadGuards::Single {
-                _guard: WorkerLoadGuard::new(worker.clone(), headers),
-            },
-            WorkerSelection::Disaggregated {
-                prefill, decode, ..
-            } => LoadGuards::Disaggregated {
-                _prefill: WorkerLoadGuard::new(prefill.clone(), headers),
-                _decode: WorkerLoadGuard::new(decode.clone(), headers),
-            },
+    fn new(worker: &Arc<dyn Worker>, headers: Option<&HeaderMap>) -> Self {
+        Self::Single {
+            _guard: WorkerLoadGuard::new(Arc::clone(worker), headers),
         }
     }
 
-    /// One guard set per concurrent sub-request.
-    pub fn scaled(selection: &WorkerSelection, headers: Option<&HeaderMap>, count: usize) -> Self {
+    pub fn scaled(worker: &Arc<dyn Worker>, headers: Option<&HeaderMap>, count: usize) -> Self {
         if count <= 1 {
-            Self::new(selection, headers)
+            Self::new(worker, headers)
         } else {
             Self::Batch {
-                _guards: (0..count).map(|_| Self::new(selection, headers)).collect(),
+                _guards: (0..count).map(|_| Self::new(worker, headers)).collect(),
             }
         }
+    }
+}
+
+/// One client request's Prefill and Decode load reservations.
+///
+/// Batch prompts share one Prefill admission reservation. Decode load, and
+/// Prefill load without admission, remain one unit per backend sub-request.
+pub(crate) struct PdLoadGuards {
+    pub prefill: PrefillLoadGuard,
+    pub decode: WorkerLoadGuard,
+}
+
+impl PdLoadGuards {
+    pub(crate) fn share_across(self, parts: usize) -> Option<Vec<Self>> {
+        if parts == 0 {
+            return None;
+        }
+
+        if parts == 1 {
+            return Some(vec![self]);
+        }
+
+        let mut split = Vec::with_capacity(parts);
+        split.push(self);
+        while split.len() < parts {
+            let replica = {
+                let first = &split[0];
+                Self {
+                    prefill: first.prefill.replicate(),
+                    decode: first.decode.replicate(),
+                }
+            };
+            split.push(replica);
+        }
+        Some(split)
+    }
+}
+
+enum StreamReservation {
+    Prefill { _guard: PrefillLoadGuard },
+    Decode { _guard: WorkerLoadGuard },
+}
+
+/// A backend stream and the reservation for that backend phase. The reservation
+/// belongs to the task that drains the upstream stream, not the client body.
+pub(crate) struct ExecutionStream {
+    stream: ProtoStream,
+    reservation: Option<StreamReservation>,
+}
+
+impl ExecutionStream {
+    pub fn untracked(stream: ProtoStream) -> Self {
+        Self {
+            stream,
+            reservation: None,
+        }
+    }
+
+    pub fn tracked_prefill(stream: ProtoStream, guard: PrefillLoadGuard) -> Self {
+        Self {
+            stream,
+            reservation: Some(StreamReservation::Prefill { _guard: guard }),
+        }
+    }
+
+    pub fn tracked_decode(stream: ProtoStream, guard: WorkerLoadGuard) -> Self {
+        Self {
+            stream,
+            reservation: Some(StreamReservation::Decode { _guard: guard }),
+        }
+    }
+
+    pub async fn next(
+        &mut self,
+    ) -> Option<Result<super::proto_wrapper::ProtoGenerateResponse, tonic::Status>> {
+        let response = self.stream.next().await;
+        if !matches!(&response, Some(Ok(_))) {
+            self.reservation = None;
+        }
+        response
+    }
+
+    pub async fn next_or_closed<T>(
+        &mut self,
+        sender: &UnboundedSender<T>,
+    ) -> Result<
+        Option<Result<super::proto_wrapper::ProtoGenerateResponse, tonic::Status>>,
+        &'static str,
+    > {
+        let response = tokio::select! {
+            biased;
+            () = sender.closed() => Err("client disconnected"),
+            response = self.stream.next() => Ok(response),
+        };
+        if !matches!(&response, Ok(Some(Ok(_)))) {
+            self.reservation = None;
+        }
+        response
+    }
+
+    pub fn mark_completed(&mut self) {
+        self.stream.mark_completed();
     }
 }
 
@@ -906,14 +992,14 @@ impl ClientSelection {
 }
 
 /// Result of request execution (streams from workers)
-/// Uses ProtoStream to automatically abort on cancellation
+/// Uses the underlying ProtoStream to abort unfinished requests on cancellation.
 pub(crate) enum ExecutionResult {
     Single {
-        stream: ProtoStream,
+        stream: ExecutionStream,
     },
     PrefillDecode {
-        prefill: ProtoStream,
-        decode: Box<ProtoStream>,
+        prefill: ExecutionStream,
+        decode: Box<ExecutionStream>,
         /// PD timing context, for honest PD TTFT (prefill start to first decode token).
         pd_timing: PdTiming,
     },
@@ -956,6 +1042,7 @@ pub(crate) enum FinalResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::worker::{BasicWorkerBuilder, PrefillAdmission, WorkerType};
 
     fn completion_prep(texts: &[&str], joined: Option<&str>) -> PreparationOutput {
         PreparationOutput::Completion {
@@ -992,5 +1079,79 @@ mod tests {
         assert_eq!(plan.request_id(), "cmpl_shared");
         assert_eq!(plan.request_type(), "generate");
         assert_eq!(plan.mode_label(), "prefill_decode");
+    }
+
+    #[tokio::test]
+    async fn batch_prompts_preserve_phase_load_semantics() {
+        let prefill: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("grpc://prefill:30000")
+                .worker_type(WorkerType::Prefill)
+                .build(),
+        );
+        let decode: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("grpc://decode:30000")
+                .worker_type(WorkerType::Decode)
+                .build(),
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert("x-smg-routing-key", "batch-key".parse().unwrap());
+
+        let admission = PrefillAdmission::new(1, 0, std::time::Duration::from_secs(1));
+        let admitted = admission
+            .admit(Some(&headers), {
+                let prefill = Arc::clone(&prefill);
+                move |capacity| capacity.select(Arc::clone(&prefill), ())
+            })
+            .await
+            .unwrap();
+        let guards = PdLoadGuards {
+            prefill: PrefillLoadGuard::Admission {
+                _reservation: Arc::new(admitted.reservation),
+            },
+            decode: WorkerLoadGuard::new(Arc::clone(&decode), Some(&headers)),
+        };
+
+        let mut children = guards.share_across(3).unwrap();
+        assert_eq!(prefill.load(), 1);
+        assert_eq!(decode.load(), 3);
+        assert_eq!(prefill.routing_key_load(), 1);
+        assert_eq!(decode.routing_key_load(), 1);
+
+        drop(children.pop());
+        assert_eq!(prefill.load(), 1);
+        assert_eq!(decode.load(), 2);
+        assert_eq!(prefill.routing_key_load(), 1);
+        assert_eq!(decode.routing_key_load(), 1);
+
+        drop(children);
+        assert_eq!(prefill.load(), 0);
+        assert_eq!(decode.load(), 0);
+        assert_eq!(prefill.routing_key_load(), 0);
+        assert_eq!(decode.routing_key_load(), 0);
+
+        let guards = PdLoadGuards {
+            prefill: PrefillLoadGuard::Unbounded {
+                _guard: WorkerLoadGuard::new(Arc::clone(&prefill), Some(&headers)),
+            },
+            decode: WorkerLoadGuard::new(Arc::clone(&decode), Some(&headers)),
+        };
+
+        let mut children = guards.share_across(3).unwrap();
+        assert_eq!(prefill.load(), 3);
+        assert_eq!(decode.load(), 3);
+        assert_eq!(prefill.routing_key_load(), 1);
+        assert_eq!(decode.routing_key_load(), 1);
+
+        drop(children.pop());
+        assert_eq!(prefill.load(), 2);
+        assert_eq!(decode.load(), 2);
+        assert_eq!(prefill.routing_key_load(), 1);
+        assert_eq!(decode.routing_key_load(), 1);
+
+        drop(children);
+        assert_eq!(prefill.load(), 0);
+        assert_eq!(decode.load(), 0);
+        assert_eq!(prefill.routing_key_load(), 0);
+        assert_eq!(decode.routing_key_load(), 0);
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -7,7 +7,7 @@ use bytes::Bytes;
 use openai_protocol::responses::ResponsesRequest;
 use serde_json::json;
 use smg_mcp::{McpServerBinding, McpToolSession};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 use uuid::Uuid;
 
@@ -23,6 +23,7 @@ use crate::{
     observability::metrics::Metrics,
     routers::{
         common::mcp_utils::DEFAULT_MAX_ITERATIONS,
+        error,
         grpc::{
             common::responses::{
                 build_sse_response, ensure_mcp_connection, persist_response_if_needed,
@@ -66,6 +67,7 @@ pub(crate) async fn serve_harmony_responses_stream(
 
     // Create SSE channel
     let (tx, rx) = mpsc::unbounded_channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
 
     // Create response event emitter
     let response_id = format!("resp_{}", Uuid::now_v7());
@@ -105,6 +107,7 @@ pub(crate) async fn serve_harmony_responses_stream(
                 mcp_servers,
                 &mut emitter,
                 &tx,
+                ready_tx,
             )
             .await;
         } else {
@@ -115,13 +118,20 @@ pub(crate) async fn serve_harmony_responses_stream(
                 tenant_request_meta,
                 &mut emitter,
                 &tx,
+                ready_tx,
             )
             .await;
         }
     });
 
-    // Return SSE stream response
-    build_sse_response(rx)
+    match ready_rx.await {
+        Ok(Ok(())) => build_sse_response(rx),
+        Ok(Err(response)) => response,
+        Err(_) => error::internal_error(
+            "responses_stream_start_failed",
+            "Responses stream failed before the backend request started",
+        ),
+    }
 }
 
 /// Execute MCP tool loop with streaming
@@ -132,6 +142,10 @@ pub(crate) async fn serve_harmony_responses_stream(
 /// - Loops through tool execution iterations
 /// - Emits final response.completed event
 /// - Persists response internally
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the streaming tool loop requires request, MCP, event, and startup state"
+)]
 async fn execute_mcp_tool_loop_streaming(
     ctx: &ResponsesContext,
     mut current_request: ResponsesRequest,
@@ -140,7 +154,9 @@ async fn execute_mcp_tool_loop_streaming(
     mcp_servers: Vec<McpServerBinding>,
     emitter: &mut ResponseStreamEventEmitter,
     tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+    ready: oneshot::Sender<Result<(), Response>>,
 ) {
+    let mut ready = Some(ready);
     let max_tool_calls = current_request.max_tool_calls.map(|n| n as usize);
 
     // Note: For streaming, the emitter's original_request (set before spawn) preserves
@@ -220,17 +236,30 @@ async fn execute_mcp_tool_loop_streaming(
         );
 
         // Execute pipeline and get stream + load guards
-        let (execution_result, _load_guards) = match ctx
-            .pipeline
-            .execute_harmony_responses_streaming(
+        let pipeline_result = tokio::select! {
+            biased;
+            () = tx.closed() => return,
+            result = ctx.pipeline.execute_harmony_responses_streaming(
                 &current_request,
                 ctx,
                 Some(tenant_request_meta.clone()),
-            )
-            .await
-        {
-            Ok(result) => result,
+                &mut ready,
+            ) => result,
+        };
+        let (execution_result, _load_guards) = match pipeline_result {
+            Ok(result) => {
+                if let Some(ready) = ready.take() {
+                    if ready.send(Ok(())).is_err() {
+                        return;
+                    }
+                }
+                result
+            }
             Err(err_response) => {
+                if let Some(ready) = ready.take() {
+                    let _ = ready.send(Err(err_response));
+                    return;
+                }
                 emitter.emit_error(
                     &format!("Pipeline execution failed: {err_response:?}"),
                     Some("pipeline_error"),
@@ -436,17 +465,36 @@ async fn execute_without_mcp_streaming(
     tenant_request_meta: TenantRequestMeta,
     emitter: &mut ResponseStreamEventEmitter,
     tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+    ready: oneshot::Sender<Result<(), Response>>,
 ) {
     debug!("No MCP tools - executing single iteration");
+    let mut ready = Some(ready);
 
     // Execute pipeline and get stream + load guards
-    let (execution_result, _load_guards) = match ctx
-        .pipeline
-        .execute_harmony_responses_streaming(current_request, ctx, Some(tenant_request_meta))
-        .await
-    {
-        Ok(result) => result,
+    let pipeline_result = tokio::select! {
+        biased;
+        () = tx.closed() => return,
+        result = ctx.pipeline.execute_harmony_responses_streaming(
+            current_request,
+            ctx,
+            Some(tenant_request_meta),
+            &mut ready,
+        ) => result,
+    };
+    let (execution_result, _load_guards) = match pipeline_result {
+        Ok(result) => {
+            if let Some(ready) = ready.take() {
+                if ready.send(Ok(())).is_err() {
+                    return;
+                }
+            }
+            result
+        }
         Err(err_response) => {
+            if let Some(ready) = ready.take() {
+                let _ = ready.send(Err(err_response));
+                return;
+            }
             emitter.emit_error(
                 &format!("Pipeline execution failed: {err_response:?}"),
                 Some("pipeline_error"),

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -48,7 +48,8 @@ use crate::{
                 },
             },
             context,
-            proto_wrapper::{ProtoResponseVariant, ProtoStream},
+            context::ExecutionStream,
+            proto_wrapper::ProtoResponseVariant,
             utils,
         },
     },
@@ -175,7 +176,7 @@ impl HarmonyStreamingProcessor {
 
     /// Process streaming chunks from a single stream
     async fn process_single_stream(
-        grpc_stream: ProtoStream,
+        grpc_stream: ExecutionStream,
         dispatch: context::DispatchMetadata,
         original_request: Arc<ChatCompletionRequest>,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
@@ -195,17 +196,17 @@ impl HarmonyStreamingProcessor {
 
     /// Process streaming chunks from prefill/decode streams (prefill + decode)
     async fn process_prefill_decode_stream(
-        mut prefill_stream: ProtoStream,
-        decode_stream: ProtoStream,
+        mut prefill_stream: ExecutionStream,
+        decode_stream: ExecutionStream,
         dispatch: context::DispatchMetadata,
         original_request: Arc<ChatCompletionRequest>,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
-        // Phase 1: Process prefill stream (collect metadata)
+        // Phase 1: Process prefill stream and collect metadata.
         let mut prompt_tokens: HashMap<u32, u32> = HashMap::new();
         let mut cached_tokens: HashMap<u32, u32> = HashMap::new();
 
-        while let Some(result) = prefill_stream.next().await {
+        while let Some(result) = prefill_stream.next_or_closed(tx).await? {
             let response = result.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
 
             if let ProtoResponseVariant::Complete(complete_wrapper) = response.into_response() {
@@ -213,7 +214,6 @@ impl HarmonyStreamingProcessor {
                 cached_tokens.insert(complete_wrapper.index(), complete_wrapper.cached_tokens());
             }
         }
-
         // Phase 2: Decode (shared helper)
         Self::process_chat_decode_stream(
             decode_stream,
@@ -224,9 +224,6 @@ impl HarmonyStreamingProcessor {
             &mut cached_tokens,
         )
         .await?;
-
-        // Mark prefill stream completed AFTER decode succeeds
-        // This ensures that if client disconnects during decode, BOTH streams send abort
         prefill_stream.mark_completed();
         Ok(())
     }
@@ -238,7 +235,7 @@ impl HarmonyStreamingProcessor {
     /// (prefill/decode stream) or empty (single stream). Values from `Complete` messages
     /// are inserted only if not already present.
     async fn process_chat_decode_stream(
-        mut decode_stream: ProtoStream,
+        mut decode_stream: ExecutionStream,
         dispatch: &context::DispatchMetadata,
         original_request: &ChatCompletionRequest,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
@@ -260,7 +257,7 @@ impl HarmonyStreamingProcessor {
         let stream_options = &original_request.stream_options;
 
         // Process stream
-        while let Some(result) = decode_stream.next().await {
+        while let Some(result) = decode_stream.next_or_closed(tx).await? {
             let response = result.map_err(|e| format!("Stream error: {}", e.message()))?;
 
             match response.into_response() {
@@ -570,16 +567,16 @@ impl HarmonyStreamingProcessor {
     }
 
     async fn process_responses_prefill_decode_stream(
-        mut prefill_stream: ProtoStream,
-        decode_stream: ProtoStream,
+        mut prefill_stream: ExecutionStream,
+        decode_stream: ExecutionStream,
         emitter: &mut ResponseStreamEventEmitter,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
         session: Option<&McpToolSession<'_>>,
         format_registry: Option<&FormatRegistry>,
     ) -> Result<ResponsesIterationResult, String> {
-        // Phase 1: Drain prefill stream, collecting cached_tokens from Complete messages
+        // Phase 1: Drain prefill stream and collect cached tokens.
         let mut prefill_cached_tokens_by_index: HashMap<u32, u32> = HashMap::new();
-        while let Some(result) = prefill_stream.next().await {
+        while let Some(result) = prefill_stream.next_or_closed(tx).await? {
             let response = result.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
             if let ProtoResponseVariant::Complete(complete_wrapper) = response.into_response() {
                 prefill_cached_tokens_by_index
@@ -587,7 +584,6 @@ impl HarmonyStreamingProcessor {
             }
         }
         let prefill_cached_tokens: u32 = prefill_cached_tokens_by_index.values().sum();
-
         // Phase 2: Process decode stream
         let result = Self::process_decode_stream(
             decode_stream,
@@ -597,15 +593,14 @@ impl HarmonyStreamingProcessor {
             format_registry,
             prefill_cached_tokens,
         )
-        .await;
-
+        .await?;
         prefill_stream.mark_completed();
-        result
+        Ok(result)
     }
 
     /// Process decode stream for tool call events.
     async fn process_decode_stream(
-        mut decode_stream: ProtoStream,
+        mut decode_stream: ExecutionStream,
         emitter: &mut ResponseStreamEventEmitter,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
         session: Option<&McpToolSession<'_>>,
@@ -638,7 +633,7 @@ impl HarmonyStreamingProcessor {
 
         // Process stream
         let mut chunk_count = 0;
-        while let Some(result) = decode_stream.next().await {
+        while let Some(result) = decode_stream.next_or_closed(tx).await? {
             chunk_count += 1;
             let response = result.map_err(|e| format!("Decode stream error: {}", e.message()))?;
 

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -15,6 +15,7 @@ use openai_protocol::{
     messages::CreateMessageRequest,
 };
 use reasoning_parser::ParserFactory as ReasoningParserFactory;
+use tokio::sync::oneshot;
 use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::{debug, error};
 
@@ -53,7 +54,7 @@ use crate::{
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     policies::PolicyRegistry,
     routers::error,
-    worker::WorkerRegistry,
+    worker::{PrefillAdmission, WorkerRegistry},
 };
 
 /// Which endpoint a pipeline serves. Selects the endpoint-specific stage list
@@ -78,6 +79,7 @@ pub(crate) enum Endpoint {
 pub(crate) struct PipelineDeps {
     worker_registry: Arc<WorkerRegistry>,
     policy_registry: Arc<PolicyRegistry>,
+    prefill_admission: Option<Arc<PrefillAdmission>>,
     tool_parser_factory: ToolParserFactory,
     reasoning_parser_factory: ReasoningParserFactory,
     configured_tool_parser: Option<String>,
@@ -90,6 +92,7 @@ impl PipelineDeps {
     pub(crate) fn new(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
+        prefill_admission: Option<Arc<PrefillAdmission>>,
         tool_parser_factory: ToolParserFactory,
         reasoning_parser_factory: ReasoningParserFactory,
         configured_tool_parser: Option<String>,
@@ -98,6 +101,7 @@ impl PipelineDeps {
         Self {
             worker_registry,
             policy_registry,
+            prefill_admission,
             tool_parser_factory,
             reasoning_parser_factory,
             configured_tool_parser,
@@ -110,10 +114,12 @@ impl PipelineDeps {
     pub(crate) fn pair(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
+        prefill_admission: Option<Arc<PrefillAdmission>>,
     ) -> Self {
         Self {
             worker_registry,
             policy_registry,
+            prefill_admission,
             tool_parser_factory: ToolParserFactory::default(),
             reasoning_parser_factory: ReasoningParserFactory::default(),
             configured_tool_parser: None,
@@ -176,11 +182,21 @@ impl PipelineDeps {
         Self {
             worker_registry: Arc::new(WorkerRegistry::new()),
             policy_registry: Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
+            prefill_admission: None,
             tool_parser_factory: ToolParserFactory::default(),
             reasoning_parser_factory: ReasoningParserFactory::default(),
             configured_tool_parser: None,
             configured_reasoning_parser: None,
         }
+    }
+
+    fn worker_selection_stage(&self, mode: WorkerSelectionMode) -> WorkerSelectionStage {
+        WorkerSelectionStage::new(
+            self.worker_registry.clone(),
+            self.policy_registry.clone(),
+            mode,
+            self.prefill_admission.clone(),
+        )
     }
 }
 
@@ -188,6 +204,8 @@ impl PipelineDeps {
 ///
 /// Orchestrates all stages from request preparation to response delivery.
 /// Configured differently for regular vs PD mode.
+pub(crate) type StreamStartSender = oneshot::Sender<Result<(), Response>>;
+
 #[derive(Clone)]
 pub(crate) struct RequestPipeline {
     stages: Arc<Vec<Box<dyn PipelineStage>>>,
@@ -259,11 +277,7 @@ impl RequestPipeline {
                 let (processor, streaming_processor) = deps.configured_processors(backend);
                 let mut stages: Vec<Box<dyn PipelineStage>> = vec![
                     Box::new(ChatGeneratePreparationStage::new()),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
+                    Box::new(deps.worker_selection_stage(worker_selection)),
                     Box::new(ClientAcquisitionStage),
                 ];
                 if matches!(mode, Mode::EncodePrefillDecode) {
@@ -275,7 +289,7 @@ impl RequestPipeline {
                         plan_kind,
                     )) as Box<dyn PipelineStage>,
                     Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
+                    Box::new(RequestExecutionStage),
                     Box::new(ChatGenerateResponseProcessingStage::new(
                         processor,
                         streaming_processor,
@@ -287,11 +301,7 @@ impl RequestPipeline {
                 let (processor, streaming_processor) = deps.configured_processors(backend);
                 let mut stages: Vec<Box<dyn PipelineStage>> = vec![
                     Box::new(MessagePreparationStage),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
+                    Box::new(deps.worker_selection_stage(worker_selection)),
                     Box::new(ClientAcquisitionStage),
                 ];
                 if matches!(mode, Mode::EncodePrefillDecode) {
@@ -303,7 +313,7 @@ impl RequestPipeline {
                         plan_kind,
                     )) as Box<dyn PipelineStage>,
                     Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
+                    Box::new(RequestExecutionStage),
                     Box::new(MessageResponseProcessingStage::new(
                         processor,
                         streaming_processor,
@@ -316,11 +326,7 @@ impl RequestPipeline {
                 let (processor, streaming_processor) = PipelineDeps::default_processors(backend);
                 let mut stages: Vec<Box<dyn PipelineStage>> = vec![
                     Box::new(CompletionPreparationStage),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
+                    Box::new(deps.worker_selection_stage(worker_selection)),
                     Box::new(ClientAcquisitionStage),
                 ];
                 if matches!(mode, Mode::EncodePrefillDecode) {
@@ -332,7 +338,7 @@ impl RequestPipeline {
                         plan_kind,
                     )) as Box<dyn PipelineStage>,
                     Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
+                    Box::new(RequestExecutionStage),
                     Box::new(CompletionResponseProcessingStage::new(
                         processor,
                         streaming_processor,
@@ -347,18 +353,14 @@ impl RequestPipeline {
                 }
                 vec![
                     Box::new(harmony::stages::HarmonyPreparationStage::new()),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
+                    Box::new(deps.worker_selection_stage(worker_selection)),
                     Box::new(ClientAcquisitionStage),
                     Box::new(harmony::stages::HarmonyRequestBuildingStage::new(
                         inject_pd_metadata,
                         plan_kind,
                     )),
                     Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
+                    Box::new(RequestExecutionStage),
                     Box::new(harmony::stages::HarmonyResponseProcessingStage::new()),
                 ]
             }
@@ -369,15 +371,11 @@ impl RequestPipeline {
                 }
                 vec![
                     Box::new(EmbeddingPreparationStage::new()),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
+                    Box::new(deps.worker_selection_stage(worker_selection)),
                     Box::new(ClientAcquisitionStage),
                     Box::new(EmbeddingRequestBuildingStage::new()),
                     Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
+                    Box::new(RequestExecutionStage),
                     Box::new(EmbeddingResponseProcessingStage::new()),
                 ]
             }
@@ -388,15 +386,11 @@ impl RequestPipeline {
                 }
                 vec![
                     Box::new(EmbeddingPreparationStage::new()),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
+                    Box::new(deps.worker_selection_stage(worker_selection)),
                     Box::new(ClientAcquisitionStage),
                     Box::new(EmbeddingRequestBuildingStage::new()),
                     Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
+                    Box::new(RequestExecutionStage),
                     Box::new(ClassifyResponseProcessingStage::new()),
                 ]
             }
@@ -416,6 +410,7 @@ impl RequestPipeline {
         model_id: String,
         components: Arc<SharedComponents>,
         tenant_request_meta: Option<TenantRequestMeta>,
+        mut stream_start: Option<&mut Option<StreamStartSender>>,
     ) -> Response {
         let start = Instant::now();
         let streaming = request.stream;
@@ -434,6 +429,13 @@ impl RequestPipeline {
         );
 
         for stage in self.stages.iter() {
+            if stage.begins_backend_dispatch() {
+                if let Some(stream_start) = stream_start.as_deref_mut() {
+                    if let Some(sender) = stream_start.take() {
+                        let _ = sender.send(Ok(()));
+                    }
+                }
+            }
             match stage.execute(&mut ctx).await {
                 Ok(Some(response)) => {
                     // Stage completed with streaming response - record success and return
@@ -1135,6 +1137,7 @@ impl RequestPipeline {
         request: &openai_protocol::responses::ResponsesRequest,
         harmony_ctx: &ResponsesContext,
         tenant_request_meta: Option<TenantRequestMeta>,
+        stream_start: &mut Option<StreamStartSender>,
     ) -> Result<(ExecutionResult, Option<LoadGuards>), Response> {
         // Create RequestContext for this Responses request
         let mut ctx = RequestContext::for_responses(
@@ -1146,6 +1149,11 @@ impl RequestPipeline {
         ctx.input.tenant_request_meta = tenant_request_meta;
 
         for (idx, stage) in self.stages.iter().enumerate() {
+            if stage.begins_backend_dispatch() {
+                if let Some(sender) = stream_start.take() {
+                    let _ = sender.send(Ok(()));
+                }
+            }
             match stage.execute(&mut ctx).await {
                 Ok(Some(response)) => {
                     error!(
@@ -1481,7 +1489,7 @@ mod alias_pipeline_tests {
             .unwrap();
 
         let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin));
-        let deps = PipelineDeps::pair(worker_registry.clone(), policy_registry);
+        let deps = PipelineDeps::pair(worker_registry.clone(), policy_registry, None);
         let pipeline = RequestPipeline::build(Endpoint::Chat, Mode::PrefillDecode, &deps).unwrap();
         let components = Arc::new(SharedComponents {
             tokenizer_registry,

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -125,7 +125,8 @@ async fn route_responses_streaming(
             &request,
             params,
             mcp_servers,
-        );
+        )
+        .await;
     }
 
     // 3. Convert ResponsesRequest → ChatCompletionRequest

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -11,11 +11,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use axum::{
-    body::Body,
-    http::{header, StatusCode},
-    response::Response,
-};
+use axum::{body::Body, response::Response};
 use bytes::Bytes;
 use futures_util::StreamExt;
 use openai_protocol::{
@@ -35,8 +31,7 @@ use smg_data_connector::{
     ResponseStorage,
 };
 use smg_mcp::{McpServerBinding, McpToolSession, ToolExecutionInput};
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, trace, warn};
 use uuid::Uuid;
 
@@ -54,6 +49,7 @@ use crate::{
             mcp_utils::{prepare_hosted_dispatch_args, DEFAULT_MAX_ITERATIONS},
             openai_bridge::{self, ResponseFormat},
         },
+        error,
         grpc::{
             common::responses::{
                 build_sse_response, persist_response_if_needed,
@@ -94,8 +90,13 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
             params.model_id,
             ctx.components.clone(),
             Some(params.tenant_request_meta),
+            None,
         )
         .await;
+
+    if !chat_response.status().is_success() {
+        return chat_response;
+    }
 
     // Extract body from chat response
     let (_parts, body) = chat_response.into_parts();
@@ -173,7 +174,15 @@ async fn process_and_transform_sse_stream(
     let mut stream = body.into_data_stream();
 
     // Process stream chunks (each chunk is a complete SSE event)
-    while let Some(chunk_result) = stream.next().await {
+    loop {
+        let chunk_result = tokio::select! {
+            biased;
+            () = tx.closed() => return Err("Client disconnected".to_string()),
+            chunk = stream.next() => chunk,
+        };
+        let Some(chunk_result) = chunk_result else {
+            break;
+        };
         let chunk = chunk_result.map_err(|e| format!("Stream read error: {e}"))?;
 
         // Convert chunk to string
@@ -431,7 +440,7 @@ impl StreamingResponseAccumulator {
 /// This streams each iteration's response to the client while accumulating
 /// to check for tool calls. If tool calls are found, executes them and
 /// continues with the next streaming iteration.
-pub(super) fn execute_tool_loop_streaming(
+pub(super) async fn execute_tool_loop_streaming(
     ctx: &ResponsesContext,
     current_request: ResponsesRequest,
     original_request: &ResponsesRequest,
@@ -440,6 +449,7 @@ pub(super) fn execute_tool_loop_streaming(
 ) -> Response {
     // Create SSE channel for client
     let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();
+    let (ready_tx, ready_rx) = oneshot::channel();
 
     // Clone data for background task
     let ctx_clone = ctx.clone();
@@ -458,6 +468,7 @@ pub(super) fn execute_tool_loop_streaming(
             params,
             mcp_servers,
             tx.clone(),
+            ready_tx,
         )
         .await;
 
@@ -470,33 +481,14 @@ pub(super) fn execute_tool_loop_streaming(
         let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
     });
 
-    // Build SSE response
-    let stream = UnboundedReceiverStream::new(rx);
-    let body = Body::from_stream(stream);
-
-    #[expect(
-        clippy::expect_used,
-        reason = "Response::builder with valid status and no invalid headers is infallible"
-    )]
-    let mut response = Response::builder()
-        .status(StatusCode::OK)
-        .body(body)
-        .expect("infallible: valid status code, no invalid headers");
-
-    response.headers_mut().insert(
-        header::CONTENT_TYPE,
-        header::HeaderValue::from_static("text/event-stream"),
-    );
-    response.headers_mut().insert(
-        header::CACHE_CONTROL,
-        header::HeaderValue::from_static("no-cache"),
-    );
-    response.headers_mut().insert(
-        header::CONNECTION,
-        header::HeaderValue::from_static("keep-alive"),
-    );
-
-    response
+    match ready_rx.await {
+        Ok(Ok(())) => build_sse_response(rx),
+        Ok(Err(response)) => response,
+        Err(_) => error::internal_error(
+            "responses_stream_start_failed",
+            "Responses stream failed before the backend request started",
+        ),
+    }
 }
 
 /// Internal streaming tool loop implementation
@@ -507,7 +499,9 @@ async fn execute_tool_loop_streaming_internal(
     params: ResponsesCallContext,
     mcp_servers: Vec<McpServerBinding>,
     tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+    ready: oneshot::Sender<Result<(), Response>>,
 ) -> Result<(), String> {
+    let mut ready = Some(ready);
     let mut state = ToolLoopState::new(original_request.input.clone());
     let max_tool_calls = original_request.max_tool_calls.map(|n| n as usize);
 
@@ -567,23 +561,47 @@ async fn execute_tool_loop_streaming_internal(
         }
 
         // Convert to chat request
-        let mut chat_request = conversions::responses_to_chat(&current_request)
-            .map_err(|e| format!("Failed to convert request: {e}"))?;
+        let mut chat_request = match conversions::responses_to_chat(&current_request) {
+            Ok(request) => request,
+            Err(conversion_error) => {
+                let message = format!("Failed to convert request: {conversion_error}");
+                if let Some(ready) = ready.take() {
+                    let _ = ready.send(Err(error::bad_request("convert_request_failed", message)));
+                    return Ok(());
+                }
+                return Err(message);
+            }
+        };
 
         // Prepare tools and tool_choice for this iteration (same logic as non-streaming)
         prepare_chat_tools_and_choice(&mut chat_request, &mcp_chat_tools, state.iteration);
 
         // Execute chat streaming
-        let response = ctx
-            .pipeline
-            .execute_chat(
+        let response = tokio::select! {
+            biased;
+            () = tx.closed() => return Err("Client disconnected".to_string()),
+            response = ctx.pipeline.execute_chat(
                 Arc::new(chat_request),
                 params.headers.clone(),
                 params.model_id.clone(),
                 ctx.components.clone(),
                 Some(params.tenant_request_meta.clone()),
-            )
-            .await;
+                Some(&mut ready),
+            ) => response,
+        };
+
+        if !response.status().is_success() {
+            if let Some(ready) = ready.take() {
+                let _ = ready.send(Err(response));
+                return Ok(());
+            }
+            return Err(format!("Chat pipeline returned HTTP {}", response.status()));
+        }
+        if let Some(ready) = ready.take() {
+            if ready.send(Ok(())).is_err() {
+                return Ok(());
+            }
+        }
 
         // Convert chat stream to Responses API events while accumulating for tool call detection
         // Stream text naturally - it only appears on final iteration (tool iterations have empty content)
@@ -939,7 +957,15 @@ async fn convert_and_accumulate_stream(
     let mut accumulator = ChatResponseAccumulator::new();
     let mut stream = body.into_data_stream();
 
-    while let Some(chunk_result) = stream.next().await {
+    loop {
+        let chunk_result = tokio::select! {
+            biased;
+            () = tx.closed() => return Err("Client disconnected".to_string()),
+            chunk = stream.next() => chunk,
+        };
+        let Some(chunk_result) = chunk_result else {
+            break;
+        };
         let chunk = chunk_result.map_err(|e| format!("Stream read error: {e}"))?;
 
         // Parse chunk

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -40,8 +40,8 @@ use crate::{
         common::sse::SseEncoder,
         grpc::{
             common::{response_formatting::CompletionTokenTracker, responses::build_sse_response},
-            context,
-            proto_wrapper::{ProtoResponseVariant, ProtoStream},
+            context::{self, ExecutionStream},
+            proto_wrapper::ProtoResponseVariant,
             utils,
             utils::message_utils,
         },
@@ -51,10 +51,10 @@ use crate::{
 /// One backend stream of a `/v1/completions` request. Batched requests fan
 /// out into several, each remapped by a prompt-major choice-index offset.
 enum CompletionStreamUnit {
-    Single(ProtoStream),
+    Single(ExecutionStream),
     PrefillDecode {
-        prefill: ProtoStream,
-        decode: Box<ProtoStream>,
+        prefill: ExecutionStream,
+        decode: Box<ExecutionStream>,
     },
 }
 
@@ -222,7 +222,7 @@ impl StreamingProcessor {
     /// Process streaming chunks from a single stream (Regular mode)
     pub async fn process_streaming_chunks(
         &self,
-        grpc_stream: ProtoStream,
+        grpc_stream: ExecutionStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
@@ -247,7 +247,7 @@ impl StreamingProcessor {
     #[expect(clippy::too_many_arguments)]
     async fn process_streaming_chunks_inner(
         &self,
-        mut grpc_stream: ProtoStream,
+        mut grpc_stream: ExecutionStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
@@ -364,7 +364,7 @@ impl StreamingProcessor {
         }
 
         // Phase 2: Main streaming loop
-        while let Some(response) = grpc_stream.next().await {
+        while let Some(response) = grpc_stream.next_or_closed(tx).await? {
             let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
 
             match gen_response.into_response() {
@@ -686,8 +686,8 @@ impl StreamingProcessor {
     #[expect(clippy::too_many_arguments)]
     pub async fn process_prefill_decode_streaming_chunks(
         &self,
-        mut prefill_stream: ProtoStream,
-        decode_stream: ProtoStream,
+        mut prefill_stream: ExecutionStream,
+        decode_stream: ExecutionStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
@@ -695,44 +695,24 @@ impl StreamingProcessor {
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
         pd_timing: context::PdTiming,
     ) -> Result<(), String> {
-        // Phase 1.5: Collect input_logprobs from prefill stream if requested
-        if original_request.logprobs {
-            while let Some(response) = prefill_stream.next().await {
-                let gen_response =
-                    response.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
-                match gen_response.into_response() {
-                    ProtoResponseVariant::Complete(_complete) => {
-                        // Input logprobs collected but not yet used in streaming
-                        // (OpenAI spec doesn't require prompt logprobs in streaming responses)
-                        break;
-                    }
-                    _ => continue,
-                }
-            }
+        while let Some(response) = prefill_stream.next_or_closed(tx).await? {
+            response.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
         }
-
         // Phase 2-5: Process decode stream (same as single mode). Pass pd_timing
         // so the first decode token yields honest PD TTFT.
         // Note: decode_stream will be marked completed inside process_streaming_chunks
-        let result = self
-            .process_streaming_chunks_inner(
-                decode_stream,
-                dispatch,
-                tokenizer,
-                stop_params,
-                original_request,
-                tx,
-                Some(pd_timing),
-            )
-            .await;
-
-        // Mark prefill stream as completed AFTER decode completes successfully
-        // This ensures that if client disconnects during decode, BOTH streams send abort
-        if result.is_ok() {
-            prefill_stream.mark_completed();
-        }
-
-        result
+        self.process_streaming_chunks_inner(
+            decode_stream,
+            dispatch,
+            tokenizer,
+            stop_params,
+            original_request,
+            tx,
+            Some(pd_timing),
+        )
+        .await?;
+        prefill_stream.mark_completed();
+        Ok(())
     }
 
     /// Process streaming generate response and return SSE response
@@ -833,7 +813,7 @@ impl StreamingProcessor {
     /// TODO: add streaming logprob support
     async fn process_generate_streaming(
         tokenizer: Arc<dyn Tokenizer>,
-        mut stream: ProtoStream,
+        mut stream: ExecutionStream,
         ctx: GenerateStreamContext,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
@@ -846,7 +826,7 @@ impl StreamingProcessor {
         // Reusable SSE encoder shared across every chunk emitted for this stream.
         let mut sse_encoder = SseEncoder::new();
 
-        while let Some(response) = stream.next().await {
+        while let Some(response) = stream.next_or_closed(tx).await? {
             let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
 
             match gen_response.into_response() {
@@ -947,39 +927,29 @@ impl StreamingProcessor {
     /// Process prefill/decode streaming for generate endpoint (PD mode with logprobs support)
     async fn process_generate_prefill_decode_streaming(
         tokenizer: Arc<dyn Tokenizer>,
-        mut prefill_stream: ProtoStream,
-        decode_stream: ProtoStream,
+        mut prefill_stream: ExecutionStream,
+        decode_stream: ExecutionStream,
         ctx: GenerateStreamContext,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
         pd_timing: context::PdTiming,
     ) -> Result<(), String> {
-        // Collect input_logprobs from prefill stream if requested
-        let input_token_logprobs = if ctx.return_logprob {
-            let mut input_logprobs = None;
-            while let Some(response) = prefill_stream.next().await {
-                let gen_response =
-                    response.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
-                match gen_response.into_response() {
-                    ProtoResponseVariant::Complete(complete) => {
-                        // Extract input_logprobs from prefill Complete message (convert proto to SGLang format)
-                        input_logprobs = complete
-                            .input_logprobs()
-                            .as_ref()
-                            .map(utils::convert_generate_input_logprobs);
-                        break;
-                    }
-                    _ => continue,
+        let mut input_token_logprobs = None;
+        while let Some(response) = prefill_stream.next_or_closed(tx).await? {
+            let gen_response =
+                response.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
+            if ctx.return_logprob && input_token_logprobs.is_none() {
+                if let ProtoResponseVariant::Complete(complete) = gen_response.into_response() {
+                    input_token_logprobs = complete
+                        .input_logprobs()
+                        .as_ref()
+                        .map(utils::convert_generate_input_logprobs);
                 }
             }
-            input_logprobs
-        } else {
-            None
-        };
-
+        }
         // Process decode stream with input_logprobs prepended. Pass pd_timing so
         // the first decode token yields honest PD TTFT.
         // Note: decode_stream will be marked completed inside the function
-        let result = Self::process_generate_streaming_with_input_logprobs(
+        Self::process_generate_streaming_with_input_logprobs(
             tokenizer,
             decode_stream,
             ctx,
@@ -987,21 +957,15 @@ impl StreamingProcessor {
             tx,
             Some(pd_timing),
         )
-        .await;
-
-        // Mark prefill stream as completed AFTER decode completes successfully
-        // This ensures that if client disconnects during decode, BOTH streams send abort
-        if result.is_ok() {
-            prefill_stream.mark_completed();
-        }
-
-        result
+        .await?;
+        prefill_stream.mark_completed();
+        Ok(())
     }
 
     /// Process generate streaming with optional input_logprobs
     async fn process_generate_streaming_with_input_logprobs(
         tokenizer: Arc<dyn Tokenizer>,
-        mut stream: ProtoStream,
+        mut stream: ExecutionStream,
         ctx: GenerateStreamContext,
         input_token_logprobs: Option<Vec<Vec<Option<f64>>>>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
@@ -1018,7 +982,7 @@ impl StreamingProcessor {
         // Reusable SSE encoder shared across every chunk emitted for this stream.
         let mut sse_encoder = SseEncoder::new();
 
-        while let Some(response) = stream.next().await {
+        while let Some(response) = stream.next_or_closed(tx).await? {
             let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
 
             match gen_response.into_response() {
@@ -1693,7 +1657,7 @@ impl StreamingProcessor {
     /// state tracking. Always n=1 (no per-index HashMap).
     pub async fn process_messages_streaming_chunks(
         &self,
-        mut grpc_stream: ProtoStream,
+        mut grpc_stream: ExecutionStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
@@ -1858,7 +1822,7 @@ impl StreamingProcessor {
         )?;
 
         // Phase 2: Main streaming loop
-        while let Some(response) = grpc_stream.next().await {
+        while let Some(response) = grpc_stream.next_or_closed(tx).await? {
             let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
 
             match gen_response.into_response() {
@@ -2320,40 +2284,28 @@ impl StreamingProcessor {
     #[expect(clippy::too_many_arguments)]
     pub async fn process_prefill_decode_messages_streaming_chunks(
         &self,
-        mut prefill_stream: ProtoStream,
-        decode_stream: ProtoStream,
+        mut prefill_stream: ExecutionStream,
+        decode_stream: ExecutionStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<CreateMessageRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
-        // Consume prefill stream (Messages API does not expose prompt logprobs)
-        while let Some(response) = prefill_stream.next().await {
-            let gen_response =
-                response.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
-            match gen_response.into_response() {
-                ProtoResponseVariant::Complete(_) => break,
-                _ => continue,
-            }
+        while let Some(response) = prefill_stream.next_or_closed(tx).await? {
+            response.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
         }
-
-        let result = self
-            .process_messages_streaming_chunks(
-                decode_stream,
-                dispatch,
-                tokenizer,
-                stop_params,
-                original_request,
-                tx,
-            )
-            .await;
-
-        if result.is_ok() {
-            prefill_stream.mark_completed();
-        }
-
-        result
+        self.process_messages_streaming_chunks(
+            decode_stream,
+            dispatch,
+            tokenizer,
+            stop_params,
+            original_request,
+            tx,
+        )
+        .await?;
+        prefill_stream.mark_completed();
+        Ok(())
     }
 
     // =========================================================================
@@ -2565,7 +2517,7 @@ impl StreamingProcessor {
     #[expect(clippy::too_many_arguments)]
     async fn process_completion_streaming_chunks(
         &self,
-        mut grpc_stream: ProtoStream,
+        mut grpc_stream: ExecutionStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
@@ -2598,7 +2550,7 @@ impl StreamingProcessor {
         let mut reasoning_tokens: HashMap<u32, u32> = HashMap::new();
         let mut total_completion = CompletionTokenTracker::new();
 
-        while let Some(response) = grpc_stream.next().await {
+        while let Some(response) = grpc_stream.next_or_closed(tx).await? {
             let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
 
             match gen_response.into_response() {
@@ -2856,8 +2808,8 @@ impl StreamingProcessor {
     #[expect(clippy::too_many_arguments)]
     async fn process_prefill_decode_completion_streaming_chunks(
         &self,
-        mut prefill_stream: ProtoStream,
-        decode_stream: ProtoStream,
+        mut prefill_stream: ExecutionStream,
+        decode_stream: ExecutionStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
@@ -2866,17 +2818,10 @@ impl StreamingProcessor {
         index_offset: u32,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<CompletionStreamOutcome, String> {
-        while let Some(response) = prefill_stream.next().await {
-            let gen_response =
-                response.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
-
-            match gen_response.into_response() {
-                ProtoResponseVariant::Complete(_) => break,
-                _ => continue,
-            }
+        while let Some(response) = prefill_stream.next_or_closed(tx).await? {
+            response.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
         }
-
-        let result = self
+        let outcome = self
             .process_completion_streaming_chunks(
                 decode_stream,
                 dispatch,
@@ -2887,15 +2832,9 @@ impl StreamingProcessor {
                 index_offset,
                 tx,
             )
-            .await;
-
-        // Mark prefill stream as completed AFTER decode completes successfully
-        // This ensures that if client disconnects during decode, BOTH streams send abort
-        if result.is_ok() {
-            prefill_stream.mark_completed();
-        }
-
-        result
+            .await?;
+        prefill_stream.mark_completed();
+        Ok(outcome)
     }
 
     /// Format a `CompletionStreamResponse` into the SSE buffer.

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -38,7 +38,7 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
         common::retry::{is_retryable_status, RetryExecutor},
-        error, RouterTrait,
+        error, RouterTrait, PD_PREFILL_QUEUE_FULL, PD_PREFILL_QUEUE_TIMEOUT,
     },
     worker::{ConnectionMode, WorkerRegistry, WorkerType},
 };
@@ -86,6 +86,14 @@ const QWEN3_ASR_LABEL_KEYS: &[&str] = &[
     "tokenizer",
     "tokenizer_path",
 ];
+
+fn is_retryable_response(response: &Response) -> bool {
+    is_retryable_status(response.status())
+        && !matches!(
+            error::extract_error_code_from_response(response),
+            PD_PREFILL_QUEUE_FULL | PD_PREFILL_QUEUE_TIMEOUT
+        )
+}
 
 fn strip_chatml_like_tokens(text: &str) -> String {
     let mut remaining = text;
@@ -360,13 +368,18 @@ impl GrpcRouter {
         let configured_deps = PipelineDeps::new(
             worker_registry.clone(),
             policy_registry.clone(),
+            ctx.prefill_admission.clone(),
             tool_parser_factory.clone(),
             reasoning_parser_factory.clone(),
             ctx.configured_tool_parser.clone(),
             ctx.configured_reasoning_parser.clone(),
         );
         // Deps for the parser-free endpoints (completion/embeddings/classify).
-        let pair_deps = PipelineDeps::pair(worker_registry.clone(), policy_registry.clone());
+        let pair_deps = PipelineDeps::pair(
+            worker_registry.clone(),
+            policy_registry.clone(),
+            ctx.prefill_admission.clone(),
+        );
 
         // Present in every mode: chat/generate, messages, completion.
         let pipeline = RequestPipeline::build(Endpoint::Chat, mode, &configured_deps)
@@ -526,12 +539,19 @@ impl GrpcRouter {
                 let tenant_meta = tenant_meta_cloned.clone();
                 async move {
                     pipeline
-                        .execute_chat(request, headers, model_id, components, Some(tenant_meta))
+                        .execute_chat(
+                            request,
+                            headers,
+                            model_id,
+                            components,
+                            Some(tenant_meta),
+                            None,
+                        )
                         .await
                 }
             },
             // Should retry: check if status is retryable
-            |res, _attempt| is_retryable_status(res.status()),
+            |res, _attempt| is_retryable_response(res),
             // On backoff: record retry metrics
             |delay, attempt| {
                 self.record_retry(metrics_labels::ENDPOINT_CHAT);
@@ -581,7 +601,7 @@ impl GrpcRouter {
                 }
             },
             // Should retry: check if status is retryable
-            |res, _attempt| is_retryable_status(res.status()),
+            |res, _attempt| is_retryable_response(res),
             // On backoff: record retry metrics
             |delay, attempt| {
                 self.record_retry(metrics_labels::ENDPOINT_GENERATE);
@@ -726,7 +746,7 @@ impl GrpcRouter {
                         .await
                 }
             },
-            |res, _attempt| is_retryable_status(res.status()),
+            |res, _attempt| is_retryable_response(res),
             |delay, attempt| {
                 self.record_retry(metrics_labels::ENDPOINT_MESSAGES);
                 Metrics::record_worker_retry_backoff(attempt, delay);
@@ -777,7 +797,7 @@ impl GrpcRouter {
                         .await
                 }
             },
-            |res, _attempt| is_retryable_status(res.status()),
+            |res, _attempt| is_retryable_response(res),
             |delay, attempt| {
                 self.record_retry(metrics_labels::ENDPOINT_COMPLETIONS);
                 Metrics::record_worker_retry_backoff(attempt, delay);
@@ -1231,6 +1251,17 @@ mod tests {
             .status(),
             StatusCode::OK
         );
+    }
+
+    #[test]
+    fn local_prefill_queue_rejections_are_not_retryable() {
+        for code in [PD_PREFILL_QUEUE_FULL, PD_PREFILL_QUEUE_TIMEOUT] {
+            let response = error::too_many_requests(code, "Prefill admission rejected");
+            assert!(!is_retryable_response(&response));
+        }
+
+        let upstream = StatusCode::TOO_MANY_REQUESTS.into_response();
+        assert!(is_retryable_response(&upstream));
     }
 }
 

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -32,7 +32,7 @@ use crate::{
         metrics::{bool_to_static_str, metrics_labels, Metrics},
         otel_trace::inject_trace_context_http,
     },
-    policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
+    policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo, WorkerLeg},
     routers::{
         common::{
             header_utils,
@@ -41,29 +41,122 @@ use crate::{
         },
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},
-        RouterTrait,
+        RouterTrait, PD_PREFILL_QUEUE_FULL, PD_PREFILL_QUEUE_TIMEOUT,
     },
-    worker::{HashRing, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType, UNKNOWN_MODEL_ID},
+    worker::{
+        acquire_prefill, HashRing, PrefillAcquireError, PrefillAdmission,
+        PrefillAdmissionRejection, PrefillCandidateError, PrefillLoadGuard,
+        PrefillSelectionContext, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType,
+        UNKNOWN_MODEL_ID,
+    },
 };
 
-#[derive(Debug)]
+type PdWorkerPair = (Arc<dyn Worker>, Arc<dyn Worker>);
+type PdWorkerPools = (Vec<Arc<dyn Worker>>, Vec<Arc<dyn Worker>>);
+
+/// One admitted PD request: the chosen pair and the load it holds.
+struct AdmittedPdPair {
+    prefill: Arc<dyn Worker>,
+    decode: Arc<dyn Worker>,
+    prefill_guard: PrefillLoadGuard,
+    decode_guard: WorkerLoadGuard,
+}
+
 pub struct PDRouter {
     pub worker_registry: Arc<WorkerRegistry>,
     pub policy_registry: Arc<PolicyRegistry>,
     pub client: Client,
     pub retry_config: RetryConfig,
     pub api_key: Option<String>,
+    prefill_admission: Option<Arc<PrefillAdmission>>,
+}
+
+impl std::fmt::Debug for PDRouter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PDRouter")
+            .field("worker_registry", &self.worker_registry)
+            .field("policy_registry", &self.policy_registry)
+            .field("client", &self.client)
+            .field("retry_config", &self.retry_config)
+            .field("api_key_configured", &self.api_key.is_some())
+            .field(
+                "prefill_admission_enabled",
+                &self.prefill_admission.is_some(),
+            )
+            .finish()
+    }
 }
 
 #[derive(Clone)]
 struct PDRequestContext<'a> {
     route: &'static str,
-    batch_size: Option<usize>,
+    bootstrap_batch_size: Option<usize>,
     is_stream: bool,
     return_logprob: bool,
     request_text: Option<String>,
     model_id: &'a str,
     headers: Option<HeaderMap>,
+}
+
+#[derive(Debug)]
+enum PDSelectionError {
+    Unavailable(String),
+    QueueFull,
+    QueueTimeout,
+}
+
+#[derive(Debug)]
+enum PDCandidateError {
+    Unavailable(String),
+    PrefillAtCapacity,
+}
+
+impl std::fmt::Display for PDSelectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unavailable(message) => f.write_str(message),
+            Self::QueueFull => f.write_str("Prefill admission queue is full"),
+            Self::QueueTimeout => f.write_str("Timed out waiting for Prefill admission"),
+        }
+    }
+}
+
+impl From<PrefillAdmissionRejection> for PDSelectionError {
+    fn from(value: PrefillAdmissionRejection) -> Self {
+        match value {
+            PrefillAdmissionRejection::QueueFull => Self::QueueFull,
+            PrefillAdmissionRejection::QueueTimeout => Self::QueueTimeout,
+            PrefillAdmissionRejection::Unavailable => {
+                Self::Unavailable("No available prefill and decode worker pair".to_string())
+            }
+        }
+    }
+}
+
+impl From<PDCandidateError> for PDSelectionError {
+    fn from(value: PDCandidateError) -> Self {
+        match value {
+            PDCandidateError::Unavailable(message) => Self::Unavailable(message),
+            PDCandidateError::PrefillAtCapacity => {
+                Self::Unavailable("No available prefill workers".to_string())
+            }
+        }
+    }
+}
+
+impl From<PrefillAcquireError<PDCandidateError>> for PDSelectionError {
+    fn from(value: PrefillAcquireError<PDCandidateError>) -> Self {
+        match value {
+            PrefillAcquireError::Candidate(error) => error.into(),
+            PrefillAcquireError::Rejected(rejection) => rejection.into(),
+        }
+    }
+}
+
+impl PrefillCandidateError for PDCandidateError {
+    fn is_at_capacity(&self) -> bool {
+        matches!(self, Self::PrefillAtCapacity)
+    }
 }
 
 impl PDRouter {
@@ -169,15 +262,33 @@ impl PDRouter {
             client: ctx.client.clone(),
             retry_config: ctx.router_config.effective_retry_config(),
             api_key: ctx.router_config.api_key.clone(),
+            prefill_admission: ctx.prefill_admission.clone(),
         })
     }
 
-    fn handle_server_selection_error(error: String) -> Response {
+    fn handle_server_selection_error(error: PDSelectionError) -> Response {
         error!("Failed to select PD pair error={}", error);
-        error::service_unavailable(
-            "server_selection_failed",
-            format!("No available servers: {error}"),
-        )
+        match error {
+            PDSelectionError::Unavailable(message) => error::service_unavailable(
+                "server_selection_failed",
+                format!("No available servers: {message}"),
+            ),
+            PDSelectionError::QueueFull => {
+                error::too_many_requests(PD_PREFILL_QUEUE_FULL, "Prefill admission queue is full")
+            }
+            PDSelectionError::QueueTimeout => error::too_many_requests(
+                PD_PREFILL_QUEUE_TIMEOUT,
+                "Timed out waiting for Prefill admission",
+            ),
+        }
+    }
+
+    fn should_retry(response: &Response) -> bool {
+        is_retryable_status(response.status())
+            && !matches!(
+                error::extract_error_code_from_response(response),
+                PD_PREFILL_QUEUE_FULL | PD_PREFILL_QUEUE_TIMEOUT
+            )
     }
 
     fn handle_serialization_error(error: impl std::fmt::Display) -> Response {
@@ -185,7 +296,7 @@ impl PDRouter {
         error::internal_error("serialization_failed", "Failed to serialize request")
     }
 
-    fn get_generate_batch_size(req: &GenerateRequest) -> Option<usize> {
+    fn get_generate_bootstrap_batch_size(req: &GenerateRequest) -> Option<usize> {
         // GenerateRequest doesn't support batch via arrays, only via input_ids
         if let Some(InputIds::Batch(batches)) = &req.input_ids {
             if !batches.is_empty() {
@@ -195,7 +306,7 @@ impl PDRouter {
         None
     }
 
-    fn get_chat_batch_size(req: &ChatCompletionRequest) -> Option<usize> {
+    fn get_chat_bootstrap_batch_size(req: &ChatCompletionRequest) -> Option<usize> {
         if let Some(n) = req.n {
             if n > 1 {
                 return Some(n as usize);
@@ -204,7 +315,7 @@ impl PDRouter {
         None
     }
 
-    fn get_completion_batch_size(req: &CompletionRequest) -> Option<usize> {
+    fn get_completion_bootstrap_batch_size(req: &CompletionRequest) -> Option<usize> {
         if let StringOrArray::Array(arr) = &req.prompt {
             if !arr.is_empty() {
                 return Some(arr.len());
@@ -282,6 +393,36 @@ impl PDRouter {
         }
     }
 
+    fn select_dp_ranks(
+        &self,
+        prefill: &dyn Worker,
+        decode: &dyn Worker,
+        request_text: Option<&str>,
+    ) -> (Option<isize>, Option<isize>) {
+        let mut prefill_rank = prefill.dp_rank().map(|rank| rank as isize);
+        let mut decode_rank = decode.dp_rank().map(|rank| rank as isize);
+
+        if prefill_rank.is_some() && decode_rank.is_some() {
+            return (prefill_rank, decode_rank);
+        }
+        let Some(dp_rank_policy) = self.policy_registry.get_dp_rank_policy() else {
+            return (prefill_rank, decode_rank);
+        };
+
+        let estimated_cost = request_text.map_or(1, |text| {
+            let word_count = text.split_whitespace().count();
+            ((word_count as f64 * 1.3).ceil() as isize).max(1)
+        });
+        if prefill_rank.is_none() {
+            prefill_rank = dp_rank_policy.select_dp_rank(prefill, estimated_cost);
+        }
+        if decode_rank.is_none() {
+            decode_rank = dp_rank_policy.select_dp_rank(decode, estimated_cost);
+        }
+
+        (prefill_rank, decode_rank)
+    }
+
     async fn execute_dual_dispatch<T: Serialize + Clone>(
         &self,
         headers: Option<&HeaderMap>,
@@ -326,8 +467,8 @@ impl PDRouter {
                     let shared_request = Arc::clone(&shared_request);
                     let context = context.clone();
                     async move {
-                        let (prefill, decode) = match self
-                            .select_pd_pair(
+                        let admitted = match self
+                            .select_pd_pair_with_admission(
                                 context.request_text.as_deref(),
                                 context.model_id,
                                 context.headers.as_ref(),
@@ -339,6 +480,8 @@ impl PDRouter {
                                 return Self::handle_server_selection_error(e);
                             }
                         };
+                        let (prefill, decode) =
+                            (Arc::clone(&admitted.prefill), Arc::clone(&admitted.decode));
 
                         debug!(
                             "PD retry attempt {} using prefill={} decode={}",
@@ -359,7 +502,7 @@ impl PDRouter {
                         json_request = match Self::inject_bootstrap_into_value(
                             json_request,
                             prefill.as_ref(),
-                            context.batch_size,
+                            context.bootstrap_batch_size,
                         ) {
                             Ok(v) => v,
                             Err(e) => {
@@ -371,34 +514,11 @@ impl PDRouter {
                         let mut prefill_json_request = json_request.clone();
                         let mut decode_json_request = json_request;
 
-                        let mut prefill_rank = prefill.dp_rank().map(|rank| rank as isize);
-                        let mut decode_rank = decode.dp_rank().map(|rank| rank as isize);
-
-                        let dp_rank_policy_opt = self.policy_registry.get_dp_rank_policy();
-                        if let Some(dp_rank_policy) = dp_rank_policy_opt.as_ref() {
-                            let estimated_cost: isize = match context.request_text.as_ref() {
-                                Some(text) => {
-                                    // Calculate token count using a simple heuristic
-                                    // In a real implementation, we would use the tokenizer
-                                    // For now, use a simple words-to-tokens ratio
-                                    let word_count = text.split_whitespace().count();
-                                    // Assume average 1.3 tokens per word
-                                    let token_count = (word_count as f64 * 1.3).ceil() as isize;
-                                    token_count.max(1)
-                                }
-                                None => 1, // Use at least 1 to avoid no-op
-                            };
-                            let policy_prefill_rank =
-                                dp_rank_policy.select_dp_rank(prefill.as_ref(), estimated_cost);
-                            let policy_decode_rank =
-                                dp_rank_policy.select_dp_rank(decode.as_ref(), estimated_cost);
-                            if let Some(rank) = policy_prefill_rank {
-                                prefill_rank = Some(rank);
-                            }
-                            if let Some(rank) = policy_decode_rank {
-                                decode_rank = Some(rank);
-                            }
-                        }
+                        let (prefill_rank, decode_rank) = self.select_dp_ranks(
+                            prefill.as_ref(),
+                            decode.as_ref(),
+                            context.request_text.as_deref(),
+                        );
 
                         if let Some(p_rank) = prefill_rank {
                             Self::inject_dp_rank_to_json(
@@ -432,8 +552,7 @@ impl PDRouter {
                                 prefill_json_request,
                                 decode_json_request,
                                 context,
-                                Arc::clone(&prefill),
-                                Arc::clone(&decode),
+                                admitted,
                             )
                             .await;
 
@@ -460,7 +579,7 @@ impl PDRouter {
                     }
                 }
             },
-            |res, _attempt| is_retryable_status(res.status()),
+            |res, _attempt| Self::should_retry(res),
             |delay, attempt| {
                 // Layer 3 worker metrics (PD mode uses both prefill and decode workers)
                 Metrics::record_worker_retry(metrics_labels::WORKER_PREFILL, endpoint);
@@ -485,7 +604,7 @@ impl PDRouter {
                 endpoint,
                 duration,
             );
-        } else if !is_retryable_status(response.status()) {
+        } else if !Self::should_retry(&response) {
             Metrics::record_router_error(
                 metrics_labels::ROUTER_HTTP,
                 metrics_labels::BACKEND_PD,
@@ -504,7 +623,7 @@ impl PDRouter {
         res: reqwest::Response,
         context: &PDRequestContext<'_>,
         decode: Arc<dyn Worker>,
-        load_guards: Vec<WorkerLoadGuard>,
+        decode_guard: WorkerLoadGuard,
     ) -> Response {
         let status = res.status();
 
@@ -523,6 +642,7 @@ impl PDRouter {
                     json!({ "message": format!("Decode server error: {}", e), "status": status.as_u16() })
                 }
             };
+            drop(decode_guard);
 
             let sse_data = format!(
                 "data: {}\n\n",
@@ -538,11 +658,13 @@ impl PDRouter {
                 context.return_logprob,
                 Some(decode_url),
                 Some(response_headers),
-                load_guards,
+                None,
             )
         } else {
             // Handle non-streaming error response
-            match res.bytes().await {
+            let error_body = res.bytes().await;
+            drop(decode_guard);
+            match error_body {
                 Ok(error_body) => {
                     // Try to parse error message from body, fallback to status-based error
                     let error_message = if let Ok(error_json) =
@@ -619,14 +741,14 @@ impl PDRouter {
         prefill_json_request: Value,
         decode_json_request: Value,
         context: PDRequestContext<'_>,
-        prefill: Arc<dyn Worker>,
-        decode: Arc<dyn Worker>,
+        admitted: AdmittedPdPair,
     ) -> Response {
-        let load_guards = vec![
-            WorkerLoadGuard::new(prefill.clone(), headers),
-            WorkerLoadGuard::new(decode.clone(), headers),
-        ];
-
+        let AdmittedPdPair {
+            prefill,
+            decode,
+            prefill_guard,
+            decode_guard,
+        } = admitted;
         let mut headers_with_trace = headers.cloned().unwrap_or_default();
         inject_trace_context_http(&mut headers_with_trace);
         let headers = Some(&headers_with_trace);
@@ -657,24 +779,30 @@ impl PDRouter {
         }
         .emit();
 
-        // Send both requests concurrently. Use try_join so that if either side
-        // hits a transport error, the other is cancelled immediately — otherwise
-        // the surviving request hangs waiting for a PD bootstrap that will never
-        // come (see #831).
-        // Each leg captures its own head-arrival elapsed when its `send()`
-        // resolves, so the two are independent even though `try_join!` returns
-        // only once both heads arrive: decode TTFT isn't conflated with the
-        // prefill-head wait, and prefill duration isn't conflated with a slower
-        // decode head. Recorded on the success path only.
+        // Wait only for both response heads here. Decode can reject the request
+        // before Prefill reaches EOF, and that rejection must cancel Prefill
+        // instead of waiting for a bootstrap that Decode will never consume.
         let runtime = prefill.metadata().spec.runtime_type.as_str();
         let dispatch_start = Instant::now();
         let prefill_fut = async {
-            let resp = prefill_request.send().await?;
-            Ok::<_, reqwest::Error>((dispatch_start.elapsed(), resp))
+            let response = prefill_request.send().await.map_err(|e| {
+                error!("PD prefill transport error: {e}");
+                error::bad_gateway(
+                    "PD disaggregation request failed",
+                    format!("Prefill transport error: {e}"),
+                )
+            })?;
+            Ok::<_, Response>((dispatch_start.elapsed(), response))
         };
         let decode_fut = async {
-            let resp = decode_request.send().await?;
-            Ok::<_, reqwest::Error>((dispatch_start.elapsed(), resp))
+            let response = decode_request.send().await.map_err(|e| {
+                error!("PD decode transport error: {e}");
+                error::bad_gateway(
+                    "PD disaggregation request failed",
+                    format!("Decode transport error: {e}"),
+                )
+            })?;
+            Ok::<_, Response>((dispatch_start.elapsed(), response))
         };
         let pd_result = tokio::try_join!(prefill_fut, decode_fut);
 
@@ -683,15 +811,7 @@ impl PDRouter {
         let ((prefill_head_elapsed, prefill_response), (decode_head_elapsed, decode_response)) =
             match pd_result {
                 Ok(pair) => pair,
-                Err(e) => {
-                    error!("PD request transport error, both sides aborted: {e}");
-                    // Don't record_outcome here — the caller (execute_dual_dispatch)
-                    // records outcomes from the response status after we return.
-                    return error::bad_gateway(
-                        "PD disaggregation request failed",
-                        format!("Transport error: {e}"),
-                    );
-                }
+                Err(response) => return response,
             };
 
         // Process decode response
@@ -706,8 +826,10 @@ impl PDRouter {
                 status
             );
 
+            drop(prefill_response);
+            drop(prefill_guard);
             return self
-                .handle_decode_error_response(decode_response, &context, decode, load_guards)
+                .handle_decode_error_response(decode_response, &context, decode, decode_guard)
                 .await;
         }
 
@@ -722,24 +844,21 @@ impl PDRouter {
             decode_head_elapsed,
         );
 
-        // Process prefill response
         let prefill_drain_start = Instant::now();
         let prefill_body = match self
             .process_prefill_response(prefill_response, prefill.url(), context.return_logprob)
             .await
         {
             Ok((_, body)) => body,
-            Err(error_response) => return error_response,
+            Err(response) => return response,
         };
-
-        // Prefill RPC duration: prefill-head elapsed + body drain, independent
-        // of decode so a slower decode head never inflates it.
         Metrics::record_pd_prefill_duration(
             metrics_labels::BACKEND_PD,
             context.model_id,
             runtime,
             prefill_head_elapsed + prefill_drain_start.elapsed(),
         );
+        drop(prefill_guard);
 
         if context.is_stream {
             // Streaming response
@@ -762,7 +881,7 @@ impl PDRouter {
                 context.return_logprob,
                 None,
                 Some(response_headers),
-                load_guards,
+                Some(decode_guard),
             )
         } else {
             // Non-streaming response
@@ -801,80 +920,140 @@ impl PDRouter {
         prefill_policy.needs_request_text() || decode_policy.needs_request_text()
     }
 
-    #[expect(
-        clippy::unused_async,
-        reason = "async for API consistency; callers await uniformly"
-    )]
-    async fn select_pd_pair(
+    async fn select_pd_pair_with_admission(
         &self,
         request_text: Option<&str>,
         model_id: &str,
         headers: Option<&HeaderMap>,
-    ) -> Result<(Arc<dyn Worker>, Arc<dyn Worker>), String> {
-        debug!("Selecting PD pair: model_id={:?}", model_id);
+    ) -> Result<AdmittedPdPair, PDSelectionError> {
+        debug!("Selecting admitted PD pair: model_id={:?}", model_id);
 
-        let is_unknown_model = model_id == UNKNOWN_MODEL_ID;
-
-        let prefill_workers = {
-            let by_model: Vec<_> = self
-                .worker_registry
-                .get_by_model(model_id)
-                .iter()
-                .filter(|w| matches!(w.worker_type(), WorkerType::Prefill))
-                .cloned()
-                .collect();
-            if by_model.is_empty() && is_unknown_model {
-                // "auto" means pick any — fall back to all prefill workers
-                self.worker_registry.get_prefill_workers().to_vec()
-            } else {
-                by_model
-            }
-        };
-
-        let decode_workers = {
-            let by_model: Vec<_> = self
-                .worker_registry
-                .get_by_model(model_id)
-                .iter()
-                .filter(|w| matches!(w.worker_type(), WorkerType::Decode))
-                .cloned()
-                .collect();
-            if by_model.is_empty() && is_unknown_model {
-                // Only fall back to all workers when model is "unknown" (wildcard)
-                self.worker_registry.get_decode_workers().to_vec()
-            } else {
-                by_model
-            }
-        };
+        let ((prefill, decode), prefill_guard) = acquire_prefill(
+            self.prefill_admission.as_deref(),
+            headers,
+            |(prefill, _): &PdWorkerPair| prefill,
+            |capacity| self.select_pd_candidate(request_text, model_id, headers, capacity),
+        )
+        .await?;
+        let decode_guard = WorkerLoadGuard::new(Arc::clone(&decode), headers);
 
         let prefill_policy = self.policy_registry.get_prefill_policy();
         let decode_policy = self.policy_registry.get_decode_policy();
+        Self::record_pd_selection(model_id, &prefill_policy, &decode_policy);
 
-        // Get cached hash ring for consistent hashing
+        Ok(AdmittedPdPair {
+            prefill,
+            decode,
+            prefill_guard,
+            decode_guard,
+        })
+    }
+
+    fn select_pd_candidate(
+        &self,
+        request_text: Option<&str>,
+        model_id: &str,
+        headers: Option<&HeaderMap>,
+        capacity: Option<&PrefillSelectionContext<'_>>,
+    ) -> Result<PdWorkerPair, PDCandidateError> {
+        let (prefill_workers, decode_workers) = self.pd_worker_pools(model_id);
+        let prefill_policy = self.policy_registry.get_prefill_policy();
+        let decode_policy = self.policy_registry.get_decode_policy();
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
 
-        let prefill = self.pick_worker_by_policy_arc(
-            &prefill_workers,
-            &prefill_policy,
-            request_text,
-            headers,
-            hash_ring.clone(),
-            "prefill",
-            crate::policies::WorkerLeg::Prefill,
-        )?;
+        let mut available_prefill = Self::available_workers(&prefill_workers, "prefill")
+            .map_err(PDCandidateError::Unavailable)?;
+        let available_decode = Self::available_workers(&decode_workers, "decode")
+            .map_err(PDCandidateError::Unavailable)?;
+        let target_header = if prefill_policy.name() == "consistent_hashing" {
+            header_utils::extract_target_worker(headers)
+        } else {
+            None
+        };
+        let targeted = target_header.is_some();
 
-        let decode = self.pick_worker_by_policy_arc(
-            &decode_workers,
-            &decode_policy,
-            request_text,
-            headers,
-            hash_ring,
-            "decode",
-            crate::policies::WorkerLeg::Decode,
-        )?;
+        if let Some(capacity) = capacity {
+            if !targeted {
+                available_prefill.retain(|worker| capacity.has_capacity(worker));
+                if available_prefill.is_empty() {
+                    return Err(PDCandidateError::PrefillAtCapacity);
+                }
+            }
+        }
 
-        // Record worker selection metrics (Layer 3)
-        let model = model_id;
+        if let Some(target_header) = target_header {
+            let target = target_header
+                .parse::<usize>()
+                .ok()
+                .and_then(|index| available_prefill.get(index))
+                .ok_or_else(|| {
+                    PDCandidateError::Unavailable(
+                        "Target Prefill worker is unavailable".to_string(),
+                    )
+                })?;
+            if capacity.is_some_and(|capacity| !capacity.has_capacity(target)) {
+                return Err(PDCandidateError::PrefillAtCapacity);
+            }
+        }
+
+        let prefill = self
+            .pick_worker_by_policy_arc(
+                &available_prefill,
+                &prefill_policy,
+                request_text,
+                headers,
+                hash_ring.clone(),
+                "prefill",
+                WorkerLeg::Prefill,
+            )
+            .map_err(PDCandidateError::Unavailable)?;
+
+        let decode = self
+            .pick_worker_by_policy_arc(
+                &available_decode,
+                &decode_policy,
+                request_text,
+                headers,
+                hash_ring,
+                "decode",
+                WorkerLeg::Decode,
+            )
+            .map_err(PDCandidateError::Unavailable)?;
+
+        Ok((prefill, decode))
+    }
+
+    fn pd_worker_pools(&self, model_id: &str) -> PdWorkerPools {
+        let is_unknown_model = model_id == UNKNOWN_MODEL_ID;
+        let by_model = self.worker_registry.get_by_model(model_id);
+        let mut prefill_workers: Vec<_> = by_model
+            .iter()
+            .filter(|worker| matches!(worker.worker_type(), WorkerType::Prefill))
+            .cloned()
+            .collect();
+        let mut decode_workers: Vec<_> = by_model
+            .iter()
+            .filter(|worker| matches!(worker.worker_type(), WorkerType::Decode))
+            .cloned()
+            .collect();
+
+        if is_unknown_model {
+            if prefill_workers.is_empty() {
+                prefill_workers = self.worker_registry.get_prefill_workers().to_vec();
+            }
+            if decode_workers.is_empty() {
+                decode_workers = self.worker_registry.get_decode_workers().to_vec();
+            }
+        }
+
+        (prefill_workers, decode_workers)
+    }
+
+    fn record_pd_selection(
+        model: &str,
+        prefill_policy: &Arc<dyn LoadBalancingPolicy>,
+        decode_policy: &Arc<dyn LoadBalancingPolicy>,
+    ) {
         Metrics::record_worker_selection(
             metrics_labels::WORKER_PREFILL,
             metrics_labels::CONNECTION_HTTP,
@@ -887,8 +1066,6 @@ impl PDRouter {
             model,
             decode_policy.name(),
         );
-
-        Ok((prefill, decode))
     }
 
     #[expect(
@@ -903,8 +1080,42 @@ impl PDRouter {
         headers: Option<&HeaderMap>,
         hash_ring: Option<Arc<HashRing>>,
         worker_type: &str,
-        leg: crate::policies::WorkerLeg,
+        leg: WorkerLeg,
     ) -> Result<Arc<dyn Worker>, String> {
+        let selected_idx = self
+            .policy_registry
+            .select_worker(
+                policy,
+                workers,
+                &SelectWorkerInfo {
+                    request_text,
+                    tokens: None,
+                    headers,
+                    hash_ring,
+                    leg,
+                },
+            )
+            .ok_or_else(|| {
+                format!(
+                    "Policy {} failed to select a {} worker",
+                    policy.name(),
+                    worker_type
+                )
+            })?;
+
+        workers.get(selected_idx).cloned().ok_or_else(|| {
+            format!(
+                "Policy {} returned an invalid {} worker index",
+                policy.name(),
+                worker_type
+            )
+        })
+    }
+
+    fn available_workers(
+        workers: &[Arc<dyn Worker>],
+        worker_type: &str,
+    ) -> Result<Vec<Arc<dyn Worker>>, String> {
         if workers.is_empty() {
             return Err(format!(
                 "No {worker_type} workers available. Please check if {worker_type} servers are configured and healthy."
@@ -923,28 +1134,7 @@ impl PDRouter {
             ));
         }
 
-        let selected_idx = self
-            .policy_registry
-            .select_worker(
-                policy,
-                &available_workers,
-                &SelectWorkerInfo {
-                    request_text,
-                    tokens: None, // HTTP doesn't have tokens, use gRPC for PrefixHash
-                    headers,
-                    hash_ring,
-                    leg,
-                },
-            )
-            .ok_or_else(|| {
-                format!(
-                    "Policy {} failed to select a {} worker",
-                    policy.name(),
-                    worker_type
-                )
-            })?;
-
-        Ok(available_workers[selected_idx].clone())
+        Ok(available_workers)
     }
 
     #[expect(clippy::too_many_arguments)]
@@ -960,10 +1150,8 @@ impl PDRouter {
         return_logprob: bool,
         decode_url: Option<String>,
         headers: Option<HeaderMap>,
-        load_guards: Vec<WorkerLoadGuard>,
+        decode_guard: Option<WorkerLoadGuard>,
     ) -> Response {
-        use crate::worker::AttachedBody;
-
         let (tx, rx) = mpsc::unbounded_channel();
 
         #[expect(
@@ -971,6 +1159,7 @@ impl PDRouter {
             reason = "fire-and-forget stream relay; gateway shutdown need not wait for decode stream forwarding"
         )]
         tokio::spawn(async move {
+            let _decode_guard = decode_guard;
             futures_util::pin_mut!(stream);
             // Reusable SSE encoder for the logprob-merge re-encode path.
             let mut encoder = SseEncoder::new();
@@ -978,7 +1167,15 @@ impl PDRouter {
             // previous chunk ended with an EOL); used to anchor the [DONE]
             // sentinel detection when the match sits at the start of a chunk.
             let mut at_line_start = true;
-            while let Some(chunk_result) = stream.next().await {
+            loop {
+                let chunk_result = tokio::select! {
+                    biased;
+                    () = tx.closed() => break,
+                    chunk_result = stream.next() => chunk_result,
+                };
+                let Some(chunk_result) = chunk_result else {
+                    break;
+                };
                 match chunk_result {
                     Ok(chunk) => {
                         let is_done = Self::chunk_contains_done_event(&chunk, at_line_start);
@@ -1026,7 +1223,7 @@ impl PDRouter {
         response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
         *response.headers_mut() = response_headers;
 
-        AttachedBody::wrap_response(response, load_guards)
+        response
     }
 
     /// Build a non-streaming PD response with `Content-Type: application/json`.
@@ -1309,6 +1506,16 @@ impl PDRouter {
         // Re-serialize via the shared encoder (reuses its buffer across chunks).
         encoder.encode_data(&decode_json).map_err(|_| ())
     }
+
+    async fn send_health_generate(&self, url: &str) -> Result<StatusCode, reqwest::Error> {
+        let response = self.client.get(url).send().await?;
+        let status = response.status();
+        let mut body = response.bytes_stream();
+        while let Some(chunk) = body.next().await {
+            let _ = chunk?;
+        }
+        Ok(status)
+    }
 }
 
 #[async_trait]
@@ -1320,40 +1527,49 @@ impl RouterTrait for PDRouter {
     async fn health_generate(&self, _req: Request<Body>) -> Response {
         // Note: This endpoint actually causes the model to generate tokens, so we only test one pair
 
-        // Select a random worker pair using the policy
-        let (prefill, decode) = match self.select_pd_pair(None, UNKNOWN_MODEL_ID, None).await {
+        let AdmittedPdPair {
+            prefill,
+            decode,
+            prefill_guard,
+            decode_guard,
+        } = match self
+            .select_pd_pair_with_admission(None, UNKNOWN_MODEL_ID, None)
+            .await
+        {
             Ok(pair) => pair,
-            Err(e) => {
-                return error::service_unavailable(
-                    "no_healthy_worker_pair",
-                    format!("No healthy worker pair available: {e}"),
-                );
-            }
+            Err(error) => return Self::handle_server_selection_error(error),
         };
 
-        let prefill_url = format!("{}/health_generate", prefill.url());
+        let prefill_url = prefill.endpoint_url("/health_generate");
+        let decode_url = decode.endpoint_url("/health_generate");
         let (prefill_result, decode_result) = tokio::join!(
-            self.client.get(&prefill_url).send(),
-            self.client
-                .get(format!("{}/health_generate", decode.url()))
-                .send()
+            async {
+                let result = self.send_health_generate(&prefill_url).await;
+                drop(prefill_guard);
+                result
+            },
+            async {
+                let result = self.send_health_generate(&decode_url).await;
+                drop(decode_guard);
+                result
+            }
         );
 
         // Check results
         let mut errors = Vec::new();
 
         match prefill_result {
-            Ok(res) if res.status().is_success() => {
+            Ok(status) if status.is_success() => {
                 debug!(
                     "Health generate passed for prefill server: {}",
                     prefill.url()
                 );
             }
-            Ok(res) => {
+            Ok(status) => {
                 errors.push(format!(
                     "Prefill {} returned status {}",
                     prefill.url(),
-                    res.status()
+                    status
                 ));
             }
             Err(e) => {
@@ -1362,14 +1578,14 @@ impl RouterTrait for PDRouter {
         }
 
         match decode_result {
-            Ok(res) if res.status().is_success() => {
+            Ok(status) if status.is_success() => {
                 debug!("Health generate passed for decode server: {}", decode.url());
             }
-            Ok(res) => {
+            Ok(status) => {
                 errors.push(format!(
                     "Decode {} returned status {}",
                     decode.url(),
-                    res.status()
+                    status
                 ));
             }
             Err(e) => {
@@ -1425,11 +1641,11 @@ impl RouterTrait for PDRouter {
             None
         };
 
-        let batch_size = Self::get_generate_batch_size(body);
+        let bootstrap_batch_size = Self::get_generate_bootstrap_batch_size(body);
 
         let context = PDRequestContext {
             route: "/generate",
-            batch_size,
+            bootstrap_batch_size,
             is_stream,
             return_logprob,
             request_text,
@@ -1457,11 +1673,11 @@ impl RouterTrait for PDRouter {
         };
 
         // Calculate batch size
-        let batch_size = Self::get_chat_batch_size(body);
+        let bootstrap_batch_size = Self::get_chat_bootstrap_batch_size(body);
 
         let context = PDRequestContext {
             route: "/v1/chat/completions",
-            batch_size,
+            bootstrap_batch_size,
             is_stream,
             return_logprob,
             request_text,
@@ -1492,11 +1708,11 @@ impl RouterTrait for PDRouter {
         };
 
         // Calculate batch size
-        let batch_size = Self::get_completion_batch_size(body);
+        let bootstrap_batch_size = Self::get_completion_bootstrap_batch_size(body);
 
         let context = PDRequestContext {
             route: "/v1/completions",
-            batch_size,
+            bootstrap_batch_size,
             is_stream,
             return_logprob,
             request_text,
@@ -1523,7 +1739,7 @@ impl RouterTrait for PDRouter {
 
         let context = PDRequestContext {
             route: "/v1/rerank",
-            batch_size: None,
+            bootstrap_batch_size: None,
             is_stream: false,
             return_logprob: false,
             request_text: req_text,
@@ -1541,12 +1757,15 @@ impl RouterTrait for PDRouter {
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::HashMap, time::Duration};
+
     use openai_protocol::model_card::ModelCard;
 
     use super::*;
     use crate::{
         config::PolicyConfig,
-        worker::{BasicWorkerBuilder, WorkerType},
+        policies::MinimumTokensPolicy,
+        worker::{BasicWorkerBuilder, WorkerLoadManager, WorkerType},
     };
 
     fn create_test_pd_router() -> PDRouter {
@@ -1559,6 +1778,7 @@ mod tests {
             client: Client::new(),
             retry_config: RetryConfig::default(),
             api_key: Some("test_api_key".to_string()),
+            prefill_admission: None,
         }
     }
 
@@ -1677,8 +1897,34 @@ mod tests {
         assert_eq!(request.url().as_str(), "http://127.0.0.1:30000/generate");
     }
 
-    #[tokio::test]
-    async fn test_select_healthy_prefill_worker() {
+    #[test]
+    fn test_dp_aware_prefill_rank_is_not_overridden_by_minimum_tokens() {
+        let router = create_test_pd_router();
+        let prefill = BasicWorkerBuilder::new("http://prefill:8000")
+            .worker_type(WorkerType::Prefill)
+            .dp_config(2, 4)
+            .build();
+        let decode = BasicWorkerBuilder::new("http://decode:8000")
+            .worker_type(WorkerType::Decode)
+            .build();
+
+        let load_manager = Arc::new(WorkerLoadManager::new());
+        load_manager.update_dp_loads(&HashMap::from([
+            (prefill.url().to_owned(), HashMap::from([(0, 0), (2, 100)])),
+            (decode.url().to_owned(), HashMap::from([(3, 0)])),
+        ]));
+        router
+            .policy_registry
+            .set_dp_rank_policy(Arc::new(MinimumTokensPolicy::new(Some(load_manager))));
+
+        assert_eq!(
+            router.select_dp_ranks(&prefill, &decode, Some("one two")),
+            (Some(2), Some(3))
+        );
+    }
+
+    #[test]
+    fn test_select_healthy_prefill_worker() {
         let router = create_test_pd_router();
 
         let healthy_worker =
@@ -1698,7 +1944,7 @@ mod tests {
             .worker_registry
             .register_or_replace(Arc::from(decode_worker));
 
-        let result = router.select_pd_pair(None, UNKNOWN_MODEL_ID, None).await;
+        let result = router.select_pd_candidate(None, UNKNOWN_MODEL_ID, None, None);
 
         assert!(result.is_ok());
         let (prefill, _decode) = result.unwrap();
@@ -1707,8 +1953,8 @@ mod tests {
         assert!(prefill.is_healthy());
     }
 
-    #[tokio::test]
-    async fn test_select_pd_pair_accepts_model_alias() {
+    #[test]
+    fn test_select_pd_pair_accepts_model_alias() {
         let router = create_test_pd_router();
         for (url, worker_type) in [
             ("http://prefill", WorkerType::Prefill),
@@ -1723,26 +1969,162 @@ mod tests {
         }
 
         let (prefill, decode) = router
-            .select_pd_pair(None, "GLM-5.2-Coding", None)
-            .await
+            .select_pd_candidate(None, "GLM-5.2-Coding", None, None)
             .expect("alias should select a PD pair");
         assert_eq!(prefill.url(), "http://prefill");
         assert_eq!(decode.url(), "http://decode");
 
         assert!(router
-            .select_pd_pair(None, "GLM-5.2-Unknown", None)
-            .await
+            .select_pd_candidate(None, "GLM-5.2-Unknown", None, None)
             .is_err());
     }
 
-    #[tokio::test]
-    async fn test_empty_worker_lists() {
+    #[test]
+    fn test_empty_worker_lists() {
         let router = create_test_pd_router();
 
-        let result = router.select_pd_pair(None, UNKNOWN_MODEL_ID, None).await;
+        let result = router.select_pd_candidate(None, UNKNOWN_MODEL_ID, None, None);
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("No prefill workers available"));
+        assert!(matches!(
+            result,
+            Err(PDCandidateError::Unavailable(message))
+                if message.contains("No prefill workers available")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_admission_skips_full_prefill_worker() {
+        let mut router = create_test_pd_router();
+        let full: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://full".to_string(),
+            WorkerType::Prefill,
+            true,
+        ));
+        let available: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://available".to_string(),
+            WorkerType::Prefill,
+            true,
+        ));
+        let decode: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+        for worker in [&full, &available, &decode] {
+            router
+                .worker_registry
+                .register_or_replace(Arc::clone(worker));
+        }
+
+        let admission = Arc::new(PrefillAdmission::new(1, 0, Duration::from_secs(1)));
+        let occupied = admission
+            .admit(None, {
+                let full = Arc::clone(&full);
+                move |capacity| capacity.select(Arc::clone(&full), ())
+            })
+            .await
+            .unwrap();
+        router.prefill_admission = Some(admission);
+
+        let admitted = router
+            .select_pd_pair_with_admission(None, UNKNOWN_MODEL_ID, None)
+            .await
+            .expect("selection should continue after the preferred worker is full");
+        let AdmittedPdPair {
+            prefill: selected,
+            prefill_guard,
+            decode_guard,
+            ..
+        } = admitted;
+
+        assert_eq!(selected.url(), available.url());
+        assert_eq!(full.load(), 1);
+        assert_eq!(available.load(), 1);
+        assert_eq!(decode.load(), 1);
+
+        drop(prefill_guard);
+        drop(decode_guard);
+        drop(occupied);
+        assert_eq!(full.load(), 0);
+        assert_eq!(available.load(), 0);
+        assert_eq!(decode.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_explicit_target_at_capacity_is_not_reassigned() {
+        let mut router = create_test_pd_router();
+        router.policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::ConsistentHashing));
+        let available: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://available".to_string(),
+            WorkerType::Prefill,
+            true,
+        ));
+        let target: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://target".to_string(),
+            WorkerType::Prefill,
+            true,
+        ));
+        let decode: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+        for worker in [&available, &target, &decode] {
+            router
+                .worker_registry
+                .register_or_replace(Arc::clone(worker));
+        }
+
+        let admission = Arc::new(PrefillAdmission::new(1, 0, Duration::from_secs(1)));
+        let occupied = admission
+            .admit(None, {
+                let target = Arc::clone(&target);
+                move |capacity| capacity.select(Arc::clone(&target), ())
+            })
+            .await
+            .unwrap();
+        router.prefill_admission = Some(admission);
+
+        let target_index = router
+            .pd_worker_pools(UNKNOWN_MODEL_ID)
+            .0
+            .iter()
+            .position(|worker| worker.url() == target.url())
+            .unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-smg-target-worker",
+            target_index.to_string().parse().unwrap(),
+        );
+
+        let error = match router
+            .select_pd_pair_with_admission(None, UNKNOWN_MODEL_ID, Some(&headers))
+            .await
+        {
+            Ok(_) => panic!("a full explicit target must not be replaced"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error, PDSelectionError::QueueFull));
+        assert_eq!(available.load(), 0);
+        assert_eq!(target.load(), 1);
+        assert_eq!(decode.load(), 0);
+        drop(occupied);
+    }
+
+    #[test]
+    fn test_local_queue_rejections_are_not_retried() {
+        for error in [PDSelectionError::QueueFull, PDSelectionError::QueueTimeout] {
+            let local = PDRouter::handle_server_selection_error(error);
+            assert_eq!(local.status(), StatusCode::TOO_MANY_REQUESTS);
+            assert!(!PDRouter::should_retry(&local));
+        }
+
+        let upstream = Response::builder()
+            .status(StatusCode::TOO_MANY_REQUESTS)
+            .body(Body::empty())
+            .unwrap();
+        assert!(PDRouter::should_retry(&upstream));
     }
 
     #[test]
@@ -1775,11 +2157,6 @@ mod tests {
     async fn test_streaming_decode_error_emits_valid_json_sse() {
         let router = create_test_pd_router();
 
-        let prefill: Arc<dyn Worker> = Arc::from(create_test_worker(
-            "http://prefill".to_string(),
-            WorkerType::Prefill,
-            true,
-        ));
         let decode: Arc<dyn Worker> = Arc::from(create_test_worker(
             "http://decode".to_string(),
             WorkerType::Decode,
@@ -1794,7 +2171,7 @@ mod tests {
 
         let context = PDRequestContext {
             route: "/v1/chat/completions",
-            batch_size: None,
+            bootstrap_batch_size: None,
             is_stream: true,
             return_logprob: false,
             request_text: None,
@@ -1802,13 +2179,10 @@ mod tests {
             headers: None,
         };
 
-        let load_guards = vec![
-            WorkerLoadGuard::new(prefill.clone(), None),
-            WorkerLoadGuard::new(decode.clone(), None),
-        ];
+        let decode_guard = WorkerLoadGuard::new(decode.clone(), None);
 
         let response = router
-            .handle_decode_error_response(decode_response, &context, decode, load_guards)
+            .handle_decode_error_response(decode_response, &context, decode, decode_guard)
             .await;
 
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
@@ -1829,75 +2203,88 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_streaming_load_tracking() {
+    async fn test_streaming_decode_load_tracks_upstream_lifetime() {
         use futures_util::StreamExt;
-        use tokio::time::{sleep, Duration};
+        use tokio::time::{timeout, Duration};
 
         let router = create_test_pd_router();
-
-        let prefill_worker =
-            create_test_worker("http://prefill".to_string(), WorkerType::Prefill, true);
         let decode_worker =
             create_test_worker("http://decode".to_string(), WorkerType::Decode, true);
 
         router
             .worker_registry
-            .register_or_replace(Arc::from(prefill_worker));
-        router
-            .worker_registry
             .register_or_replace(Arc::from(decode_worker));
 
-        let prefill_workers = router.worker_registry.get_prefill_workers();
         let decode_workers = router.worker_registry.get_decode_workers();
-
-        let prefill_ref = prefill_workers[0].clone();
         let decode_ref = decode_workers[0].clone();
 
-        assert_eq!(prefill_ref.load(), 0);
         assert_eq!(decode_ref.load(), 0);
 
         let (tx, rx) = mpsc::unbounded_channel();
         let stream = UnboundedReceiverStream::new(rx);
+        let decode_guard = WorkerLoadGuard::new(decode_ref.clone(), None);
 
-        {
-            let guards = vec![
-                WorkerLoadGuard::new(prefill_ref.clone(), None),
-                WorkerLoadGuard::new(decode_ref.clone(), None),
-            ];
+        let _response = router.create_streaming_response(
+            stream.map(Ok),
+            StatusCode::OK,
+            None,
+            false,
+            None,
+            None,
+            Some(decode_guard),
+        );
 
-            assert_eq!(prefill_ref.load(), 1);
-            assert_eq!(decode_ref.load(), 1);
+        assert_eq!(decode_ref.load(), 1);
+        tx.send(Bytes::from("test data")).unwrap();
+        tokio::task::yield_now().await;
+        assert_eq!(decode_ref.load(), 1);
 
-            let response = router.create_streaming_response(
-                stream.map(Ok),
-                StatusCode::OK,
-                None,
-                false,
-                None,
-                None,
-                guards,
-            );
+        drop(tx);
+        timeout(Duration::from_secs(1), async {
+            while decode_ref.load() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("decode load should be released when the upstream stream ends");
+    }
 
-            // Guards are now attached to response body, so load should be 1
-            assert_eq!(prefill_ref.load(), 1);
-            assert_eq!(decode_ref.load(), 1);
+    #[tokio::test]
+    async fn test_streaming_decode_load_releases_on_client_disconnect() {
+        use futures_util::StreamExt;
+        use tokio::time::{timeout, Duration};
 
-            tx.send(Bytes::from("test data")).unwrap();
+        let router = create_test_pd_router();
+        let decode_worker =
+            create_test_worker("http://decode".to_string(), WorkerType::Decode, true);
 
-            sleep(Duration::from_millis(10)).await;
+        router
+            .worker_registry
+            .register_or_replace(Arc::from(decode_worker));
 
-            // Load still 1 while response body exists
-            assert_eq!(prefill_ref.load(), 1);
-            assert_eq!(decode_ref.load(), 1);
+        let decode_ref = router.worker_registry.get_decode_workers()[0].clone();
+        let (_upstream_tx, upstream_rx) = mpsc::unbounded_channel::<Bytes>();
+        let decode_guard = WorkerLoadGuard::new(decode_ref.clone(), None);
 
-            drop(tx);
+        let response = router.create_streaming_response(
+            UnboundedReceiverStream::new(upstream_rx).map(Ok),
+            StatusCode::OK,
+            None,
+            false,
+            None,
+            None,
+            Some(decode_guard),
+        );
 
-            // Response (and its body with guards) dropped here
-            drop(response);
-        }
+        assert_eq!(decode_ref.load(), 1);
+        drop(response);
 
-        // Guards dropped when response dropped
-        assert_eq!(prefill_ref.load(), 0);
-        assert_eq!(decode_ref.load(), 0);
+        timeout(Duration::from_secs(1), async {
+            while decode_ref.load() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("decode load should be released when the client disconnects");
     }
 }

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -46,6 +46,9 @@ pub use factory::RouterFactory;
 // Re-export HTTP routers for convenience
 pub use http::{pd_router, pd_types, router};
 
+pub(crate) const PD_PREFILL_QUEUE_FULL: &str = "pd_prefill_queue_full";
+pub(crate) const PD_PREFILL_QUEUE_TIMEOUT: &str = "pd_prefill_queue_timeout";
+
 /// Core trait for all router implementations
 ///
 /// This trait provides a unified interface for routing requests,

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1323,6 +1323,7 @@ mod tests {
             rate_limiter: Some(Arc::new(TokenBucket::new(1000, 1000))),
             rate_limit_manager: None,
             worker_registry: worker_registry.clone(),
+            prefill_admission: None,
             policy_registry: Arc::new(crate::policies::PolicyRegistry::with_override(
                 router_config.policy.clone(),
                 router_config.routing_key_override.clone(),

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -11,6 +11,7 @@ pub mod kv_event_monitor;
 pub mod manager;
 pub mod metrics_aggregator;
 pub mod monitor;
+pub mod prefill_admission;
 pub mod registry;
 pub mod resilience;
 pub mod sampling_defaults;
@@ -40,6 +41,11 @@ pub use openai_protocol::{
     model_card::ModelCard,
     model_type::{Endpoint, ModelType},
     worker::{ProviderType, WorkerGroupKey},
+};
+pub use prefill_admission::{
+    acquire_prefill, AdmittedPrefill, PrefillAcquireError, PrefillAdmission,
+    PrefillAdmissionAttempt, PrefillAdmissionRejection, PrefillCandidateError, PrefillLoadGuard,
+    PrefillReservation, PrefillSelection, PrefillSelectionContext,
 };
 pub use registry::{WorkerOrigin, WorkerRegistry};
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};

--- a/model_gateway/src/worker/prefill_admission.rs
+++ b/model_gateway/src/worker/prefill_admission.rs
@@ -1,0 +1,1151 @@
+use std::{
+    collections::VecDeque,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+
+use super::{Worker, WorkerLoadGuard};
+use crate::observability::metrics::Metrics;
+
+const HEAD_RECHECK_INTERVAL: Duration = Duration::from_secs(1);
+
+/// The result of one capacity-aware Prefill worker selection attempt.
+///
+/// The callback passed to [`PrefillAdmission::admit`] must first return
+/// [`Self::Unavailable`] when no healthy, model-matching worker exists. It
+/// must then return [`Self::AtCapacity`] without running its routing policy
+/// when no remaining candidate has capacity. This matters for policies such
+/// as cache-aware routing whose selection method commits routing state.
+pub enum PrefillAdmissionAttempt<T> {
+    Selected(PrefillSelection<T>),
+    AtCapacity,
+    Unavailable,
+}
+
+/// A selected worker and the caller-owned value associated with it.
+///
+/// Callers cannot construct this type directly. Use
+/// [`PrefillSelectionContext::select`] so the capacity check and selection
+/// stay under the admission lock.
+pub struct PrefillSelection<T> {
+    worker: Arc<dyn Worker>,
+    value: T,
+}
+
+/// Capacity view supplied to a worker selection attempt.
+pub struct PrefillSelectionContext<'a> {
+    max_inflight_requests_per_worker: usize,
+    selection_allowed: bool,
+    _lock: &'a PrefillAdmissionState,
+}
+
+impl PrefillSelectionContext<'_> {
+    /// Return whether this Router can start another Prefill request on `worker`.
+    /// This returns `false` for a new request when an older request is queued;
+    /// the caller can still detect `Unavailable`, but cannot run its policy or
+    /// bypass the queue.
+    pub fn has_capacity(&self, worker: &Arc<dyn Worker>) -> bool {
+        self.selection_allowed && worker.load() < self.max_inflight_requests_per_worker
+    }
+
+    /// Commit a worker selected from candidates for which
+    /// [`Self::has_capacity`] returned `true`.
+    pub fn select<T>(&self, worker: Arc<dyn Worker>, value: T) -> PrefillAdmissionAttempt<T> {
+        if self.has_capacity(&worker) {
+            PrefillAdmissionAttempt::Selected(PrefillSelection { worker, value })
+        } else {
+            PrefillAdmissionAttempt::AtCapacity
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrefillAdmissionRejection {
+    QueueFull,
+    QueueTimeout,
+    Unavailable,
+}
+
+/// A successful Prefill admission.
+#[must_use = "dropping the result releases the Prefill reservation"]
+pub struct AdmittedPrefill<T> {
+    pub selected: T,
+    pub reservation: PrefillReservation,
+}
+
+/// One Router-local Prefill slot on a specific worker.
+///
+/// Dropping this value releases both the admission count and the worker load,
+/// then wakes the head of the Router-wide FIFO queue.
+#[must_use = "the reservation must be held until the Prefill phase ends"]
+pub struct PrefillReservation {
+    inner: Arc<PrefillAdmissionInner>,
+    worker: Arc<dyn Worker>,
+    load_guard: Option<WorkerLoadGuard>,
+}
+
+impl Drop for PrefillReservation {
+    fn drop(&mut self) {
+        let Some(load_guard) = self.load_guard.take() else {
+            return;
+        };
+
+        let next = self.inner.release(&self.worker, load_guard);
+        if let Some(waiter) = next {
+            waiter.notify.notify_one();
+        }
+    }
+}
+
+/// The Prefill load held for one client request.
+///
+/// With admission enabled this is a queue reservation bounded by the per-worker
+/// limit. With admission disabled the load is still tracked, but not bounded.
+/// Batch sub-requests share one reservation and take one unit of unbounded load
+/// each, which keeps worker load accounting the same as before admission.
+pub enum PrefillLoadGuard {
+    Admission {
+        _reservation: Arc<PrefillReservation>,
+    },
+    Unbounded {
+        _guard: WorkerLoadGuard,
+    },
+}
+
+impl PrefillLoadGuard {
+    /// Acquire another guard for the same request.
+    ///
+    /// This is explicit instead of `Clone` because the unbounded variant
+    /// increments externally visible worker load.
+    pub(crate) fn replicate(&self) -> Self {
+        match self {
+            Self::Admission { _reservation } => Self::Admission {
+                _reservation: Arc::clone(_reservation),
+            },
+            Self::Unbounded { _guard } => Self::Unbounded {
+                _guard: _guard.replicate(),
+            },
+        }
+    }
+}
+
+/// A candidate-selection error that can also mean "every eligible Prefill
+/// worker is at its limit", which makes the request wait instead of fail.
+pub trait PrefillCandidateError {
+    fn is_at_capacity(&self) -> bool;
+}
+
+/// Why [`acquire_prefill`] could not reserve Prefill capacity.
+pub enum PrefillAcquireError<E> {
+    /// Candidate selection failed. Only reachable with admission disabled;
+    /// otherwise the reason is folded into [`PrefillAdmissionRejection`].
+    Candidate(E),
+    Rejected(PrefillAdmissionRejection),
+}
+
+/// Select a Prefill worker for one client request and hold its load.
+///
+/// With admission enabled the selection runs at the head of the FIFO queue and
+/// under the admission lock, so `select` must filter candidates with
+/// [`PrefillSelectionContext::has_capacity`] before it invokes a stateful
+/// routing policy. With admission disabled `select` receives `None` and runs
+/// once.
+pub async fn acquire_prefill<C, E, S, P>(
+    admission: Option<&PrefillAdmission>,
+    headers: Option<&http::HeaderMap>,
+    prefill_of: P,
+    mut select: S,
+) -> Result<(C, PrefillLoadGuard), PrefillAcquireError<E>>
+where
+    S: for<'a> FnMut(Option<&PrefillSelectionContext<'a>>) -> Result<C, E> + Send,
+    P: Fn(&C) -> &Arc<dyn Worker> + Send + Sync,
+    E: PrefillCandidateError,
+{
+    let Some(admission) = admission else {
+        let candidate = select(None).map_err(PrefillAcquireError::Candidate)?;
+        let guard = PrefillLoadGuard::Unbounded {
+            _guard: WorkerLoadGuard::new(Arc::clone(prefill_of(&candidate)), headers),
+        };
+        return Ok((candidate, guard));
+    };
+
+    let admitted = admission
+        .admit(headers, |capacity| match select(Some(capacity)) {
+            Ok(candidate) => capacity.select(Arc::clone(prefill_of(&candidate)), candidate),
+            Err(error) if error.is_at_capacity() => PrefillAdmissionAttempt::AtCapacity,
+            Err(_) => PrefillAdmissionAttempt::Unavailable,
+        })
+        .await
+        .map_err(PrefillAcquireError::Rejected)?;
+
+    Ok((
+        admitted.selected,
+        PrefillLoadGuard::Admission {
+            _reservation: Arc::new(admitted.reservation),
+        },
+    ))
+}
+
+/// Router-local, strict FIFO admission for the Prefill phase of PD requests.
+///
+/// Waiting requests do not hold a worker. Only the queue head receives a
+/// capacity-positive view and can select a worker. The callback runs while the
+/// admission lock is held, so candidate filtering, a stateful routing-policy
+/// call, and reservation are serialized with every other Prefill admission in
+/// this Router process.
+#[derive(Clone)]
+pub struct PrefillAdmission {
+    inner: Arc<PrefillAdmissionInner>,
+}
+
+struct PrefillAdmissionInner {
+    max_inflight_requests_per_worker: usize,
+    queue_size: usize,
+    queue_timeout: Duration,
+    state: Mutex<PrefillAdmissionState>,
+}
+
+struct PrefillAdmissionState {
+    waiters: VecDeque<Arc<PrefillWaiter>>,
+}
+
+struct PrefillWaiter {
+    notify: Notify,
+}
+
+impl PrefillAdmission {
+    pub fn new(
+        max_inflight_requests_per_worker: usize,
+        queue_size: usize,
+        queue_timeout: Duration,
+    ) -> Self {
+        assert!(
+            max_inflight_requests_per_worker > 0,
+            "Prefill admission requires a positive per-worker limit"
+        );
+        assert!(
+            queue_size == 0 || !queue_timeout.is_zero(),
+            "Prefill admission requires a positive timeout when its queue is enabled"
+        );
+
+        Self {
+            inner: Arc::new(PrefillAdmissionInner {
+                max_inflight_requests_per_worker,
+                queue_size,
+                queue_timeout,
+                state: Mutex::new(PrefillAdmissionState {
+                    waiters: VecDeque::with_capacity(queue_size.min(64)),
+                }),
+            }),
+        }
+    }
+
+    /// Admit one client request and select its Prefill worker.
+    ///
+    /// The callback may run more than once while a request waits. On each run
+    /// it must refresh the worker set and health state. It must filter
+    /// candidates with [`PrefillSelectionContext::has_capacity`] before it
+    /// invokes a stateful routing policy, then return the result through
+    /// [`PrefillSelectionContext::select`]. When an older request is already
+    /// queued, the callback runs only to detect `Unavailable`; capacity is
+    /// hidden so the new request cannot invoke its policy or bypass the queue.
+    pub async fn admit<T, F>(
+        &self,
+        headers: Option<&http::HeaderMap>,
+        mut attempt: F,
+    ) -> Result<AdmittedPrefill<T>, PrefillAdmissionRejection>
+    where
+        F: for<'a> FnMut(&PrefillSelectionContext<'a>) -> PrefillAdmissionAttempt<T> + Send,
+    {
+        let (waiter, queued_at) = {
+            let mut state = self.inner.state.lock();
+            let selection_allowed = state.waiters.is_empty();
+
+            match self.try_admit_locked(&state, headers, selection_allowed, &mut attempt) {
+                LockedAttempt::Selected(admitted) => return Ok(admitted),
+                LockedAttempt::Unavailable => {
+                    Metrics::record_pd_prefill_admission_rejection("unavailable");
+                    return Err(PrefillAdmissionRejection::Unavailable);
+                }
+                LockedAttempt::AtCapacity => {}
+            }
+
+            if state.waiters.len() >= self.inner.queue_size {
+                Metrics::record_pd_prefill_admission_rejection("queue_full");
+                return Err(PrefillAdmissionRejection::QueueFull);
+            }
+
+            let waiter = Arc::new(PrefillWaiter {
+                notify: Notify::new(),
+            });
+            let queued_at = Instant::now();
+            state.waiters.push_back(Arc::clone(&waiter));
+            Metrics::set_pd_prefill_admission_queued(state.waiters.len());
+            (waiter, queued_at)
+        };
+
+        let mut ticket = QueueTicket {
+            inner: Arc::clone(&self.inner),
+            waiter,
+            queued: true,
+            queued_at,
+        };
+        let timeout = tokio::time::sleep(self.inner.queue_timeout);
+        let deadline = timeout.deadline();
+        tokio::pin!(timeout);
+
+        loop {
+            let waiter = Arc::clone(&ticket.waiter);
+            let is_head = {
+                let state = self.inner.state.lock();
+                ticket.is_head(&state)
+            };
+            let recheck = tokio::time::sleep(HEAD_RECHECK_INTERVAL);
+            tokio::pin!(recheck);
+            tokio::select! {
+                biased;
+                () = &mut timeout => {
+                    Metrics::record_pd_prefill_admission_rejection("queue_timeout");
+                    return Err(PrefillAdmissionRejection::QueueTimeout);
+                }
+                () = waiter.notify.notified() => {}
+                // Open circuit breakers become HalfOpen on their next state
+                // check and do not emit a registry event. Poll only the queue
+                // head so that recovery can make progress without waking the
+                // rest of the FIFO queue.
+                () = &mut recheck, if is_head => {}
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                Metrics::record_pd_prefill_admission_rejection("queue_timeout");
+                return Err(PrefillAdmissionRejection::QueueTimeout);
+            }
+
+            let decision = {
+                let mut state = self.inner.state.lock();
+                if ticket.is_head(&state) {
+                    match self.try_admit_locked(&state, headers, true, &mut attempt) {
+                        LockedAttempt::Selected(admitted) => {
+                            let next = ticket.remove_head(&mut state);
+                            Some(QueuedAttempt::Selected(admitted, next))
+                        }
+                        LockedAttempt::Unavailable => {
+                            let next = ticket.remove_head(&mut state);
+                            Some(QueuedAttempt::Unavailable(next))
+                        }
+                        LockedAttempt::AtCapacity => None,
+                    }
+                } else {
+                    None
+                }
+            };
+
+            match decision {
+                Some(QueuedAttempt::Selected(admitted, next)) => {
+                    if let Some(waiter) = next {
+                        waiter.notify.notify_one();
+                    }
+                    return Ok(admitted);
+                }
+                Some(QueuedAttempt::Unavailable(next)) => {
+                    if let Some(waiter) = next {
+                        waiter.notify.notify_one();
+                    }
+                    Metrics::record_pd_prefill_admission_rejection("unavailable");
+                    return Err(PrefillAdmissionRejection::Unavailable);
+                }
+                None => {}
+            }
+        }
+    }
+
+    /// Wake the queue head after worker registration, removal, replacement, or
+    /// health state changes can affect its selection result.
+    pub fn notify_capacity_changed(&self) {
+        if let Some(waiter) = self.inner.head_waiter() {
+            waiter.notify.notify_one();
+        }
+    }
+
+    pub fn queued_requests(&self) -> usize {
+        self.inner.state.lock().waiters.len()
+    }
+
+    fn try_admit_locked<T, F>(
+        &self,
+        state: &PrefillAdmissionState,
+        headers: Option<&http::HeaderMap>,
+        selection_allowed: bool,
+        attempt: &mut F,
+    ) -> LockedAttempt<T>
+    where
+        F: for<'a> FnMut(&PrefillSelectionContext<'a>) -> PrefillAdmissionAttempt<T>,
+    {
+        let selection = attempt(&PrefillSelectionContext {
+            max_inflight_requests_per_worker: self.inner.max_inflight_requests_per_worker,
+            selection_allowed,
+            _lock: state,
+        });
+
+        match selection {
+            PrefillAdmissionAttempt::Selected(PrefillSelection { worker, value }) => {
+                let Some(load_guard) = WorkerLoadGuard::try_new(
+                    Arc::clone(&worker),
+                    headers,
+                    self.inner.max_inflight_requests_per_worker,
+                ) else {
+                    return LockedAttempt::AtCapacity;
+                };
+                Metrics::set_pd_prefill_admission_inflight(worker.url(), worker.load());
+
+                LockedAttempt::Selected(AdmittedPrefill {
+                    selected: value,
+                    reservation: PrefillReservation {
+                        inner: Arc::clone(&self.inner),
+                        worker,
+                        load_guard: Some(load_guard),
+                    },
+                })
+            }
+            PrefillAdmissionAttempt::AtCapacity => LockedAttempt::AtCapacity,
+            PrefillAdmissionAttempt::Unavailable => LockedAttempt::Unavailable,
+        }
+    }
+}
+
+enum LockedAttempt<T> {
+    Selected(AdmittedPrefill<T>),
+    AtCapacity,
+    Unavailable,
+}
+
+enum QueuedAttempt<T> {
+    Selected(AdmittedPrefill<T>, Option<Arc<PrefillWaiter>>),
+    Unavailable(Option<Arc<PrefillWaiter>>),
+}
+
+impl PrefillAdmissionInner {
+    fn head_waiter(&self) -> Option<Arc<PrefillWaiter>> {
+        self.state.lock().waiters.front().cloned()
+    }
+
+    fn release(
+        &self,
+        worker: &Arc<dyn Worker>,
+        load_guard: WorkerLoadGuard,
+    ) -> Option<Arc<PrefillWaiter>> {
+        let state = self.state.lock();
+        drop(load_guard);
+        Metrics::set_pd_prefill_admission_inflight(worker.url(), worker.load());
+
+        state.waiters.front().cloned()
+    }
+}
+
+struct QueueTicket {
+    inner: Arc<PrefillAdmissionInner>,
+    waiter: Arc<PrefillWaiter>,
+    queued: bool,
+    queued_at: Instant,
+}
+
+impl QueueTicket {
+    fn is_head(&self, state: &PrefillAdmissionState) -> bool {
+        state
+            .waiters
+            .front()
+            .is_some_and(|head| Arc::ptr_eq(head, &self.waiter))
+    }
+
+    fn remove_head(&mut self, state: &mut PrefillAdmissionState) -> Option<Arc<PrefillWaiter>> {
+        let _ = state.waiters.pop_front();
+        self.queued = false;
+        Metrics::set_pd_prefill_admission_queued(state.waiters.len());
+        Metrics::record_pd_prefill_admission_wait(self.queued_at.elapsed());
+        state.waiters.front().cloned()
+    }
+}
+
+impl Drop for QueueTicket {
+    fn drop(&mut self) {
+        if !self.queued {
+            return;
+        }
+
+        let next = {
+            let mut state = self.inner.state.lock();
+            let Some(position) = state
+                .waiters
+                .iter()
+                .position(|waiter| Arc::ptr_eq(waiter, &self.waiter))
+            else {
+                return;
+            };
+            let was_head = position == 0;
+            let _ = state.waiters.remove(position);
+            self.queued = false;
+            Metrics::set_pd_prefill_admission_queued(state.waiters.len());
+            Metrics::record_pd_prefill_admission_wait(self.queued_at.elapsed());
+            if was_head {
+                state.waiters.front().cloned()
+            } else {
+                None
+            }
+        };
+
+        if let Some(waiter) = next {
+            waiter.notify.notify_one();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use openai_protocol::worker::WorkerStatus;
+    use tokio::sync::{mpsc, oneshot};
+
+    use super::*;
+    use crate::worker::{BasicWorkerBuilder, CircuitBreakerConfig, WorkerType};
+
+    fn worker(url: &str) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(WorkerType::Prefill)
+                .build(),
+        )
+    }
+
+    async fn wait_for_queued(admission: &PrefillAdmission, expected: usize) {
+        for _ in 0..1_000 {
+            if admission.queued_requests() == expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!(
+            "queue depth did not reach {expected}; actual={}",
+            admission.queued_requests()
+        );
+    }
+
+    #[tokio::test]
+    async fn one_client_request_uses_one_worker_slot() {
+        let admission = PrefillAdmission::new(1, 0, Duration::from_secs(1));
+        let worker = worker("http://prefill-one");
+
+        let admitted = admission
+            .admit(None, {
+                let worker = Arc::clone(&worker);
+                move |capacity| capacity.select(Arc::clone(&worker), "selected")
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(admitted.selected, "selected");
+        assert_eq!(worker.load(), 1);
+        drop(admitted.reservation);
+        assert_eq!(worker.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn zero_size_queue_rejects_at_capacity() {
+        let admission = PrefillAdmission::new(1, 0, Duration::from_secs(1));
+        let worker = worker("http://prefill-no-queue");
+        let first = admission
+            .admit(None, {
+                let worker = Arc::clone(&worker);
+                move |capacity| capacity.select(Arc::clone(&worker), ())
+            })
+            .await
+            .unwrap();
+
+        let result = admission
+            .admit(None, {
+                let worker = Arc::clone(&worker);
+                move |capacity| capacity.select(Arc::clone(&worker), ())
+            })
+            .await;
+        assert!(matches!(result, Err(PrefillAdmissionRejection::QueueFull)));
+        drop(first);
+    }
+
+    #[tokio::test]
+    async fn full_queue_rejects_without_bypassing_waiter() {
+        let admission = PrefillAdmission::new(1, 1, Duration::from_secs(1));
+        let worker = worker("http://prefill-full-queue");
+        let first = admission
+            .admit(None, {
+                let worker = Arc::clone(&worker);
+                move |capacity| capacity.select(Arc::clone(&worker), ())
+            })
+            .await
+            .unwrap();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is aborted and joined before the test ends"
+        )]
+        let waiter = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            async move {
+                admission
+                    .admit(None, move |capacity| {
+                        capacity.select(Arc::clone(&worker), ())
+                    })
+                    .await
+            }
+        });
+        wait_for_queued(&admission, 1).await;
+
+        let policy_called = Arc::new(AtomicBool::new(false));
+        let result = admission
+            .admit(None, {
+                let policy_called = Arc::clone(&policy_called);
+                let worker = Arc::clone(&worker);
+                move |capacity| {
+                    if !capacity.has_capacity(&worker) {
+                        return PrefillAdmissionAttempt::AtCapacity;
+                    }
+                    policy_called.store(true, Ordering::Relaxed);
+                    capacity.select(Arc::clone(&worker), ())
+                }
+            })
+            .await;
+        assert!(matches!(result, Err(PrefillAdmissionRejection::QueueFull)));
+        assert!(!policy_called.load(Ordering::Relaxed));
+
+        waiter.abort();
+        assert!(matches!(
+            waiter.await,
+            Err(error) if error.is_cancelled()
+        ));
+        drop(first);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn queued_request_times_out_and_removes_its_ticket() {
+        let admission = PrefillAdmission::new(1, 1, Duration::from_secs(5));
+        let worker = worker("http://prefill-timeout");
+        let first = admission
+            .admit(None, {
+                let worker = Arc::clone(&worker);
+                move |capacity| capacity.select(Arc::clone(&worker), ())
+            })
+            .await
+            .unwrap();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let waiter = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            async move {
+                admission
+                    .admit(None, move |capacity| {
+                        capacity.select(Arc::clone(&worker), ())
+                    })
+                    .await
+            }
+        });
+        wait_for_queued(&admission, 1).await;
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert!(matches!(
+            waiter.await.unwrap(),
+            Err(PrefillAdmissionRejection::QueueTimeout)
+        ));
+        assert_eq!(admission.queued_requests(), 0);
+        drop(first);
+    }
+
+    #[tokio::test]
+    async fn released_worker_load_is_visible_to_the_next_selection() {
+        let admission = PrefillAdmission::new(1, 1, Duration::from_secs(1));
+        let worker = worker("http://prefill-release-order");
+        let first = admission
+            .admit(None, {
+                let worker = Arc::clone(&worker);
+                move |capacity| capacity.select(Arc::clone(&worker), ())
+            })
+            .await
+            .unwrap();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let waiter = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            async move {
+                admission
+                    .admit(None, move |capacity| {
+                        if !capacity.has_capacity(&worker) {
+                            return PrefillAdmissionAttempt::AtCapacity;
+                        }
+                        assert_eq!(worker.load(), 0);
+                        capacity.select(Arc::clone(&worker), ())
+                    })
+                    .await
+            }
+        });
+        wait_for_queued(&admission, 1).await;
+
+        drop(first);
+        let admitted = waiter.await.unwrap().unwrap();
+        drop(admitted);
+    }
+
+    #[tokio::test]
+    async fn queued_requests_are_admitted_in_strict_fifo_order() {
+        let admission = PrefillAdmission::new(1, 2, Duration::from_secs(1));
+        let worker = worker("http://prefill-fifo");
+        let initial = admission
+            .admit(None, {
+                let worker = Arc::clone(&worker);
+                move |capacity| capacity.select(Arc::clone(&worker), ())
+            })
+            .await
+            .unwrap();
+        let (acquired_tx, mut acquired_rx) = mpsc::unbounded_channel();
+        let (release_first_tx, release_first_rx) = oneshot::channel();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let first = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            let acquired_tx = acquired_tx.clone();
+            async move {
+                let admitted = admission
+                    .admit(None, move |capacity| {
+                        capacity.select(Arc::clone(&worker), ())
+                    })
+                    .await
+                    .unwrap();
+                acquired_tx.send(1).unwrap();
+                let _ = release_first_rx.await;
+                drop(admitted);
+            }
+        });
+        wait_for_queued(&admission, 1).await;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let second = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            async move {
+                let admitted = admission
+                    .admit(None, move |capacity| {
+                        capacity.select(Arc::clone(&worker), ())
+                    })
+                    .await
+                    .unwrap();
+                acquired_tx.send(2).unwrap();
+                drop(admitted);
+            }
+        });
+        wait_for_queued(&admission, 2).await;
+
+        drop(initial);
+        assert_eq!(acquired_rx.recv().await, Some(1));
+        assert!(acquired_rx.try_recv().is_err());
+        release_first_tx.send(()).unwrap();
+        assert_eq!(acquired_rx.recv().await, Some(2));
+
+        first.await.unwrap();
+        second.await.unwrap();
+        assert_eq!(worker.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn admitted_head_wakes_next_head_while_capacity_remains() {
+        let admission = PrefillAdmission::new(2, 2, Duration::from_secs(1));
+        let worker = worker("http://prefill-drain");
+        let available = Arc::new(AtomicBool::new(false));
+        let (acquired_tx, mut acquired_rx) = mpsc::unbounded_channel();
+        let (release_first_tx, release_first_rx) = oneshot::channel();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let first = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            let available = Arc::clone(&available);
+            let acquired_tx = acquired_tx.clone();
+            async move {
+                let admitted = admission
+                    .admit(None, move |capacity| {
+                        if available.load(Ordering::Relaxed) {
+                            capacity.select(Arc::clone(&worker), ())
+                        } else {
+                            PrefillAdmissionAttempt::AtCapacity
+                        }
+                    })
+                    .await
+                    .unwrap();
+                acquired_tx.send(1).unwrap();
+                let _ = release_first_rx.await;
+                drop(admitted);
+            }
+        });
+        wait_for_queued(&admission, 1).await;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let second = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            let available = Arc::clone(&available);
+            async move {
+                let admitted = admission
+                    .admit(None, move |capacity| {
+                        if available.load(Ordering::Relaxed) {
+                            capacity.select(Arc::clone(&worker), ())
+                        } else {
+                            PrefillAdmissionAttempt::AtCapacity
+                        }
+                    })
+                    .await
+                    .unwrap();
+                acquired_tx.send(2).unwrap();
+                drop(admitted);
+            }
+        });
+        wait_for_queued(&admission, 2).await;
+
+        available.store(true, Ordering::Relaxed);
+        admission.notify_capacity_changed();
+        assert_eq!(acquired_rx.recv().await, Some(1));
+        assert_eq!(acquired_rx.recv().await, Some(2));
+        release_first_tx.send(()).unwrap();
+
+        first.await.unwrap();
+        second.await.unwrap();
+        assert_eq!(worker.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn queue_head_rechecks_circuit_breaker_recovery_without_event() {
+        let admission = PrefillAdmission::new(1, 1, Duration::from_secs(5));
+        let full = worker("http://prefill-full");
+        let occupied = admission
+            .admit(None, {
+                let full = Arc::clone(&full);
+                move |capacity| capacity.select(Arc::clone(&full), ())
+            })
+            .await
+            .unwrap();
+        let recovering: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://prefill-recovering")
+                .worker_type(WorkerType::Prefill)
+                .circuit_breaker_config(CircuitBreakerConfig {
+                    failure_threshold: 1,
+                    timeout_duration: Duration::from_millis(250),
+                    ..Default::default()
+                })
+                .build(),
+        );
+        recovering.set_status(WorkerStatus::Ready);
+        recovering.record_circuit_breaker_outcome(false);
+        assert!(!recovering.is_available());
+
+        let admitted = tokio::time::timeout(
+            Duration::from_secs(3),
+            admission.admit(None, {
+                let full = Arc::clone(&full);
+                let recovering = Arc::clone(&recovering);
+                move |capacity| {
+                    if recovering.is_available() {
+                        capacity.select(Arc::clone(&recovering), ())
+                    } else {
+                        capacity.select(Arc::clone(&full), ())
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("queue head should recheck a silently recovered worker")
+        .unwrap();
+
+        assert_eq!(full.load(), 1);
+        assert_eq!(recovering.load(), 1);
+        drop(admitted);
+        drop(occupied);
+        assert_eq!(full.load(), 0);
+        assert_eq!(recovering.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn cancelled_waiters_are_removed_without_blocking_fifo() {
+        let admission = PrefillAdmission::new(1, 2, Duration::from_secs(1));
+        let worker = worker("http://prefill-cancel-head");
+        let initial = admission
+            .admit(None, {
+                let worker = Arc::clone(&worker);
+                move |capacity| capacity.select(Arc::clone(&worker), ())
+            })
+            .await
+            .unwrap();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is aborted and joined before the test ends"
+        )]
+        let cancelled = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            async move {
+                admission
+                    .admit(None, move |capacity| {
+                        capacity.select(Arc::clone(&worker), ())
+                    })
+                    .await
+            }
+        });
+        wait_for_queued(&admission, 1).await;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is aborted and joined before the test ends"
+        )]
+        let middle = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            async move {
+                admission
+                    .admit(None, move |capacity| {
+                        capacity.select(Arc::clone(&worker), ())
+                    })
+                    .await
+            }
+        });
+        wait_for_queued(&admission, 2).await;
+        middle.abort();
+        assert!(matches!(
+            middle.await,
+            Err(error) if error.is_cancelled()
+        ));
+        wait_for_queued(&admission, 1).await;
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let next = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            let attempts = Arc::clone(&attempts);
+            async move {
+                admission
+                    .admit(None, move |capacity| {
+                        attempts.fetch_add(1, Ordering::Relaxed);
+                        capacity.select(Arc::clone(&worker), ())
+                    })
+                    .await
+            }
+        });
+        wait_for_queued(&admission, 2).await;
+
+        cancelled.abort();
+        assert!(matches!(
+            cancelled.await,
+            Err(error) if error.is_cancelled()
+        ));
+        wait_for_queued(&admission, 1).await;
+        for _ in 0..1_000 {
+            if attempts.load(Ordering::Relaxed) > 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(attempts.load(Ordering::Relaxed) > 0);
+
+        drop(initial);
+        let admitted = next.await.unwrap().unwrap();
+        drop(admitted);
+    }
+
+    #[tokio::test]
+    async fn queued_request_selects_again_without_worker_binding() {
+        let admission = PrefillAdmission::new(1, 1, Duration::from_secs(1));
+        let first_worker = worker("http://prefill-a");
+        let second_worker = worker("http://prefill-b");
+        let first = admission
+            .admit(None, {
+                let worker = Arc::clone(&first_worker);
+                move |capacity| capacity.select(Arc::clone(&worker), ())
+            })
+            .await
+            .unwrap();
+        let second = admission
+            .admit(None, {
+                let worker = Arc::clone(&second_worker);
+                move |capacity| capacity.select(Arc::clone(&worker), ())
+            })
+            .await
+            .unwrap();
+        let policy_calls = Arc::new(AtomicUsize::new(0));
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let waiter = tokio::spawn({
+            let admission = admission.clone();
+            let first_worker = Arc::clone(&first_worker);
+            let second_worker = Arc::clone(&second_worker);
+            let policy_calls = Arc::clone(&policy_calls);
+            async move {
+                admission
+                    .admit(None, move |capacity| {
+                        let selected = if capacity.has_capacity(&first_worker) {
+                            Some(Arc::clone(&first_worker))
+                        } else if capacity.has_capacity(&second_worker) {
+                            Some(Arc::clone(&second_worker))
+                        } else {
+                            None
+                        };
+                        let Some(selected) = selected else {
+                            return PrefillAdmissionAttempt::AtCapacity;
+                        };
+                        policy_calls.fetch_add(1, Ordering::Relaxed);
+                        let url = selected.url().to_owned();
+                        capacity.select(selected, url)
+                    })
+                    .await
+            }
+        });
+        wait_for_queued(&admission, 1).await;
+        assert_eq!(policy_calls.load(Ordering::Relaxed), 0);
+
+        drop(second);
+        let admitted = waiter.await.unwrap().unwrap();
+        assert_eq!(admitted.selected, "http://prefill-b");
+        assert_eq!(policy_calls.load(Ordering::Relaxed), 1);
+        drop(admitted);
+        drop(first);
+    }
+
+    #[tokio::test]
+    async fn unavailable_head_exposes_the_next_waiter() {
+        let admission = PrefillAdmission::new(1, 2, Duration::from_secs(1));
+        let worker = worker("http://prefill-unavailable-head");
+        let unavailable = Arc::new(AtomicBool::new(false));
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let first = tokio::spawn({
+            let admission = admission.clone();
+            let unavailable = Arc::clone(&unavailable);
+            async move {
+                admission
+                    .admit(None, move |_| {
+                        if unavailable.load(Ordering::Relaxed) {
+                            PrefillAdmissionAttempt::<()>::Unavailable
+                        } else {
+                            PrefillAdmissionAttempt::AtCapacity
+                        }
+                    })
+                    .await
+            }
+        });
+        wait_for_queued(&admission, 1).await;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is joined before the test ends"
+        )]
+        let second = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            async move {
+                admission
+                    .admit(None, move |capacity| {
+                        capacity.select(Arc::clone(&worker), ())
+                    })
+                    .await
+            }
+        });
+        wait_for_queued(&admission, 2).await;
+
+        unavailable.store(true, Ordering::Relaxed);
+        admission.notify_capacity_changed();
+        assert!(matches!(
+            first.await.unwrap(),
+            Err(PrefillAdmissionRejection::Unavailable)
+        ));
+        let admitted = second.await.unwrap().unwrap();
+        drop(admitted);
+    }
+
+    #[tokio::test]
+    async fn unavailable_is_not_queued() {
+        let admission = PrefillAdmission::new(1, 2, Duration::from_secs(1));
+        let worker = worker("http://prefill-unavailable");
+        let occupied = admission
+            .admit(None, {
+                let worker = Arc::clone(&worker);
+                move |capacity| capacity.select(Arc::clone(&worker), ())
+            })
+            .await
+            .unwrap();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test waiter task is aborted and joined before the test ends"
+        )]
+        let queued = tokio::spawn({
+            let admission = admission.clone();
+            let worker = Arc::clone(&worker);
+            async move {
+                admission
+                    .admit(None, move |capacity| {
+                        capacity.select(Arc::clone(&worker), ())
+                    })
+                    .await
+            }
+        });
+        wait_for_queued(&admission, 1).await;
+
+        let result = admission
+            .admit(None, |_| PrefillAdmissionAttempt::<()>::Unavailable)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(PrefillAdmissionRejection::Unavailable)
+        ));
+        assert_eq!(admission.queued_requests(), 1);
+
+        queued.abort();
+        assert!(matches!(
+            queued.await,
+            Err(error) if error.is_cancelled()
+        ));
+        drop(occupied);
+    }
+}

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -1667,10 +1667,10 @@ impl WorkerRegistry {
                 let status = existing.status();
                 if state.health {
                     if matches!(status, WorkerStatus::Pending | WorkerStatus::NotReady) {
-                        existing.set_status(WorkerStatus::Ready);
+                        self.transition_status(&existing_id, WorkerStatus::Ready);
                     }
                 } else if status == WorkerStatus::Ready {
-                    existing.set_status(WorkerStatus::NotReady);
+                    self.transition_status(&existing_id, WorkerStatus::NotReady);
                 }
                 tracing::debug!(
                     url = %state.url,

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -273,6 +273,22 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
     /// Increment the load counter
     fn increment_load(&self);
 
+    /// Increment the load counter only when the resulting value does not exceed `max`.
+    ///
+    /// Implementations backed by an atomic counter should override this method
+    /// with a compare-and-update operation. This fallback preserves the limit
+    /// for existing external implementations, but can reject usable capacity
+    /// during concurrent attempts.
+    fn try_increment_load(&self, max: usize) -> bool {
+        self.increment_load();
+        if self.load() <= max {
+            true
+        } else {
+            self.decrement_load();
+            false
+        }
+    }
+
     /// Decrement the load counter
     fn decrement_load(&self);
 
@@ -898,6 +914,14 @@ impl WorkerRuntime {
         self.load_counter.fetch_add(1, Ordering::Relaxed);
     }
 
+    pub fn try_increment_load(&self, max: usize) -> bool {
+        self.load_counter
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1).filter(|next| *next <= max)
+            })
+            .is_ok()
+    }
+
     /// Saturating decrement. Returns `true` if the counter was decremented,
     /// `false` if it was already zero — callers can log when that happens.
     pub fn try_decrement_load(&self) -> bool {
@@ -1101,6 +1125,14 @@ impl Worker for BasicWorker {
     fn increment_load(&self) {
         self.runtime.load().increment_load();
         self.update_running_requests_metrics();
+    }
+
+    fn try_increment_load(&self, max: usize) -> bool {
+        let incremented = self.runtime.load().try_increment_load(max);
+        if incremented {
+            self.update_running_requests_metrics();
+        }
+        incremented
     }
 
     fn decrement_load(&self) {
@@ -1330,14 +1362,46 @@ impl Worker for BasicWorker {
 /// immediately but the stream continues in the background.
 pub struct WorkerLoadGuard {
     worker: Arc<dyn Worker>,
-    routing_key: Option<String>,
+    routing_key: Option<Arc<str>>,
 }
 
 impl WorkerLoadGuard {
     pub fn new(worker: Arc<dyn Worker>, headers: Option<&http::HeaderMap>) -> Self {
         worker.increment_load();
 
-        let routing_key = extract_routing_key(headers).map(String::from);
+        Self::from_acquired_load(worker, headers)
+    }
+
+    pub fn try_new(
+        worker: Arc<dyn Worker>,
+        headers: Option<&http::HeaderMap>,
+        max: usize,
+    ) -> Option<Self> {
+        if !worker.try_increment_load(max) {
+            return None;
+        }
+
+        Some(Self::from_acquired_load(worker, headers))
+    }
+
+    /// Acquire another load guard for the same worker and routing key.
+    ///
+    /// This is explicit instead of implementing `Clone` because replication
+    /// increments externally visible worker load.
+    pub(crate) fn replicate(&self) -> Self {
+        self.worker.increment_load();
+        if let Some(ref key) = self.routing_key {
+            self.worker.increment_routing_key_load(key);
+        }
+
+        Self {
+            worker: Arc::clone(&self.worker),
+            routing_key: self.routing_key.clone(),
+        }
+    }
+
+    fn from_acquired_load(worker: Arc<dyn Worker>, headers: Option<&http::HeaderMap>) -> Self {
+        let routing_key = extract_routing_key(headers).map(Arc::<str>::from);
 
         if let Some(ref key) = routing_key {
             worker.increment_routing_key_load(key);
@@ -2346,6 +2410,23 @@ mod tests {
 
         assert_eq!(worker.load(), 0);
         assert_eq!(worker.routing_key_load(), 0);
+    }
+
+    #[test]
+    fn test_worker_load_guard_respects_atomic_limit() {
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://test:8000")
+                .worker_type(WorkerType::Prefill)
+                .build(),
+        );
+
+        let first = WorkerLoadGuard::try_new(Arc::clone(&worker), None, 1).unwrap();
+        assert!(WorkerLoadGuard::try_new(Arc::clone(&worker), None, 1).is_none());
+
+        drop(first);
+        let second = WorkerLoadGuard::try_new(Arc::clone(&worker), None, 1).unwrap();
+        drop(second);
+        assert_eq!(worker.load(), 0);
     }
 
     #[test]

--- a/model_gateway/src/workflow/steps/local/drain_workers.rs
+++ b/model_gateway/src/workflow/steps/local/drain_workers.rs
@@ -151,6 +151,7 @@ mod tests {
             rate_limiter: Some(Arc::new(TokenBucket::new(1000, 1000))),
             rate_limit_manager: None,
             worker_registry: Arc::clone(&registry),
+            prefill_admission: None,
             policy_registry: Arc::new(crate::policies::PolicyRegistry::new(
                 router_config.policy.clone(),
             )),

--- a/model_gateway/src/workflow/steps/shared/activate.rs
+++ b/model_gateway/src/workflow/steps/shared/activate.rs
@@ -15,14 +15,28 @@ pub struct ActivateWorkersStep;
 #[async_trait]
 impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for ActivateWorkersStep {
     async fn execute(&self, context: &mut WorkflowContext<D>) -> WorkflowResult<StepResult> {
+        let app_context = context
+            .data
+            .get_app_context()
+            .ok_or_else(|| WorkflowError::ContextValueNotFound("app_context".to_string()))?
+            .clone();
+
         let workers = context
             .data
             .get_actual_workers()
             .ok_or_else(|| WorkflowError::ContextValueNotFound("workers".to_string()))?;
 
+        let mut activated = false;
         for worker in workers {
             if worker.status() != WorkerStatus::Ready {
                 worker.set_status(WorkerStatus::Ready);
+                activated = true;
+            }
+        }
+
+        if activated {
+            if let Some(admission) = &app_context.prefill_admission {
+                admission.notify_capacity_changed();
             }
         }
 


### PR DESCRIPTION
## What this PR does

Today SMG has no limit on how many Prefill requests it sends to one Prefill worker. When a Prefill worker is full, SMG keeps sending. The extra requests wait inside the engine, where SMG cannot see them or bound their wait time.

This PR adds an optional per-worker Prefill limit. When a worker is at its limit, new requests wait in a bounded FIFO queue inside SMG until a slot opens.

## How to turn it on

| Option | Meaning | Default |
|--------|---------|---------|
| `--prefill-max-inflight-requests-per-worker` | Max in-flight Prefill requests per Prefill worker. `<= 0` turns the feature off. | `-1` (off) |
| `--prefill-queue-size` | How many requests may wait. `0` means never wait, reject at once. | `100` |
| `--prefill-queue-timeout-secs` | Longest time one request may wait for a slot. | `60` |

Set a positive per-worker limit and the feature is on. Startup rejects these combinations:

- queue options without a positive limit
- admission together with `--priority-scheduler-enabled`
- admission in a routing mode other than PD or EPD

## What counts as one slot

- One client request takes one slot. Batch inputs and `n > 1` do not take more. All backend sub-requests of one client request share the same slot. The slot remains occupied until every Prefill sub-request finishes. With admission disabled, each sub-request releases its own worker load when it finishes.
- The slot is taken when a worker is selected. It is released when the Prefill response is fully read, fails, or is cancelled. Decode does not hold the slot.
- Worker load counters do not change. Decode load, and Prefill load when the feature is off, still count one per backend sub-request.
- The limit and the queue belong to one SMG process. With `--dp-aware`, each rank is a separate worker with its own limit.

## How the queue works

- A waiting request is not tied to any worker. Only the request at the head of the queue picks a worker.
- At the head, SMG rereads worker health, capacity, runtime pairing and cache state. It drops workers that are at the limit. Then it runs the Prefill policy. Filtering, policy choice and slot reservation happen under one lock, so a stateful policy like `cache_aware` never picks a worker and then fails to get a slot.
- The capacity filter lives in the shared `placement::select_pair`. HTTP PD and gRPC PD use it the same way. gRPC EPD uses it on the prefill leg.
- New requests never skip ahead of waiting requests.
- With `consistent_hashing`, `X-SMG-Target-Worker` is strict. The request waits for that worker. It does not move to another worker.
- The head of the queue wakes up when a slot is released, or when a worker is added, removed, replaced, or changes health.
- The head also rechecks once per second. A circuit breaker that moves from open to half-open does so lazily and emits no event, so without this poll a waiting request would never see the recovery. Only the head polls.
- Cancelling a request removes it from the queue and wakes the next one.
- A gRPC retry goes through admission again and takes a new slot for the new worker. The failed attempt releases its slot before the backoff.

## Errors

- Queue full: `429`, code `pd_prefill_queue_full`.
- Wait timed out: `429`, code `pd_prefill_queue_timeout`.
- SMG does not retry these two errors.
- No healthy worker for the model keeps the old behavior: `503` shed or availability error, or `404` when nobody serves the model. These requests are not queued.

## What does not change

- Decode workers keep their load tracking and get no limit. Decode scheduling stays in the engine. The Decode bootstrap-room admission on `main` is untouched and works next to this gate.
- HTTP PD, gRPC PD and gRPC EPD share one admission controller.
- Decode load is taken only after the Prefill slot is reserved. A rejected candidate no longer briefly raises Decode load.
- The streaming `/v1/responses` handlers now wait for the backend request to start before they reply. Before, they replied `200` and an SSE stream at once, which would turn an admission `429` into a `200` followed by an SSE `error` event. Now the client gets the real HTTP status.

## Metrics

| Metric | Type | Labels |
|--------|------|--------|
| `smg_pd_prefill_admission_inflight` | Gauge | `worker` |
| `smg_pd_prefill_admission_queued` | Gauge | none |
| `smg_pd_prefill_admission_wait_seconds` | Histogram | none |
| `smg_pd_prefill_admission_rejections_total` | Counter | `reason` |

These count SMG admission only. Engine queue metrics are unchanged.

## Prefill completion

HTTP PD reads the Prefill body and releases its slot independently of the Decode response head. Non-streaming Decode therefore does not hold Prefill capacity while generating output. If either leg fails with an HTTP or transport error, SMG cancels the other leg.

gRPC PD releases each fan-out sample's guard on that sample's terminal response. The first completed sample cannot release the shared admission slot while other Prefill samples are unfinished. Single-dispatch EOF collectors retain their existing guard lifetime. Removing a worker resets its admission gauge.

## Validation

[GitHub CI for `c491928b`](https://github.com/smg-project/smg/actions/runs/35420226855) passed all enabled checks, including unit tests and PD end-to-end tests. Commit `13ff477f` narrows regression tests. Commit `d5463494` limits the generic `FanoutChild for FanoutStream<C>` implementation to `#[cfg(test)]`; production callers continue to use `ProtoStream`. No nested fan-out support or new tests were added. Commit `74ff486a` removes the unsupported native multi-sample Prefill test and corrects explanatory comments; runtime code is unchanged. CI reruns on the latest head.

Validation of `13ff477f` ran in a dedicated HPC8 development Pod with 32 CPUs and 128 GiB of memory:

| Check | Result |
|---|---|
| Three targeted library tests | 3 passed, 0 failed |
| `cargo clippy -p smg --lib --tests -- -D warnings` | pass |
| `cargo +nightly fmt --all -- --check` | pass |

The retained tests cover independent Prefill sample completion with admission on/off and terminal/EOF collection, and clearing the admission gauge on worker removal. Duplicate terminal messages and generic destructor cleanup cases were removed because they do not represent the request flow changed here.

The seven changed source files on HPC8 matched the local source hashes. No repository compilation or tests ran locally.

A fresh dedicated HPC8 Pod also validated `d5463494`: `cargo check -p smg --lib`, the two related Prefill stream tests (2 passed, 0 failed), and `cargo +nightly fmt --all -- --check` all passed. The changed source hash matched the local file; the Pod was deleted after validation.

The native multi-sample Prefill test was removed after auditing all supported PD runtimes: vLLM forces Prefill to n=1; SGLang and TokenSpeed split text requests into independent n=1 dispatches. The multimodal exception does not establish a valid native multi-sample PD handoff: samples share a bootstrap room, which can cause duplicate pre-allocation rejection or stalled transfers. A generic backend's ability to return multiple samples is insufficient evidence for this PD test.

For the retained fan-out case, the existing [TokenSpeed GPU CI job](https://github.com/smg-project/smg/actions/runs/35420226855/job/105845108402) explicitly passed `test_batched_completion_serves_every_choice[2p2d]` with n=4. Worker removal calls `Metrics::remove_worker_metrics` from the registry's actual removal path. The latest change only deletes a test and revises comments; formatting and diff checks pass, and no new runtime test result is claimed for that deletion.

<details>
<summary>Checklist</summary>

- [x] Formatting passes
- [x] Clippy passes
- [x] `smg` library tests pass
- [x] `routing_tests` passes
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>



