### PR TITLE
fix(router): expire pooled upstream connections before backend keep-alive and retry pre-response transport failures

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -512,6 +512,7 @@ struct Router {
     zmq_engine_count: Option<usize>,
     overlap_decay: f32,
     selection_temperature: f32,
+    upstream_pool_idle_timeout_secs: u64,
 }
 
 impl Router {
@@ -859,6 +860,7 @@ impl Router {
             .enable_wasm(self.enable_wasm)
             .dp_aware(self.dp_aware)
             .upstream_http2(self.upstream_http2)
+            .upstream_pool_idle_timeout_secs(self.upstream_pool_idle_timeout_secs)
             .multimodal_tensor_transport(multimodal_tensor_transport)
             .multimodal_shm_min_bytes(self.multimodal_shm_min_bytes)
             .routing_key_override(config::RoutingKeyOverrideConfig {
@@ -1018,6 +1020,7 @@ impl Router {
         upstream_http2 = false,
         overlap_decay = 0.0,
         selection_temperature = 0.0,
+        upstream_pool_idle_timeout_secs = 3,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1154,6 +1157,7 @@ impl Router {
         upstream_http2: bool,
         overlap_decay: f32,
         selection_temperature: f32,
+        upstream_pool_idle_timeout_secs: u64,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1304,6 +1308,7 @@ impl Router {
             zmq_engine_count,
             overlap_decay,
             selection_temperature,
+            upstream_pool_idle_timeout_secs,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -212,6 +212,7 @@ class RouterArgs:
     upstream_http2: bool = False
     overlap_decay: float = 0.0
     selection_temperature: float = 0.0
+    upstream_pool_idle_timeout_secs: int = 3
 
     @staticmethod
     def add_cli_args(
@@ -340,6 +341,17 @@ class RouterArgs:
                 " multiplexing every request to a worker over one connection."
                 " Requires every HTTP worker to serve HTTP/2 without an upgrade"
                 " handshake."
+            ),
+        )
+        worker_group.add_argument(
+            f"--{prefix}upstream-pool-idle-timeout-secs",
+            type=int,
+            default=RouterArgs.upstream_pool_idle_timeout_secs,
+            help=(
+                "Idle timeout in seconds for pooled upstream connections. Must"
+                " stay below the backend HTTP server's keep-alive timeout (vLLM"
+                " and SGLang default to 5). 0 keeps idle connections forever."
+                " Defaults to 3."
             ),
         )
         worker_group.add_argument(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1221,6 +1221,7 @@ class TestRouterArgsFieldOrder:
         "upstream_http2",
         "overlap_decay",
         "selection_temperature",
+        "upstream_pool_idle_timeout_secs",
     ]
 
     def test_complete_field_sequence_is_frozen(self):
@@ -1238,7 +1239,11 @@ class TestRouterArgsFieldOrder:
 
         names = [f.name for f in dataclasses.fields(RouterArgs)]
         marker = names.index("worker_startup_delay")
-        for appended in ("overlap_decay", "selection_temperature"):
+        for appended in (
+            "overlap_decay",
+            "selection_temperature",
+            "upstream_pool_idle_timeout_secs",
+        ):
             assert names.index(appended) > marker, (
                 f"{appended} must be appended after worker_startup_delay to "
                 "preserve positional callers"

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -456,8 +456,15 @@ impl AppContextBuilder {
         // backend to avoid unnecessary TLS initialization overhead.
         let has_tls_config = config.client_identity.is_some() || !config.ca_certificates.is_empty();
 
+        // Idle pooled connections must expire before the backend server's
+        // keep-alive closes them (vLLM/SGLang default: 5s), or checkout races
+        // the server's FIN and non-idempotent sends fail.
+        let pool_idle_timeout = match config.upstream_pool_idle_timeout_secs {
+            0 => None,
+            secs => Some(Duration::from_secs(secs)),
+        };
         let mut client_builder = Client::builder()
-            .pool_idle_timeout(Some(Duration::from_secs(50)))
+            .pool_idle_timeout(pool_idle_timeout)
             .pool_max_idle_per_host(500)
             .timeout(Duration::from_secs(timeout_secs))
             .connect_timeout(Duration::from_secs(10))

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -205,6 +205,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn upstream_pool_idle_timeout_secs(mut self, secs: u64) -> Self {
+        self.config.upstream_pool_idle_timeout_secs = secs;
+        self
+    }
+
     pub fn request_timeout_secs(mut self, timeout: u64) -> Self {
         self.config.request_timeout_secs = timeout;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -51,6 +51,12 @@ pub struct RouterConfig {
     pub runtime_worker_threads: Option<usize>,
     pub max_payload_size: usize,
     pub request_timeout_secs: u64,
+    /// Idle timeout for pooled upstream connections. Must stay below the
+    /// backend HTTP server's keep-alive timeout (vLLM and SGLang default to
+    /// 5s), or the pool hands out connections the server has already closed
+    /// and non-idempotent sends fail. `0` keeps idle connections forever.
+    #[serde(default = "default_upstream_pool_idle_timeout_secs")]
+    pub upstream_pool_idle_timeout_secs: u64,
     pub worker_startup_timeout_secs: u64,
     /// Grace period before the first worker-startup check fires. The engine is
     /// left alone for this long, then polled every
@@ -632,6 +638,10 @@ fn default_load_factor() -> f64 {
     1.25
 }
 
+fn default_upstream_pool_idle_timeout_secs() -> u64 {
+    3
+}
+
 fn default_prefix_hash_balance_abs_threshold() -> usize {
     10
 }
@@ -881,8 +891,9 @@ impl Default for RouterConfig {
             port: 3001,
             health_check_port: None,
             runtime_worker_threads: None,
-            max_payload_size: 536_870_912,     // 512MB
-            request_timeout_secs: 1800,        // 30 minutes
+            max_payload_size: 536_870_912, // 512MB
+            request_timeout_secs: 1800,    // 30 minutes
+            upstream_pool_idle_timeout_secs: default_upstream_pool_idle_timeout_secs(),
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading
             worker_startup_delay_secs: 0,
             worker_startup_check_interval_secs: 30,
@@ -1034,6 +1045,7 @@ mod tests {
         assert_eq!(config.port, 3001);
         assert_eq!(config.max_payload_size, 536_870_912);
         assert_eq!(config.request_timeout_secs, 1800);
+        assert_eq!(config.upstream_pool_idle_timeout_secs, 3);
         assert_eq!(config.worker_startup_timeout_secs, 1800);
         assert_eq!(config.worker_startup_check_interval_secs, 30);
         assert_eq!(config.load_monitor_interval_secs, 10);

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -495,6 +495,13 @@ struct CliArgs {
     #[arg(long, default_value_t = 1800, help_heading = "Request Handling")]
     request_timeout_secs: u64,
 
+    /// Idle timeout in seconds for pooled upstream connections. Must stay
+    /// below the backend HTTP server's keep-alive timeout (vLLM and SGLang
+    /// default to 5), or reused connections the server already closed fail
+    /// non-idempotent sends. 0 keeps idle connections forever.
+    #[arg(long, default_value_t = 3, help_heading = "Request Handling")]
+    upstream_pool_idle_timeout_secs: u64,
+
     /// Grace period in seconds to wait for in-flight requests during shutdown
     #[arg(long, default_value_t = 180, help_heading = "Request Handling")]
     shutdown_grace_period_secs: u64,
@@ -1534,6 +1541,7 @@ impl CliArgs {
             .runtime_worker_threads(self.runtime_worker_threads)
             .max_payload_size(self.max_payload_size)
             .request_timeout_secs(self.request_timeout_secs)
+            .upstream_pool_idle_timeout_secs(self.upstream_pool_idle_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
             .worker_startup_delay_secs(self.worker_startup_delay)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -931,6 +931,15 @@ impl Metrics {
         .record(duration.as_secs_f64());
     }
 
+    /// Record a single-shot resend after a pre-response transport failure.
+    pub fn record_upstream_send_retry(router_type: &'static str) {
+        counter!(
+            "smg_router_upstream_send_retries_total",
+            "router_type" => router_type
+        )
+        .increment(1);
+    }
+
     /// Record upstream backend response.
     /// Uses static strings for common status codes and interning for error_code.
     pub fn record_router_upstream_response(

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -41,6 +41,7 @@ use crate::{
         },
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},
+        http::router::send_with_stale_conn_retry,
         RouterTrait,
     },
     worker::{HashRing, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType, UNKNOWN_MODEL_ID},
@@ -98,7 +99,7 @@ impl PDRouter {
             }
         }
 
-        match request_builder.send().await {
+        match send_with_stale_conn_retry(request_builder).await {
             Ok(res) if res.status().is_success() => {
                 let response_headers = header_utils::preserve_response_headers(res.headers());
 
@@ -675,11 +676,11 @@ impl PDRouter {
         let runtime = prefill.metadata().spec.runtime_type.as_str();
         let dispatch_start = Instant::now();
         let prefill_fut = async {
-            let resp = prefill_request.send().await?;
+            let resp = send_with_stale_conn_retry(prefill_request).await?;
             Ok::<_, reqwest::Error>((dispatch_start.elapsed(), resp))
         };
         let decode_fut = async {
-            let resp = decode_request.send().await?;
+            let resp = send_with_stale_conn_retry(decode_request).await?;
             Ok::<_, reqwest::Error>((dispatch_start.elapsed(), resp))
         };
         let pd_result = tokio::try_join!(prefill_fut, decode_fut);

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -165,7 +165,7 @@ impl Router {
                     }
                 }
 
-                match request_builder.send().await {
+                match send_with_stale_conn_retry(request_builder).await {
                     Ok(res) => {
                         let status = StatusCode::from_u16(res.status().as_u16())
                             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
@@ -568,7 +568,9 @@ impl Router {
                         request_builder = request_builder.header(name.clone(), value.clone());
                     }
 
-                    request_builder.send().await.map_err(convert_reqwest_error)
+                    send_with_stale_conn_retry(request_builder)
+                        .await
+                        .map_err(convert_reqwest_error)
                 }
             })
             .collect();
@@ -787,7 +789,7 @@ impl Router {
             worker.api_key(),
         );
 
-        let res = match request_builder.send().await {
+        let res = match send_with_stale_conn_retry(request_builder).await {
             Ok(res) => res,
             Err(e) => {
                 error!(
@@ -1079,7 +1081,7 @@ impl Router {
             api_key.as_ref(),
         );
 
-        let res = match request_builder.send().await {
+        let res = match send_with_stale_conn_retry(request_builder).await {
             Ok(res) => res,
             Err(e) => {
                 error!(
@@ -1291,6 +1293,38 @@ fn build_transcription_form(
     }
 
     Ok(form)
+}
+
+/// True for transport failures surfaced without any response: no upstream
+/// status, not a timeout, and not a response-phase (body/decode) or local
+/// (builder/redirect) error. The dominant producer is a pooled connection
+/// the backend closed while idle; the backend never processed the request,
+/// so one resend is safe for any route.
+fn is_pre_response_transport_error(e: &reqwest::Error) -> bool {
+    e.status().is_none()
+        && !e.is_timeout()
+        && !e.is_body()
+        && !e.is_decode()
+        && !e.is_builder()
+        && !e.is_redirect()
+}
+
+/// Send with a single retry on pre-response transport failures. Requests
+/// whose body cannot be cloned (multipart streams) fail through unchanged.
+pub(crate) async fn send_with_stale_conn_retry(
+    builder: reqwest::RequestBuilder,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let retry = builder.try_clone();
+    match builder.send().await {
+        Err(e) if is_pre_response_transport_error(&e) => match retry {
+            Some(retry) => {
+                Metrics::record_upstream_send_retry(metrics_labels::ROUTER_HTTP);
+                retry.send().await
+            }
+            None => Err(e),
+        },
+        other => other,
+    }
 }
 
 fn convert_reqwest_error(e: reqwest::Error) -> Response {
@@ -1618,10 +1652,86 @@ impl RouterTrait for Router {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        net::SocketAddr,
+        sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
+    };
+
     use openai_protocol::worker::HealthCheckConfig;
 
     use super::*;
     use crate::{config::types::PolicyConfig, worker::BasicWorkerBuilder};
+
+    /// Accepts `kill_first` connections and closes them before any response
+    /// bytes, then serves a minimal 200 on every later connection. Returns
+    /// (addr, accepted-connection counter).
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test-only server task; lives no longer than the test"
+    )]
+    async fn flaky_upstream(kill_first: usize) -> (SocketAddr, Arc<AtomicUsize>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let accepted_clone = Arc::clone(&accepted);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                let n = accepted_clone.fetch_add(1, AtomicOrdering::SeqCst);
+                if n < kill_first {
+                    drop(sock);
+                    continue;
+                }
+                let mut buf = [0u8; 4096];
+                let _ = sock.read(&mut buf).await;
+                let _ = sock
+                    .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok")
+                    .await;
+            }
+        });
+        (addr, accepted)
+    }
+
+    #[tokio::test]
+    async fn stale_conn_retry_recovers_on_second_connection() {
+        let (addr, accepted) = flaky_upstream(1).await;
+        let client = Client::new();
+        let builder = client.post(format!("http://{addr}/generate")).body("{}");
+
+        let res = send_with_stale_conn_retry(builder).await.unwrap();
+        assert_eq!(res.status().as_u16(), 200);
+        assert_eq!(accepted.load(AtomicOrdering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn stale_conn_retry_is_bounded_to_one() {
+        let (addr, accepted) = flaky_upstream(usize::MAX).await;
+        let client = Client::new();
+        let builder = client.post(format!("http://{addr}/generate")).body("{}");
+
+        let err = send_with_stale_conn_retry(builder).await.unwrap_err();
+        assert!(is_pre_response_transport_error(&err));
+        assert_eq!(accepted.load(AtomicOrdering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn stale_conn_retry_skips_unclonable_bodies() {
+        let (addr, accepted) = flaky_upstream(usize::MAX).await;
+        let client = Client::new();
+        let stream_body = reqwest::Body::wrap_stream(stream::once(async {
+            Ok::<_, std::io::Error>(Bytes::from_static(b"{}"))
+        }));
+        let builder = client
+            .post(format!("http://{addr}/generate"))
+            .body(stream_body);
+
+        send_with_stale_conn_retry(builder).await.unwrap_err();
+        assert_eq!(accepted.load(AtomicOrdering::SeqCst), 1);
+    }
 
     fn no_health_check() -> HealthCheckConfig {
         HealthCheckConfig {


### PR DESCRIPTION
## Description

### Problem

The shared upstream client pools idle connections for 50 seconds (hardcoded), but SMG's primary backends close idle connections after 5 seconds (vLLM `VLLM_HTTP_TIMEOUT_KEEP_ALIVE = 5`, SGLang's uvicorn default is the same). Any pooled connection idle for more than the server's keep-alive is dead on reuse: the send loses the race with the server's close, hyper will not retry the non-idempotent POST, and the request fails as a 500 with `error_code="call_upstream_request_error"`.

Uniform load masks this — every worker sees traffic often enough that pools never idle past 5s. Affinity policies (cache_aware, prefix_hash) expose it: traffic concentrates, many workers idle past the server keep-alive, and when concentration shifts, a wave of stale pools is reused at once.

### Solution

Two changes, one defect:

1. **Make the pool idle timeout configurable and default it below the backend keep-alive.** New `--upstream-pool-idle-timeout-secs` (default 3, `0` = keep idle connections forever). At 3s the pool discards idle connections before vLLM/SGLang's 5s server close, so reuse of server-closed connections stops being the steady state.
2. **Retry pre-response transport failures once.** A send that fails with no upstream status, no timeout, and no response-phase error means the backend never processed the request, so a single resend is safe for any route. `send_with_stale_conn_retry` clones the request up front (`RequestBuilder::try_clone`); requests with non-clonable streaming bodies (multipart) fail through unchanged. Applied to all upstream dispatch sites in the HTTP router and PD router. Retries are counted by a new `smg_router_upstream_send_retries_total` metric. Timeouts are deliberately not retried: the request may be executing on the backend, and resending would double load exactly when the fleet is slow.

## Changes

- `model_gateway/src/config/types.rs`, `config/builder.rs`, `main.rs`: `upstream_pool_idle_timeout_secs` (serde default 3, CLI flag, builder method).
- `model_gateway/src/app_context.rs`: client pool idle timeout from config instead of the hardcoded 50s.
- `model_gateway/src/routers/http/router.rs`: `is_pre_response_transport_error` + `send_with_stale_conn_retry`; all four dispatch sites rewired.
- `model_gateway/src/routers/http/pd_router.rs`: proxy, prefill, and decode dispatches rewired.
- `model_gateway/src/observability/metrics.rs`: `record_upstream_send_retry`.
- `bindings/python`: `upstream_pool_idle_timeout_secs` appended at the positional tail (lib.rs, `RouterArgs`, CLI arg, frozen field-sequence test).

## Test Plan

New tests:

- `stale_conn_retry_recovers_on_second_connection` — first connection killed pre-response, retry succeeds; exactly 2 connections accepted.
- `stale_conn_retry_is_bounded_to_one` — persistently failing upstream: exactly 2 attempts, then the transport error surfaces.
- `stale_conn_retry_skips_unclonable_bodies` — streaming body: no retry, single connection.
- Config default asserted in `test_router_config_default`.
- Python: frozen `RouterArgs` field sequence and tail-append tests extended.

Gates: `cargo +nightly fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p smg`, `cargo build -p smg-python`, `cargo build -p smg-golang`, `pytest tests/test_arg_parser.py` (45 passed).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
