### PR TITLE
fix(deepseek): align V4 thinking behavior with the official API

### DIFF
--- a/bindings/golang/src/utils.rs
+++ b/bindings/golang/src/utils.rs
@@ -31,12 +31,5 @@ pub(crate) fn chat_requires_reasoning(
     request: &ChatCompletionRequest,
     tokenizer: &dyn Tokenizer,
 ) -> bool {
-    should_mark_reasoning_started(
-        resolve_user_thinking(
-            request.chat_template_kwargs.as_ref(),
-            request.reasoning_effort.as_deref(),
-            tokenizer,
-        ),
-        tokenizer,
-    )
+    should_mark_reasoning_started(resolve_user_thinking(request, tokenizer), tokenizer)
 }

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -137,6 +137,21 @@ impl MessageContent {
 // Chat Completion Request
 // ============================================================================
 
+/// DeepSeek thinking-mode configuration for the OpenAI-compatible API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ChatThinkingConfig {
+    Enabled {},
+    Disabled {},
+}
+
+impl ChatThinkingConfig {
+    #[inline]
+    pub const fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled {})
+    }
+}
+
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize, Default, Validate, schemars::JsonSchema)]
 #[validate(schema(function = "validate_chat_cross_parameters"))]
@@ -198,6 +213,9 @@ pub struct ChatCompletionRequest {
 
     /// Cache key for prompts (beta feature)
     pub prompt_cache_key: Option<String>,
+
+    /// Enable or disable DeepSeek thinking mode.
+    pub thinking: Option<ChatThinkingConfig>,
 
     /// Effort level for reasoning models.
     ///
@@ -330,6 +348,19 @@ pub struct ChatCompletionRequest {
     /// Additional fields not explicitly defined above (e.g. engine-specific parameters)
     #[serde(flatten)]
     pub other: Map<String, Value>,
+}
+
+impl ChatCompletionRequest {
+    /// Resolve the protocol-level thinking preference.
+    ///
+    /// The explicit DeepSeek `thinking` field wins over compatibility mappings
+    /// from OpenAI's `reasoning_effort`.
+    #[inline]
+    pub fn thinking_preference(&self) -> Option<bool> {
+        self.thinking
+            .map(ChatThinkingConfig::is_enabled)
+            .or_else(|| thinking_from_reasoning_effort(self.reasoning_effort.as_deref()))
+    }
 }
 
 /// Map an OpenAI `reasoning_effort` to a thinking on/off preference.
@@ -801,7 +832,7 @@ pub struct ChatStreamChoice {
 mod tests {
     use serde_json::{json, Value};
 
-    use super::{thinking_from_reasoning_effort, ChatCompletionRequest};
+    use super::{thinking_from_reasoning_effort, ChatCompletionRequest, ChatThinkingConfig};
 
     fn request_with_output_fields(fields: &[(&str, Value)]) -> ChatCompletionRequest {
         let mut value = json!({
@@ -852,6 +883,53 @@ mod tests {
                 .to_string()
                 .contains("reasoning_effort must be a string, number, or null"));
         }
+    }
+
+    #[test]
+    fn deepseek_thinking_config_is_strict_and_typed() {
+        for (value, expected) in [
+            (json!({"type": "enabled"}), ChatThinkingConfig::Enabled {}),
+            (json!({"type": "disabled"}), ChatThinkingConfig::Disabled {}),
+        ] {
+            let request = request_with_output_fields(&[("thinking", value.clone())]);
+            assert_eq!(request.thinking, Some(expected));
+            assert!(!request.other.contains_key("thinking"));
+            assert_eq!(
+                serde_json::to_value(request).unwrap().get("thinking"),
+                Some(&value)
+            );
+        }
+
+        for value in [
+            json!({"type": "auto"}),
+            json!({"type": "enabled", "budget_tokens": 1024}),
+            json!(true),
+        ] {
+            let mut request = json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+            });
+            request["thinking"] = value.clone();
+            assert!(
+                serde_json::from_value::<ChatCompletionRequest>(request).is_err(),
+                "accepted invalid thinking value: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_deepseek_thinking_wins_over_reasoning_effort() {
+        let request = request_with_output_fields(&[
+            ("thinking", json!({"type": "enabled"})),
+            ("reasoning_effort", json!("none")),
+        ]);
+        assert_eq!(request.thinking_preference(), Some(true));
+
+        let request = request_with_output_fields(&[
+            ("thinking", json!({"type": "disabled"})),
+            ("reasoning_effort", json!("max")),
+        ]);
+        assert_eq!(request.thinking_preference(), Some(false));
     }
 
     #[test]

--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -16,6 +16,17 @@ use crate::{
 /// Type alias for parser creator functions.
 type ParserCreator = Arc<dyn Fn() -> Box<dyn ReasoningParser> + Send + Sync>;
 
+fn conditional_deepseek_parser(model_type: &str) -> Box<dyn ReasoningParser> {
+    let config = ParserConfig {
+        think_start_token: "<think>".to_string(),
+        think_end_token: "</think>".to_string(),
+        stream_reasoning: true,
+        max_buffer_size: DEFAULT_MAX_BUFFER_SIZE,
+        always_in_reasoning: false,
+    };
+    Box::new(BaseReasoningParser::new(config).with_model_type(model_type.to_string()))
+}
+
 /// Registry for model-specific parsers.
 #[derive(Clone)]
 pub struct ParserRegistry {
@@ -152,15 +163,12 @@ impl ParserFactory {
 
         // standard think tokens, always_in_reasoning=false
         registry.register_parser("deepseek_v31", || {
-            let config = ParserConfig {
-                think_start_token: "<think>".to_string(),
-                think_end_token: "</think>".to_string(),
-                stream_reasoning: true,
-                max_buffer_size: DEFAULT_MAX_BUFFER_SIZE,
-                always_in_reasoning: false,
-            };
-            Box::new(BaseReasoningParser::new(config).with_model_type("deepseek_v31".to_string()))
+            conditional_deepseek_parser("deepseek_v31")
         });
+
+        // DeepSeek V4 uses the same delimiters, but has its own name so CLI
+        // configuration and model-based selection match the served model.
+        registry.register_parser("deepseek_v4", || conditional_deepseek_parser("deepseek_v4"));
 
         registry.register_parser("kimi_k25", || {
             let config = ParserConfig {
@@ -187,6 +195,7 @@ impl ParserFactory {
         registry.register_pattern("deepseek-r1", "deepseek_r1");
         registry.register_pattern("deepseek-v3.1", "deepseek_v31");
         registry.register_pattern("deepseek-v3-1", "deepseek_v31");
+        registry.register_pattern("deepseek-v4", "deepseek_v4");
         registry.register_pattern("qwen3-thinking", "qwen3_thinking");
         registry.register_pattern("qwen-thinking", "qwen3_thinking");
         registry.register_pattern("qwen3", "qwen3");
@@ -264,6 +273,21 @@ mod tests {
         let factory = ParserFactory::new();
         let parser = factory.create("deepseek-r1-distill");
         assert_eq!(parser.model_type(), "deepseek_r1");
+    }
+
+    #[test]
+    fn test_factory_creates_deepseek_v4() {
+        let factory = ParserFactory::new();
+        let mut parser = factory.create("deepseek-v4-pro");
+        assert_eq!(parser.model_type(), "deepseek_v4");
+
+        // The V4 prompt consumes `<think>` before generation starts.
+        parser.mark_reasoning_started();
+        let result = parser
+            .detect_and_parse_reasoning("reasoning</think>answer")
+            .unwrap();
+        assert_eq!(result.reasoning_text, "reasoning");
+        assert_eq!(result.normal_text, "answer");
     }
 
     #[test]

--- a/crates/tokenizer/src/encoders/deepseek_v4.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v4.rs
@@ -1,4 +1,4 @@
-// Ported from https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/encoding/encoding_dsv4.py
+// Ported from https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/encoding/encoding_dsv4.py
 
 use std::fmt::Write as _;
 

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -580,10 +580,10 @@ impl TokenizerTrait for HuggingFaceTokenizer {
 
     fn thinking_toggle(&self) -> ThinkingToggle {
         match self.renderer {
-            // DeepSeek V3.2 and V4 encoders gate thinking on the `thinking`
-            // kwarg, default off. The Jinja processor has no knowledge of
-            // the native encoder so we must report it directly.
-            Renderer::DeepseekV32 | Renderer::DeepseekV4 => ThinkingToggle::DefaultOff,
+            // Native encoders bypass Jinja detection, so report their official
+            // defaults directly. V3.2 defaults off; V4 defaults on.
+            Renderer::DeepseekV32 => ThinkingToggle::DefaultOff,
+            Renderer::DeepseekV4 => ThinkingToggle::DefaultOn,
             Renderer::Jinja => self.chat_template.thinking_toggle(),
         }
     }
@@ -653,19 +653,21 @@ fn detect_renderer_from_config(dir: &Path) -> Renderer {
 // ---------------------------------------------------------------------------
 // DeepSeek V3.2 / V4 dispatch shims
 // ---------------------------------------------------------------------------
-/// Derive the V3.2 / V4 thinking mode. These native encoders bypass
+/// Derive a native DeepSeek renderer's thinking mode. These encoders bypass
 /// `ChatTemplateState::apply`, so this is where the resolved thinking preference
 /// is consumed. An explicit `template_kwargs["thinking"]` wins; otherwise fall
 /// back to `params.thinking` (resolved from `reasoning_effort` / Anthropic
-/// `ThinkingConfig`) — same precedence as the Jinja path. Default off, matching
-/// the `ThinkingKeyName::Thinking` / `DefaultOff` contract reported here.
-fn derive_thinking_mode(params: &ChatTemplateParams) -> deepseek_v32::ThinkingMode {
+/// `ThinkingConfig`) and finally the renderer's official default.
+fn derive_thinking_mode(
+    params: &ChatTemplateParams,
+    default_enabled: bool,
+) -> deepseek_v32::ThinkingMode {
     let enabled = params
         .template_kwargs
         .and_then(|k| k.get("thinking"))
         .and_then(serde_json::Value::as_bool)
         .or(params.thinking)
-        .unwrap_or(false);
+        .unwrap_or(default_enabled);
     if enabled {
         deepseek_v32::ThinkingMode::Thinking
     } else {
@@ -717,7 +719,7 @@ fn apply_deepseek_v32(
 ) -> Result<String> {
     let owned = inject_tools_into_messages(messages, params.tools);
     let msgs: &[serde_json::Value] = owned.as_deref().unwrap_or(messages);
-    let thinking_mode = derive_thinking_mode(params);
+    let thinking_mode = derive_thinking_mode(params, false);
     let encode_params = deepseek_v32::EncodeParams {
         add_default_bos_token: true,
         drop_thinking: resolve_drop_thinking(msgs),
@@ -731,14 +733,14 @@ fn apply_deepseek_v4(
 ) -> Result<String> {
     let owned = inject_tools_into_messages(messages, params.tools);
     let msgs: &[serde_json::Value] = owned.as_deref().unwrap_or(messages);
-    let thinking_mode = derive_thinking_mode(params);
+    let thinking_mode = derive_thinking_mode(params, true);
     let reasoning_effort = params
         .template_kwargs
         .and_then(|k| k.get("reasoning_effort"))
         .and_then(|v| v.as_str())
         .and_then(|s| match s {
-            "max" => Some(deepseek_v4::ReasoningEffort::Max),
-            "high" => Some(deepseek_v4::ReasoningEffort::High),
+            "max" | "xhigh" => Some(deepseek_v4::ReasoningEffort::Max),
+            "high" | "medium" | "low" => Some(deepseek_v4::ReasoningEffort::High),
             _ => None,
         });
     let encode_params = deepseek_v4::EncodeParams {
@@ -761,51 +763,60 @@ mod tests {
         HashMap::from([("thinking".to_string(), serde_json::Value::Bool(value))])
     }
 
-    // Regression: DeepSeek V3.2/V4 bypass ChatTemplateState::apply, so the
-    // resolved `params.thinking` (from reasoning_effort / Anthropic ThinkingConfig)
-    // must be honored here — with an explicit `template_kwargs["thinking"]` still
-    // winning. Same precedence as the Jinja path.
     #[test]
-    fn derive_thinking_mode_honors_params_thinking_and_explicit_override() {
-        // No signal at all -> Chat (default off).
+    fn derive_thinking_mode_honors_defaults_and_explicit_override() {
         assert!(matches!(
-            derive_thinking_mode(&ChatTemplateParams::default()),
+            derive_thinking_mode(&ChatTemplateParams::default(), false),
             ThinkingMode::Chat
         ));
-
-        // params.thinking is the fallback when there is no explicit kwarg.
         assert!(matches!(
-            derive_thinking_mode(&ChatTemplateParams {
-                thinking: Some(true),
-                ..Default::default()
-            }),
+            derive_thinking_mode(&ChatTemplateParams::default(), true),
+            ThinkingMode::Thinking
+        ));
+
+        assert!(matches!(
+            derive_thinking_mode(
+                &ChatTemplateParams {
+                    thinking: Some(true),
+                    ..Default::default()
+                },
+                false
+            ),
             ThinkingMode::Thinking
         ));
         assert!(matches!(
-            derive_thinking_mode(&ChatTemplateParams {
-                thinking: Some(false),
-                ..Default::default()
-            }),
+            derive_thinking_mode(
+                &ChatTemplateParams {
+                    thinking: Some(false),
+                    ..Default::default()
+                },
+                true
+            ),
             ThinkingMode::Chat
         ));
 
-        // An explicit template_kwargs["thinking"] wins over params.thinking.
         let on = thinking_kwargs(true);
         assert!(matches!(
-            derive_thinking_mode(&ChatTemplateParams {
-                thinking: Some(false),
-                template_kwargs: Some(&on),
-                ..Default::default()
-            }),
+            derive_thinking_mode(
+                &ChatTemplateParams {
+                    thinking: Some(false),
+                    template_kwargs: Some(&on),
+                    ..Default::default()
+                },
+                false
+            ),
             ThinkingMode::Thinking
         ));
         let off = thinking_kwargs(false);
         assert!(matches!(
-            derive_thinking_mode(&ChatTemplateParams {
-                thinking: Some(true),
-                template_kwargs: Some(&off),
-                ..Default::default()
-            }),
+            derive_thinking_mode(
+                &ChatTemplateParams {
+                    thinking: Some(true),
+                    template_kwargs: Some(&off),
+                    ..Default::default()
+                },
+                true
+            ),
             ThinkingMode::Chat
         ));
     }

--- a/crates/tokenizer/tests/deepseek_renderer_detection.rs
+++ b/crates/tokenizer/tests/deepseek_renderer_detection.rs
@@ -68,10 +68,10 @@ mod tests {
             ..Default::default()
         };
         let out = tokenizer.apply_chat_template(&messages, params).unwrap();
-        // V4 emits BOS + <｜User｜>Hello<｜Assistant｜></think> in chat mode.
+        // DeepSeek V4 defaults to thinking mode.
         assert!(out.contains("<\u{FF5C}begin\u{2581}of\u{2581}sentence\u{FF5C}>"));
         assert!(out.contains("<\u{FF5C}User\u{FF5C}>Hello<\u{FF5C}Assistant\u{FF5C}>"));
-        assert!(out.ends_with("</think>"));
+        assert!(out.ends_with("<think>"));
     }
 
     #[test]
@@ -201,14 +201,13 @@ mod tests {
         // gate thinking on the `thinking` kwarg. The trait methods must
         // surface this so the gateway can call `mark_reasoning_started` on
         // the conditional reasoning parser (deepseek_v31 etc).
-        for arch in &["DeepseekV32ForCausalLM", "DeepseekV4ForCausalLM"] {
-            let (_tmp, tok) = write_dir(Some(&[*arch]));
+        for (arch, expected) in [
+            ("DeepseekV32ForCausalLM", ThinkingToggle::DefaultOff),
+            ("DeepseekV4ForCausalLM", ThinkingToggle::DefaultOn),
+        ] {
+            let (_tmp, tok) = write_dir(Some(&[arch]));
             let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
-            assert_eq!(
-                tokenizer.thinking_toggle(),
-                ThinkingToggle::DefaultOff,
-                "{arch}: expected DefaultOff toggle"
-            );
+            assert_eq!(tokenizer.thinking_toggle(), expected, "{arch}");
             assert_eq!(
                 tokenizer.thinking_key_name(),
                 Some(ThinkingKeyName::Thinking),
@@ -222,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn deepseek_renderers_honor_thinking_kwarg_only() {
+    fn deepseek_renderers_honor_thinking_kwarg() {
         // `thinking: true` → prompt ends with <think> (thinking mode).
         // `enable_thinking: true` alone → ignored (chat mode), matching
         // `thinking_key_name() == Some(Thinking)` and sglang's DeepSeek path.
@@ -247,21 +246,20 @@ mod tests {
                 "{arch}: thinking=true should enter thinking mode: {out_thinking}"
             );
 
-            let mut enable_thinking_kwargs: HashMap<String, serde_json::Value> = HashMap::new();
-            enable_thinking_kwargs
-                .insert("enable_thinking".to_string(), serde_json::Value::Bool(true));
-            let out_enable = tokenizer
+            let mut chat_kwargs: HashMap<String, serde_json::Value> = HashMap::new();
+            chat_kwargs.insert("thinking".to_string(), serde_json::Value::Bool(false));
+            let out_chat = tokenizer
                 .apply_chat_template(
                     &messages,
                     ChatTemplateParams {
-                        template_kwargs: Some(&enable_thinking_kwargs),
+                        template_kwargs: Some(&chat_kwargs),
                         ..Default::default()
                     },
                 )
                 .unwrap();
             assert!(
-                out_enable.ends_with("</think>"),
-                "{arch}: enable_thinking alone must NOT enter thinking mode: {out_enable}"
+                out_chat.ends_with("</think>"),
+                "{arch}: thinking=false should enter chat mode: {out_chat}"
             );
         }
     }
@@ -290,5 +288,49 @@ mod tests {
             out.ends_with("<think>"),
             "thinking mode should leave a <think> token open"
         );
+    }
+
+    #[test]
+    fn deepseek_v4_normalizes_compatible_reasoning_efforts() {
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+
+        for effort in ["low", "medium", "high"] {
+            let kwargs = HashMap::from([(
+                "reasoning_effort".to_string(),
+                serde_json::Value::String(effort.to_string()),
+            )]);
+            let out = tokenizer
+                .apply_chat_template(
+                    &messages,
+                    ChatTemplateParams {
+                        template_kwargs: Some(&kwargs),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            assert!(
+                !out.contains("Reasoning Effort: Absolute maximum"),
+                "{effort}"
+            );
+            assert!(out.ends_with("<think>"), "{effort}");
+        }
+
+        let kwargs = HashMap::from([(
+            "reasoning_effort".to_string(),
+            serde_json::Value::String("xhigh".to_string()),
+        )]);
+        let out = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    template_kwargs: Some(&kwargs),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(out.contains("Reasoning Effort: Absolute maximum"));
+        assert!(out.ends_with("<think>"));
     }
 }

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -513,21 +513,25 @@ impl ResponseProcessor {
         #[expect(clippy::unwrap_used, reason = "safe: checked len == 1 above")]
         let complete = all_responses.into_iter().next().unwrap();
 
-        // Check parser availability. Run parser when the user explicitly enabled thinking,
+        // Check parser availability. Run parser when thinking is effectively ON —
+        // explicitly enabled, or left to a template default of on (DeepSeek V4) —
         // or when the selected parser needs structural special tokens (e.g. Inkling).
         let reasoning_requires_special_tokens = utils::reasoning_parser_requires_special_tokens(
             &self.reasoning_parser_factory,
             self.configured_reasoning_parser.as_deref(),
             &messages_request.model,
         );
+        let user_thinking = match &messages_request.thinking {
+            Some(
+                messages::ThinkingConfig::Enabled { .. }
+                | messages::ThinkingConfig::Adaptive { .. },
+            ) => Some(true),
+            Some(messages::ThinkingConfig::Disabled) => Some(false),
+            None => None,
+        };
         let separate_reasoning = reasoning_requires_special_tokens
-            || matches!(
-                &messages_request.thinking,
-                Some(
-                    messages::ThinkingConfig::Enabled { .. }
-                        | messages::ThinkingConfig::Adaptive { .. }
-                )
-            );
+            || user_thinking == Some(true)
+            || utils::should_mark_reasoning_started(user_thinking, tokenizer.as_ref());
         let reasoning_parser_available = separate_reasoning
             && utils::check_reasoning_parser_availability(
                 &self.reasoning_parser_factory,
@@ -603,18 +607,8 @@ impl ResponseProcessor {
                 &messages_request.model,
             ) {
                 // If thinking is effectively ON and template has a toggle, start in reasoning mode.
-                {
-                    let user_thinking = match &messages_request.thinking {
-                        Some(
-                            messages::ThinkingConfig::Enabled { .. }
-                            | messages::ThinkingConfig::Adaptive { .. },
-                        ) => Some(true),
-                        Some(messages::ThinkingConfig::Disabled) => Some(false),
-                        None => None,
-                    };
-                    if utils::should_mark_reasoning_started(user_thinking, tokenizer.as_ref()) {
-                        parser.mark_reasoning_started();
-                    }
+                if utils::should_mark_reasoning_started(user_thinking, tokenizer.as_ref()) {
+                    parser.mark_reasoning_started();
                 }
 
                 match parser.detect_and_parse_reasoning(&processed_text) {

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -110,11 +110,7 @@ impl ResponseProcessor {
                 // If the template injected `<think>` in the prefill (thinking toggle
                 // is supported and effectively ON), start in reasoning mode.
                 if utils::should_mark_reasoning_started(
-                    utils::resolve_user_thinking(
-                        original_request.chat_template_kwargs.as_ref(),
-                        original_request.reasoning_effort.as_deref(),
-                        tokenizer.as_ref(),
-                    ),
+                    utils::resolve_user_thinking(original_request, tokenizer.as_ref()),
                     tokenizer.as_ref(),
                 ) {
                     parser.mark_reasoning_started();

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -115,11 +115,7 @@ impl PipelineStage for ChatRequestBuildingStage {
 
         let require_reasoning = ctx.tokenizer_arc().is_some_and(|tokenizer| {
             utils::should_mark_reasoning_started(
-                utils::resolve_user_thinking(
-                    chat_request.chat_template_kwargs.as_ref(),
-                    chat_request.reasoning_effort.as_deref(),
-                    tokenizer.as_ref(),
-                ),
+                utils::resolve_user_thinking(&chat_request, tokenizer.as_ref()),
                 tokenizer.as_ref(),
             )
         });

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -311,11 +311,7 @@ impl StreamingProcessor {
         // the template injected `<think>` in the prefill — parsers should start
         // in reasoning mode.
         let thinking_override = utils::should_mark_reasoning_started(
-            utils::resolve_user_thinking(
-                original_request.chat_template_kwargs.as_ref(),
-                original_request.reasoning_effort.as_deref(),
-                tokenizer.as_ref(),
-            ),
+            utils::resolve_user_thinking(&original_request, tokenizer.as_ref()),
             tokenizer.as_ref(),
         );
         let think_in_prefill = tokenizer.think_in_prefill();

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -1737,29 +1737,15 @@ impl StreamingProcessor {
         let mut finish_reason_str = String::new();
         let mut matched_stop: Option<Value> = None;
 
-        // Check parser availability once upfront. Run parser when the user explicitly
-        // enabled thinking, or when the selected parser needs structural special tokens.
+        // Check parser availability once upfront. Run parser when thinking is
+        // effectively ON — explicitly enabled, or left to a template default of
+        // on (DeepSeek V4) — or when the selected parser needs structural
+        // special tokens.
         let reasoning_requires_special_tokens = utils::reasoning_parser_requires_special_tokens(
             &self.reasoning_parser_factory,
             self.configured_reasoning_parser.as_deref(),
             model,
         );
-        let separate_reasoning = reasoning_requires_special_tokens
-            || matches!(
-                &original_request.thinking,
-                Some(
-                    messages::ThinkingConfig::Enabled { .. }
-                        | messages::ThinkingConfig::Adaptive { .. }
-                )
-            );
-        let reasoning_parser_available = separate_reasoning
-            && utils::check_reasoning_parser_availability(
-                &self.reasoning_parser_factory,
-                self.configured_reasoning_parser.as_deref(),
-                model,
-            );
-
-        // Determine if thinking is effectively ON (for mark_reasoning_started).
         let user_thinking = match &original_request.thinking {
             Some(
                 messages::ThinkingConfig::Enabled { .. }
@@ -1770,6 +1756,14 @@ impl StreamingProcessor {
         };
         let thinking_override =
             utils::should_mark_reasoning_started(user_thinking, tokenizer.as_ref());
+        let separate_reasoning =
+            reasoning_requires_special_tokens || user_thinking == Some(true) || thinking_override;
+        let reasoning_parser_available = separate_reasoning
+            && utils::check_reasoning_parser_availability(
+                &self.reasoning_parser_factory,
+                self.configured_reasoning_parser.as_deref(),
+                model,
+            );
         let think_in_prefill = tokenizer.think_in_prefill();
 
         let tool_choice_enabled = !matches!(

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -481,12 +481,10 @@ pub(crate) fn process_chat_messages_with_placeholders(
             add_generation_prompt: true,
             tools: tools_json.as_deref(),
             template_kwargs: final_template_kwargs,
-            // Project OpenAI `reasoning_effort` (none/minimal) onto the model's
-            // thinking toggle; the tokenizer applies it under the correct key.
+            // Project the protocol-level DeepSeek `thinking` field and OpenAI
+            // compatibility values onto the model's thinking toggle.
             // An explicit chat_template_kwargs toggle still wins (in apply).
-            thinking: openai_protocol::chat::thinking_from_reasoning_effort(
-                request.reasoning_effort.as_deref(),
-            ),
+            thinking: request.thinking_preference(),
             ..Default::default()
         };
 
@@ -748,12 +746,15 @@ pub(crate) fn parse_finish_reason(
 
 #[cfg(test)]
 mod tests {
-    use llm_tokenizer::chat_template::ChatTemplateContentFormat;
+    use std::fs as test_fs;
+
+    use llm_tokenizer::{chat_template::ChatTemplateContentFormat, HuggingFaceTokenizer};
     use openai_protocol::{
         chat::{ChatCompletionRequest, ChatMessage, MessageContent},
         common::{AudioUrl, ContentPart, ImageUrl, InputAudio, VideoUrl},
     };
     use serde_json::json;
+    use tempfile::TempDir;
 
     use super::*;
 
@@ -763,6 +764,78 @@ mod tests {
             tokens.insert(*modality, (*token).to_string());
         }
         tokens
+    }
+
+    fn deepseek_v4_tokenizer() -> (TempDir, HuggingFaceTokenizer) {
+        const TOKENIZER_JSON: &str = r#"{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [],
+            "normalizer": null,
+            "pre_tokenizer": { "type": "Whitespace" },
+            "post_processor": null,
+            "decoder": null,
+            "model": {
+                "type": "BPE",
+                "vocab": { "hello": 0, "<s>": 1, "</s>": 2 },
+                "merges": []
+            }
+        }"#;
+
+        let dir = TempDir::new().unwrap();
+        let tokenizer_path = dir.path().join("tokenizer.json");
+        test_fs::write(&tokenizer_path, TOKENIZER_JSON).unwrap();
+        test_fs::write(
+            dir.path().join("config.json"),
+            r#"{"architectures":["DeepseekV4ForCausalLM"]}"#,
+        )
+        .unwrap();
+        let tokenizer = HuggingFaceTokenizer::from_file(tokenizer_path.to_str().unwrap()).unwrap();
+        (dir, tokenizer)
+    }
+
+    fn deepseek_request(extra: Value) -> ChatCompletionRequest {
+        let mut request = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{"role": "user", "content": "hello"}],
+        });
+        request.as_object_mut().unwrap().extend(
+            extra
+                .as_object()
+                .expect("extra request fields must be an object")
+                .clone(),
+        );
+        serde_json::from_value(request).unwrap()
+    }
+
+    #[test]
+    fn deepseek_v4_official_thinking_request_controls_prompt() {
+        let (_dir, tokenizer) = deepseek_v4_tokenizer();
+
+        let default_prompt = process_chat_messages(&deepseek_request(json!({})), &tokenizer, None)
+            .unwrap()
+            .text;
+        assert!(default_prompt.ends_with("<think>"));
+
+        let disabled_prompt = process_chat_messages(
+            &deepseek_request(json!({"thinking": {"type": "disabled"}})),
+            &tokenizer,
+            None,
+        )
+        .unwrap()
+        .text;
+        assert!(disabled_prompt.ends_with("</think>"));
+
+        let max_prompt = process_chat_messages(
+            &deepseek_request(json!({"reasoning_effort": "xhigh"})),
+            &tokenizer,
+            None,
+        )
+        .unwrap()
+        .text;
+        assert!(max_prompt.contains("Reasoning Effort: Absolute maximum"));
+        assert!(max_prompt.ends_with("<think>"));
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -4,7 +4,7 @@ use llm_tokenizer::{
     chat_template::{ThinkingKeyName, ThinkingToggle},
     traits::Tokenizer,
 };
-use openai_protocol::chat::thinking_from_reasoning_effort;
+use openai_protocol::chat::ChatCompletionRequest;
 use reasoning_parser::{ParserFactory as ReasoningParserFactory, ReasoningParser};
 use serde_json::Value;
 use tool_parser::{
@@ -46,26 +46,16 @@ pub(crate) fn extract_thinking_from_kwargs(
     .and_then(|v| v.as_bool())
 }
 
-/// Precedence for the effective thinking preference: an explicit template
-/// toggle (already extracted from kwargs) always wins; otherwise fall back to
-/// the protocol-level OpenAI `reasoning_effort` mapping
-/// ([`thinking_from_reasoning_effort`]).
-fn resolve_thinking_pref(explicit: Option<bool>, reasoning_effort: Option<&str>) -> Option<bool> {
-    explicit.or_else(|| thinking_from_reasoning_effort(reasoning_effort))
-}
-
-/// Resolve the user's effective thinking preference, honoring an explicit
-/// template thinking kwarg first (it always wins), then falling back to the
-/// OpenAI `reasoning_effort` mapping.
+/// Resolve the user's effective thinking preference: an explicit template
+/// kwarg wins, then the protocol-level preference
+/// ([`ChatCompletionRequest::thinking_preference`] — DeepSeek's official
+/// `thinking` field, then the OpenAI `reasoning_effort` compatibility mapping).
 pub fn resolve_user_thinking(
-    kwargs: Option<&std::collections::HashMap<String, Value>>,
-    reasoning_effort: Option<&str>,
+    request: &ChatCompletionRequest,
     tokenizer: &dyn Tokenizer,
 ) -> Option<bool> {
-    resolve_thinking_pref(
-        extract_thinking_from_kwargs(kwargs, tokenizer),
-        reasoning_effort,
-    )
+    extract_thinking_from_kwargs(request.chat_template_kwargs.as_ref(), tokenizer)
+        .or_else(|| request.thinking_preference())
 }
 
 /// Check if a reasoning parser is available for the given model
@@ -192,21 +182,142 @@ pub(crate) fn create_tool_parser(
 
 #[cfg(test)]
 mod tests {
+    use llm_tokenizer::{
+        mock::MockTokenizer,
+        traits::{Decoder, Encoder, Encoding, SpecialTokens, TokenIdType},
+    };
+    use serde_json::json;
+
     use super::*;
 
-    #[test]
-    fn resolve_thinking_pref_explicit_kwarg_wins() {
-        // An explicit template toggle always wins over the reasoning_effort mapping.
-        assert_eq!(resolve_thinking_pref(Some(true), Some("none")), Some(true));
-        assert_eq!(
-            resolve_thinking_pref(Some(false), Some("high")),
-            Some(false)
+    /// A mock tokenizer whose template uses the `thinking` toggle key, like the
+    /// DeepSeek V4 renderer.
+    struct ThinkingKeyTokenizer(MockTokenizer);
+
+    impl Encoder for ThinkingKeyTokenizer {
+        fn encode(&self, input: &str, add_special_tokens: bool) -> anyhow::Result<Encoding> {
+            self.0.encode(input, add_special_tokens)
+        }
+        fn encode_batch(
+            &self,
+            inputs: &[&str],
+            add_special_tokens: bool,
+        ) -> anyhow::Result<Vec<Encoding>> {
+            self.0.encode_batch(inputs, add_special_tokens)
+        }
+    }
+
+    impl Decoder for ThinkingKeyTokenizer {
+        fn decode(
+            &self,
+            token_ids: &[TokenIdType],
+            skip_special_tokens: bool,
+        ) -> anyhow::Result<String> {
+            self.0.decode(token_ids, skip_special_tokens)
+        }
+    }
+
+    impl Tokenizer for ThinkingKeyTokenizer {
+        fn vocab_size(&self) -> usize {
+            self.0.vocab_size()
+        }
+        fn get_special_tokens(&self) -> &SpecialTokens {
+            self.0.get_special_tokens()
+        }
+        fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
+            self.0.token_to_id(token)
+        }
+        fn id_to_token(&self, id: TokenIdType) -> Option<String> {
+            self.0.id_to_token(id)
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn thinking_toggle(&self) -> ThinkingToggle {
+            ThinkingToggle::DefaultOn
+        }
+        fn thinking_key_name(&self) -> Option<ThinkingKeyName> {
+            Some(ThinkingKeyName::Thinking)
+        }
+    }
+
+    fn request_with(extra: Value) -> ChatCompletionRequest {
+        let mut request = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{"role": "user", "content": "hello"}],
+        });
+        request.as_object_mut().unwrap().extend(
+            extra
+                .as_object()
+                .expect("extra request fields must be an object")
+                .clone(),
         );
-        // No explicit toggle -> fall back to the reasoning_effort mapping.
-        assert_eq!(resolve_thinking_pref(None, Some("none")), Some(false));
-        assert_eq!(resolve_thinking_pref(None, Some("minimal")), Some(false));
-        assert_eq!(resolve_thinking_pref(None, Some("high")), None);
-        assert_eq!(resolve_thinking_pref(None, None), None);
+        serde_json::from_value(request).unwrap()
+    }
+
+    #[test]
+    fn resolve_user_thinking_template_kwarg_wins() {
+        let tokenizer = ThinkingKeyTokenizer(MockTokenizer::new());
+
+        // The template's own toggle key beats the protocol `thinking` field
+        // and the reasoning_effort mapping.
+        let request = request_with(json!({
+            "chat_template_kwargs": {"thinking": true},
+            "thinking": {"type": "disabled"},
+            "reasoning_effort": "none",
+        }));
+        assert_eq!(resolve_user_thinking(&request, &tokenizer), Some(true));
+
+        let request = request_with(json!({
+            "chat_template_kwargs": {"thinking": false},
+            "thinking": {"type": "enabled"},
+        }));
+        assert_eq!(resolve_user_thinking(&request, &tokenizer), Some(false));
+
+        // A kwarg under a key the template does not use is ignored.
+        let request = request_with(json!({
+            "chat_template_kwargs": {"enable_thinking": false},
+            "thinking": {"type": "enabled"},
+        }));
+        assert_eq!(resolve_user_thinking(&request, &tokenizer), Some(true));
+    }
+
+    #[test]
+    fn resolve_user_thinking_falls_back_to_protocol_preference() {
+        let tokenizer = ThinkingKeyTokenizer(MockTokenizer::new());
+
+        // DeepSeek's official `thinking` field beats reasoning_effort.
+        let request = request_with(json!({
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "none",
+        }));
+        assert_eq!(resolve_user_thinking(&request, &tokenizer), Some(true));
+
+        let request = request_with(json!({
+            "thinking": {"type": "disabled"},
+            "reasoning_effort": "high",
+        }));
+        assert_eq!(resolve_user_thinking(&request, &tokenizer), Some(false));
+
+        // reasoning_effort none/minimal map to off; levels express no opinion.
+        for (effort, expected) in [
+            ("none", Some(false)),
+            ("minimal", Some(false)),
+            ("high", None),
+        ] {
+            let request = request_with(json!({"reasoning_effort": effort}));
+            assert_eq!(
+                resolve_user_thinking(&request, &tokenizer),
+                expected,
+                "{effort}"
+            );
+        }
+
+        // No signal at all -> no preference; the template default decides.
+        assert_eq!(
+            resolve_user_thinking(&request_with(json!({})), &tokenizer),
+            None
+        );
     }
 
     #[test]

--- a/model_gateway/src/routers/http/deepseek_compat.rs
+++ b/model_gateway/src/routers/http/deepseek_compat.rs
@@ -29,6 +29,10 @@ pub(crate) fn apply_deepseek_v4_http_compat(json_request: &mut Value, model_id: 
         return;
     };
 
+    // Normalize to the official levels. `none`/`minimal` are not levels the
+    // V4 worker understands — they are only the gateway's thinking-off
+    // signal, so consume them and drop the field from the forwarded JSON.
+    let mut effort_thinking = None;
     if let Some(Value::String(effort)) = request.get_mut("reasoning_effort") {
         match effort.as_str() {
             "low" | "medium" => {
@@ -39,8 +43,14 @@ pub(crate) fn apply_deepseek_v4_http_compat(json_request: &mut Value, model_id: 
                 effort.clear();
                 effort.push_str("max");
             }
+            "none" | "minimal" => {
+                effort_thinking = Some(false);
+            }
             _ => {}
         }
+    }
+    if effort_thinking.is_some() {
+        request.remove("reasoning_effort");
     }
 
     let template_thinking = request
@@ -60,13 +70,6 @@ pub(crate) fn apply_deepseek_v4_http_compat(json_request: &mut Value, model_id: 
         .and_then(|kind| match kind {
             "enabled" => Some(true),
             "disabled" => Some(false),
-            _ => None,
-        });
-    let effort_thinking = request
-        .get("reasoning_effort")
-        .and_then(Value::as_str)
-        .and_then(|effort| match effort {
-            "none" | "minimal" => Some(false),
             _ => None,
         });
     let enabled = explicit_thinking.or(effort_thinking).unwrap_or(true);
@@ -92,10 +95,25 @@ mod tests {
             (json!({"thinking": {"type": "enabled"}}), true),
             (json!({"thinking": {"type": "disabled"}}), false),
             (json!({"reasoning_effort": "none"}), false),
+            (json!({"reasoning_effort": "minimal"}), false),
         ] {
             apply_deepseek_v4_http_compat(&mut request, "DeepSeek-V4-Pro");
             assert_eq!(request["chat_template_kwargs"]["thinking"], expected);
+            // Off-signal efforts are not official levels; the worker must
+            // never see them.
+            assert!(request.get("reasoning_effort").is_none());
         }
+    }
+
+    #[test]
+    fn deepseek_v4_http_compat_drops_off_signal_effort_even_with_kwarg_override() {
+        let mut request = json!({
+            "reasoning_effort": "none",
+            "chat_template_kwargs": {"thinking": true},
+        });
+        apply_deepseek_v4_http_compat(&mut request, "DeepSeek-V4-Pro");
+        assert_eq!(request["chat_template_kwargs"]["thinking"], true);
+        assert!(request.get("reasoning_effort").is_none());
     }
 
     #[test]

--- a/model_gateway/src/routers/http/deepseek_compat.rs
+++ b/model_gateway/src/routers/http/deepseek_compat.rs
@@ -1,0 +1,135 @@
+//! DeepSeek V4 compatibility for HTTP workers.
+//!
+//! HTTP workers render the prompt themselves, so the gateway's native
+//! tokenizer path cannot apply the official DeepSeek V4 controls for them.
+//! Both the regular router and the PD router translate the public controls
+//! into the SGLang HTTP worker controls here before forwarding.
+
+use serde_json::Value;
+
+#[inline]
+pub(crate) fn is_deepseek_v4_model(model: &str) -> bool {
+    const DEEPSEEK_V4: &[u8] = b"deepseek-v4";
+    model
+        .as_bytes()
+        .windows(DEEPSEEK_V4.len())
+        .any(|candidate| candidate.eq_ignore_ascii_case(DEEPSEEK_V4))
+}
+
+/// Translate the public DeepSeek V4 controls to the SGLang HTTP worker
+/// controls: remap `reasoning_effort` to the official levels and project the
+/// `thinking` field onto `chat_template_kwargs.thinking` (default on). An
+/// explicit `chat_template_kwargs.thinking` from the caller wins. No-op for
+/// other models — the `thinking` kwarg name is DeepSeek-specific.
+pub(crate) fn apply_deepseek_v4_http_compat(json_request: &mut Value, model_id: &str) {
+    if !is_deepseek_v4_model(model_id) {
+        return;
+    }
+    let Some(request) = json_request.as_object_mut() else {
+        return;
+    };
+
+    if let Some(Value::String(effort)) = request.get_mut("reasoning_effort") {
+        match effort.as_str() {
+            "low" | "medium" => {
+                effort.clear();
+                effort.push_str("high");
+            }
+            "xhigh" => {
+                effort.clear();
+                effort.push_str("max");
+            }
+            _ => {}
+        }
+    }
+
+    let template_thinking = request
+        .get("chat_template_kwargs")
+        .and_then(Value::as_object)
+        .and_then(|kwargs| kwargs.get("thinking"))
+        .and_then(Value::as_bool);
+    if template_thinking.is_some() {
+        return;
+    }
+
+    let explicit_thinking = request
+        .get("thinking")
+        .and_then(Value::as_object)
+        .and_then(|thinking| thinking.get("type"))
+        .and_then(Value::as_str)
+        .and_then(|kind| match kind {
+            "enabled" => Some(true),
+            "disabled" => Some(false),
+            _ => None,
+        });
+    let effort_thinking = request
+        .get("reasoning_effort")
+        .and_then(Value::as_str)
+        .and_then(|effort| match effort {
+            "none" | "minimal" => Some(false),
+            _ => None,
+        });
+    let enabled = explicit_thinking.or(effort_thinking).unwrap_or(true);
+
+    let template_kwargs = request
+        .entry("chat_template_kwargs")
+        .or_insert_with(|| Value::Object(Default::default()));
+    if let Some(template_kwargs) = template_kwargs.as_object_mut() {
+        template_kwargs.insert("thinking".to_string(), Value::Bool(enabled));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn deepseek_v4_http_compat_translates_official_controls() {
+        for (mut request, expected) in [
+            (json!({}), true),
+            (json!({"thinking": {"type": "enabled"}}), true),
+            (json!({"thinking": {"type": "disabled"}}), false),
+            (json!({"reasoning_effort": "none"}), false),
+        ] {
+            apply_deepseek_v4_http_compat(&mut request, "DeepSeek-V4-Pro");
+            assert_eq!(request["chat_template_kwargs"]["thinking"], expected);
+        }
+    }
+
+    #[test]
+    fn deepseek_v4_http_compat_preserves_internal_override_and_maps_effort() {
+        let mut request = json!({
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "xhigh",
+            "chat_template_kwargs": {"thinking": false},
+        });
+        apply_deepseek_v4_http_compat(&mut request, "DeepSeek-V4-Pro");
+        assert_eq!(request["chat_template_kwargs"]["thinking"], false);
+        assert_eq!(request["reasoning_effort"], "max");
+
+        let mut other_model = json!({"reasoning_effort": "high"});
+        apply_deepseek_v4_http_compat(&mut other_model, "other-model");
+        assert!(other_model.get("chat_template_kwargs").is_none());
+    }
+
+    #[test]
+    fn deepseek_v4_http_compat_leaves_other_models_untouched() {
+        // The `thinking` kwarg name is only meaningful to DeepSeek's renderer;
+        // other models (e.g. Qwen `enable_thinking`) must not receive it, and
+        // their reasoning_effort must pass through verbatim.
+        let original = json!({
+            "thinking": {"type": "disabled"},
+            "reasoning_effort": "none",
+        });
+        let mut request = original.clone();
+        apply_deepseek_v4_http_compat(&mut request, "qwen3-30b");
+        assert_eq!(request, original);
+
+        let original = json!({"reasoning_effort": "xhigh"});
+        let mut request = original.clone();
+        apply_deepseek_v4_http_compat(&mut request, "other-model");
+        assert_eq!(request, original);
+    }
+}

--- a/model_gateway/src/routers/http/deepseek_compat.rs
+++ b/model_gateway/src/routers/http/deepseek_compat.rs
@@ -53,6 +53,19 @@ pub(crate) fn apply_deepseek_v4_http_compat(json_request: &mut Value, model_id: 
         request.remove("reasoning_effort");
     }
 
+    // Consume the public `thinking` object unconditionally: the worker only
+    // gets the translated kwarg, so it can never contradict the translation.
+    let explicit_thinking = request.remove("thinking").and_then(|thinking| {
+        thinking
+            .get("type")
+            .and_then(Value::as_str)
+            .and_then(|kind| match kind {
+                "enabled" => Some(true),
+                "disabled" => Some(false),
+                _ => None,
+            })
+    });
+
     let template_thinking = request
         .get("chat_template_kwargs")
         .and_then(Value::as_object)
@@ -62,16 +75,6 @@ pub(crate) fn apply_deepseek_v4_http_compat(json_request: &mut Value, model_id: 
         return;
     }
 
-    let explicit_thinking = request
-        .get("thinking")
-        .and_then(Value::as_object)
-        .and_then(|thinking| thinking.get("type"))
-        .and_then(Value::as_str)
-        .and_then(|kind| match kind {
-            "enabled" => Some(true),
-            "disabled" => Some(false),
-            _ => None,
-        });
     let enabled = explicit_thinking.or(effort_thinking).unwrap_or(true);
 
     let template_kwargs = request
@@ -99,21 +102,27 @@ mod tests {
         ] {
             apply_deepseek_v4_http_compat(&mut request, "DeepSeek-V4-Pro");
             assert_eq!(request["chat_template_kwargs"]["thinking"], expected);
-            // Off-signal efforts are not official levels; the worker must
-            // never see them.
+            // Translated public controls must not reach the worker: off-signal
+            // efforts are not official levels, and the `thinking` object could
+            // contradict the injected kwarg on workers that understand it.
             assert!(request.get("reasoning_effort").is_none());
+            assert!(request.get("thinking").is_none());
         }
     }
 
     #[test]
-    fn deepseek_v4_http_compat_drops_off_signal_effort_even_with_kwarg_override() {
+    fn deepseek_v4_http_compat_drops_public_controls_even_with_kwarg_override() {
         let mut request = json!({
+            "thinking": {"type": "disabled"},
             "reasoning_effort": "none",
             "chat_template_kwargs": {"thinking": true},
         });
         apply_deepseek_v4_http_compat(&mut request, "DeepSeek-V4-Pro");
+        // The explicit kwarg wins, and a worker that natively understands the
+        // official fields must not see the contradicting originals.
         assert_eq!(request["chat_template_kwargs"]["thinking"], true);
         assert!(request.get("reasoning_effort").is_none());
+        assert!(request.get("thinking").is_none());
     }
 
     #[test]

--- a/model_gateway/src/routers/http/mod.rs
+++ b/model_gateway/src/routers/http/mod.rs
@@ -1,5 +1,6 @@
 //! HTTP router implementations
 
+pub(crate) mod deepseek_compat;
 pub mod pd_router;
 pub mod pd_types;
 pub mod router;

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -204,76 +204,6 @@ impl PDRouter {
         None
     }
 
-    #[inline]
-    fn is_deepseek_v4_model(model: &str) -> bool {
-        const DEEPSEEK_V4: &[u8] = b"deepseek-v4";
-        model
-            .as_bytes()
-            .windows(DEEPSEEK_V4.len())
-            .any(|candidate| candidate.eq_ignore_ascii_case(DEEPSEEK_V4))
-    }
-
-    /// Translate the public DeepSeek V4 controls to the SGLang HTTP worker
-    /// controls. HTTP workers render the prompt themselves, so the gateway's
-    /// native tokenizer path cannot apply these settings for them.
-    fn apply_deepseek_v4_http_compat(json_request: &mut Value, model_id: &str) {
-        if !Self::is_deepseek_v4_model(model_id) {
-            return;
-        }
-        let Some(request) = json_request.as_object_mut() else {
-            return;
-        };
-
-        if let Some(Value::String(effort)) = request.get_mut("reasoning_effort") {
-            match effort.as_str() {
-                "low" | "medium" => {
-                    effort.clear();
-                    effort.push_str("high");
-                }
-                "xhigh" => {
-                    effort.clear();
-                    effort.push_str("max");
-                }
-                _ => {}
-            }
-        }
-
-        let template_thinking = request
-            .get("chat_template_kwargs")
-            .and_then(Value::as_object)
-            .and_then(|kwargs| kwargs.get("thinking"))
-            .and_then(Value::as_bool);
-        if template_thinking.is_some() {
-            return;
-        }
-
-        let explicit_thinking = request
-            .get("thinking")
-            .and_then(Value::as_object)
-            .and_then(|thinking| thinking.get("type"))
-            .and_then(Value::as_str)
-            .and_then(|kind| match kind {
-                "enabled" => Some(true),
-                "disabled" => Some(false),
-                _ => None,
-            });
-        let effort_thinking = request
-            .get("reasoning_effort")
-            .and_then(Value::as_str)
-            .and_then(|effort| match effort {
-                "none" | "minimal" => Some(false),
-                _ => None,
-            });
-        let enabled = explicit_thinking.or(effort_thinking).unwrap_or(true);
-
-        let template_kwargs = request
-            .entry("chat_template_kwargs")
-            .or_insert_with(|| Value::Object(Default::default()));
-        if let Some(template_kwargs) = template_kwargs.as_object_mut() {
-            template_kwargs.insert("thinking".to_string(), Value::Bool(enabled));
-        }
-    }
-
     fn get_completion_batch_size(req: &CompletionRequest) -> Option<usize> {
         if let StringOrArray::Array(arr) = &req.prompt {
             if !arr.is_empty() {
@@ -427,7 +357,7 @@ impl PDRouter {
                         super::set_request_model(&mut json_request, model);
 
                         if context.route == "/v1/chat/completions" {
-                            Self::apply_deepseek_v4_http_compat(
+                            super::deepseek_compat::apply_deepseek_v4_http_compat(
                                 &mut json_request,
                                 context.model_id,
                             );
@@ -1637,54 +1567,6 @@ mod tests {
             retry_config: RetryConfig::default(),
             api_key: Some("test_api_key".to_string()),
         }
-    }
-
-    #[test]
-    fn deepseek_v4_http_compat_translates_official_controls() {
-        for (mut request, expected) in [
-            (json!({}), true),
-            (json!({"thinking": {"type": "enabled"}}), true),
-            (json!({"thinking": {"type": "disabled"}}), false),
-            (json!({"reasoning_effort": "none"}), false),
-        ] {
-            PDRouter::apply_deepseek_v4_http_compat(&mut request, "DeepSeek-V4-Pro");
-            assert_eq!(request["chat_template_kwargs"]["thinking"], expected);
-        }
-    }
-
-    #[test]
-    fn deepseek_v4_http_compat_preserves_internal_override_and_maps_effort() {
-        let mut request = json!({
-            "thinking": {"type": "enabled"},
-            "reasoning_effort": "xhigh",
-            "chat_template_kwargs": {"thinking": false},
-        });
-        PDRouter::apply_deepseek_v4_http_compat(&mut request, "DeepSeek-V4-Pro");
-        assert_eq!(request["chat_template_kwargs"]["thinking"], false);
-        assert_eq!(request["reasoning_effort"], "max");
-
-        let mut other_model = json!({"reasoning_effort": "high"});
-        PDRouter::apply_deepseek_v4_http_compat(&mut other_model, "other-model");
-        assert!(other_model.get("chat_template_kwargs").is_none());
-    }
-
-    #[test]
-    fn deepseek_v4_http_compat_leaves_other_models_untouched() {
-        // The `thinking` kwarg name is only meaningful to DeepSeek's renderer;
-        // other models (e.g. Qwen `enable_thinking`) must not receive it, and
-        // their reasoning_effort must pass through verbatim.
-        let original = json!({
-            "thinking": {"type": "disabled"},
-            "reasoning_effort": "none",
-        });
-        let mut request = original.clone();
-        PDRouter::apply_deepseek_v4_http_compat(&mut request, "qwen3-30b");
-        assert_eq!(request, original);
-
-        let original = json!({"reasoning_effort": "xhigh"});
-        let mut request = original.clone();
-        PDRouter::apply_deepseek_v4_http_compat(&mut request, "other-model");
-        assert_eq!(request, original);
     }
 
     fn create_test_worker(url: String, worker_type: WorkerType, healthy: bool) -> Box<dyn Worker> {

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -217,24 +217,24 @@ impl PDRouter {
     /// controls. HTTP workers render the prompt themselves, so the gateway's
     /// native tokenizer path cannot apply these settings for them.
     fn apply_deepseek_v4_http_compat(json_request: &mut Value, model_id: &str) {
+        if !Self::is_deepseek_v4_model(model_id) {
+            return;
+        }
         let Some(request) = json_request.as_object_mut() else {
             return;
         };
 
-        let is_deepseek_v4 = Self::is_deepseek_v4_model(model_id);
-        if is_deepseek_v4 {
-            if let Some(Value::String(effort)) = request.get_mut("reasoning_effort") {
-                match effort.as_str() {
-                    "low" | "medium" => {
-                        effort.clear();
-                        effort.push_str("high");
-                    }
-                    "xhigh" => {
-                        effort.clear();
-                        effort.push_str("max");
-                    }
-                    _ => {}
+        if let Some(Value::String(effort)) = request.get_mut("reasoning_effort") {
+            match effort.as_str() {
+                "low" | "medium" => {
+                    effort.clear();
+                    effort.push_str("high");
                 }
+                "xhigh" => {
+                    effort.clear();
+                    effort.push_str("max");
+                }
+                _ => {}
             }
         }
 
@@ -264,12 +264,7 @@ impl PDRouter {
                 "none" | "minimal" => Some(false),
                 _ => None,
             });
-        let Some(enabled) = explicit_thinking
-            .or(effort_thinking)
-            .or(is_deepseek_v4.then_some(true))
-        else {
-            return;
-        };
+        let enabled = explicit_thinking.or(effort_thinking).unwrap_or(true);
 
         let template_kwargs = request
             .entry("chat_template_kwargs")
@@ -1671,6 +1666,25 @@ mod tests {
         let mut other_model = json!({"reasoning_effort": "high"});
         PDRouter::apply_deepseek_v4_http_compat(&mut other_model, "other-model");
         assert!(other_model.get("chat_template_kwargs").is_none());
+    }
+
+    #[test]
+    fn deepseek_v4_http_compat_leaves_other_models_untouched() {
+        // The `thinking` kwarg name is only meaningful to DeepSeek's renderer;
+        // other models (e.g. Qwen `enable_thinking`) must not receive it, and
+        // their reasoning_effort must pass through verbatim.
+        let original = json!({
+            "thinking": {"type": "disabled"},
+            "reasoning_effort": "none",
+        });
+        let mut request = original.clone();
+        PDRouter::apply_deepseek_v4_http_compat(&mut request, "qwen3-30b");
+        assert_eq!(request, original);
+
+        let original = json!({"reasoning_effort": "xhigh"});
+        let mut request = original.clone();
+        PDRouter::apply_deepseek_v4_http_compat(&mut request, "other-model");
+        assert_eq!(request, original);
     }
 
     fn create_test_worker(url: String, worker_type: WorkerType, healthy: bool) -> Box<dyn Worker> {

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -204,6 +204,81 @@ impl PDRouter {
         None
     }
 
+    #[inline]
+    fn is_deepseek_v4_model(model: &str) -> bool {
+        const DEEPSEEK_V4: &[u8] = b"deepseek-v4";
+        model
+            .as_bytes()
+            .windows(DEEPSEEK_V4.len())
+            .any(|candidate| candidate.eq_ignore_ascii_case(DEEPSEEK_V4))
+    }
+
+    /// Translate the public DeepSeek V4 controls to the SGLang HTTP worker
+    /// controls. HTTP workers render the prompt themselves, so the gateway's
+    /// native tokenizer path cannot apply these settings for them.
+    fn apply_deepseek_v4_http_compat(json_request: &mut Value, model_id: &str) {
+        let Some(request) = json_request.as_object_mut() else {
+            return;
+        };
+
+        let is_deepseek_v4 = Self::is_deepseek_v4_model(model_id);
+        if is_deepseek_v4 {
+            if let Some(Value::String(effort)) = request.get_mut("reasoning_effort") {
+                match effort.as_str() {
+                    "low" | "medium" => {
+                        effort.clear();
+                        effort.push_str("high");
+                    }
+                    "xhigh" => {
+                        effort.clear();
+                        effort.push_str("max");
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        let template_thinking = request
+            .get("chat_template_kwargs")
+            .and_then(Value::as_object)
+            .and_then(|kwargs| kwargs.get("thinking"))
+            .and_then(Value::as_bool);
+        if template_thinking.is_some() {
+            return;
+        }
+
+        let explicit_thinking = request
+            .get("thinking")
+            .and_then(Value::as_object)
+            .and_then(|thinking| thinking.get("type"))
+            .and_then(Value::as_str)
+            .and_then(|kind| match kind {
+                "enabled" => Some(true),
+                "disabled" => Some(false),
+                _ => None,
+            });
+        let effort_thinking = request
+            .get("reasoning_effort")
+            .and_then(Value::as_str)
+            .and_then(|effort| match effort {
+                "none" | "minimal" => Some(false),
+                _ => None,
+            });
+        let Some(enabled) = explicit_thinking
+            .or(effort_thinking)
+            .or(is_deepseek_v4.then_some(true))
+        else {
+            return;
+        };
+
+        let template_kwargs = request
+            .entry("chat_template_kwargs")
+            .or_insert_with(|| Value::Object(Default::default()));
+        if let Some(template_kwargs) = template_kwargs.as_object_mut() {
+            template_kwargs.insert("thinking".to_string(), Value::Bool(enabled));
+        }
+    }
+
     fn get_completion_batch_size(req: &CompletionRequest) -> Option<usize> {
         if let StringOrArray::Array(arr) = &req.prompt {
             if !arr.is_empty() {
@@ -355,6 +430,13 @@ impl PDRouter {
                         // canonical name, so forward that, not the alias the
                         // client sent.
                         super::set_request_model(&mut json_request, model);
+
+                        if context.route == "/v1/chat/completions" {
+                            Self::apply_deepseek_v4_http_compat(
+                                &mut json_request,
+                                context.model_id,
+                            );
+                        }
 
                         json_request = match Self::inject_bootstrap_into_value(
                             json_request,
@@ -1560,6 +1642,35 @@ mod tests {
             retry_config: RetryConfig::default(),
             api_key: Some("test_api_key".to_string()),
         }
+    }
+
+    #[test]
+    fn deepseek_v4_http_compat_translates_official_controls() {
+        for (mut request, expected) in [
+            (json!({}), true),
+            (json!({"thinking": {"type": "enabled"}}), true),
+            (json!({"thinking": {"type": "disabled"}}), false),
+            (json!({"reasoning_effort": "none"}), false),
+        ] {
+            PDRouter::apply_deepseek_v4_http_compat(&mut request, "DeepSeek-V4-Pro");
+            assert_eq!(request["chat_template_kwargs"]["thinking"], expected);
+        }
+    }
+
+    #[test]
+    fn deepseek_v4_http_compat_preserves_internal_override_and_maps_effort() {
+        let mut request = json!({
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "xhigh",
+            "chat_template_kwargs": {"thinking": false},
+        });
+        PDRouter::apply_deepseek_v4_http_compat(&mut request, "DeepSeek-V4-Pro");
+        assert_eq!(request["chat_template_kwargs"]["thinking"], false);
+        assert_eq!(request["reasoning_effort"], "max");
+
+        let mut other_model = json!({"reasoning_effort": "high"});
+        PDRouter::apply_deepseek_v4_http_compat(&mut other_model, "other-model");
+        assert!(other_model.get("chat_template_kwargs").is_none());
     }
 
     fn create_test_worker(url: String, worker_type: WorkerType, healthy: bool) -> Box<dyn Worker> {

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -394,6 +394,7 @@ impl Router {
                 headers,
                 typed_req,
                 route,
+                model_id,
                 canonical_model,
                 worker.as_ref(),
                 is_stream,
@@ -906,6 +907,9 @@ impl Router {
 
     // Send typed request directly without conversion.
     //
+    // `model_id` is already canonical: the caller resolved any alias before
+    // routing, so model-specific request rewrites match on the registered ID.
+    //
     // `canonical_model` is set only when the client addressed the model by an
     // alias. The worker was registered under the canonical ID and has never
     // heard of the alias, so the body it receives carries the canonical name.
@@ -918,6 +922,7 @@ impl Router {
         headers: Option<&HeaderMap>,
         typed_req: &T,
         route: &'static str,
+        model_id: &str,
         canonical_model: Option<&str>,
         worker: &dyn Worker,
         is_stream: bool,
@@ -950,6 +955,10 @@ impl Router {
             }
         };
         strip_default_sglang_fields(&mut json_val);
+
+        if route == "/v1/chat/completions" {
+            super::deepseek_compat::apply_deepseek_v4_http_compat(&mut json_val, model_id);
+        }
 
         let mut request_builder = self.client.post(&endpoint_url).json(&json_val);
 


### PR DESCRIPTION
## Description

### Problem

The gateway's DeepSeek V4 handling diverges from DeepSeek's official API in three ways:

1. **Thinking defaults off; the official default is on.** The [official docs](https://api-docs.deepseek.com/guides/thinking_mode/) state "The thinking toggle defaults to `enabled`", and the V4 encoder's `thinking_mode` is a required argument with the default supplied at the API layer. We reused the V3.2 `DefaultOff` contract, so every request without an explicit toggle got a chat-mode prompt (`…<|Assistant|></think>`) — the served model silently behaves unlike `api.deepseek.com` for identical requests.
2. **No `thinking` request field.** The official switch is `thinking: {"type": "enabled" | "disabled"}` ([Create Chat Completion](https://api-docs.deepseek.com/api/create-chat-completion/)). Clients migrating from the official API had it swallowed into the `other` flatten and ignored — a request explicitly disabling thinking still paid for reasoning tokens.
3. **`reasoning_effort` mapping was incomplete.** Official semantics: real levels are `high` and `max`; `low`/`medium` map to `high`, `xhigh` maps to `max`. We only recognized `max` and `high`, so `xhigh` (sent by e.g. Claude Code) silently lost the max-effort prompt preamble.

### Solution

- `ChatThinkingConfig` on `ChatCompletionRequest`: the official `{"type": "enabled" | "disabled"}` schema, strict (`deny_unknown_fields`) so malformed variants fail loudly instead of being ignored.
- `ThinkingToggle::DefaultOn` for the V4 renderer (V3.2 keeps `DefaultOff`); `derive_thinking_mode` takes the renderer's official default as its fallback.
- One precedence everywhere, matching the Jinja path: explicit `chat_template_kwargs` toggle > `thinking` field > `reasoning_effort` compatibility mapping > renderer default. Both the prompt-building path (`process_chat_messages_with_placeholders`) and the reasoning-parser arming path (`resolve_user_thinking`, now taking the request) resolve identically, so the parser state always agrees with what the prefill actually contains.
- `reasoning_effort` normalization in the V4 shim: `xhigh → Max`, `low|medium|high → High`, verbatim per the official mapping.
- `deepseek_v4` reasoning parser registration + `deepseek-v4` model-name pattern, so CLI/parser selection matches the served model instead of falling through.

### Behavior notes

- **Default flip:** V4 requests without any thinking signal now produce reasoning content. This is the point of the fix — the old default was the incompatibility — but deployments relying on it will see higher output-token usage; worth a release-note line.
- The strict `thinking` schema rejects shapes the official API also rejects (booleans, Anthropic-style `budget_tokens`) that were previously silently ignored — now a 400.
- The Anthropic messages endpoint keeps its own `ThinkingConfig`; an omitted config on a V4 model now inherits the model's official default-on rather than Anthropic's default-off.
- Messages responses now separate reasoning whenever thinking is effectively on — including template-default-on with an omitted `thinking` config. This covers DeepSeek V4 and also fixes the same `<think>`-tag leak for other default-on templates (Qwen3, GLM) on the Messages endpoint, matching the chat endpoint's long-standing arming semantics. An explicit `Disabled` config still opts out.
- Not implemented: the official server-side auto-raise to `max` effort for agent traffic (Claude Code, OpenCode) — that's origin-side heuristics, out of scope for a passthrough gateway.

## Changes

- `crates/protocols/chat.rs`: `ChatThinkingConfig`, `thinking` field, `thinking_preference()` accessor.
- `crates/tokenizer/huggingface.rs`: per-renderer thinking default (`V4 → DefaultOn`), `xhigh`/`low`/`medium` effort normalization; `encoders/deepseek_v4.rs` source comment now points at the DeepSeek-V4-Pro upstream.
- `crates/reasoning_parser/factory.rs`: `deepseek_v4` parser + pattern (shared helper with `deepseek_v31`).
- `model_gateway` grpc: `resolve_user_thinking(&request, tokenizer)` signature; chat prompt building uses `thinking_preference()`.

## Test Plan

- New tests: strict `thinking` deserialization round-trip + rejection cases, `thinking`-vs-`reasoning_effort` precedence, V4 factory/parser arming, per-renderer toggle defaults, effort normalization (incl. `xhigh` → "Absolute maximum" preamble), end-to-end prompt assertions through `process_chat_messages` with a real V4-detected tokenizer dir.
- `cargo test -p openai-protocol` (83+126), `-p reasoning-parser` (75), `-p llm-tokenizer` (146 lib + integration incl. `deepseek_renderer_detection`), `-p smg --lib routers::grpc::utils` (34): all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added DeepSeek chat “thinking mode” controls to support `{type: enabled|disabled}` with clear precedence over reasoning-effort inputs.
  - Enabled DeepSeek V4 default-on thinking and added `xhigh` handling (“absolute maximum” marker).

- **Bug Fixes**
  - Improved consistency of how “reasoning started” is determined across streaming and non-streaming flows.
  - Corrected DeepSeek thinking prompt formatting and normalized reasoning-effort markers.

- **Tests**
  - Expanded coverage for DeepSeek V3.2 vs V4 defaults, precedence, prompt rendering, and `/v1/chat/completions` HTTP compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
