### PR TITLE
fix(bindings): forward zmq_engine_count for TokenSpeed grouped launches

### DIFF
--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -1101,7 +1101,7 @@ class RouterArgs:
             help=(
                 "DP engines per startup ZMQ worker: each ipc:// worker becomes a "
                 "grouped worker whose handshake awaits this many engines on one "
-                "socket set (vLLM only; default: 1)"
+                "socket set (vLLM and TokenSpeed; default: 1)"
             ),
         )
         backend_group.add_argument(

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -944,10 +944,11 @@ class ServeOrchestrator:
         # --backend does not reach.)
         if getattr(self.args, "connection_mode", "grpc") == "zmq":
             router_args.backend = self.backend
-            # A grouped vLLM launch (engine-level --data-parallel-size N after
-            # `--`) needs the router to await N engines per worker handshake.
+            # A grouped launch (engine-level --data-parallel-size N after `--`)
+            # puts N engines on one socket set for both ZMQ runtimes, so the
+            # router must await N engines per worker handshake.
             engine_dp = _backend_arg_int(self.backend_args, "--data-parallel-size", 1)
-            if engine_dp > 1 and self.backend == "vllm":
+            if engine_dp > 1:
                 router_args.zmq_engine_count = engine_dp
         # Router-level retries and circuit breaker are redundant when there is a
         # single worker — per-worker resilience already handles failures — so

--- a/bindings/python/tests/test_serve.py
+++ b/bindings/python/tests/test_serve.py
@@ -1388,6 +1388,48 @@ class TestServeOrchestrator:
             assert result.backend == backend
             assert result.worker_urls == [_zmq_ipc_url(31000)]
 
+    def test_build_router_args_zmq_engine_count_from_engine_dp(self):
+        """Engine-level --data-parallel-size groups N engines on one socket set
+        for both ZMQ runtimes, so the router must await N engines."""
+        from types import SimpleNamespace
+
+        for backend in ("vllm", "tokenspeed"):
+            args = _make_args(backend=backend, data_parallel_size=1, connection_mode="zmq")
+            orch = ServeOrchestrator(backend, args, ["--data-parallel-size", "2"])
+            orch.workers = [(MagicMock(), 31000)]
+
+            router_args = SimpleNamespace(
+                backend="sglang",
+                zmq_engine_count=None,
+                disable_retries=True,
+                disable_circuit_breaker=True,
+                policy="passthrough",
+            )
+            with patch("smg.serve.RouterArgs.from_cli_args", return_value=router_args):
+                result = orch._build_router_args()
+
+            assert result.zmq_engine_count == 2, backend
+
+    def test_build_router_args_zmq_engine_count_unset_without_engine_dp(self):
+        """An ungrouped ZMQ launch leaves zmq_engine_count alone (defaults to 1)."""
+        from types import SimpleNamespace
+
+        args = _make_args(backend="tokenspeed", data_parallel_size=1, connection_mode="zmq")
+        orch = ServeOrchestrator("tokenspeed", args, [])
+        orch.workers = [(MagicMock(), 31000)]
+
+        router_args = SimpleNamespace(
+            backend="sglang",
+            zmq_engine_count=None,
+            disable_retries=True,
+            disable_circuit_breaker=True,
+            policy="passthrough",
+        )
+        with patch("smg.serve.RouterArgs.from_cli_args", return_value=router_args):
+            result = orch._build_router_args()
+
+        assert result.zmq_engine_count is None
+
     def test_build_router_args_grpc_keeps_router_backend(self):
         """Off the ZMQ path the router backend stays whatever --router-backend
         chose (gRPC/HTTP workers keep runtime auto-detection)."""

--- a/e2e_test/infra/constants.py
+++ b/e2e_test/infra/constants.py
@@ -158,7 +158,7 @@ def get_connection_mode_override() -> "ConnectionMode | None":
 
 
 def get_zmq_engine_count() -> int:
-    """DP engines per ZMQ worker (grouped vLLM launch).
+    """DP engines per ZMQ worker (grouped vLLM/TokenSpeed launch).
 
     Set ``E2E_ZMQ_ENGINE_COUNT`` to run a ZMQ lane with grouped workers: the
     worker launches that many engines on one socket set and the gateway's

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -164,6 +164,14 @@ fn parse_transport_mode(value: &str) -> Result<TransportMode, String> {
         .ok_or_else(|| format!("invalid value '{value}'; expected inline, shm, auto, or rdma"))
 }
 
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    match value.parse::<usize>() {
+        Ok(n) if n >= 1 => Ok(n),
+        Ok(_) => Err(format!("invalid value '{value}'; expected a count >= 1")),
+        Err(err) => Err(format!("invalid value '{value}': {err}")),
+    }
+}
+
 #[derive(Parser, Debug)]
 struct CliArgs {
     // ==================== Worker Configuration ====================
@@ -347,7 +355,7 @@ struct CliArgs {
 
     /// DP engines per startup ZMQ worker: each ipc:// worker becomes a grouped
     /// worker whose handshake awaits this many engines on one socket set.
-    #[arg(long, help_heading = "Worker Configuration")]
+    #[arg(long, value_parser = parse_positive_usize, help_heading = "Worker Configuration")]
     zmq_engine_count: Option<usize>,
 
     /// Speak HTTP/2 to workers via prior knowledge (h2c on cleartext),
@@ -1870,6 +1878,26 @@ mod tests {
             .chain(args.iter().map(|s| (*s).to_string()))
             .collect();
         Cli::parse_from(argv).router_args
+    }
+
+    /// A grouped ZMQ handshake needs at least one engine, so `0` (and any
+    /// non-positive value) must be rejected at parse time rather than silently
+    /// degrading to an ungrouped worker.
+    #[test]
+    fn zmq_engine_count_rejects_non_positive() {
+        assert_eq!(
+            cli_args_from(&["--zmq-engine-count", "2"]).zmq_engine_count,
+            Some(2)
+        );
+        assert_eq!(cli_args_from(&[]).zmq_engine_count, None);
+
+        for bad in ["0", "-1"] {
+            let argv = ["smg", "--zmq-engine-count", bad];
+            assert!(
+                Cli::try_parse_from(argv).is_err(),
+                "--zmq-engine-count {bad} should be rejected"
+            );
+        }
     }
 
     /// The indexer prune flags are router-only settings and must flow into


### PR DESCRIPTION
## Description

### Problem

The audit findings around the ZMQ grouped-worker engine count:

- **"smg serve forwards zmq_engine_count only for vLLM, breaking the TokenSpeed grouped-DP launch it documents"** (also filed as "serve.py auto-sets zmq_engine_count for vLLM only; TokenSpeed dp>1 launch leaves the router awaiting 1 engine"). `_build_router_args` derived the router-side engine count from the engine-level `--data-parallel-size` only when `backend == "vllm"`, even though `TokenspeedWorkerLauncher._build_zmq_command` documents and supports grouped launches (N ranks on one socket set). Via `smg serve --backend tokenspeed --connection-mode zmq -- --data-parallel-size 2`, the gateway awaited a single engine, so the second rank's HELLO either aborted the handshake (`duplicate HELLO ... after INIT phase`) or was never answered.
- **"Stale '(vLLM only)' help text on --zmq-engine-count contradicts TokenSpeed DP support"** — the argparse help and the e2e `get_zmq_engine_count` docstring both still said vLLM only.
- **"--zmq-engine-count accepts 0/negative with no value_parser; values are silently coerced or fail with an opaque error"** — `0` parsed fine and was silently treated as ungrouped by the `.filter(|&n| n > 1)` downstream.
- **"serve.py's ZMQ router-args derivation (backend pin + engine_dp) has no unit test"** — the `zmq_engine_count`/`engine_dp` half of that branch was untested (the backend pin already was).

### Solution

Drop the vLLM-only condition so any ZMQ backend with engine-level dp>1 forwards the engine count to the router, correct the stale help text and docstring, reject non-positive `--zmq-engine-count` at parse time with a clear message, and cover the derivation with unit tests.

## Changes

- `bindings/python/src/smg/serve.py`: drop the `self.backend == "vllm"` condition so any ZMQ backend with engine-level dp>1 sets `router_args.zmq_engine_count`.
- `bindings/python/src/smg/router_args.py`, `e2e_test/infra/constants.py`: help text / docstring now name both vLLM and TokenSpeed.
- `model_gateway/src/main.rs`: new `parse_positive_usize` value parser on `--zmq-engine-count`, rejecting `0` and negatives at parse time with a clear message.
- Tests: `test_build_router_args_zmq_engine_count_from_engine_dp` (vllm + tokenspeed), `test_build_router_args_zmq_engine_count_unset_without_engine_dp`, and `zmq_engine_count_rejects_non_positive` in `main.rs`.

## Test Plan

- `cargo test -p smg --bin smg zmq_engine_count` — 1 passed.
- `cargo clippy -p smg --bin smg --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all` — clean.
- `PYTHONPATH=src pytest tests/test_serve.py -k router_args` from `bindings/python` — 14 passed. Full `tests/test_serve.py` is 140 passed / 11 failed, all 11 pre-existing import failures from optional deps missing in this sandbox (`grpc`, `yaml`), untouched by this change.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
