### PR TITLE
fix(grpc): preserve oversized integer tool-call arguments digit-exact

### DIFF
--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -1,6 +1,7 @@
 //! Chat message processing, tool constraints, and shared utilities for gRPC routers.
 
 use std::{
+    borrow::Cow,
     collections::HashMap,
     sync::{Arc, OnceLock},
 };
@@ -135,6 +136,85 @@ pub(crate) async fn encode_blocking(
         .map_err(|e| anyhow!("tokenization task failed: {e}"))?
 }
 
+/// True iff `token` is a syntactically valid JSON integer literal: an optional
+/// leading `-`, then either a lone `0` or a nonzero digit followed by digits.
+fn is_canonical_json_integer(token: &str) -> bool {
+    let digits = token.strip_prefix('-').unwrap_or(token);
+    !digits.is_empty()
+        && digits.bytes().all(|b| b.is_ascii_digit())
+        && (digits == "0" || !digits.starts_with('0'))
+}
+
+/// Rewrite integer literals that neither `i64` nor `u64` can hold into JSON
+/// strings, so parsing the result into a [`Value`] cannot round them through
+/// `f64` and silently corrupt their digits.
+///
+/// Tool-call arguments routinely carry identifiers the model must echo
+/// verbatim; a 20+-digit integer coerced to `f64` comes back with different
+/// digits and the tool receives a corrupted id. Quoting trades native numeric
+/// typing in the rendered template for digit-exact fidelity, the right trade
+/// at magnitudes only ids reach. In-range integers and float-shaped tokens
+/// (fraction or exponent present) pass through untouched, as does anything
+/// inside string values. Tokens that are not canonical JSON integers are also
+/// left alone so malformed input still fails in the parser, not here.
+fn quote_unrepresentable_integers(input: &str) -> Cow<'_, str> {
+    let bytes = input.as_bytes();
+    let mut rewritten: Option<String> = None;
+    let mut copied_until = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if b == b'"' {
+            in_string = true;
+            i += 1;
+            continue;
+        }
+        if b != b'-' && !b.is_ascii_digit() {
+            i += 1;
+            continue;
+        }
+        // In valid JSON a number token runs until a structural character or
+        // whitespace, none of which this set can consume.
+        let start = i;
+        while i < bytes.len() && matches!(bytes[i], b'0'..=b'9' | b'.' | b'e' | b'E' | b'+' | b'-')
+        {
+            i += 1;
+        }
+        let token = &input[start..i];
+        if is_canonical_json_integer(token)
+            && token.parse::<i64>().is_err()
+            && token.parse::<u64>().is_err()
+        {
+            let out = rewritten.get_or_insert_with(|| String::with_capacity(input.len() + 8));
+            out.push_str(&input[copied_until..start]);
+            out.push('"');
+            out.push_str(token);
+            out.push('"');
+            copied_until = i;
+        }
+    }
+    match rewritten {
+        Some(mut out) => {
+            out.push_str(&input[copied_until..]);
+            Cow::Owned(out)
+        }
+        None => Cow::Borrowed(input),
+    }
+}
+
 /// Process tool call arguments in messages
 /// Per Transformers docs, tool call arguments in assistant messages should be dicts
 pub(crate) fn process_tool_call_arguments(messages: &mut [Value]) -> Result<(), String> {
@@ -159,8 +239,9 @@ pub(crate) fn process_tool_call_arguments(messages: &mut [Value]) -> Result<(), 
                 continue;
             };
 
