### PR TITLE
feat(tools): suppress native tool-call syntax when tool_choice is none

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -526,6 +526,7 @@ struct Router {
     worker_overload_token_usage: Option<f64>,
     worker_overload_protection: bool,
     disable_load_monitoring: bool,
+    tool_choice_none_ban: bool,
 }
 
 impl Router {
@@ -900,6 +901,7 @@ impl Router {
             .maybe_redis(redis_config)
             .maybe_reasoning_parser(self.reasoning_parser.as_ref())
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
+            .tool_choice_none_ban(self.tool_choice_none_ban)
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
             .maybe_storage_hook_wasm_path(self.storage_hook_wasm_path.as_deref())
             .enable_wasm(self.enable_wasm)
@@ -1083,6 +1085,7 @@ impl Router {
         worker_overload_token_usage = None,
         worker_overload_protection = false,
         disable_load_monitoring = false,
+        tool_choice_none_ban = false,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1233,6 +1236,7 @@ impl Router {
         worker_overload_token_usage: Option<f64>,
         worker_overload_protection: bool,
         disable_load_monitoring: bool,
+        tool_choice_none_ban: bool,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1397,6 +1401,7 @@ impl Router {
             worker_overload_token_usage,
             worker_overload_protection,
             disable_load_monitoring,
+            tool_choice_none_ban,
         })
     }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -495,6 +495,7 @@ struct Router {
     model_aliases: HashMap<String, String>,
     worker_startup_delay: u64,
     worker_ports_annotation: String,
+    tool_choice_none_ban: bool,
 }
 
 impl Router {
@@ -833,6 +834,7 @@ impl Router {
             .maybe_redis(redis_config)
             .maybe_reasoning_parser(self.reasoning_parser.as_ref())
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
+            .tool_choice_none_ban(self.tool_choice_none_ban)
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
             .maybe_storage_hook_wasm_path(self.storage_hook_wasm_path.as_deref())
             .enable_wasm(self.enable_wasm)
@@ -989,6 +991,7 @@ impl Router {
         model_aliases = HashMap::new(),
         worker_startup_delay = 0,
         worker_ports_annotation = String::from("smg.ai/worker-ports"),
+        tool_choice_none_ban = false,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1118,6 +1121,7 @@ impl Router {
         model_aliases: HashMap<String, String>,
         worker_startup_delay: u64,
         worker_ports_annotation: String,
+        tool_choice_none_ban: bool,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1261,6 +1265,7 @@ impl Router {
             model_aliases,
             worker_startup_delay,
             worker_ports_annotation,
+            tool_choice_none_ban,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -242,6 +242,7 @@ class RouterArgs:
     worker_overload_protection: bool = False
     # Restore the conditional load-monitor poll gate (default: poll always)
     disable_load_monitoring: bool = False
+    tool_choice_none_ban: bool = False
 
     @staticmethod
     def add_cli_args(
@@ -1279,6 +1280,16 @@ class RouterArgs:
             default=None,
             choices=tool_call_parser_choices,
             help="Specify the parser for tool-call interactions (e.g., json, qwen)",
+        )
+        parser_group.add_argument(
+            f"--{prefix}tool-choice-none-ban",
+            action="store_true",
+            help=(
+                "With tools present but tool_choice 'none', ban the resolved"
+                " parser's tool-call opener strings at decode time (requires"
+                " engine support for the any_text/excludes structural-tag"
+                " format)"
+            ),
         )
         parser_group.add_argument(
             f"--{prefix}mcp-config-path",

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -204,6 +204,7 @@ class RouterArgs:
     # Append new fields here to preserve positional callers.
     model_aliases: dict[str, str] = dataclasses.field(default_factory=dict)
     worker_startup_delay: int = 0
+    tool_choice_none_ban: bool = False
 
     @staticmethod
     def add_cli_args(
@@ -993,6 +994,16 @@ class RouterArgs:
             default=None,
             choices=tool_call_parser_choices,
             help="Specify the parser for tool-call interactions (e.g., json, qwen)",
+        )
+        parser_group.add_argument(
+            f"--{prefix}tool-choice-none-ban",
+            action="store_true",
+            help=(
+                "With tools present but tool_choice 'none', ban the resolved"
+                " parser's tool-call opener strings at decode time (requires"
+                " engine support for the any_text/excludes structural-tag"
+                " format)"
+            ),
         )
         parser_group.add_argument(
             f"--{prefix}mcp-config-path",

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1401,6 +1401,7 @@ class TestRouterArgsFieldOrder:
         "worker_overload_token_usage",
         "worker_overload_protection",
         "disable_load_monitoring",
+        "tool_choice_none_ban",
     ]
 
     def test_complete_field_sequence_is_frozen(self):

--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -60,6 +60,12 @@ impl ToolConstraint {
 struct ParserEntry {
     creator: ParserCreator,
     build_structural_tag: Option<BuildStructuralTagFn>,
+    /// Strings that exclusively open this parser's native tool-call syntax,
+    /// used to build the `tool_choice: "none"` suppression constraint. Empty
+    /// for parsers without one (no suppression possible). Curated per parser:
+    /// this is NOT the structural-tag trigger list — triggers may include
+    /// markers ordinary generation must emit.
+    tool_call_ban_strings: &'static [&'static str],
 }
 
 /// Registry for model-specific tool parsers with pooling support.
@@ -97,6 +103,7 @@ impl ParserRegistry {
             Arc::new(ParserEntry {
                 creator: Arc::new(creator),
                 build_structural_tag: None,
+                tool_call_ban_strings: &[],
             }),
         );
     }
@@ -105,11 +112,16 @@ impl ParserRegistry {
     ///
     /// The `build_structural_tag` function takes `(&[Tool], at_least_one)` and returns
     /// the full xgrammar structural tag JSON for this parser's native tool-call format.
+    /// `tool_call_ban_strings` is the parser's curated `tool_choice: "none"`
+    /// suppression inventory: strings that exclusively open its native
+    /// tool-call syntax (NOT the trigger list — triggers may include markers
+    /// ordinary generation must emit). Pass an empty slice to opt out.
     pub fn register_parser_with_structural_tag<F>(
         &self,
         name: &str,
         creator: F,
         build_structural_tag: fn(&[Tool], bool) -> serde_json::Value,
+        tool_call_ban_strings: &'static [&'static str],
     ) where
         F: Fn() -> Box<dyn ToolParser> + Send + Sync + 'static,
     {
@@ -119,6 +131,7 @@ impl ParserRegistry {
             Arc::new(ParserEntry {
                 creator: Arc::new(creator),
                 build_structural_tag: Some(Arc::new(build_structural_tag)),
+                tool_call_ban_strings,
             }),
         );
     }
@@ -181,6 +194,29 @@ impl ParserRegistry {
     /// via `--tool-call-parser`).
     pub fn has_structural_tag_for_parser(&self, configured: Option<&str>) -> bool {
         configured.is_some_and(|p| self.has_structural_tag(p))
+    }
+
+    /// Build the decode-time suppression constraint for `tool_choice: "none"`:
+    /// free-form output that may never contain the strings opening the
+    /// configured parser's native tool-call syntax, expressed as an xgrammar
+    /// structural tag (`any_text` with `excludes`).
+    ///
+    /// Returns `None` when no parser is configured, the name is unknown, or
+    /// the parser has no curated ban inventory — callers fall back to today's
+    /// behavior (no constraint; parsing is separately disabled for `"none"`).
+    pub fn tool_call_ban_constraint(&self, configured: Option<&str>) -> Option<ToolConstraint> {
+        let entries = self.entries.read();
+        let entry = entries.get(configured?)?;
+        if entry.tool_call_ban_strings.is_empty() {
+            return None;
+        }
+        let tag = serde_json::json!({
+            "format": {
+                "type": "any_text",
+                "excludes": entry.tool_call_ban_strings,
+            }
+        });
+        Some(ToolConstraint::StructuralTag(tag.to_string()))
     }
 
     /// Generate tool call constraint.
@@ -314,6 +350,7 @@ impl ParserFactory {
             "mistral",
             || Box::new(MistralParser::new()),
             MistralParser::build_structural_tag,
+            MistralParser::TOOL_CALL_BAN_STRINGS,
         );
         registry.register_parser("qwen", || Box::new(QwenParser::new()));
         registry.register_parser("qwen_xml", || Box::new(QwenXmlParser::new()));
@@ -335,16 +372,19 @@ impl ParserFactory {
             "kimik2",
             || Box::new(KimiK2Parser::new()),
             KimiK2Parser::build_structural_tag,
+            KimiK2Parser::TOOL_CALL_BAN_STRINGS,
         );
         registry.register_parser_with_structural_tag(
             "kimi_k3",
             || Box::new(KimiK3Parser::new()),
             KimiK3Parser::build_structural_tag,
+            KimiK3Parser::TOOL_CALL_BAN_STRINGS,
         );
         registry.register_parser_with_structural_tag(
             "inkling",
             || Box::new(InklingParser::new()),
             InklingParser::build_structural_tag,
+            InklingParser::TOOL_CALL_BAN_STRINGS,
         );
         registry.register_parser("minimax_m2", || Box::new(MinimaxM2Parser::new()));
         registry.register_parser("cohere", || Box::new(CohereParser::new()));

--- a/crates/tool_parser/src/parsers/inkling.rs
+++ b/crates/tool_parser/src/parsers/inkling.rs
@@ -77,8 +77,10 @@ impl InklingParser {
     }
 
     /// Strings that only ever open Inkling's native tool-call syntax; banning
-    /// them makes tool calls unreachable when `tool_choice` is `"none"`.
-    pub const TOOL_CALL_BAN_STRINGS: &'static [&'static str] = &[TOOL_CALL_JSON_START];
+    /// them makes tool calls unreachable when `tool_choice` is `"none"`. Both
+    /// invocation modes are covered: JSON-arguments and TML text-mode.
+    pub const TOOL_CALL_BAN_STRINGS: &'static [&'static str] =
+        &[TOOL_CALL_JSON_START, TOOL_CALL_TEXT_START];
 
     /// Build an xgrammar structural tag that constrains the JSON arguments for
     /// each declared tool while retaining Inkling's native TML framing.

--- a/crates/tool_parser/src/parsers/inkling.rs
+++ b/crates/tool_parser/src/parsers/inkling.rs
@@ -76,6 +76,10 @@ impl InklingParser {
         }
     }
 
+    /// Strings that only ever open Inkling's native tool-call syntax; banning
+    /// them makes tool calls unreachable when `tool_choice` is `"none"`.
+    pub const TOOL_CALL_BAN_STRINGS: &'static [&'static str] = &[TOOL_CALL_JSON_START];
+
     /// Build an xgrammar structural tag that constrains the JSON arguments for
     /// each declared tool while retaining Inkling's native TML framing.
     pub fn build_structural_tag(tools: &[Tool], at_least_one: bool) -> Value {

--- a/crates/tool_parser/src/parsers/kimi_k3.rs
+++ b/crates/tool_parser/src/parsers/kimi_k3.rs
@@ -123,6 +123,14 @@ pub struct KimiK3Parser {
 }
 
 impl KimiK3Parser {
+    /// Strings that only ever open K3's native tool-call syntax; banning them
+    /// makes tool calls unreachable when `tool_choice` is `"none"`. ONLY the
+    /// tools-section opener qualifies: the structural-tag triggers also list
+    /// `<|close|>think<|sep|>` / `<|close|>response<|sep|>` (as tag-begin
+    /// prefixes), but those close sections ordinary generation must emit, so
+    /// excluding them would corrupt normal output.
+    pub const TOOL_CALL_BAN_STRINGS: &'static [&'static str] = &[TOOLS_OPEN];
+
     /// Build an xgrammar structural tag that constrains Kimi-K3 XTML tool
     /// calls to the declared `tools`.
     ///

--- a/crates/tool_parser/src/parsers/kimik2.rs
+++ b/crates/tool_parser/src/parsers/kimik2.rs
@@ -51,6 +51,13 @@ pub struct KimiK2Parser {
 }
 
 impl KimiK2Parser {
+    /// Strings that only ever open K2's native tool-call syntax; banning them
+    /// makes tool calls unreachable when `tool_choice` is `"none"`. Both the
+    /// section opener and the per-call opener appear exclusively in tool-call
+    /// output, so both are safe to exclude.
+    pub const TOOL_CALL_BAN_STRINGS: &'static [&'static str] =
+        &["<|tool_calls_section_begin|>", "<|tool_call_begin|>"];
+
     /// Build structural tag for Kimi K2 tool call format.
     ///
     /// Uses dual triggers following sglang's approach:

--- a/crates/tool_parser/src/parsers/mistral.rs
+++ b/crates/tool_parser/src/parsers/mistral.rs
@@ -45,6 +45,10 @@ pub struct MistralParser {
 }
 
 impl MistralParser {
+    /// Strings that only ever open Mistral's native tool-call syntax; banning
+    /// them makes tool calls unreachable when `tool_choice` is `"none"`.
+    pub const TOOL_CALL_BAN_STRINGS: &'static [&'static str] = &["[TOOL_CALLS]"];
+
     /// Build structural tag for Mistral tool call format.
     ///
     /// Mistral outputs tool calls as a JSON array after `[TOOL_CALLS]`:

--- a/crates/tool_parser/tests/tool_constraint_ban.rs
+++ b/crates/tool_parser/tests/tool_constraint_ban.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::expect_used,
+    reason = "test-only helpers outside #[test] fns; failures are test failures"
+)]
+
 //! Suppression-constraint coverage: the `tool_choice: "none"` ban tag.
 //!
 //! The ban is a structural tag whose format is free text excluding the
@@ -5,16 +10,15 @@
 //! model-native framing (and a curated opener inventory) produce one.
 
 use serde_json::Value;
-use tool_parser::{ParserFactory, ToolConstraint};
+use tool_parser::ParserFactory;
 
 fn ban_tag_json(factory: &ParserFactory, parser: &str) -> Value {
     let constraint = factory
         .registry()
         .tool_call_ban_constraint(Some(parser))
-        .unwrap_or_else(|| panic!("{parser} should produce a ban constraint"));
-    let ToolConstraint::StructuralTag(json) = constraint else {
-        panic!("ban constraint must be a structural tag");
-    };
+        .expect("parser should produce a ban constraint");
+    let (kind, json) = constraint.to_tuple();
+    assert_eq!(kind, "structural_tag", "ban constraint for {parser}");
     serde_json::from_str(&json).expect("ban tag must be valid JSON")
 }
 

--- a/crates/tool_parser/tests/tool_constraint_ban.rs
+++ b/crates/tool_parser/tests/tool_constraint_ban.rs
@@ -56,9 +56,13 @@ fn curated_ban_inventories_per_parser() {
         excludes(&ban_tag_json(&factory, "kimi_k3")),
         vec!["<|open|>tools<|sep|>"]
     );
+    // Both Inkling invocation modes: JSON-arguments and TML text-mode.
     assert_eq!(
         excludes(&ban_tag_json(&factory, "inkling")),
-        vec!["<|content_invoke_tool_json|>"]
+        vec![
+            "<|content_invoke_tool_json|>",
+            "<|content_invoke_tool_text|>"
+        ]
     );
 }
 

--- a/crates/tool_parser/tests/tool_constraint_ban.rs
+++ b/crates/tool_parser/tests/tool_constraint_ban.rs
@@ -1,0 +1,118 @@
+//! Suppression-constraint coverage: the `tool_choice: "none"` ban tag.
+//!
+//! The ban is a structural tag whose format is free text excluding the
+//! strings that open a parser's native tool-call syntax. Only parsers with
+//! model-native framing (and a curated opener inventory) produce one.
+
+use serde_json::Value;
+use tool_parser::{ParserFactory, ToolConstraint};
+
+fn ban_tag_json(factory: &ParserFactory, parser: &str) -> Value {
+    let constraint = factory
+        .registry()
+        .tool_call_ban_constraint(Some(parser))
+        .unwrap_or_else(|| panic!("{parser} should produce a ban constraint"));
+    let ToolConstraint::StructuralTag(json) = constraint else {
+        panic!("ban constraint must be a structural tag");
+    };
+    serde_json::from_str(&json).expect("ban tag must be valid JSON")
+}
+
+fn excludes(tag: &Value) -> Vec<&str> {
+    tag["format"]["excludes"]
+        .as_array()
+        .expect("excludes must be an array")
+        .iter()
+        .map(|v| v.as_str().expect("excludes entries must be strings"))
+        .collect()
+}
+
+#[test]
+fn ban_tag_shape_is_any_text_with_excludes() {
+    let factory = ParserFactory::new();
+    let tag = ban_tag_json(&factory, "mistral");
+    assert_eq!(tag["format"]["type"], "any_text");
+    assert!(tag["format"]["excludes"].is_array());
+    // Top-level envelope matches the positive structural tags: one "format" key.
+    assert!(tag.get("format").is_some());
+    assert_eq!(tag.as_object().map(serde_json::Map::len), Some(1));
+}
+
+#[test]
+fn curated_ban_inventories_per_parser() {
+    let factory = ParserFactory::new();
+    assert_eq!(
+        excludes(&ban_tag_json(&factory, "mistral")),
+        vec!["[TOOL_CALLS]"]
+    );
+    assert_eq!(
+        excludes(&ban_tag_json(&factory, "kimik2")),
+        vec!["<|tool_calls_section_begin|>", "<|tool_call_begin|>"]
+    );
+    // K3 bans ONLY the tools-section opener: its structural-tag triggers also
+    // include think/response section closers that ordinary generation must
+    // emit, and excluding those would corrupt normal output.
+    assert_eq!(
+        excludes(&ban_tag_json(&factory, "kimi_k3")),
+        vec!["<|open|>tools<|sep|>"]
+    );
+    assert_eq!(
+        excludes(&ban_tag_json(&factory, "inkling")),
+        vec!["<|content_invoke_tool_json|>"]
+    );
+}
+
+#[test]
+fn parsers_without_native_framing_produce_no_ban() {
+    let factory = ParserFactory::new();
+    for parser in ["json", "qwen", "qwen_xml", "pythonic", "llama", "deepseek"] {
+        assert!(
+            factory
+                .registry()
+                .tool_call_ban_constraint(Some(parser))
+                .is_none(),
+            "{parser} has no curated ban inventory"
+        );
+    }
+}
+
+#[test]
+fn unknown_or_absent_parser_produces_no_ban() {
+    let factory = ParserFactory::new();
+    assert!(factory
+        .registry()
+        .tool_call_ban_constraint(Some("no-such-parser"))
+        .is_none());
+    assert!(factory.registry().tool_call_ban_constraint(None).is_none());
+}
+
+#[test]
+fn generate_tool_constraint_still_skips_none_choice() {
+    use openai_protocol::common::{Function, Tool, ToolChoice, ToolChoiceValue};
+
+    let factory = ParserFactory::new();
+    let tools = vec![Tool {
+        tool_type: "function".to_string(),
+        function: Function {
+            name: "get_weather".to_string(),
+            description: None,
+            parameters: serde_json::json!({"type": "object"}),
+            strict: None,
+        },
+    }];
+    // The ban is a separate opt-in surface; the standard constraint generator
+    // keeps returning no constraint for tool_choice "none" and "auto".
+    for choice in [
+        ToolChoice::Value(ToolChoiceValue::None),
+        ToolChoice::Value(ToolChoiceValue::Auto),
+    ] {
+        let constraint = factory
+            .registry()
+            .generate_tool_constraint(Some("mistral"), &tools, &choice)
+            .expect("constraint generation must not error");
+        assert!(
+            constraint.is_none(),
+            "no constraint expected for {choice:?}"
+        );
+    }
+}

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -613,6 +613,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn tool_choice_none_ban(mut self, enable: bool) -> Self {
+        self.config.tool_choice_none_ban = enable;
+        self
+    }
+
     // ==================== Tokenizer Cache ====================
 
     pub fn tokenizer_cache(mut self, cache: TokenizerCacheConfig) -> Self {

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -546,6 +546,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn tool_choice_none_ban(mut self, enable: bool) -> Self {
+        self.config.tool_choice_none_ban = enable;
+        self
+    }
+
     // ==================== Tokenizer Cache ====================
 
     pub fn tokenizer_cache(mut self, cache: TokenizerCacheConfig) -> Self {

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -245,6 +245,13 @@ pub struct RouterConfig {
     pub reasoning_parser: Option<String>,
     /// For tool-call interactions
     pub tool_call_parser: Option<String>,
+    /// When tools are present but `tool_choice` is `"none"`, emit a
+    /// decode-time constraint banning the resolved parser's tool-call opener
+    /// strings, so the model cannot start native tool-call syntax at all.
+    /// Off by default: requires engines whose grammar backend understands the
+    /// `any_text`/`excludes` structural-tag format.
+    #[serde(default)]
+    pub tool_choice_none_ban: bool,
     #[serde(default)]
     pub tokenizer_cache: TokenizerCacheConfig,
     /// Server TLS certificate (PEM)
@@ -1109,6 +1116,7 @@ impl Default for RouterConfig {
             redis: None,
             reasoning_parser: None,
             tool_call_parser: None,
+            tool_choice_none_ban: false,
             tokenizer_cache: TokenizerCacheConfig::default(),
             client_identity: None,
             ca_certificates: vec![],
@@ -1222,6 +1230,21 @@ mod tests {
             config.tenant_resolution.tenant_header_name,
             DEFAULT_TENANT_HEADER_NAME
         );
+        assert!(!config.tool_choice_none_ban);
+    }
+
+    #[test]
+    fn test_tool_choice_none_ban_absent_from_config_defaults_off() {
+        // Existing config files predate the field; they must keep parsing
+        // with the ban disabled.
+        let mut value = serde_json::to_value(RouterConfig::default()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("tool_choice_none_ban")
+            .expect("field is serialized");
+        let config: RouterConfig = serde_json::from_value(value).unwrap();
+        assert!(!config.tool_choice_none_ban);
     }
 
     #[test]

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -175,6 +175,13 @@ pub struct RouterConfig {
     pub reasoning_parser: Option<String>,
     /// For tool-call interactions
     pub tool_call_parser: Option<String>,
+    /// When tools are present but `tool_choice` is `"none"`, emit a
+    /// decode-time constraint banning the resolved parser's tool-call opener
+    /// strings, so the model cannot start native tool-call syntax at all.
+    /// Off by default: requires engines whose grammar backend understands the
+    /// `any_text`/`excludes` structural-tag format.
+    #[serde(default)]
+    pub tool_choice_none_ban: bool,
     #[serde(default)]
     pub tokenizer_cache: TokenizerCacheConfig,
     /// Server TLS certificate (PEM)
@@ -877,6 +884,7 @@ impl Default for RouterConfig {
             redis: None,
             reasoning_parser: None,
             tool_call_parser: None,
+            tool_choice_none_ban: false,
             tokenizer_cache: TokenizerCacheConfig::default(),
             client_identity: None,
             ca_certificates: vec![],
@@ -987,6 +995,21 @@ mod tests {
             config.tenant_resolution.tenant_header_name,
             DEFAULT_TENANT_HEADER_NAME
         );
+        assert!(!config.tool_choice_none_ban);
+    }
+
+    #[test]
+    fn test_tool_choice_none_ban_absent_from_config_defaults_off() {
+        // Existing config files predate the field; they must keep parsing
+        // with the ban disabled.
+        let mut value = serde_json::to_value(RouterConfig::default()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("tool_choice_none_ban")
+            .expect("field is serialized");
+        let config: RouterConfig = serde_json::from_value(value).unwrap();
+        assert!(!config.tool_choice_none_ban);
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -2382,6 +2382,33 @@ mod tests {
         );
     }
 
+    /// `--tool-choice-none-ban` must flow into `RouterConfig` and survive
+    /// nesting into `ServerConfig.router_config` — the consumers (the gRPC
+    /// preparation stages) read it off `RouterConfig`. Two-path
+    /// config-plumbing guard, plus the off-by-default contract.
+    #[test]
+    fn tool_choice_none_ban_flows_into_both_configs() {
+        let cli = cli_args_from(&["--tool-choice-none-ban"]);
+
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert!(
+            router_config.tool_choice_none_ban,
+            "tool_choice_none_ban must reach RouterConfig via to_router_config"
+        );
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert!(
+            server_config.router_config.tool_choice_none_ban,
+            "tool_choice_none_ban must survive into ServerConfig via to_server_config"
+        );
+
+        let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
+        assert!(
+            !defaults.tool_choice_none_ban,
+            "tool_choice_none_ban must default off"
+        );
+    }
+
     /// The overload thresholds must reach `RouterConfig` and survive nesting
     /// into `ServerConfig.router_config` — the consumer (load monitor) reads
     /// them off `RouterConfig`. Two-path config-plumbing guard.

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -886,6 +886,12 @@ struct CliArgs {
     #[arg(long, help_heading = "Parsers")]
     tool_call_parser: Option<String>,
 
+    /// With tools present but tool_choice "none", ban the resolved parser's
+    /// tool-call opener strings at decode time (requires engine support for
+    /// the any_text/excludes structural-tag format)
+    #[arg(long, default_value_t = false, help_heading = "Parsers")]
+    tool_choice_none_ban: bool,
+
     /// Path to MCP server configuration file
     #[arg(long, help_heading = "Parsers")]
     mcp_config_path: Option<String>,
@@ -1860,6 +1866,7 @@ impl CliArgs {
             .maybe_redis(redis)
             .maybe_reasoning_parser(self.reasoning_parser.as_ref())
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
+            .tool_choice_none_ban(self.tool_choice_none_ban)
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
             .dp_aware(self.dp_aware)
             .routing_key_override(RoutingKeyOverrideConfig {

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -637,6 +637,12 @@ struct CliArgs {
     #[arg(long, help_heading = "Parsers")]
     tool_call_parser: Option<String>,
 
+    /// With tools present but tool_choice "none", ban the resolved parser's
+    /// tool-call opener strings at decode time (requires engine support for
+    /// the any_text/excludes structural-tag format)
+    #[arg(long, default_value_t = false, help_heading = "Parsers")]
+    tool_choice_none_ban: bool,
+
     /// Path to MCP server configuration file
     #[arg(long, help_heading = "Parsers")]
     mcp_config_path: Option<String>,
@@ -1564,6 +1570,7 @@ impl CliArgs {
             .maybe_redis(redis)
             .maybe_reasoning_parser(self.reasoning_parser.as_ref())
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
+            .tool_choice_none_ban(self.tool_choice_none_ban)
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
             .dp_aware(self.dp_aware)
             .routing_key_override(RoutingKeyOverrideConfig {

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -235,24 +235,31 @@ impl ChatPreparationStage {
         let tool_call_constraint = if let (Some(tools), Some(tool_choice)) =
             (body_ref.tools.as_ref(), request.tool_choice.as_ref())
         {
-            ctx.components
-                .tool_parser_factory
-                .registry()
-                .generate_tool_constraint(
-                    ctx.components
-                        .parser_resolver
-                        .tool_parser(&request.model)
-                        .as_deref(),
-                    tools,
-                    tool_choice,
-                )
-                .map_err(|e| {
-                    error!(function = "ChatPreparationStage::execute", error = %e, "Invalid tool configuration");
-                    error::bad_request(
-                        "invalid_tool_configuration",
-                        format!("Invalid tool configuration: {e}"),
-                    )
-                })?
+            let resolved_parser = ctx.components.parser_resolver.tool_parser(&request.model);
+            if !tools.is_empty()
+                && ctx.components.parser_resolver.tool_choice_none_ban()
+                && matches!(tool_choice, ToolChoice::Value(ToolChoiceValue::None))
+            {
+                // Opt-in: ban the parser's tool-call opener strings so the
+                // model cannot start native tool-call syntax at all (the
+                // prompt still advertises the tools; parsing stays disabled).
+                ctx.components
+                    .tool_parser_factory
+                    .registry()
+                    .tool_call_ban_constraint(resolved_parser.as_deref())
+            } else {
+                ctx.components
+                    .tool_parser_factory
+                    .registry()
+                    .generate_tool_constraint(resolved_parser.as_deref(), tools, tool_choice)
+                    .map_err(|e| {
+                        error!(function = "ChatPreparationStage::execute", error = %e, "Invalid tool configuration");
+                        error::bad_request(
+                            "invalid_tool_configuration",
+                            format!("Invalid tool configuration: {e}"),
+                        )
+                    })?
+            }
         } else {
             None
         };

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -263,24 +263,30 @@ impl MessagePreparationStage {
         let tool_call_constraint = if let (false, Some(tool_choice)) =
             (filtered_tools.is_empty(), chat_tool_choice.as_ref())
         {
-            ctx.components
-                .tool_parser_factory
-                .registry()
-                .generate_tool_constraint(
-                    ctx.components
-                        .parser_resolver
-                        .tool_parser(&request.model)
-                        .as_deref(),
-                    &filtered_tools,
-                    tool_choice,
-                )
-                .map_err(|e| {
-                    error!(function = "MessagePreparationStage::execute", error = %e, "Invalid tool configuration");
-                    error::bad_request(
-                        "invalid_tool_configuration",
-                        format!("Invalid tool configuration: {e}"),
-                    )
-                })?
+            let resolved_parser = ctx.components.parser_resolver.tool_parser(&request.model);
+            if ctx.components.parser_resolver.tool_choice_none_ban()
+                && matches!(tool_choice, ToolChoice::Value(ToolChoiceValue::None))
+            {
+                // Opt-in: ban the parser's tool-call opener strings so the
+                // model cannot start native tool-call syntax at all (the
+                // prompt still advertises the tools; parsing stays disabled).
+                ctx.components
+                    .tool_parser_factory
+                    .registry()
+                    .tool_call_ban_constraint(resolved_parser.as_deref())
+            } else {
+                ctx.components
+                    .tool_parser_factory
+                    .registry()
+                    .generate_tool_constraint(resolved_parser.as_deref(), &filtered_tools, tool_choice)
+                    .map_err(|e| {
+                        error!(function = "MessagePreparationStage::execute", error = %e, "Invalid tool configuration");
+                        error::bad_request(
+                            "invalid_tool_configuration",
+                            format!("Invalid tool configuration: {e}"),
+                        )
+                    })?
+            }
         } else {
             None
         };

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -359,7 +359,8 @@ impl GrpcRouter {
                 worker_registry.clone(),
                 ctx.configured_tool_parser.clone(),
                 ctx.configured_reasoning_parser.clone(),
-            ),
+            )
+            .with_tool_choice_none_ban(ctx.router_config.tool_choice_none_ban),
             multimodal,
         });
 

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -32,6 +32,9 @@ pub(crate) struct ParserResolver {
     worker_registry: Option<Arc<WorkerRegistry>>,
     configured_tool_parser: Option<String>,
     configured_reasoning_parser: Option<String>,
+    /// Emit the tool-call suppression constraint when tools are present but
+    /// `tool_choice` is `"none"` (RouterConfig `tool_choice_none_ban`).
+    tool_choice_none_ban: bool,
 }
 
 impl ParserResolver {
@@ -44,6 +47,7 @@ impl ParserResolver {
             worker_registry: Some(worker_registry),
             configured_tool_parser,
             configured_reasoning_parser,
+            tool_choice_none_ban: false,
         }
     }
 
@@ -54,7 +58,19 @@ impl ParserResolver {
             worker_registry: None,
             configured_tool_parser: None,
             configured_reasoning_parser: None,
+            tool_choice_none_ban: false,
         }
+    }
+
+    #[must_use]
+    pub(crate) fn with_tool_choice_none_ban(mut self, enabled: bool) -> Self {
+        self.tool_choice_none_ban = enabled;
+        self
+    }
+
+    /// Whether the `tool_choice: "none"` suppression constraint is enabled.
+    pub(crate) fn tool_choice_none_ban(&self) -> bool {
+        self.tool_choice_none_ban
     }
 
     /// Effective tool-parser name for `model`, if any.
@@ -513,6 +529,16 @@ mod parser_resolver_tests {
         let resolver = ParserResolver::disabled();
         assert_eq!(resolver.tool_parser("m"), None);
         assert_eq!(resolver.reasoning_parser("m"), None);
+    }
+
+    #[test]
+    fn tool_choice_none_ban_defaults_off_and_round_trips() {
+        let registry = registry_with_card(ModelCard::new("m"));
+        let resolver = ParserResolver::new(registry, None, None);
+        assert!(!resolver.tool_choice_none_ban());
+        assert!(!ParserResolver::disabled().tool_choice_none_ban());
+        let enabled = resolver.with_tool_choice_none_ban(true);
+        assert!(enabled.tool_choice_none_ban());
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem
When a request carries tools but sets `tool_choice: "none"`, SMG honors the choice only on the response side: parsing is disabled, so any tool call the model emits is left as literal text in `content`. Nothing on the request side stops the model from *starting* tool-call syntax — the prompt still advertises the full tool list, and `generate_tool_constraint` returns no constraint for the `none` case. Models regularly emit tool-call markup anyway, and the client receives it as garbled prose.

### Solution
An opt-in decode-time suppression constraint. Each parser with model-native tool-call framing (mistral, kimik2, kimi_k3, inkling) now carries a curated inventory of strings that *exclusively* open its tool-call syntax, and the factory can build a ban tag from it:

```json
{"format": {"type": "any_text", "excludes": ["<|tool_calls_section_begin|>", "<|tool_call_begin|>"]}}
```

Free-form output whose `excludes` list makes the openers unreachable — the model cannot begin a tool call at all. The inventory is deliberately **not** the structural-tag trigger list: kimi_k3's triggers include `<|close|>think<|sep|>` / `<|close|>response<|sep|>`, which ordinary generation must emit; banning those would corrupt normal output. Only strings that never appear outside tool calls qualify.

Gating: a new `RouterConfig` bool (`--tool-choice-none-ban`, default **off**), because the `any_text`/`excludes` structural-tag format requires current grammar-backend support in the engine. When enabled, the chat and messages preparation stages attach the ban whenever tools are present, `tool_choice` is exactly `"none"`, and the resolved parser has an inventory. Everything else is unchanged: required/auto/function constraint generation, the none-case parse gate, and `skip_special_tokens` derivation.

## Changes
- `crates/tool_parser/src/factory.rs`: `ParserEntry.tool_call_ban_strings`, extended `register_parser_with_structural_tag` signature, new `ParserRegistry::tool_call_ban_constraint`.
- `crates/tool_parser/src/parsers/{mistral,kimik2,kimi_k3,inkling}.rs`: `TOOL_CALL_BAN_STRINGS` curated consts (kimi_k3's documents why section closers are excluded from the ban).
- `model_gateway`: `RouterConfig.tool_choice_none_ban` (+serde default, builder setter, CLI flag, conversion wiring), flag carried on `ParserResolver`, ban branch in the chat and messages preparation stages.

## Test Plan
- New `crates/tool_parser/tests/tool_constraint_ban.rs` (5 tests): tag shape is `format`/`any_text`/`excludes`; exact curated inventories for all four parsers; parsers without native framing, unknown names, and no configured parser produce no ban; `generate_tool_constraint` still returns no constraint for none/auto.
- `ParserResolver` flag defaults off and round-trips; `RouterConfig` default asserts the flag off; deserializing a config without the field keeps it off.
- `cargo test -p smg --lib` 1478 passed; full tool-parser suite green; `cargo clippy -p smg -p tool-parser --all-targets` clean.

<details>
<summary>Checklist</summary>

- [x] Format your code: `make fmt`
- [x] Run lint checks: `cargo clippy -p smg -p tool-parser --all-targets -- -D warnings`
- [x] Add unit tests for new functionality
- [x] Update documentation if needed (CLI help text carries the flag docs)

</details>