### PR TITLE
feat(router): pre-scoring worker filter stage with label matching

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -495,6 +495,7 @@ struct Router {
     model_aliases: HashMap<String, String>,
     worker_startup_delay: u64,
     worker_ports_annotation: String,
+    worker_filter_header: Option<String>,
 }
 
 impl Router {
@@ -833,6 +834,7 @@ impl Router {
             .maybe_redis(redis_config)
             .maybe_reasoning_parser(self.reasoning_parser.as_ref())
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
+            .worker_filter_header(self.worker_filter_header.clone())
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
             .maybe_storage_hook_wasm_path(self.storage_hook_wasm_path.as_deref())
             .enable_wasm(self.enable_wasm)
@@ -989,6 +991,7 @@ impl Router {
         model_aliases = HashMap::new(),
         worker_startup_delay = 0,
         worker_ports_annotation = String::from("smg.ai/worker-ports"),
+        worker_filter_header = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1118,6 +1121,7 @@ impl Router {
         model_aliases: HashMap<String, String>,
         worker_startup_delay: u64,
         worker_ports_annotation: String,
+        worker_filter_header: Option<String>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1261,6 +1265,7 @@ impl Router {
             model_aliases,
             worker_startup_delay,
             worker_ports_annotation,
+            worker_filter_header,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -204,6 +204,7 @@ class RouterArgs:
     # Append new fields here to preserve positional callers.
     model_aliases: dict[str, str] = dataclasses.field(default_factory=dict)
     worker_startup_delay: int = 0
+    worker_filter_header: str | None = None
 
     @staticmethod
     def add_cli_args(
@@ -505,6 +506,17 @@ class RouterArgs:
             f"--{prefix}routing-key-override",
             action="store_true",
             help="Honor X-SMG-Routing-Key for sticky routing on any policy",
+        )
+        routing_group.add_argument(
+            f"--{prefix}worker-filter-header",
+            type=str,
+            default=None,
+            help=(
+                "Enable the label worker filter: name of the request header"
+                " carrying comma-separated key=value pairs a worker's labels"
+                " must all match (e.g. x-smg-worker-labels). Unset disables"
+                " filtering."
+            ),
         )
         routing_group.add_argument(
             f"--{prefix}dp-minimum-tokens-scheduler",

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -552,10 +552,12 @@ impl AppContextBuilder {
 
     /// Create policy registry
     fn with_policy_registry(mut self, config: &RouterConfig) -> Self {
-        self.policy_registry = Some(Arc::new(PolicyRegistry::with_override(
+        let registry = PolicyRegistry::with_override(
             config.policy.clone(),
             config.routing_key_override.clone(),
-        )));
+        );
+        registry.set_worker_filters(crate::policies::worker_filters_from_config(config));
+        self.policy_registry = Some(Arc::new(registry));
         self
     }
 

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -145,6 +145,12 @@ impl RouterConfigBuilder {
         self
     }
 
+    /// Header name enabling the label worker filter (`None` disables).
+    pub fn worker_filter_header(mut self, header: Option<String>) -> Self {
+        self.config.worker_filter_header = header;
+        self
+    }
+
     // ==================== Connection ====================
 
     /// Explicit runtime for startup workers over ZMQ (`None` keeps

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -31,6 +31,12 @@ pub struct RouterConfig {
     /// Per-request sticky-routing override (honors `X-SMG-Routing-Key`).
     #[serde(default)]
     pub routing_key_override: RoutingKeyOverrideConfig,
+    /// Enables the label worker filter on every policy-based selection path:
+    /// the named request header carries comma-separated `key=value` pairs,
+    /// and only workers whose spec labels contain ALL pairs are candidates.
+    /// Requests without the header are unaffected. `None` disables filtering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_filter_header: Option<String>,
     pub host: String,
     pub port: u16,
     /// Dedicated port for the isolated Kubernetes liveness/readiness/health
@@ -819,6 +825,7 @@ impl Default for RouterConfig {
             },
             policy: PolicyConfig::Random,
             routing_key_override: RoutingKeyOverrideConfig::default(),
+            worker_filter_header: None,
             host: "0.0.0.0".to_string(),
             port: 3001,
             health_check_port: None,

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -92,6 +92,7 @@ impl ConfigValidator {
     pub(crate) fn validate(config: &RouterConfig) -> ConfigResult<()> {
         Self::validate_mode(&config.mode)?;
         Self::validate_policy(&config.policy)?;
+        Self::validate_worker_filter(config)?;
         Self::validate_server_settings(config)?;
         Self::validate_storage_context_headers(config)?;
         Self::validate_tenant_resolution(config)?;
@@ -129,6 +130,22 @@ impl ConfigValidator {
 
         Self::validate_tokenizer_cache(&config.tokenizer_cache)?;
 
+        Ok(())
+    }
+
+    /// The worker-filter header must be a valid HTTP header name; an invalid
+    /// name would make the filter silently inert (HeaderMap lookups never
+    /// match), which is worse than failing at startup.
+    fn validate_worker_filter(config: &RouterConfig) -> ConfigResult<()> {
+        if let Some(name) = &config.worker_filter_header {
+            if name.trim().is_empty() || HeaderName::try_from(name.trim()).is_err() {
+                return Err(ConfigError::InvalidValue {
+                    field: "worker_filter_header".to_string(),
+                    value: name.clone(),
+                    reason: "Must be a valid HTTP header name".to_string(),
+                });
+            }
+        }
         Ok(())
     }
 
@@ -1396,6 +1413,26 @@ mod tests {
         );
 
         assert!(ConfigValidator::validate(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_worker_filter_header() {
+        let make = |header: Option<&str>| RouterConfig {
+            worker_filter_header: header.map(str::to_string),
+            ..RouterConfig::new(
+                RoutingMode::Regular {
+                    worker_urls: vec!["http://worker1:8000".to_string()],
+                },
+                PolicyConfig::Random,
+            )
+        };
+
+        assert!(ConfigValidator::validate(&make(None)).is_ok());
+        assert!(ConfigValidator::validate(&make(Some("x-smg-worker-labels"))).is_ok());
+        // Invalid header names would make the filter silently inert; reject
+        // at startup instead.
+        assert!(ConfigValidator::validate(&make(Some(""))).is_err());
+        assert!(ConfigValidator::validate(&make(Some("bad header name"))).is_err());
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -232,6 +232,12 @@ struct CliArgs {
     #[arg(long, default_value_t = 14400, help_heading = "Routing Policy")]
     max_idle_secs: u64,
 
+    /// Enable the label worker filter: name of the request header carrying
+    /// comma-separated key=value pairs a worker's labels must all match
+    /// (e.g. "x-smg-worker-labels"). Unset disables filtering.
+    #[arg(long, help_heading = "Routing Policy")]
+    worker_filter_header: Option<String>,
+
     /// Assignment mode for manual policy when encountering a new routing key
     #[arg(long, default_value = "random", value_parser = ["random", "min_load", "min_group"], help_heading = "Routing Policy")]
     assignment_mode: String,
@@ -1572,6 +1578,7 @@ impl CliArgs {
                 max_idle_secs: self.max_idle_secs,
                 assignment_mode: Self::parse_assignment_mode(&self.assignment_mode),
             })
+            .worker_filter_header(self.worker_filter_header.clone())
             .retries(!self.disable_retries)
             .circuit_breaker(!self.disable_circuit_breaker)
             .enable_wasm(self.enable_wasm)

--- a/model_gateway/src/policies/filter.rs
+++ b/model_gateway/src/policies/filter.rs
@@ -1,0 +1,191 @@
+//! Pre-scoring candidate filters for policy-based worker selection.
+//!
+//! Filters run between eligibility (health + circuit breaker) and policy
+//! scoring: each filter answers keep/drop for one candidate worker given the
+//! per-request selection info. Filters express HARD requirements — a worker
+//! that fails one may not serve the request at all; preferences (ordering,
+//! weighting) belong in policies.
+//!
+//! The chain lives on the `PolicyRegistry` and applies to every policy-based
+//! selection path uniformly. An empty chain adds no cost. When a non-empty
+//! candidate set is filtered down to nothing, selection reports
+//! "all filtered" — an unavailability outcome (503), deliberately distinct
+//! from an empty pool (the model may not exist → 404 on some paths) and from
+//! backpressure (429): retrying elsewhere just bounces, and a 404 would lie
+//! to the client about the model's existence.
+
+use std::{fmt::Debug, sync::Arc};
+
+use super::SelectWorkerInfo;
+use crate::{config::types::RouterConfig, worker::Worker};
+
+/// A hard candidate requirement applied before policy scoring.
+pub trait WorkerFilter: Send + Sync + Debug {
+    /// Filter name for logs and debugging.
+    fn name(&self) -> &'static str;
+
+    /// Whether `worker` may remain in the candidate set for this request.
+    fn keep(&self, worker: &dyn Worker, info: &SelectWorkerInfo) -> bool;
+}
+
+/// Label filter driven by a request header.
+///
+/// The header value is parsed as comma-separated `key=value` pairs; only
+/// workers whose spec labels contain ALL pairs survive. Requests without the
+/// header keep every candidate, so the filter is inert until a client asks
+/// for narrowing. Malformed pairs (no `=`, empty key) are ignored.
+///
+/// Worker labels already flow end to end (k8s discovery selectors, the
+/// `/workers` management API), so this enables tenant pinning, canary
+/// cohorts, and hardware classes with no new worker-side surface.
+#[derive(Debug)]
+pub struct LabelHeaderFilter {
+    /// Stored lowercase; `HeaderMap` lookups are case-insensitive by name.
+    header_name: String,
+}
+
+impl LabelHeaderFilter {
+    pub fn new(header_name: impl AsRef<str>) -> Self {
+        Self {
+            header_name: header_name.as_ref().to_ascii_lowercase(),
+        }
+    }
+}
+
+impl WorkerFilter for LabelHeaderFilter {
+    fn name(&self) -> &'static str {
+        "label_header"
+    }
+
+    fn keep(&self, worker: &dyn Worker, info: &SelectWorkerInfo) -> bool {
+        let Some(required) = info
+            .headers
+            .and_then(|headers| headers.get(&self.header_name))
+            .and_then(|value| value.to_str().ok())
+        else {
+            return true;
+        };
+        let labels = &worker.metadata().spec.labels;
+        label_pairs(required)
+            .all(|(key, value)| labels.get(key).is_some_and(|actual| actual == value))
+    }
+}
+
+/// Build the configured filter chain: currently the label header filter when
+/// `worker_filter_header` is set (validated as a header name at config
+/// time). Empty when nothing is configured — filtering costs nothing.
+pub fn worker_filters_from_config(config: &RouterConfig) -> Vec<Arc<dyn WorkerFilter>> {
+    let mut filters: Vec<Arc<dyn WorkerFilter>> = Vec::new();
+    if let Some(header) = config.worker_filter_header.as_deref() {
+        let header = header.trim();
+        if !header.is_empty() {
+            filters.push(Arc::new(LabelHeaderFilter::new(header)));
+        }
+    }
+    filters
+}
+
+/// Parse `k=v,k2=v2` into pairs, skipping malformed entries.
+fn label_pairs(value: &str) -> impl Iterator<Item = (&str, &str)> {
+    value.split(',').filter_map(|pair| {
+        let (key, value) = pair.split_once('=')?;
+        let (key, value) = (key.trim(), value.trim());
+        (!key.is_empty()).then_some((key, value))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use openai_protocol::worker::HealthCheckConfig;
+
+    use super::*;
+    use crate::worker::{BasicWorkerBuilder, WorkerType};
+
+    fn no_health_check() -> HealthCheckConfig {
+        HealthCheckConfig {
+            disable_health_check: true,
+            ..Default::default()
+        }
+    }
+
+    fn labeled_worker(labels: &[(&str, &str)]) -> Arc<dyn Worker> {
+        let mut map = HashMap::new();
+        for (k, v) in labels {
+            map.insert((*k).to_string(), (*v).to_string());
+        }
+        Arc::new(
+            BasicWorkerBuilder::new("http://w:8000")
+                .worker_type(WorkerType::Regular)
+                .health_config(no_health_check())
+                .labels(map)
+                .build(),
+        )
+    }
+
+    fn info_with_headers(headers: &http::HeaderMap) -> SelectWorkerInfo<'_> {
+        SelectWorkerInfo {
+            headers: Some(headers),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn missing_header_keeps_everything() {
+        let filter = LabelHeaderFilter::new("X-SMG-Worker-Labels");
+        let worker = labeled_worker(&[]);
+        let headers = http::HeaderMap::new();
+        assert!(filter.keep(worker.as_ref(), &info_with_headers(&headers)));
+        assert!(filter.keep(worker.as_ref(), &SelectWorkerInfo::default()));
+    }
+
+    #[test]
+    fn requires_all_pairs() {
+        let filter = LabelHeaderFilter::new("X-SMG-Worker-Labels");
+        let full_match = labeled_worker(&[("tenant", "acme"), ("tier", "gpu-h100"), ("x", "y")]);
+        let partial = labeled_worker(&[("tenant", "acme")]);
+        let wrong_value = labeled_worker(&[("tenant", "acme"), ("tier", "cpu")]);
+        let unlabeled = labeled_worker(&[]);
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "x-smg-worker-labels",
+            "tenant=acme, tier=gpu-h100".parse().unwrap(),
+        );
+        let info = info_with_headers(&headers);
+
+        assert!(filter.keep(full_match.as_ref(), &info));
+        assert!(!filter.keep(partial.as_ref(), &info));
+        assert!(!filter.keep(wrong_value.as_ref(), &info));
+        assert!(!filter.keep(unlabeled.as_ref(), &info));
+    }
+
+    #[test]
+    fn malformed_pairs_are_ignored() {
+        let filter = LabelHeaderFilter::new("X-SMG-Worker-Labels");
+        let worker = labeled_worker(&[("tenant", "acme")]);
+
+        let mut headers = http::HeaderMap::new();
+        // Bare token and empty key are skipped; the valid pair still applies.
+        headers.insert(
+            "x-smg-worker-labels",
+            "garbage, =nokey, tenant=acme".parse().unwrap(),
+        );
+        assert!(filter.keep(worker.as_ref(), &info_with_headers(&headers)));
+
+        // Only malformed entries → no requirements → keep.
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-smg-worker-labels", "garbage".parse().unwrap());
+        assert!(filter.keep(worker.as_ref(), &info_with_headers(&headers)));
+    }
+
+    #[test]
+    fn empty_value_matches_empty_label() {
+        let filter = LabelHeaderFilter::new("X-SMG-Worker-Labels");
+        let worker = labeled_worker(&[("flag", "")]);
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-smg-worker-labels", "flag=".parse().unwrap());
+        assert!(filter.keep(worker.as_ref(), &info_with_headers(&headers)));
+    }
+}

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -14,6 +14,7 @@ mod cache_aware;
 mod consistent_hashing;
 mod dp_min_token;
 mod factory;
+mod filter;
 mod least_load;
 mod manual;
 mod passthrough;
@@ -29,6 +30,7 @@ pub use cache_aware::{CacheAwarePolicy, TreeHandle, TreeKind};
 pub use consistent_hashing::ConsistentHashingPolicy;
 pub use dp_min_token::MinimumTokensPolicy;
 pub use factory::PolicyFactory;
+pub use filter::{worker_filters_from_config, LabelHeaderFilter, WorkerFilter};
 // Re-export PrefixMatchResult from kv_index for production use
 pub use kv_index::PrefixMatchResult;
 pub use least_load::LeastLoadPolicy;
@@ -37,7 +39,7 @@ pub use passthrough::PassthroughPolicy;
 pub use power_of_two::PowerOfTwoPolicy;
 pub use prefix_hash::{PrefixHashConfig, PrefixHashPolicy};
 pub use random::RandomPolicy;
-pub use registry::PolicyRegistry;
+pub use registry::{PolicyRegistry, SelectionOutcome};
 pub use round_robin::RoundRobinPolicy;
 
 /// Core trait for load balancing policies

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -15,7 +15,7 @@ use tracing::{debug, info, warn};
 /// When the last worker of a model is removed, the policy mapping is cleaned up.
 use super::{
     BucketPolicy, CacheAwarePolicy, DPRankLoadPolicy, LoadBalancingPolicy, ManualConfig,
-    ManualPolicy, PolicyFactory, SelectWorkerInfo,
+    ManualPolicy, PolicyFactory, SelectWorkerInfo, WorkerFilter,
 };
 use crate::{
     config::types::{PolicyConfig, RoutingKeyOverrideConfig},
@@ -23,6 +23,34 @@ use crate::{
     routers::common::header_utils::extract_routing_key,
     worker::{KvEventMonitor, Worker},
 };
+
+/// Result of a registry-level worker selection.
+///
+/// Three-way rather than `Option<usize>` so the caller can distinguish the
+/// filter-exhaustion case and map it to 503 unavailability: retrying another
+/// worker just bounces (every candidate failed a hard requirement), a 429
+/// would misreport it as backpressure, and a 404 would deny the model exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionOutcome {
+    /// A worker was selected; the index refers to the caller's slice.
+    Selected(usize),
+    /// Empty candidate set or the policy declined — callers keep their
+    /// pre-existing behavior for this case.
+    NotSelected,
+    /// Candidates existed, but the filter chain removed them all.
+    AllFiltered,
+}
+
+impl SelectionOutcome {
+    /// The selected index, if any. Collapses the miss reasons — use the full
+    /// match where AllFiltered must map to its own error.
+    pub fn selected(self) -> Option<usize> {
+        match self {
+            SelectionOutcome::Selected(idx) => Some(idx),
+            SelectionOutcome::NotSelected | SelectionOutcome::AllFiltered => None,
+        }
+    }
+}
 
 /// Registry for managing model-to-policy mappings
 #[derive(Clone)]
@@ -61,6 +89,13 @@ pub struct PolicyRegistry {
     /// override is enabled; consulted (instead of the configured policy) for keyed
     /// requests via [`PolicyRegistry::select_worker`].
     routing_key_sticky: Option<Arc<ManualPolicy>>,
+
+    /// Ordered pre-scoring candidate filters, applied in
+    /// [`PolicyRegistry::select_worker`] before the policy (and before the
+    /// routing-key override) on every policy-based selection path. Empty by
+    /// default; injected post-construction like the KV monitor / load
+    /// receiver. See [`crate::policies::WorkerFilter`].
+    worker_filters: Arc<RwLock<Vec<Arc<dyn WorkerFilter>>>>,
 }
 
 impl PolicyRegistry {
@@ -95,14 +130,73 @@ impl PolicyRegistry {
             load_rx: Arc::new(RwLock::new(None)),
             dp_rank_policy: Arc::new(OnceLock::new()),
             routing_key_sticky,
+            worker_filters: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
-    /// Select a worker, applying the `X-SMG-Routing-Key` sticky override when it is
-    /// enabled, the request carries the header, and the configured policy does not
-    /// already honor the key (`manual` / `consistent_hashing`). Otherwise delegates
-    /// to `policy`. `policy.name()` stays the real policy (for metrics).
+    /// Install the pre-scoring candidate filter chain (thread-safe, callable
+    /// after initialization like [`Self::set_kv_event_monitor`]). Replaces
+    /// any previous chain; an empty vector disables filtering.
+    pub fn set_worker_filters(&self, filters: Vec<Arc<dyn WorkerFilter>>) {
+        *self.worker_filters.write() = filters;
+    }
+
+    /// Select a worker: apply the pre-scoring filter chain, then the
+    /// `X-SMG-Routing-Key` sticky override / configured policy on the
+    /// surviving candidates. The returned index refers to the CALLER's
+    /// `workers` slice, mapped back across any filtering.
+    ///
+    /// Outcome semantics are three-way so callers can tell "the filters
+    /// removed everyone" (unavailability, 503) apart from "no candidates /
+    /// policy declined" (each path keeps its existing behavior for that).
+    /// Note for index-pinning clients: with a filter chain active,
+    /// `X-SMG-Target-Worker` interprets its value against the post-filter
+    /// slice the policy sees.
     pub fn select_worker(
+        &self,
+        policy: &Arc<dyn LoadBalancingPolicy>,
+        workers: &[Arc<dyn Worker>],
+        info: &SelectWorkerInfo,
+    ) -> SelectionOutcome {
+        let filters = self.worker_filters.read();
+        if !filters.is_empty() && !workers.is_empty() {
+            let kept: Vec<usize> = (0..workers.len())
+                .filter(|&idx| {
+                    filters
+                        .iter()
+                        .all(|filter| filter.keep(workers[idx].as_ref(), info))
+                })
+                .collect();
+            if kept.is_empty() {
+                debug!(
+                    candidates = workers.len(),
+                    "Worker filters removed every candidate"
+                );
+                return SelectionOutcome::AllFiltered;
+            }
+            if kept.len() < workers.len() {
+                drop(filters);
+                let filtered: Vec<Arc<dyn Worker>> =
+                    kept.iter().map(|&idx| workers[idx].clone()).collect();
+                return match self.select_with_override(policy, &filtered, info) {
+                    Some(local_idx) => SelectionOutcome::Selected(kept[local_idx]),
+                    None => SelectionOutcome::NotSelected,
+                };
+            }
+            // Nothing filtered: fall through on the original slice, no remap.
+        }
+        drop(filters);
+        match self.select_with_override(policy, workers, info) {
+            Some(idx) => SelectionOutcome::Selected(idx),
+            None => SelectionOutcome::NotSelected,
+        }
+    }
+
+    /// The pre-filter selection core: `X-SMG-Routing-Key` sticky override when
+    /// enabled, the request carries the header, and the configured policy does
+    /// not already honor the key (`manual` / `consistent_hashing`); otherwise
+    /// the policy. `policy.name()` stays the real policy (for metrics).
+    fn select_with_override(
         &self,
         policy: &Arc<dyn LoadBalancingPolicy>,
         workers: &[Arc<dyn Worker>],
@@ -679,9 +773,15 @@ mod tests {
             headers: Some(&headers),
             ..Default::default()
         };
-        let first = reg.select_worker(&policy, &workers, &info).unwrap();
+        let first = reg
+            .select_worker(&policy, &workers, &info)
+            .selected()
+            .unwrap();
         for _ in 0..5 {
-            assert_eq!(reg.select_worker(&policy, &workers, &info), Some(first));
+            assert_eq!(
+                reg.select_worker(&policy, &workers, &info),
+                SelectionOutcome::Selected(first)
+            );
         }
     }
 
@@ -701,8 +801,14 @@ mod tests {
         ];
         let info = SelectWorkerInfo::default(); // no key header
                                                 // RoundRobin alternates -> proves the configured policy is used, not sticky.
-        let a = reg.select_worker(&policy, &workers, &info).unwrap();
-        let b = reg.select_worker(&policy, &workers, &info).unwrap();
+        let a = reg
+            .select_worker(&policy, &workers, &info)
+            .selected()
+            .unwrap();
+        let b = reg
+            .select_worker(&policy, &workers, &info)
+            .selected()
+            .unwrap();
         assert_ne!(a, b);
     }
 
@@ -720,8 +826,141 @@ mod tests {
             ..Default::default()
         };
         // Override off -> the key is ignored, RoundRobin alternates.
-        let a = reg.select_worker(&policy, &workers, &info).unwrap();
-        let b = reg.select_worker(&policy, &workers, &info).unwrap();
+        let a = reg
+            .select_worker(&policy, &workers, &info)
+            .selected()
+            .unwrap();
+        let b = reg
+            .select_worker(&policy, &workers, &info)
+            .selected()
+            .unwrap();
+        assert_ne!(a, b);
+    }
+
+    /// Test filter: rejects workers whose URL is on the list.
+    #[derive(Debug)]
+    struct RejectUrls(Vec<&'static str>);
+
+    impl WorkerFilter for RejectUrls {
+        fn name(&self) -> &'static str {
+            "reject_urls"
+        }
+        fn keep(&self, worker: &dyn Worker, _info: &SelectWorkerInfo) -> bool {
+            !self.0.contains(&worker.url())
+        }
+    }
+
+    #[test]
+    fn filters_narrow_candidates_and_map_indices_back() {
+        let reg = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        reg.set_worker_filters(vec![Arc::new(RejectUrls(vec!["http://w1", "http://w2"]))]);
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+            worker("http://w3", WorkerType::Regular),
+        ];
+        // Only w3 survives; the returned index must refer to the CALLER's
+        // slice (2), not the filtered slice the policy saw (0).
+        for _ in 0..5 {
+            assert_eq!(
+                reg.select_worker(&policy, &workers, &SelectWorkerInfo::default()),
+                SelectionOutcome::Selected(2)
+            );
+        }
+    }
+
+    #[test]
+    fn all_filtered_is_distinct_from_not_selected() {
+        let reg = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        reg.set_worker_filters(vec![Arc::new(RejectUrls(vec!["http://w1"]))]);
+        let policy = reg.get_default_policy();
+
+        // Candidates existed, filters removed them all -> AllFiltered.
+        let workers = vec![worker("http://w1", WorkerType::Regular)];
+        assert_eq!(
+            reg.select_worker(&policy, &workers, &SelectWorkerInfo::default()),
+            SelectionOutcome::AllFiltered
+        );
+
+        // Empty pool (even with filters installed) -> NotSelected: the
+        // caller's historical empty-pool handling must stay reachable.
+        assert_eq!(
+            reg.select_worker(&policy, &[], &SelectWorkerInfo::default()),
+            SelectionOutcome::NotSelected
+        );
+    }
+
+    #[test]
+    fn empty_filter_chain_is_passthrough() {
+        let reg = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        reg.set_worker_filters(Vec::new());
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+        let a = reg
+            .select_worker(&policy, &workers, &SelectWorkerInfo::default())
+            .selected()
+            .unwrap();
+        let b = reg
+            .select_worker(&policy, &workers, &SelectWorkerInfo::default())
+            .selected()
+            .unwrap();
+        assert_ne!(a, b, "round robin must alternate through the passthrough");
+    }
+
+    #[test]
+    fn label_header_filter_narrows_via_registry() {
+        use std::collections::HashMap;
+
+        let reg = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        reg.set_worker_filters(vec![Arc::new(super::super::LabelHeaderFilter::new(
+            "x-smg-worker-labels",
+        ))]);
+        let policy = reg.get_default_policy();
+
+        let labeled = |url: &str, labels: &[(&str, &str)]| -> Arc<dyn Worker> {
+            let mut map = HashMap::new();
+            for (k, v) in labels {
+                map.insert((*k).to_string(), (*v).to_string());
+            }
+            Arc::new(
+                BasicWorkerBuilder::new(url)
+                    .worker_type(WorkerType::Regular)
+                    .health_config(no_health_check())
+                    .labels(map)
+                    .build(),
+            )
+        };
+        let workers = vec![
+            labeled("http://w1", &[("tenant", "acme")]),
+            labeled("http://w2", &[("tenant", "globex")]),
+        ];
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-smg-worker-labels", "tenant=globex".parse().unwrap());
+        let info = SelectWorkerInfo {
+            headers: Some(&headers),
+            ..Default::default()
+        };
+        for _ in 0..5 {
+            assert_eq!(
+                reg.select_worker(&policy, &workers, &info),
+                SelectionOutcome::Selected(1)
+            );
+        }
+
+        // Without the header the filter is inert: both workers reachable.
+        let a = reg
+            .select_worker(&policy, &workers, &SelectWorkerInfo::default())
+            .selected()
+            .unwrap();
+        let b = reg
+            .select_worker(&policy, &workers, &SelectWorkerInfo::default())
+            .selected()
+            .unwrap();
         assert_ne!(a, b);
     }
 

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -12,7 +12,9 @@ use tracing::{error, warn};
 use super::PipelineStage;
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
-    policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo, WorkerLeg},
+    policies::{
+        LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo, SelectionOutcome, WorkerLeg,
+    },
     routers::{
         error,
         grpc::{
@@ -96,34 +98,32 @@ impl PipelineStage for WorkerSelectionStage {
         let workers = match self.mode {
             WorkerSelectionMode::Regular => {
                 match self.select_single_worker(model_id, text, tokens, headers) {
-                    Some(w) => WorkerSelection::Single { worker: w },
-                    None => {
-                        error!(
-                            function = "WorkerSelectionStage::execute",
-                            mode = "Regular",
-                            model_id = %model_id,
-                            "No available workers for model"
-                        );
-                        return Err(error::model_not_found(model_id));
+                    Ok(w) => WorkerSelection::Single { worker: w },
+                    Err(miss) => {
+                        return Err(selection_miss_response(
+                            miss,
+                            model_id,
+                            "Regular",
+                            "No available workers for model",
+                        ));
                     }
                 }
             }
             WorkerSelectionMode::PrefillDecode => {
                 match self.select_pd_pair(model_id, text, tokens, headers) {
-                    Some((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
+                    Ok((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
                         encode_assignments: None,
                         prefill,
                         decode,
                         runtime_type,
                     },
-                    None => {
-                        error!(
-                            function = "WorkerSelectionStage::execute",
-                            mode = "PrefillDecode",
-                            model_id = %model_id,
-                            "No available PD worker pairs for model"
-                        );
-                        return Err(error::model_not_found(model_id));
+                    Err(miss) => {
+                        return Err(selection_miss_response(
+                            miss,
+                            model_id,
+                            "PrefillDecode",
+                            "No available PD worker pairs for model",
+                        ));
                     }
                 }
             }
@@ -149,7 +149,7 @@ impl PipelineStage for WorkerSelectionStage {
                     headers,
                     &encode_item_hashes,
                 ) {
-                    Some((encode_assignments, prefill, decode, runtime_type)) => {
+                    Ok((encode_assignments, prefill, decode, runtime_type)) => {
                         WorkerSelection::Disaggregated {
                             encode_assignments: if encode_assignments.is_empty() {
                                 None
@@ -161,14 +161,13 @@ impl PipelineStage for WorkerSelectionStage {
                             runtime_type,
                         }
                     }
-                    None => {
-                        error!(
-                            function = "WorkerSelectionStage::execute",
-                            mode = "EncodePrefillDecode",
-                            model_id = %model_id,
-                            "No available encode/prefill/decode worker set for model"
-                        );
-                        return Err(error::model_not_found(model_id));
+                    Err(miss) => {
+                        return Err(selection_miss_response(
+                            miss,
+                            model_id,
+                            "EncodePrefillDecode",
+                            "No available encode/prefill/decode worker set for model",
+                        ));
                     }
                 }
             }
@@ -221,7 +220,7 @@ impl WorkerSelectionStage {
         text: Option<&str>,
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
-    ) -> Option<Arc<dyn Worker>> {
+    ) -> Result<Arc<dyn Worker>, SelectionMiss> {
         // Treat "unknown" model as wildcard (match any worker)
         let model_filter = if model_id == UNKNOWN_MODEL_ID {
             None
@@ -246,7 +245,7 @@ impl WorkerSelectionStage {
             .collect();
 
         if available.is_empty() {
-            return None;
+            return Err(SelectionMiss::NoCandidates);
         }
 
         // Get the appropriate policy for this model
@@ -255,9 +254,9 @@ impl WorkerSelectionStage {
         // Get cached hash ring for consistent hashing (O(log n) lookup)
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
 
-        // Select worker via the registry (applies the routing-key sticky override
-        // when enabled; otherwise delegates to the configured policy).
-        let idx = self.policy_registry.select_worker(
+        // Select worker via the registry (applies the worker filter chain and
+        // the routing-key sticky override; otherwise delegates to the policy).
+        let idx = require_selected(self.policy_registry.select_worker(
             &policy,
             &available,
             &SelectWorkerInfo {
@@ -267,7 +266,7 @@ impl WorkerSelectionStage {
                 hash_ring,
                 leg: WorkerLeg::Single,
             },
-        )?;
+        ))?;
         let selected = available[idx].clone();
 
         // Record worker selection metric
@@ -278,7 +277,7 @@ impl WorkerSelectionStage {
             policy.name(),
         );
 
-        Some(selected)
+        Ok(selected)
     }
 
     fn select_pd_pair(
@@ -287,7 +286,7 @@ impl WorkerSelectionStage {
         text: Option<&str>,
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
-    ) -> Option<PdWorkerPair> {
+    ) -> Result<PdWorkerPair, SelectionMiss> {
         // Treat "unknown" model as wildcard (match any worker)
         let model_filter = if model_id == UNKNOWN_MODEL_ID {
             None
@@ -323,17 +322,20 @@ impl WorkerSelectionStage {
 
         if all_prefill.is_empty() {
             warn!("No available prefill workers");
-            return None;
+            return Err(SelectionMiss::NoCandidates);
         }
 
         if all_decode.is_empty() {
             warn!("No available decode workers");
-            return None;
+            return Err(SelectionMiss::NoCandidates);
         }
 
         // Determine the runtime type from prefill workers.
         // All workers in a PD pair must use the same runtime.
-        let first_runtime = all_prefill.first()?.metadata().spec.runtime_type;
+        let Some(first) = all_prefill.first() else {
+            return Err(SelectionMiss::NoCandidates);
+        };
+        let first_runtime = first.metadata().spec.runtime_type;
 
         // Check for mixed runtimes in both prefill and decode pools
         let prefill_mixed = all_prefill
@@ -367,7 +369,7 @@ impl WorkerSelectionStage {
 
         if available_prefill.is_empty() || available_decode.is_empty() {
             warn!("No available PD pair for runtime {:?}", target_runtime);
-            return None;
+            return Err(SelectionMiss::NoCandidates);
         }
 
         // Independent P/D policies so stateful ones (e.g. round_robin) don't share a counter.
@@ -386,13 +388,17 @@ impl WorkerSelectionStage {
             hash_ring,
             leg: WorkerLeg::Prefill,
         };
-        let prefill_idx =
-            self.policy_registry
-                .select_worker(&prefill_policy, &available_prefill, &info)?;
+        let prefill_idx = require_selected(self.policy_registry.select_worker(
+            &prefill_policy,
+            &available_prefill,
+            &info,
+        ))?;
         info.leg = WorkerLeg::Decode;
-        let decode_idx =
-            self.policy_registry
-                .select_worker(&decode_policy, &available_decode, &info)?;
+        let decode_idx = require_selected(self.policy_registry.select_worker(
+            &decode_policy,
+            &available_decode,
+            &info,
+        ))?;
 
         let model = model_id;
 
@@ -414,7 +420,7 @@ impl WorkerSelectionStage {
             decode_policy.name(),
         );
 
-        Some((
+        Ok((
             available_prefill[prefill_idx].clone(),
             available_decode[decode_idx].clone(),
             target_runtime,
@@ -434,7 +440,7 @@ impl WorkerSelectionStage {
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
         encode_item_hashes: &[Vec<u8>],
-    ) -> Option<EncodePrefillDecodeWorkerSelection> {
+    ) -> Result<EncodePrefillDecodeWorkerSelection, SelectionMiss> {
         // Treat "unknown" model as wildcard (match any worker)
         let model_filter = if model_id == UNKNOWN_MODEL_ID {
             None
@@ -475,15 +481,15 @@ impl WorkerSelectionStage {
         let needs_encode = !encode_item_hashes.is_empty();
         if needs_encode && all_encode.is_empty() {
             warn!("No available encode workers");
-            return None;
+            return Err(SelectionMiss::NoCandidates);
         }
         if all_prefill.is_empty() {
             warn!("No available prefill workers");
-            return None;
+            return Err(SelectionMiss::NoCandidates);
         }
         if all_decode.is_empty() {
             warn!("No available decode workers");
-            return None;
+            return Err(SelectionMiss::NoCandidates);
         }
 
         // Disaggregated legs must share a runtime. Pick a runtime that has at
@@ -507,7 +513,7 @@ impl WorkerSelectionStage {
             })
         else {
             warn!("No available encode/prefill/decode worker set with a shared runtime");
-            return None;
+            return Err(SelectionMiss::NoCandidates);
         };
 
         let mixed = all_prefill
@@ -547,7 +553,7 @@ impl WorkerSelectionStage {
                 "No available encode/prefill/decode worker set for runtime {:?}",
                 target_runtime
             );
-            return None;
+            return Err(SelectionMiss::NoCandidates);
         }
 
         // Select encode, prefill, and decode via their per-role policies. Encode
@@ -567,19 +573,24 @@ impl WorkerSelectionStage {
             hash_ring: hash_ring.clone(),
             leg: WorkerLeg::Prefill,
         };
-        let prefill_idx =
-            self.policy_registry
-                .select_worker(&prefill_policy, &available_prefill, &info)?;
+        let prefill_idx = require_selected(self.policy_registry.select_worker(
+            &prefill_policy,
+            &available_prefill,
+            &info,
+        ))?;
         info.leg = WorkerLeg::Decode;
-        let decode_idx =
-            self.policy_registry
-                .select_worker(&decode_policy, &available_decode, &info)?;
+        let decode_idx = require_selected(self.policy_registry.select_worker(
+            &decode_policy,
+            &available_decode,
+            &info,
+        ))?;
 
         let encode_assignments = assign_encode_workers(
             &available_encode,
             encode_item_hashes,
             model_id,
-            encode_policy.as_ref(),
+            &encode_policy,
+            &self.policy_registry,
             hash_ring.clone(),
         )?;
 
@@ -603,12 +614,68 @@ impl WorkerSelectionStage {
             decode_policy.name(),
         );
 
-        Some((
+        Ok((
             encode_assignments,
             available_prefill[prefill_idx].clone(),
             available_decode[decode_idx].clone(),
             target_runtime,
         ))
+    }
+}
+
+/// Why a selection helper yielded no workers. Keeps the historical
+/// empty-pool / policy-miss case (mapped to 404 `model_not_found`) distinct
+/// from filter exhaustion, which is unavailability
+/// ([`SelectionOutcome::AllFiltered`] → 503).
+#[derive(Debug, Clone, Copy)]
+enum SelectionMiss {
+    NoCandidates,
+    AllFiltered,
+}
+
+fn require_selected(outcome: SelectionOutcome) -> Result<usize, SelectionMiss> {
+    match outcome {
+        SelectionOutcome::Selected(idx) => Ok(idx),
+        SelectionOutcome::NotSelected => Err(SelectionMiss::NoCandidates),
+        SelectionOutcome::AllFiltered => Err(SelectionMiss::AllFiltered),
+    }
+}
+
+/// Map a selection miss to the client-facing error: the historical 404 for
+/// an empty pool / policy miss (`no_candidates_msg` preserves each mode's
+/// log line), or 503 when the worker filter chain excluded every candidate —
+/// the model exists and the pool is not overloaded, so neither 404 nor 429
+/// would be truthful.
+fn selection_miss_response(
+    miss: SelectionMiss,
+    model_id: &str,
+    mode: &str,
+    no_candidates_msg: &str,
+) -> Response {
+    match miss {
+        SelectionMiss::NoCandidates => {
+            error!(
+                function = "WorkerSelectionStage::execute",
+                mode = mode,
+                model_id = %model_id,
+                "{no_candidates_msg}"
+            );
+            error::model_not_found(model_id)
+        }
+        SelectionMiss::AllFiltered => {
+            error!(
+                function = "WorkerSelectionStage::execute",
+                mode = mode,
+                model_id = %model_id,
+                "All candidate workers were excluded by request worker filters"
+            );
+            error::service_unavailable(
+                "workers_filtered",
+                format!(
+                    "All candidate workers for model '{model_id}' were excluded by request worker filters"
+                ),
+            )
+        }
     }
 }
 
@@ -625,17 +692,23 @@ fn assign_encode_workers(
     encode_workers: &[Arc<dyn Worker>],
     item_hashes: &[Vec<u8>],
     model_id: &str,
-    policy: &dyn LoadBalancingPolicy,
+    policy: &Arc<dyn LoadBalancingPolicy>,
+    policy_registry: &PolicyRegistry,
     hash_ring: Option<Arc<HashRing>>,
-) -> Option<Vec<EncodeWorkerAssignment>> {
+) -> Result<Vec<EncodeWorkerAssignment>, SelectionMiss> {
     if item_hashes.is_empty() {
-        return Some(Vec::new());
+        return Ok(Vec::new());
     }
 
     item_hashes
         .iter()
         .enumerate()
         .map(|(item_index, content_hash)| {
+            // Per-item selection goes through the registry like every other
+            // leg so worker-side filters apply. Note the info carries the
+            // SYNTHETIC per-item routing headers (content-hash affinity), not
+            // the client's — header-driven filters are inert on this leg by
+            // construction.
             let routing_headers = encode_routing_headers(content_hash);
             let info = SelectWorkerInfo {
                 request_text: None,
@@ -644,7 +717,8 @@ fn assign_encode_workers(
                 hash_ring: hash_ring.clone(),
                 leg: WorkerLeg::Single,
             };
-            let worker_idx = policy.select_worker(encode_workers, &info)?;
+            let worker_idx =
+                require_selected(policy_registry.select_worker(policy, encode_workers, &info))?;
             let worker = encode_workers[worker_idx].clone();
             Metrics::record_worker_selection(
                 metrics_labels::WORKER_ENCODE,
@@ -652,7 +726,7 @@ fn assign_encode_workers(
                 model_id,
                 policy.name(),
             );
-            Some(EncodeWorkerAssignment { item_index, worker })
+            Ok(EncodeWorkerAssignment { item_index, worker })
         })
         .collect()
 }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -923,26 +923,31 @@ impl PDRouter {
             ));
         }
 
-        let selected_idx = self
-            .policy_registry
-            .select_worker(
-                policy,
-                &available_workers,
-                &SelectWorkerInfo {
-                    request_text,
-                    tokens: None, // HTTP doesn't have tokens, use gRPC for PrefixHash
-                    headers,
-                    hash_ring,
-                    leg,
-                },
-            )
-            .ok_or_else(|| {
-                format!(
+        let selected_idx = match self.policy_registry.select_worker(
+            policy,
+            &available_workers,
+            &SelectWorkerInfo {
+                request_text,
+                tokens: None, // HTTP doesn't have tokens, use gRPC for PrefixHash
+                headers,
+                hash_ring,
+                leg,
+            },
+        ) {
+            crate::policies::SelectionOutcome::Selected(idx) => idx,
+            crate::policies::SelectionOutcome::NotSelected => {
+                return Err(format!(
                     "Policy {} failed to select a {} worker",
                     policy.name(),
                     worker_type
-                )
-            })?;
+                ));
+            }
+            crate::policies::SelectionOutcome::AllFiltered => {
+                return Err(format!(
+                    "All candidate {worker_type} workers were excluded by request worker filters"
+                ));
+            }
+        };
 
         Ok(available_workers[selected_idx].clone())
     }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -66,6 +66,27 @@ struct PDRequestContext<'a> {
     headers: Option<HeaderMap>,
 }
 
+/// PD worker-selection failure. Typed (not a bare `String`) so worker-filter
+/// exhaustion keeps its distinct client-facing error code (`workers_filtered`)
+/// through the selection helpers, consistent with the gRPC and HTTP-regular
+/// paths; ordinary unavailability keeps the historical
+/// `server_selection_failed` wrapping. Both are 503s.
+#[derive(Debug)]
+enum PdSelectionError {
+    Unavailable(String),
+    AllFiltered(String),
+}
+
+impl std::fmt::Display for PdSelectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PdSelectionError::Unavailable(msg) | PdSelectionError::AllFiltered(msg) => {
+                f.write_str(msg)
+            }
+        }
+    }
+}
+
 impl PDRouter {
     async fn proxy_to_first_prefill_worker(
         &self,
@@ -172,12 +193,19 @@ impl PDRouter {
         })
     }
 
-    fn handle_server_selection_error(error: String) -> Response {
+    fn handle_server_selection_error(error: PdSelectionError) -> Response {
         error!("Failed to select PD pair error={}", error);
-        error::service_unavailable(
-            "server_selection_failed",
-            format!("No available servers: {error}"),
-        )
+        match error {
+            PdSelectionError::Unavailable(msg) => error::service_unavailable(
+                "server_selection_failed",
+                format!("No available servers: {msg}"),
+            ),
+            // Filter exhaustion keeps its distinct code, matching the gRPC
+            // and HTTP-regular paths: unavailability, not a selection bug.
+            PdSelectionError::AllFiltered(msg) => {
+                error::service_unavailable("workers_filtered", msg)
+            }
+        }
     }
 
     fn handle_serialization_error(error: impl std::fmt::Display) -> Response {
@@ -810,7 +838,7 @@ impl PDRouter {
         request_text: Option<&str>,
         model_id: &str,
         headers: Option<&HeaderMap>,
-    ) -> Result<(Arc<dyn Worker>, Arc<dyn Worker>), String> {
+    ) -> Result<(Arc<dyn Worker>, Arc<dyn Worker>), PdSelectionError> {
         debug!("Selecting PD pair: model_id={:?}", model_id);
 
         let is_unknown_model = model_id == UNKNOWN_MODEL_ID;
@@ -904,11 +932,11 @@ impl PDRouter {
         hash_ring: Option<Arc<HashRing>>,
         worker_type: &str,
         leg: crate::policies::WorkerLeg,
-    ) -> Result<Arc<dyn Worker>, String> {
+    ) -> Result<Arc<dyn Worker>, PdSelectionError> {
         if workers.is_empty() {
-            return Err(format!(
+            return Err(PdSelectionError::Unavailable(format!(
                 "No {worker_type} workers available. Please check if {worker_type} servers are configured and healthy."
-            ));
+            )));
         }
 
         let available_workers: Vec<Arc<dyn Worker>> = workers
@@ -918,9 +946,9 @@ impl PDRouter {
             .collect();
 
         if available_workers.is_empty() {
-            return Err(format!(
+            return Err(PdSelectionError::Unavailable(format!(
                 "No available {worker_type} workers (all circuits open or unhealthy)"
-            ));
+            )));
         }
 
         let selected_idx = match self.policy_registry.select_worker(
@@ -936,16 +964,16 @@ impl PDRouter {
         ) {
             crate::policies::SelectionOutcome::Selected(idx) => idx,
             crate::policies::SelectionOutcome::NotSelected => {
-                return Err(format!(
+                return Err(PdSelectionError::Unavailable(format!(
                     "Policy {} failed to select a {} worker",
                     policy.name(),
                     worker_type
-                ));
+                )));
             }
             crate::policies::SelectionOutcome::AllFiltered => {
-                return Err(format!(
+                return Err(PdSelectionError::AllFiltered(format!(
                     "All candidate {worker_type} workers were excluded by request worker filters"
-                ));
+                )));
             }
         };
 
@@ -1747,7 +1775,10 @@ mod tests {
         let result = router.select_pd_pair(None, UNKNOWN_MODEL_ID, None).await;
 
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("No prefill workers available"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No prefill workers available"));
     }
 
     #[test]

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -41,7 +41,7 @@ use crate::{
         metrics::{bool_to_static_str, metrics_labels, Metrics},
         otel_trace::inject_trace_context_http,
     },
-    policies::{PolicyRegistry, SelectWorkerInfo},
+    policies::{PolicyRegistry, SelectWorkerInfo, SelectionOutcome},
     routers::{
         common::{
             header_utils,
@@ -121,6 +121,14 @@ impl std::fmt::Debug for Router {
     }
 }
 
+/// Why [`Router::select_worker_for_model`] yielded no worker: the historical
+/// unavailable case (empty pool or policy declined — caller re-queries to
+/// choose 404 vs 503) vs. worker-filter exhaustion (503 `workers_filtered`).
+enum SelectMiss {
+    Unavailable,
+    AllFiltered,
+}
+
 impl Router {
     /// Create a new router with injected policy and client
     #[expect(
@@ -193,12 +201,17 @@ impl Router {
     /// Select worker considering circuit breaker state.
     /// Filters to workers serving the specified model. When model is "unknown"
     /// (generate endpoint without model), considers all HTTP workers.
+    ///
+    /// `Err(SelectMiss::Unavailable)` preserves the historical no-worker
+    /// handling (caller re-queries to pick 404 vs 503);
+    /// `Err(SelectMiss::AllFiltered)` is the worker-filter exhaustion case
+    /// (503 `workers_filtered`).
     fn select_worker_for_model(
         &self,
         model_id: &str,
         text: Option<&str>,
         headers: Option<&HeaderMap>,
-    ) -> Option<Arc<dyn Worker>> {
+    ) -> Result<Arc<dyn Worker>, SelectMiss> {
         // UNKNOWN_MODEL_ID means caller didn't specify a model — find any available worker
         let model_filter = if model_id == crate::worker::UNKNOWN_MODEL_ID {
             None
@@ -219,7 +232,7 @@ impl Router {
             .cloned()
             .collect();
         if available.is_empty() {
-            return None;
+            return Err(SelectMiss::Unavailable);
         }
 
         // Get the appropriate policy for this model
@@ -228,7 +241,7 @@ impl Router {
         // Get cached hash ring for consistent hashing (O(log n) lookup)
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
 
-        let idx = self.policy_registry.select_worker(
+        let idx = match self.policy_registry.select_worker(
             &policy,
             &available,
             &SelectWorkerInfo {
@@ -238,7 +251,11 @@ impl Router {
                 hash_ring,
                 leg: crate::policies::WorkerLeg::Single,
             },
-        )?;
+        ) {
+            SelectionOutcome::Selected(idx) => idx,
+            SelectionOutcome::NotSelected => return Err(SelectMiss::Unavailable),
+            SelectionOutcome::AllFiltered => return Err(SelectMiss::AllFiltered),
+        };
 
         // Record worker selection metric (Layer 3)
         Metrics::record_worker_selection(
@@ -248,7 +265,7 @@ impl Router {
             policy.name(),
         );
 
-        Some(available[idx].clone())
+        Ok(available[idx].clone())
     }
 
     /// Select a local, realtime-capable worker for the given model.
@@ -428,8 +445,18 @@ impl Router {
         text: &str,
     ) -> Response {
         let worker = match self.select_worker_for_model(model_id, Some(text), headers) {
-            Some(w) => w,
-            None => {
+            Ok(w) => w,
+            Err(SelectMiss::AllFiltered) => {
+                // Candidates existed but the request's worker filters excluded
+                // them all: unavailability, not model-absence.
+                return error::service_unavailable(
+                    "workers_filtered",
+                    format!(
+                        "All candidate workers for model '{model_id}' were excluded by request worker filters"
+                    ),
+                );
+            }
+            Err(SelectMiss::Unavailable) => {
                 // Distinguish "no workers for this model" from "workers exist but unavailable"
                 let model_filter = if model_id == crate::worker::UNKNOWN_MODEL_ID {
                     None
@@ -731,11 +758,19 @@ impl Router {
                 leg: crate::policies::WorkerLeg::Single,
             },
         ) {
-            Some(i) => i,
-            None => {
+            SelectionOutcome::Selected(i) => i,
+            SelectionOutcome::NotSelected => {
                 let resp = error::service_unavailable(
                     "no_available_workers",
                     "Policy returned no eligible worker",
+                );
+                record_pre_send_error(&resp);
+                return resp;
+            }
+            SelectionOutcome::AllFiltered => {
+                let resp = error::service_unavailable(
+                    "workers_filtered",
+                    "All candidate workers were excluded by request worker filters",
                 );
                 record_pre_send_error(&resp);
                 return resp;


### PR DESCRIPTION
## Description

### Problem
The only universal candidate narrowing before policy scoring is health + circuit breaker. Real narrowing concerns — tenant pinning, canary cohorts, hardware classes, adapter residency — have no seam: each would end up hacked into individual policies' `select_worker`. And when narrowing exhausts the pool, there is no honest status to return: today's paths would report 404 ("model not found" — a lie) or generic unavailability.

### Solution
A **worker-filter chain on the `PolicyRegistry`**, applied between eligibility and the policy (and the routing-key sticky override) on every policy-based selection path — gRPC regular/PD/EPD, HTTP regular, HTTP PD — including the EPD per-item encode assignment, which previously called the policy directly and bypassed the registry. Design points:

- **Filters are hard requirements.** A worker that fails one may not serve the request; preferences (ordering, weighting) stay in policies. Policies are untouched — they already only ever narrow the slice they're handed.
- **Index mapping.** The registry hands the policy the narrowed slice and maps the returned index back to the caller's slice. (Documented interplay: with a chain active, the index-pinning `X-SMG-Target-Worker` header addresses the post-filter slice.)
- **Three-way outcome.** `SelectionOutcome::{Selected, NotSelected, AllFiltered}` replaces `Option<usize>`. `AllFiltered` (candidates existed, filters removed all) maps to **503 `workers_filtered`** at every call site — it is unavailability, not backpressure (429 would misreport it, and retrying elsewhere just bounces) and not model absence (404 would lie). `NotSelected` preserves each path's existing empty-pool/policy-miss behavior exactly.
- **Zero-cost when off.** An empty chain short-circuits; nothing is cloned.

**Shipped concrete filter — label matching by request header.** A new `RouterConfig` option (`--worker-filter-header`, unset = off, validated as a header name at startup) names a header whose value is comma-separated `key=value` pairs; only workers whose spec labels contain ALL pairs survive. Requests without the header pass everything through; malformed pairs are ignored. Worker labels already flow end to end (k8s discovery, `/workers` PATCH), so tenant pinning / canary cohorts / hardware classes work with zero new worker-side surface.

Out of scope (stated deliberately): the external-proxy routers (OpenAI/Anthropic/Gemini/realtime) use a separate policy-free least-loaded selector and are untouched.

## Changes
- `model_gateway/src/policies/filter.rs` (new): `WorkerFilter` trait, `LabelHeaderFilter`, `worker_filters_from_config`.
- `model_gateway/src/policies/registry.rs`: `SelectionOutcome`, filter chain + `set_worker_filters`, `select_worker` filtering/mapping (sticky override factored into `select_with_override`).
- Call sites: gRPC `worker_selection.rs` (three modes + encode assignment routed through the registry; `SelectionMiss` → 404 vs 503 mapping), HTTP `router.rs` (both selection sites), HTTP `pd_router.rs`.
- Config: `worker_filter_header` field + validation (header-name check) + builder + CLI + wiring in `app_context`.

## Test Plan
- Filter unit tests: missing header keeps all; all-pairs semantics (partial/wrong-value/unlabeled workers drop); malformed pairs ignored; empty-value matching.
- Registry tests: narrowing + index mapping back to the caller's slice; `AllFiltered` vs `NotSelected` distinguished (empty pool still `NotSelected` with filters installed); empty chain is a passthrough (round-robin still alternates); label filter end-to-end through the registry incl. inert-without-header.
- Config tests: header-name validation (invalid/empty rejected, valid/None accepted).
- `cargo test -p smg --lib` 1485 passed; `--test routing_tests` 102 passed; `cargo clippy -p smg --all-targets` clean.

<details>
<summary>Checklist</summary>

- [x] Format your code: `make fmt`
- [x] Run lint checks: `cargo clippy -p smg --all-targets -- -D warnings`
- [x] Add unit tests for new functionality
- [x] Update documentation if needed (CLI help text carries the flag docs)

</details>