### PR TITLE
ci: wire ZMQ crates, lanes, and infra tests into PR gates

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -246,6 +246,18 @@ jobs:
           pip install ./crates/grpc_client/python
           pytest -q grpc_servicer/tests
 
+      # CPU-only unit tests for the e2e harness itself (connection-mode parsing,
+      # ZMQ/EPD command builders, ZMQ-lane collection filter). --noconftest keeps
+      # e2e_test/conftest.py — which needs the generated smg_client types and a
+      # live backend — out of the picture; PYTHONPATH replaces the sys.path setup
+      # it would otherwise do.
+      - name: Run e2e harness unit tests
+        env:
+          PYTHONPATH: e2e_test
+        run: |
+          pip install ./e2e_test
+          pytest -q --noconftest e2e_test/infra e2e_test/fixtures
+
   unit-tests:
     needs: [detect-changes]
     if: >-
@@ -448,6 +460,10 @@ jobs:
               - 'crates/reasoning_parser/**'
               - 'crates/multimodal/**'
               - 'crates/grpc_client/**'
+              # The ZMQ wire crates drive the e2e-*-chat-zmq* lanes, which gate
+              # on this filter.
+              - 'crates/engine_zmq_client/**'
+              - 'crates/mock_worker/**'
               - 'grpc_servicer/**'
               - 'e2e_test/chat_completions/**'
               - 'e2e_test/router/**'
@@ -1132,7 +1148,7 @@ jobs:
           path: benchmark_go_bindings/
 
   finish:
-    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-chat-zmq, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-vendor, go-unit-tests, go-bindings-e2e]
+    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-chat-zmq, e2e-2gpu-chat-zmq-dp, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-vendor, go-unit-tests, go-bindings-e2e]
     if: always()
     runs-on: k8s-runner-cpu
     permissions: {}
@@ -1148,6 +1164,7 @@ jobs:
                 "${{ needs.benchmarks.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-chat.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-chat-zmq.result }}" == "failure" || \
+                "${{ needs.e2e-2gpu-chat-zmq-dp.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-completions.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-embeddings.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-gateway.result }}" == "failure" || \


### PR DESCRIPTION
## Description

### Problem

Three CI wiring gaps from the audit, all in `.github/workflows/pr-test-rust.yml`:

- **detect-changes filters omit crates/engine_zmq_client, so ZMQ-only PRs skip every ZMQ e2e lane** — a PR touching only the ZMQ wire crate (transport, codec, handshake, dialects) or the mock worker matched `rust-ci` for unit tests but no filter that gates the GPU ZMQ lanes.
- **e2e-2gpu-chat-zmq-dp is absent from the finish gate; dp-lane failures cannot block merges** — the only CI coverage of grouped handshakes, least-loaded engine selection, and per-rank output attribution produced no red aggregate on failure.
- **ZMQ lane-selection and cmd-builder unit tests are not run by any CI job** — `e2e_test/infra` and `e2e_test/fixtures` unit tests (including the `_filter_zmq_items` collection filter that silently deselects tests in ZMQ lanes) were collected by no workflow.

### Solution

Wire the three gaps into the PR gates: add the ZMQ crates to the paths filter that gates the ZMQ e2e lanes, add the dp lane to the finish gate and its failure check, and run the `e2e_test/infra` and `e2e_test/fixtures` unit tests from the CPU `python-unit-tests` job.

## Changes

- Added `crates/engine_zmq_client/**` and `crates/mock_worker/**` to the `chat-completions` paths filter, which (with `common`) gates `e2e-1gpu-chat-zmq` and `e2e-2gpu-chat-zmq-dp`.
- Added `e2e-2gpu-chat-zmq-dp` to `finish.needs` and to the failure check.
- Added a CPU-only `Run e2e harness unit tests` step to `python-unit-tests`, running `pytest -q --noconftest e2e_test/infra e2e_test/fixtures` with `PYTHONPATH=e2e_test`. `--noconftest` is required: `e2e_test/conftest.py` imports `smg_client`, whose `_generated` types are only produced by the wheel-build job, and does sys.path setup that `PYTHONPATH` covers instead.

## Test Plan

- `python -m pytest -q --noconftest e2e_test/infra e2e_test/fixtures` in a clean Python 3.13 venv with only `pip install ./e2e_test` (matching the new step, minus the wheel): **43 passed, 3 skipped** — the 3 skips are `test_zmq_cmd_builders.py`'s `importorskip("smg.serve")`, which run in CI because the job installs the wheel first.
- `yaml.safe_load` of the modified workflow: parses; `python-unit-tests` steps and `finish.needs` verified to contain the new entries.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