-            // Parse JSON string to object (like Python json.loads)
-            match serde_json::from_str::<Value>(args_str) {
+            // Parse JSON string to object (like Python json.loads), guarding
+            // integers f64 would corrupt. Errors report the original text.
+            match serde_json::from_str::<Value>(&quote_unrepresentable_integers(args_str)) {
                 Ok(parsed) => *args = parsed,
                 Err(e) => {
                     return Err(format!(
@@ -1514,5 +1595,84 @@ mod tests {
         let id = generate_tool_call_id("gpt-4o", "get_weather", 0, 0);
         assert!(id.starts_with("call_"), "got: {id}");
         assert!(!id.contains("get_weather"), "got: {id}");
+    }
+
+    fn assistant_message_with_arguments(arguments: &str) -> Vec<Value> {
+        vec![json!({
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call_1",
+                "function": {"name": "lookup", "arguments": arguments}
+            }]
+        })]
+    }
+
+    fn processed_arguments(arguments: &str) -> Value {
+        let mut messages = assistant_message_with_arguments(arguments);
+        process_tool_call_arguments(&mut messages).expect("arguments should parse");
+        messages[0]["tool_calls"][0]["function"]["arguments"].clone()
+    }
+
+    #[test]
+    fn test_process_tool_call_arguments_preserves_unrepresentable_integers() {
+        let args = processed_arguments(
+            r#"{"id": 123456789012345678901234567890, "neg": -99999999999999999999}"#,
+        );
+        assert_eq!(args["id"], json!("123456789012345678901234567890"));
+        assert_eq!(args["neg"], json!("-99999999999999999999"));
+    }
+
+    #[test]
+    fn test_process_tool_call_arguments_keeps_representable_numbers_native() {
+        let args = processed_arguments(
+            r#"{"umax": 18446744073709551615, "imin": -9223372036854775808, "f": 1.5, "e": 1e2, "n": 7}"#,
+        );
+        assert_eq!(args["umax"].as_u64(), Some(u64::MAX));
+        assert_eq!(args["imin"].as_i64(), Some(i64::MIN));
+        assert!(args["f"].is_f64() && args["e"].is_f64());
+        assert_eq!(args["n"].as_i64(), Some(7));
+    }
+
+    #[test]
+    fn test_process_tool_call_arguments_handles_nested_containers() {
+        let args = processed_arguments(
+            r#"{"a": [[123456789012345678901234567890]], "b": {"c": [1, -99999999999999999999999]}}"#,
+        );
+        assert_eq!(args["a"][0][0], json!("123456789012345678901234567890"));
+        assert_eq!(args["b"]["c"][0].as_i64(), Some(1));
+        assert_eq!(args["b"]["c"][1], json!("-99999999999999999999999"));
+    }
+
+    #[test]
+    fn test_process_tool_call_arguments_invalid_json_still_errors() {
+        for bad in [
+            r"{bad",
+            r#"{"a": [1-2]}"#,
+            r#"{"a": 00123456789012345678901234567890}"#,
+        ] {
+            let mut messages = assistant_message_with_arguments(bad);
+            let err = process_tool_call_arguments(&mut messages)
+                .expect_err("malformed arguments must be rejected");
+            assert!(err.contains(bad), "error should cite original text: {err}");
+        }
+    }
+
+    #[test]
+    fn test_quote_unrepresentable_integers_ignores_digits_inside_strings() {
+        let input = r#"{"note": "ref 123456789012345678901234567890 \" tail", "big": 123456789012345678901234567890}"#;
+        let guarded = quote_unrepresentable_integers(input);
+        assert_eq!(
+            guarded,
+            r#"{"note": "ref 123456789012345678901234567890 \" tail", "big": "123456789012345678901234567890"}"#
+        );
+    }
+
+    #[test]
+    fn test_quote_unrepresentable_integers_borrows_when_untouched() {
+        let input = r#"{"a": 1, "b": [2.5, "30000000000000000000000"], "c": -3e-5}"#;
+        assert!(matches!(
+            quote_unrepresentable_integers(input),
+            Cow::Borrowed(_)
+        ));
     }
 }

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -163,6 +163,11 @@ fn quote_unrepresentable_integers(input: &str) -> Cow<'_, str> {
     let mut copied_until = 0;
     let mut in_string = false;
     let mut escaped = false;
+    // Container/positional context: numbers are rewritten only in VALUE
+    // position. An (invalid) numeric object key must stay untouched -
+    // quoting it would turn previously rejected JSON into accepted JSON.
+    let mut containers: Vec<u8> = Vec::new();
+    let mut last_sig: Option<u8> = None;
     let mut i = 0;
     while i < bytes.len() {
         let b = bytes[i];
@@ -173,25 +178,67 @@ fn quote_unrepresentable_integers(input: &str) -> Cow<'_, str> {
                 escaped = true;
             } else if b == b'"' {
                 in_string = false;
+                last_sig = Some(b'"');
             }
             i += 1;
             continue;
         }
-        if b == b'"' {
-            in_string = true;
-            i += 1;
-            continue;
+        match b {
+            b'"' => {
+                in_string = true;
+                i += 1;
+                continue;
+            }
+            b'{' | b'[' => {
+                containers.push(b);
+                last_sig = Some(b);
+                i += 1;
+                continue;
+            }
+            b'}' | b']' => {
+                containers.pop();
+                last_sig = Some(b);
+                i += 1;
+                continue;
+            }
+            b':' | b',' => {
+                last_sig = Some(b);
+                i += 1;
+                continue;
+            }
+            _ if b.is_ascii_whitespace() => {
+                i += 1;
+                continue;
+            }
+            _ => {}
         }
         if b != b'-' && !b.is_ascii_digit() {
+            last_sig = Some(b);
             i += 1;
             continue;
         }
+        // Value position: object value (after ':'), array element (after '['
+        // or a ',' whose container is an array), or a top-level scalar.
+        // Everything else - an object key after '{' or an object ',' or any
+        // malformed adjacency - is left untouched so invalid JSON keeps
+        // failing exactly as before.
+        let value_position = match last_sig {
+            None => true,
+            Some(b':') => true,
+            Some(b'[') => true,
+            Some(b',') => containers.last() == Some(&b'['),
+            _ => false,
+        };
         // In valid JSON a number token runs until a structural character or
         // whitespace, none of which this set can consume.
         let start = i;
         while i < bytes.len() && matches!(bytes[i], b'0'..=b'9' | b'.' | b'e' | b'E' | b'+' | b'-')
         {
             i += 1;
+        }
+        last_sig = Some(b'0');
+        if !value_position {
+            continue;
         }
         let token = &input[start..i];
         if is_canonical_json_integer(token)
@@ -506,18 +553,18 @@ pub(crate) fn filter_tools_by_tool_choice(
 /// so this function assumes tool_choice references valid tools.
 pub(crate) fn filter_chat_request_by_tool_choice(
     body: &ChatCompletionRequest,
-) -> std::borrow::Cow<'_, ChatCompletionRequest> {
+) -> Cow<'_, ChatCompletionRequest> {
     if let Some(tools) = &body.tools {
         if let Some(filtered_tools) = filter_tools_by_tool_choice(tools, body.tool_choice.as_ref())
         {
             let mut filtered_body = body.clone();
             filtered_body.tools = Some(filtered_tools);
-            return std::borrow::Cow::Owned(filtered_body);
+            return Cow::Owned(filtered_body);
         }
     }
 
     // No filtering needed - return original request
-    std::borrow::Cow::Borrowed(body)
+    Cow::Borrowed(body)
 }
 
 /// Process chat messages and apply template (shared by both routers)
@@ -1672,6 +1719,41 @@ mod tests {
         let input = r#"{"a": 1, "b": [2.5, "30000000000000000000000"], "c": -3e-5}"#;
         assert!(matches!(
             quote_unrepresentable_integers(input),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn test_numeric_object_keys_stay_untouched_and_invalid() {
+        // An (invalid) oversized numeric object KEY must not be quoted into
+        // valid JSON - only VALUE positions are rewritten.
+        let bad_key = r"{123456789012345678901234567890: 1}";
+        assert!(matches!(
+            quote_unrepresentable_integers(bad_key),
+            Cow::Borrowed(_)
+        ));
+        let mut messages = assistant_message_with_arguments(bad_key);
+        let err = process_tool_call_arguments(&mut messages)
+            .expect_err("numeric object keys must still be rejected");
+        assert!(
+            err.contains(bad_key),
+            "error should cite original text: {err}"
+        );
+
+        // The same oversized integer in VALUE positions is still guarded:
+        // object value, array element (first and after comma), nested.
+        let values = r#"{"k": 123456789012345678901234567890, "arr": [123456789012345678901234567890, 5, 123456789012345678901234567890]}"#;
+        let guarded = quote_unrepresentable_integers(values);
+        assert_eq!(
+            guarded,
+            r#"{"k": "123456789012345678901234567890", "arr": ["123456789012345678901234567890", 5, "123456789012345678901234567890"]}"#
+        );
+
+        // An object comma introduces a KEY, not a value - a numeric key after
+        // a valid pair stays untouched (and keeps failing downstream).
+        let bad_second_key = r#"{"a": 1, 123456789012345678901234567890: 2}"#;
+        assert!(matches!(
+            quote_unrepresentable_integers(bad_second_key),
             Cow::Borrowed(_)
         ));
     }


### PR DESCRIPTION
## Description

### Problem
`process_tool_call_arguments` parses each assistant tool call's `arguments` string into a JSON value before chat-template rendering. serde_json represents integers outside the i64/u64 range as f64, so an argument like `{"id": 123456789012345678901234567890}` silently re-renders as `1.2345678901234568e29`. The model sees the corrupted spelling in its rendered history and echoes a wrong id back to the tool on the next call.

### Solution
Pre-scan the arguments string with a minimal string-state lexer and wrap only the integer literals neither i64 nor u64 can hold in quotes, so they survive the parse digit-exact as JSON strings. The guard is deliberately narrow:
- in-range integers (up to u64::MAX / down to i64::MIN) stay native numbers — zero behavior change;
- float-shaped tokens (fraction or exponent) pass through untouched — f64 semantics are JSON-standard for those;
- digits inside string values are never touched (the lexer tracks in-string/escape state);
- non-canonical tokens (leading zeros, stray operators) are left alone so malformed input still fails in the parser, citing the original text.

Rendering such an argument quoted rather than bare is the accepted trade-off: values at that magnitude are invariably identifiers that must round-trip verbatim, and exact-but-quoted beats bare-but-corrupted.

## Changes
- `model_gateway/src/routers/grpc/utils/chat_utils.rs`: add `quote_unrepresentable_integers` (Cow-returning pre-scan; borrows when no rewrite is needed) and `is_canonical_json_integer`; apply the guard in `process_tool_call_arguments`.

## Test Plan
Six new unit tests in `chat_utils`:
- `>u64::MAX` positive and `<i64::MIN` negative integers survive digit-exact (top level and nested containers);
- u64::MAX, i64::MIN, ordinary ints, and floats stay native numbers;
- digit runs inside string values (including next to escaped quotes) are untouched;
- malformed arguments (`{bad`, `[1-2]`, leading-zero integers) still error, citing the original text;
- untouched inputs take the `Cow::Borrowed` path.

`cargo clippy -p smg --all-targets` clean; `cargo test -p smg --lib chat_utils` 30/30.

<details>
<summary>Checklist</summary>

- [x] Format your code: `make fmt`
- [x] Run lint checks: targeted `cargo clippy -p smg --all-targets -- -D warnings`
- [x] Add unit tests for new functionality
- [x] Update documentation if needed (n/a — internal fix)

</details>