### PR TITLE
test(e2e): run the responses suite on vllm and tokenspeed

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -655,6 +655,7 @@ jobs:
   # and run under e2e-1gpu-chat above.
 
   e2e-1gpu-responses:
+    name: e2e-1gpu-responses (${{ matrix.engine }})
     needs: [build-wheel, detect-changes]
     if: >-
       always()
@@ -664,13 +665,30 @@ jobs:
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.agentic == 'true')))
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - engine: sglang
+            timeout: 28
+            test_timeout: 20
+          - engine: vllm
+            timeout: 28
+            test_timeout: 20
+          # tokenspeed builds from source (~30m cold), so keep the job
+          # timeout generous even though the test step is short. Only the
+          # cross-engine gpt-oss-20b responses tests select onto this lane;
+          # the engine marker filter deselects the sglang-only cases.
+          - engine: tokenspeed
+            timeout: 50
+            test_timeout: 20
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
-      engine: sglang
+      engine: ${{ matrix.engine }}
       gpu_tier: "1"
       runner: 1-gpu-h100
-      timeout: 28
-      test_timeout: 20
+      timeout: ${{ matrix.timeout }}
+      test_timeout: ${{ matrix.test_timeout }}
       test_dirs: e2e_test/responses
       setup_agentic_deps: true
     secrets: inherit


### PR DESCRIPTION
## Description

### Problem

The `e2e-1gpu-responses` lane launched **sglang only**. But many of the
responses (OpenAI Responses API) tests are already marked
`@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")` — they were
written to run cross-engine, yet they never executed on vllm or tokenspeed
because no such lane existed. One test (`image_generation`) is marked
`@pytest.mark.engine("vllm")` and never ran anywhere.

### Solution

Turn the responses lane into an engine matrix — `sglang`, `vllm`,
`tokenspeed` — over the same `e2e_test/responses` suite. No test files change;
the existing engine marker filter selects the right subset per lane:

- **vllm** — the 5 shared `gpt-oss-20b` tests (tools call, streaming events,
  structured output, state management, sampling params) **plus** the
  `vllm`-only `Llama-3.1-8B` image-generation test (previously dead coverage).
- **tokenspeed** — the same 5 shared `gpt-oss-20b` tests.
- **sglang** — unchanged; the sglang-only `Qwen2.5-14B` cases still run here
  and deselect on the other lanes automatically.

## Changes

- **`.github/workflows/pr-test-rust.yml`** — `e2e-1gpu-responses` becomes a
  `strategy.matrix` over `{sglang, vllm, tokenspeed}`. tokenspeed keeps a
  generous job timeout (~50m) for its from-source build, matching the chat
  lane. Both new engines run `gpt-oss-20b` (tp=1), already proven on
  1-gpu-h100 by the existing sglang responses and chat lanes.

## Test Plan

Workflow-only change; validated by the responses lanes running green in this
PR's own CI (sglang / vllm / tokenspeed).

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-test-rust.yml'))"` passes
- Job id `e2e-1gpu-responses` is unchanged, so the aggregate summary gate still
  covers all three matrix legs.

<details>
<summary>Checklist</summary>

- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
