### PR TITLE
fix(grpc): deliver tool calls when a JSON-schema tool constraint meets a thinking model

### DIFF
--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -1157,13 +1157,13 @@ mod tests {
         // Qwen3-style: the generation prompt injects a CLOSED empty think
         // block only when thinking is disabled — completions never start
         // mid-reasoning, so this must not count as think-in-prefill.
-        let qwen3_style = r#"
+        let qwen3_style = r"
 {%- if add_generation_prompt %}
     {{- '<|im_start|>assistant\n' }}
     {%- if enable_thinking is defined and enable_thinking is false %}
         {{- '<think>\n\n</think>\n\n' }}
     {%- endif %}
-{%- endif %}"#;
+{%- endif %}";
         let (_, think_in_prefill) = detect_all_with_ast(qwen3_style);
         assert!(
             !think_in_prefill,
@@ -1172,10 +1172,10 @@ mod tests {
 
         // Thinking-only style: the generation prompt ends with an OPEN
         // <think>, so completions genuinely start mid-reasoning.
-        let thinking_style = r#"
+        let thinking_style = r"
 {%- if add_generation_prompt %}
     {{- '<|im_start|>assistant\n<think>\n' }}
-{%- endif %}"#;
+{%- endif %}";
         let (_, think_in_prefill) = detect_all_with_ast(thinking_style);
         assert!(
             think_in_prefill,

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -246,13 +246,21 @@ impl<'a> Detector<'a> {
     }
 
     /// Check if a list of statements contains `<think>` in EmitRaw or string constants.
+    /// `<think>` not closed by a later `</think>` in the same literal — an
+    /// open tag leaves the completion mid-reasoning, a closed pair (e.g.
+    /// Qwen3's thinking-off `<think>\n\n</think>` filler) does not.
+    fn str_has_open_think_tag(s: &str) -> bool {
+        s.rfind("<think>")
+            .is_some_and(|idx| !s[idx..].contains("</think>"))
+    }
+
     fn body_has_think_tag(stmts: &[Stmt]) -> bool {
         for stmt in stmts {
             match stmt {
-                Stmt::EmitRaw(raw) if raw.raw.contains("<think>") => return true,
+                Stmt::EmitRaw(raw) if Self::str_has_open_think_tag(raw.raw) => return true,
                 Stmt::EmitExpr(e) => {
                     if let Expr::Const(c) = &e.expr {
-                        if c.value.as_str().is_some_and(|s| s.contains("<think>")) {
+                        if c.value.as_str().is_some_and(Self::str_has_open_think_tag) {
                             return true;
                         }
                     }
@@ -1143,6 +1151,37 @@ impl ChatTemplateState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn think_in_prefill_requires_open_think_tag() {
+        // Qwen3-style: the generation prompt injects a CLOSED empty think
+        // block only when thinking is disabled — completions never start
+        // mid-reasoning, so this must not count as think-in-prefill.
+        let qwen3_style = r#"
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- endif %}
+{%- endif %}"#;
+        let (_, think_in_prefill) = detect_all_with_ast(qwen3_style);
+        assert!(
+            !think_in_prefill,
+            "closed <think></think> pair is not a prefill think"
+        );
+
+        // Thinking-only style: the generation prompt ends with an OPEN
+        // <think>, so completions genuinely start mid-reasoning.
+        let thinking_style = r#"
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n<think>\n' }}
+{%- endif %}"#;
+        let (_, think_in_prefill) = detect_all_with_ast(thinking_style);
+        assert!(
+            think_in_prefill,
+            "open <think> in the prefill must be detected"
+        );
+    }
 
     #[test]
     fn test_chat_template_state_no_template() {

--- a/e2e_test/chat_completions/test_function_calling.py
+++ b/e2e_test/chat_completions/test_function_calling.py
@@ -1591,7 +1591,9 @@ THINKING_WEATHER_TOOLS = [
 ]
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
+# TokenSpeed excluded: its cold-start kernel compilation for Qwen3-30B-A3B
+# exceeds the worker launch timeout on the 1-GPU CI rig.
+@pytest.mark.engine("sglang", "vllm", "trtllm")
 @pytest.mark.gpu(1)
 @pytest.mark.model("Qwen/Qwen3-30B-A3B")
 @pytest.mark.gateway(

--- a/e2e_test/chat_completions/test_function_calling.py
+++ b/e2e_test/chat_completions/test_function_calling.py
@@ -1566,6 +1566,132 @@ class TestToolChoiceMistral(_TestToolChoiceBase):
 
 
 # =============================================================================
+# Tool Choice Required + Thinking Tests (reasoning parser interaction)
+# Regression for: with a JSON-schema tool constraint (tool_choice "required" /
+# named function) and thinking effectively ON, the pre-armed reasoning parser
+# classified the grammar-forced JSON payload as reasoning_content, returning
+# no tool_calls and finish_reason "stop".
+# =============================================================================
+
+THINKING_WEATHER_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "Name of the city"},
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
+@pytest.mark.gpu(1)
+@pytest.mark.model("Qwen/Qwen3-30B-A3B")
+@pytest.mark.gateway(
+    extra_args=[
+        "--tool-call-parser",
+        "qwen",
+        "--reasoning-parser",
+        "qwen3",
+        "--history-backend",
+        "memory",
+    ]
+)
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestToolChoiceRequiredThinking:
+    """tool_choice "required" on a thinking model (enable_thinking defaults ON)."""
+
+    def _assert_weather_tool_call(self, tool_calls) -> None:
+        assert tool_calls, "tool_choice='required' must produce tool_calls"
+        call = tool_calls[0]
+        assert call.function.name == "get_weather"
+        args = json.loads(call.function.arguments)
+        assert isinstance(args.get("city"), str), f"expected string 'city' arg, got: {args}"
+
+    def test_required_non_streaming(self, model, api_client):
+        response = api_client.chat.completions.create(
+            model=model,
+            max_tokens=512,
+            messages=[{"role": "user", "content": "What is the weather in Paris right now?"}],
+            stream=False,
+            tools=THINKING_WEATHER_TOOLS,
+            tool_choice="required",
+        )
+
+        choice = response.choices[0]
+        self._assert_weather_tool_call(choice.message.tool_calls)
+        assert choice.finish_reason == "tool_calls", (
+            f"expected finish_reason 'tool_calls', got: {choice.finish_reason}"
+        )
+        # The grammar-forced payload must not be misclassified as reasoning.
+        reasoning = getattr(choice.message, "reasoning_content", None)
+        if reasoning:
+            try:
+                parsed = json.loads(reasoning)
+            except ValueError:
+                parsed = None
+            assert not isinstance(parsed, list), (
+                f"tool payload leaked into reasoning_content: {reasoning}"
+            )
+
+    def test_required_streaming(self, model, api_client):
+        stream = api_client.chat.completions.create(
+            model=model,
+            max_tokens=512,
+            messages=[{"role": "user", "content": "What is the weather in Paris right now?"}],
+            stream=True,
+            tools=THINKING_WEATHER_TOOLS,
+            tool_choice="required",
+        )
+
+        finish_reason = None
+        tool_name = None
+        arguments = ""
+        reasoning_parts: list[str] = []
+        for chunk in stream:
+            if not chunk.choices:
+                continue
+            choice = chunk.choices[0]
+            if choice.finish_reason:
+                finish_reason = choice.finish_reason
+            delta = choice.delta
+            if delta is None:
+                continue
+            for tool_call in delta.tool_calls or []:
+                if tool_call.function and tool_call.function.name:
+                    tool_name = tool_call.function.name
+                if tool_call.function and tool_call.function.arguments:
+                    arguments += tool_call.function.arguments
+            reasoning = getattr(delta, "reasoning_content", None)
+            if reasoning:
+                reasoning_parts.append(reasoning)
+
+        assert tool_name == "get_weather", f"expected streamed tool call, got: {tool_name}"
+        args = json.loads(arguments)
+        assert isinstance(args.get("city"), str), f"expected string 'city' arg, got: {args}"
+        assert finish_reason == "tool_calls", (
+            f"expected finish_reason 'tool_calls', got: {finish_reason}"
+        )
+        # The grammar-forced payload must not stream out as reasoning deltas.
+        reasoning_text = "".join(reasoning_parts)
+        if reasoning_text:
+            try:
+                parsed = json.loads(reasoning_text)
+            except ValueError:
+                parsed = None
+            assert not isinstance(parsed, list), (
+                f"tool payload leaked into reasoning deltas: {reasoning_text}"
+            )
+
+
+# =============================================================================
 # Multi-Turn Tool Call Tests
 # Regression for: assistant messages with tool_calls serialized without
 # `content` key due to skip_serializing_none, causing chat template crash.

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -103,6 +103,29 @@ impl ResponseProcessor {
             final_text.push_str(&t);
         }
 
+        // Check if a JSON schema constraint was used (specific function or
+        // required mode): it changes both reasoning arming and tool parsing.
+        let tool_choice_enabled = !matches!(
+            &original_request.tool_choice,
+            Some(ToolChoice::Value(ToolChoiceValue::None))
+        );
+        let has_structural_tag = self
+            .tool_parser_factory
+            .registry()
+            .has_structural_tag_for_parser(tool_parser_name);
+        let used_json_schema = if has_structural_tag {
+            false
+        } else {
+            match &original_request.tool_choice {
+                Some(ToolChoice::Function { .. }) => true,
+                Some(ToolChoice::Value(ToolChoiceValue::Required)) => true,
+                Some(ToolChoice::AllowedTools { mode, .. }) => mode == "required",
+                _ => false,
+            }
+        };
+        let tool_constraint_active =
+            tool_choice_enabled && original_request.tools.is_some() && used_json_schema;
+
         // Step 1: Handle reasoning content parsing
         let mut reasoning_text: Option<String> = None;
         let mut processed_text = final_text;
@@ -115,25 +138,25 @@ impl ResponseProcessor {
                 reasoning_parser_name,
                 &original_request.model,
             ) {
-                // If the template injected `<think>` in the prefill (thinking toggle
-                // is supported and effectively ON), start in reasoning mode.
-                if utils::should_mark_reasoning_started(
+                if utils::should_start_in_reasoning(
                     utils::resolve_user_thinking(
                         original_request.chat_template_kwargs.as_ref(),
                         original_request.reasoning_effort.as_deref(),
                         tokenizer.as_ref(),
                     ),
                     tokenizer.as_ref(),
+                    tool_constraint_active,
                 ) {
                     parser.mark_reasoning_started();
                 }
 
                 match parser.detect_and_parse_reasoning(&processed_text) {
                     Ok(result) => {
-                        if !result.reasoning_text.is_empty() {
-                            reasoning_text = Some(result.reasoning_text);
-                        }
-                        processed_text = result.normal_text;
+                        (reasoning_text, processed_text) = utils::split_reasoning_result(
+                            result,
+                            processed_text,
+                            tool_constraint_active,
+                        );
                     }
                     Err(e) => {
                         warn!("Reasoning parsing error, skipping parsing: {e}");
@@ -144,28 +167,8 @@ impl ResponseProcessor {
 
         // Step 2: Handle tool call parsing
         let mut tool_calls: Option<Vec<ToolCall>> = None;
-        let tool_choice_enabled = !matches!(
-            &original_request.tool_choice,
-            Some(ToolChoice::Value(ToolChoiceValue::None))
-        );
 
         if tool_choice_enabled && original_request.tools.is_some() {
-            // Check if JSON schema constraint was used (specific function or required mode)
-            let has_structural_tag = self
-                .tool_parser_factory
-                .registry()
-                .has_structural_tag_for_parser(tool_parser_name);
-            let used_json_schema = if has_structural_tag {
-                false
-            } else {
-                match &original_request.tool_choice {
-                    Some(ToolChoice::Function { .. }) => true,
-                    Some(ToolChoice::Value(ToolChoiceValue::Required)) => true,
-                    Some(ToolChoice::AllowedTools { mode, .. }) => mode == "required",
-                    _ => false,
-                }
-            };
-
             if used_json_schema {
                 (tool_calls, processed_text) = utils::parse_json_schema_response(
                     &processed_text,
@@ -579,6 +582,20 @@ impl ResponseProcessor {
                 &messages_request.model,
             );
 
+        // Check if a JSON schema constraint was used (specific tool or any/required
+        // mode): it changes both reasoning arming and tool parsing.
+        let has_structural_tag = self
+            .tool_parser_factory
+            .registry()
+            .has_structural_tag_for_parser(tool_parser_name.as_deref());
+        let used_json_schema = !has_structural_tag
+            && matches!(
+                &messages_request.tool_choice,
+                Some(messages::ToolChoice::Tool { .. } | messages::ToolChoice::Any { .. })
+            );
+        let tool_constraint_active =
+            tool_choice_enabled && messages_request.tools.is_some() && used_json_schema;
+
         if separate_reasoning && !reasoning_parser_available {
             tracing::debug!(
                 "No reasoning parser found for model '{}', reasoning content will not be separated",
@@ -648,17 +665,22 @@ impl ResponseProcessor {
                         Some(messages::ThinkingConfig::Disabled) => Some(false),
                         None => None,
                     };
-                    if utils::should_mark_reasoning_started(user_thinking, tokenizer.as_ref()) {
+                    if utils::should_start_in_reasoning(
+                        user_thinking,
+                        tokenizer.as_ref(),
+                        tool_constraint_active,
+                    ) {
                         parser.mark_reasoning_started();
                     }
                 }
 
                 match parser.detect_and_parse_reasoning(&processed_text) {
                     Ok(result) => {
-                        if !result.reasoning_text.is_empty() {
-                            reasoning_text = Some(result.reasoning_text);
-                        }
-                        processed_text = result.normal_text;
+                        (reasoning_text, processed_text) = utils::split_reasoning_result(
+                            result,
+                            processed_text,
+                            tool_constraint_active,
+                        );
                     }
                     Err(e) => {
                         warn!("Reasoning parsing error, skipping parsing: {e}");
@@ -671,17 +693,6 @@ impl ResponseProcessor {
         let mut tool_calls: Option<Vec<ToolCall>> = None;
 
         if tool_choice_enabled && messages_request.tools.is_some() {
-            // Check if JSON schema constraint was used (specific tool or any/required mode)
-            let has_structural_tag = self
-                .tool_parser_factory
-                .registry()
-                .has_structural_tag_for_parser(tool_parser_name.as_deref());
-            let used_json_schema = !has_structural_tag
-                && matches!(
-                    &messages_request.tool_choice,
-                    Some(messages::ToolChoice::Tool { .. } | messages::ToolChoice::Any { .. })
-                );
-
             if used_json_schema {
                 // Bridge Messages ToolChoice to Chat ToolChoice for reuse
                 let chat_tool_choice = messages_request

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -328,17 +328,6 @@ impl StreamingProcessor {
                 model,
             );
 
-        // If the template supports a thinking toggle and the user enabled it,
-        // the template injected `<think>` in the prefill — parsers should start
-        // in reasoning mode.
-        let thinking_override = utils::should_mark_reasoning_started(
-            utils::resolve_user_thinking(
-                original_request.chat_template_kwargs.as_ref(),
-                original_request.reasoning_effort.as_deref(),
-                tokenizer.as_ref(),
-            ),
-            tokenizer.as_ref(),
-        );
         let think_in_prefill = tokenizer.think_in_prefill();
 
         // Check if JSON schema constraint was used (specific function or required mode)
@@ -356,6 +345,19 @@ impl StreamingProcessor {
                 _ => false,
             }
         };
+        let tool_constraint_active = used_json_schema && tools.is_some();
+
+        // Thinking effectively ON: parsers start in reasoning mode — unless a
+        // JSON-schema tool constraint is active (see should_start_in_reasoning).
+        let thinking_override = utils::should_start_in_reasoning(
+            utils::resolve_user_thinking(
+                original_request.chat_template_kwargs.as_ref(),
+                original_request.reasoning_effort.as_deref(),
+                tokenizer.as_ref(),
+            ),
+            tokenizer.as_ref(),
+            tool_constraint_active,
+        );
 
         // Check if this is the specific function case (LLM generates parameters only, no name field).
         // Only applies when json_schema is used — structural tags include framing tokens
@@ -665,6 +667,59 @@ impl StreamingProcessor {
                         .await
                         .map_err(|_| "Failed to send unstreamed tool args".to_string())?;
                 }
+            }
+        }
+
+        // Phase 3.5: JSON-schema constraint recovery. An engine that enforces
+        // the tool grammar from the first token emits pure JSON; a pre-armed
+        // (think-in-prefill) parser then classifies the whole payload as
+        // reasoning and the tool stage never runs. The buffered raw text is
+        // the tool payload — parse it so tool calls are still delivered.
+        if tool_constraint_active {
+            for (index, buffer) in &stream_buffers {
+                if buffer.is_empty() || has_tool_calls.get(index).copied().unwrap_or(false) {
+                    continue;
+                }
+                let still_in_reasoning = match reasoning_parsers.get(index) {
+                    Some(parser) => parser.lock().await.is_in_reasoning(),
+                    None => false,
+                };
+                if !still_in_reasoning {
+                    continue;
+                }
+                let (calls, _) = utils::parse_json_schema_response(
+                    buffer,
+                    tool_choice.as_ref(),
+                    model,
+                    history_tool_calls_count,
+                );
+                let Some(calls) = calls else { continue };
+                if calls.is_empty() {
+                    continue;
+                }
+                for (call_index, call) in calls.into_iter().enumerate() {
+                    let tool_call_delta = ToolCallDelta {
+                        index: call_index as u32,
+                        id: Some(call.id),
+                        tool_type: Some("function".to_string()),
+                        function: Some(FunctionCallDelta {
+                            name: Some(call.function.name),
+                            arguments: call.function.arguments,
+                        }),
+                    };
+                    let tool_chunk = ChatCompletionStreamResponse::builder(request_id, model)
+                        .created(created)
+                        .add_choice_tool_call_delta(*index, tool_call_delta)
+                        .maybe_system_fingerprint(system_fingerprint)
+                        .build();
+                    let sse_chunk = sse_encoder
+                        .encode_data(&tool_chunk)
+                        .map_err(|e| format!("Failed to serialize recovered tool chunk: {e}"))?;
+                    tx.send(Ok(sse_chunk))
+                        .await
+                        .map_err(|_| "Failed to send recovered tool chunk".to_string())?;
+                }
+                has_tool_calls.insert(*index, true);
             }
         }
 
@@ -1878,6 +1933,10 @@ impl StreamingProcessor {
         // Parser state (simple variables — Messages is always n=1)
         let mut reasoning_parser: Option<Arc<tokio::sync::Mutex<Box<dyn ReasoningParser>>>> = None;
 
+        // Raw text accumulated under a JSON-schema tool constraint, for
+        // end-of-stream recovery when a pre-armed parser ate the payload.
+        let mut constrained_raw_text = String::new();
+
         // Stop decoder
         let mut stop_decoder = {
             let (ref stop, ref stop_token_ids, skip_special_tokens, no_stop_trim, ignore_eos) =
@@ -1932,19 +1991,6 @@ impl StreamingProcessor {
                 model,
             );
 
-        // Determine if thinking is effectively ON (for mark_reasoning_started).
-        let user_thinking = match &original_request.thinking {
-            Some(
-                messages::ThinkingConfig::Enabled { .. }
-                | messages::ThinkingConfig::Adaptive { .. },
-            ) => Some(true),
-            Some(messages::ThinkingConfig::Disabled) => Some(false),
-            None => None,
-        };
-        let thinking_override =
-            utils::should_mark_reasoning_started(user_thinking, tokenizer.as_ref());
-        let think_in_prefill = tokenizer.think_in_prefill();
-
         let tool_choice_enabled = !matches!(
             &original_request.tool_choice,
             Some(messages::ToolChoice::None)
@@ -1967,6 +2013,25 @@ impl StreamingProcessor {
                 &original_request.tool_choice,
                 Some(messages::ToolChoice::Tool { .. } | messages::ToolChoice::Any { .. })
             );
+        let tool_constraint_active = has_tools && used_json_schema;
+
+        // Determine if thinking is effectively ON (for mark_reasoning_started).
+        // Under a JSON-schema tool constraint the parser must not be pre-armed
+        // (see should_start_in_reasoning).
+        let user_thinking = match &original_request.thinking {
+            Some(
+                messages::ThinkingConfig::Enabled { .. }
+                | messages::ThinkingConfig::Adaptive { .. },
+            ) => Some(true),
+            Some(messages::ThinkingConfig::Disabled) => Some(false),
+            None => None,
+        };
+        let thinking_override = utils::should_start_in_reasoning(
+            user_thinking,
+            tokenizer.as_ref(),
+            tool_constraint_active,
+        );
+        let think_in_prefill = tokenizer.think_in_prefill();
 
         // Check if model output is arguments-only for a specific function (ToolChoice::Tool).
         // Only applies when json_schema is used — structural tags include framing tokens.
@@ -2062,6 +2127,10 @@ impl StreamingProcessor {
 
                     if chunk_text.is_empty() {
                         continue;
+                    }
+
+                    if tool_constraint_active {
+                        constrained_raw_text.push_str(&chunk_text);
                     }
 
                     // Apply reasoning parser
@@ -2365,6 +2434,95 @@ impl StreamingProcessor {
                     }
                 }
                 ProtoResponseVariant::None => continue,
+            }
+        }
+
+        // JSON-schema constraint recovery: a pre-armed (think-in-prefill)
+        // parser that never saw a think-end token streamed the grammar-forced
+        // payload as thinking. Parse the raw text so tool_use is still delivered.
+        if tool_constraint_active && !has_tool_calls && !constrained_raw_text.is_empty() {
+            let still_in_reasoning = match &reasoning_parser {
+                Some(parser) => parser.lock().await.is_in_reasoning(),
+                None => false,
+            };
+            if still_in_reasoning {
+                let chat_tool_choice = original_request
+                    .tool_choice
+                    .as_ref()
+                    .map(message_utils::convert_message_tool_choice);
+                let (calls, _) = utils::parse_json_schema_response(
+                    &constrained_raw_text,
+                    chat_tool_choice.as_ref(),
+                    model,
+                    history_tool_calls_count,
+                );
+                if let Some(calls) = calls.filter(|calls| !calls.is_empty()) {
+                    // Close any open block before emitting tool_use blocks.
+                    if thinking_block_open {
+                        Self::send_messages_event(
+                            tx,
+                            &mut sse_buffer,
+                            &MessageStreamEvent::ContentBlockStop {
+                                index: current_block_index,
+                            },
+                        )
+                        .await?;
+                        thinking_block_open = false;
+                        current_block_index += 1;
+                    }
+                    if text_block_open {
+                        Self::send_messages_event(
+                            tx,
+                            &mut sse_buffer,
+                            &MessageStreamEvent::ContentBlockStop {
+                                index: current_block_index,
+                            },
+                        )
+                        .await?;
+                        text_block_open = false;
+                        current_block_index += 1;
+                    }
+                    for call in calls {
+                        has_tool_calls = true;
+                        Self::send_messages_event(
+                            tx,
+                            &mut sse_buffer,
+                            &MessageStreamEvent::ContentBlockStart {
+                                index: current_block_index,
+                                content_block: ContentBlock::ToolUse {
+                                    id: message_utils::anthropic_tool_use_id(&call.id),
+                                    name: call.function.name.clone(),
+                                    input: Value::Object(serde_json::Map::new()),
+                                },
+                            },
+                        )
+                        .await?;
+                        if let Some(args) = call.function.arguments {
+                            if !args.is_empty() {
+                                Self::send_messages_event(
+                                    tx,
+                                    &mut sse_buffer,
+                                    &MessageStreamEvent::ContentBlockDelta {
+                                        index: current_block_index,
+                                        delta: ContentBlockDelta::InputJsonDelta {
+                                            partial_json: args,
+                                        },
+                                    },
+                                )
+                                .await?;
+                            }
+                        }
+                        Self::send_messages_event(
+                            tx,
+                            &mut sse_buffer,
+                            &MessageStreamEvent::ContentBlockStop {
+                                index: current_block_index,
+                            },
+                        )
+                        .await?;
+                        current_block_index += 1;
+                    }
+                }
             }
         }
 

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -22,7 +22,8 @@ pub(crate) use logprobs::{
 pub(crate) use metrics::{error_type_from_status, route_to_endpoint};
 pub(crate) use parsers::{
     check_reasoning_parser_availability, check_tool_parser_availability, create_reasoning_parser,
-    create_tool_parser, get_tool_parser, reasoning_parser_requires_special_tokens, ParserResolver,
+    create_tool_parser, get_tool_parser, reasoning_parser_requires_special_tokens,
+    should_start_in_reasoning, split_reasoning_result, ParserResolver,
 };
 // `pub` (not `pub(crate)`) so the Go bindings can reuse the gateway's reasoning
 // detection instead of duplicating it.

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -125,6 +125,42 @@ pub fn should_mark_reasoning_started(
     }
 }
 
+/// Whether the reasoning parser should start pre-armed (in reasoning mode).
+///
+/// Under a JSON-schema tool constraint (`tool_choice: required` / named
+/// function without a structural tag) engines may grammar-force pure JSON
+/// from the first token; a pre-armed parser would classify that payload as
+/// truncated reasoning. Templates without `<think>` in the prefill emit an
+/// explicit start token whenever reasoning does happen, so they stay
+/// un-armed under the constraint. Think-in-prefill templates keep the
+/// pre-arm: their completions genuinely begin mid-reasoning.
+pub(crate) fn should_start_in_reasoning(
+    user_thinking: Option<bool>,
+    tokenizer: &dyn Tokenizer,
+    used_json_schema: bool,
+) -> bool {
+    should_mark_reasoning_started(user_thinking, tokenizer)
+        && (tokenizer.think_in_prefill() || !used_json_schema)
+}
+
+/// Split a completed generation into `(reasoning_content, normal_text)`.
+///
+/// Under a JSON-schema tool constraint an all-reasoning result is impossible
+/// (the grammar forces a JSON payload): it means a pre-armed parser never saw
+/// a think-end token, so the original text is returned for tool parsing.
+pub(crate) fn split_reasoning_result(
+    result: reasoning_parser::ParserResult,
+    original_text: String,
+    used_json_schema: bool,
+) -> (Option<String>, String) {
+    if used_json_schema && result.normal_text.is_empty() && !result.reasoning_text.is_empty() {
+        (None, original_text)
+    } else {
+        let reasoning = (!result.reasoning_text.is_empty()).then_some(result.reasoning_text);
+        (reasoning, result.normal_text)
+    }
+}
+
 /// Extract the user's thinking preference from chat_template_kwargs.
 ///
 /// Only checks the key that the template actually uses (e.g. `enable_thinking`
@@ -315,6 +351,128 @@ pub(crate) fn create_tool_parser(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// MockTokenizer wrapper with a configurable thinking toggle and
+    /// think-in-prefill flag (trait defaults are `None`/`false`).
+    struct ToggleTok {
+        inner: llm_tokenizer::MockTokenizer,
+        toggle: ThinkingToggle,
+        prefill: bool,
+    }
+
+    impl ToggleTok {
+        fn new(toggle: ThinkingToggle, prefill: bool) -> Self {
+            Self {
+                inner: llm_tokenizer::MockTokenizer::new(),
+                toggle,
+                prefill,
+            }
+        }
+    }
+
+    impl llm_tokenizer::traits::Encoder for ToggleTok {
+        fn encode(&self, i: &str, s: bool) -> anyhow::Result<llm_tokenizer::traits::Encoding> {
+            self.inner.encode(i, s)
+        }
+        fn encode_batch(
+            &self,
+            i: &[&str],
+            s: bool,
+        ) -> anyhow::Result<Vec<llm_tokenizer::traits::Encoding>> {
+            self.inner.encode_batch(i, s)
+        }
+    }
+
+    impl llm_tokenizer::traits::Decoder for ToggleTok {
+        fn decode(&self, ids: &[u32], s: bool) -> anyhow::Result<String> {
+            self.inner.decode(ids, s)
+        }
+    }
+
+    impl Tokenizer for ToggleTok {
+        fn vocab_size(&self) -> usize {
+            self.inner.vocab_size()
+        }
+        fn get_special_tokens(&self) -> &llm_tokenizer::traits::SpecialTokens {
+            self.inner.get_special_tokens()
+        }
+        fn token_to_id(&self, t: &str) -> Option<u32> {
+            self.inner.token_to_id(t)
+        }
+        fn id_to_token(&self, id: u32) -> Option<String> {
+            self.inner.id_to_token(id)
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn thinking_toggle(&self) -> ThinkingToggle {
+            self.toggle
+        }
+        fn think_in_prefill(&self) -> bool {
+            self.prefill
+        }
+    }
+
+    #[test]
+    fn start_in_reasoning_unarmed_under_json_schema_for_toggle_templates() {
+        // Qwen3-style template: thinking toggle DefaultOn, no <think> in prefill.
+        let tok = ToggleTok::new(ThinkingToggle::DefaultOn, false);
+
+        // Unconstrained: thinking ON arms the parser.
+        assert!(should_start_in_reasoning(None, &tok, false));
+        // JSON-schema constraint: must not pre-arm (payload has no think tokens).
+        assert!(!should_start_in_reasoning(None, &tok, true));
+        // Thinking explicitly off never arms.
+        assert!(!should_start_in_reasoning(Some(false), &tok, false));
+    }
+
+    #[test]
+    fn start_in_reasoning_keeps_prearm_for_think_in_prefill_templates() {
+        // DeepSeek-style: `<think>` in the prefill, completions start mid-reasoning.
+        let tok = ToggleTok::new(ThinkingToggle::DefaultOn, true);
+
+        assert!(should_start_in_reasoning(None, &tok, true));
+        assert!(should_start_in_reasoning(None, &tok, false));
+        assert!(!should_start_in_reasoning(Some(false), &tok, true));
+
+        // No thinking toggle at all: never armed, constraint or not.
+        let plain = ToggleTok::new(ThinkingToggle::None, false);
+        assert!(!should_start_in_reasoning(None, &plain, true));
+        assert!(!should_start_in_reasoning(None, &plain, false));
+    }
+
+    #[test]
+    fn split_reasoning_result_recovers_constrained_payload() {
+        use reasoning_parser::ParserResult;
+
+        let payload = r#"[{"name":"get_weather","parameters":{"city":"Paris"}}]"#;
+
+        // All-reasoning under the constraint: the payload is recovered.
+        let all_reasoning = ParserResult::reasoning(payload.to_string());
+        let (reasoning, normal) = split_reasoning_result(all_reasoning, payload.to_string(), true);
+        assert_eq!(reasoning, None);
+        assert_eq!(normal, payload);
+
+        // All-reasoning without the constraint: kept as truncated reasoning.
+        let all_reasoning = ParserResult::reasoning("partial thought".to_string());
+        let (reasoning, normal) =
+            split_reasoning_result(all_reasoning, "partial thought".to_string(), false);
+        assert_eq!(reasoning.as_deref(), Some("partial thought"));
+        assert_eq!(normal, "");
+
+        // A proper reasoning/payload split passes through unchanged.
+        let split = ParserResult::new(payload.to_string(), "thought".to_string());
+        let (reasoning, normal) =
+            split_reasoning_result(split, format!("thought</think>{payload}"), true);
+        assert_eq!(reasoning.as_deref(), Some("thought"));
+        assert_eq!(normal, payload);
+
+        // Empty reasoning stays None.
+        let plain = ParserResult::normal("hi".to_string());
+        let (reasoning, normal) = split_reasoning_result(plain, "hi".to_string(), true);
+        assert_eq!(reasoning, None);
+        assert_eq!(normal, "hi");
+    }
 
     #[test]
     fn resolve_thinking_pref_precedence() {


### PR DESCRIPTION
## Description

### Problem

With `tool_choice: "required"` (or a named function) and a tool parser that has no structural tag, the gateway sends the engine a JSON-schema grammar constraint, so the completion is pure JSON — no think tokens can appear. But for thinking models (e.g. Qwen3, whose `enable_thinking` template toggle defaults on), the gRPC pipeline also pre-armed the reasoning parser via `mark_reasoning_started()`. The armed parser never saw a think-end token and classified the entire grammar-forced tool payload as truncated reasoning:

- `tool_calls: null`, `content: null`
- the tool-call JSON dumped into `reasoning_content`
- `finish_reason: "stop"` instead of `"tool_calls"`

Broken on both the OpenAI chat and Anthropic messages surfaces, streaming and non-streaming. Any thinking-toggle template family is affected, not just Qwen.

A compounding bug: the chat-template detector flagged Qwen3 as *think-in-prefill* because its generation prompt contains `<think>\n\n</think>` — a **closed** filler emitted only when thinking is **disabled** — so the pre-arm survived even where it never should have applied.

### Solution

- **Gate the pre-arm** (`utils::should_start_in_reasoning`): under a JSON-schema tool constraint, only genuine think-in-prefill templates keep the pre-arm (their completions really start mid-reasoning on thinking-aware engines, e.g. sglang honoring `require_reasoning`). Toggle templates emit an explicit `<think>` whenever reasoning does happen, so the un-armed parser still catches it.
- **Non-streaming recovery** (`utils::split_reasoning_result`): under the constraint an all-reasoning parse is impossible — hand the original text back to the tool stage. Covers think-in-prefill templates on engines that enforce the grammar from the first token (vLLM).
- **Streaming recovery**: at end of stream, if a still-armed parser consumed the payload (no tool calls emitted, parser still in reasoning), parse the buffered raw text and emit the tool-call deltas so `tool_calls` and the finish reason are still delivered. Applied to both chat (per-index, `n>1`-safe) and messages streaming.
- **Detector fix**: `think_in_prefill` now requires an *unclosed* `<think>` in the `add_generation_prompt` body.

Requests without a JSON-schema tool constraint (`auto`, `none`, no tools) take exactly the same code path as before. Parser crates are untouched — the wrong decisions lived in the gateway pipeline.

## Changes

- `model_gateway/src/routers/grpc/utils/parsers.rs`: new `should_start_in_reasoning` / `split_reasoning_result` helpers + unit tests.
- `model_gateway/src/routers/grpc/regular/processor.rs`: chat + messages non-streaming paths use gated arming and the recovery split; `used_json_schema` hoisted above reasoning parsing.
- `model_gateway/src/routers/grpc/regular/streaming.rs`: chat + messages streaming paths use gated arming; end-of-stream JSON-schema constraint recovery.
- `crates/tokenizer/src/chat_template.rs`: think-in-prefill detection requires an unclosed `<think>`; unit test for the Qwen3-style closed filler vs open-tag templates.
- `e2e_test/chat_completions/test_function_calling.py`: new `TestToolChoiceRequiredThinking` (streaming + non-streaming) on a thinking model — existing required-mode coverage only used a non-thinking Qwen, which is why this was never caught.

## Test Plan

Reproduced and validated on a B300 node: vLLM gRPC backend (`vllm.entrypoints.grpc_server`), `Qwen/Qwen3-0.6B`, gateway `--tool-call-parser qwen --reasoning-parser qwen3`, same request matrix before/after on this branch's base.

Request: `get_weather` tool, "What is the weather in Paris right now?", `max_tokens: 512`.

| Case | Before (main) | After (this PR) |
|---|---|---|
| `required`, non-streaming | `finish: "stop"`, `tool_calls: null`, JSON in `reasoning_content` | `tool_calls: [get_weather {"city":"Paris"}]`, `finish: "tool_calls"`, no reasoning |
| `required`, streaming | payload streamed as `reasoning_content` deltas, no tool deltas | tool-call deltas, `finish: "tool_calls"`, zero reasoning leak |
| named function | params object in `reasoning_content` | correct `tool_calls`, `finish: "tool_calls"` |
| Messages `tool_choice: {type: "any"}` (+ streaming) | same failure mode | `tool_use` block with input, `stop_reason: "tool_use"` |
| `auto` (control) | works | unchanged — reasoning separated, tool call parsed |
| `required` + `enable_thinking: false` (control) | works | unchanged |
| plain chat, thinking on (control) | works | unchanged — content + reasoning separated |

Unit tests: `cargo test -p smg --lib routers::grpc::utils::parsers`, `cargo test -p llm-tokenizer --lib chat_template`. Full workspace `cargo test` passes.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
