### PR TITLE
fix(router): gate readiness on tokenizer registration for ZMQ workers

### DIFF
--- a/model_gateway/src/health.rs
+++ b/model_gateway/src/health.rs
@@ -67,7 +67,7 @@ use crate::{
     config::{RouterConfig, RoutingMode},
     middleware::ProbeResponse,
     observability::inflight_tracker::InFlightRequestTracker,
-    worker::{event::WorkerEvent, ConnectionMode, WorkerRegistry, WorkerType},
+    worker::{event::WorkerEvent, WorkerRegistry, WorkerType},
 };
 
 /// How often the maintainer re-derives readiness from the registry even
@@ -86,7 +86,7 @@ pub struct ReadinessSnapshot {
     /// modes), or at least one healthy prefill AND one healthy decode
     /// worker in PrefillDecode mode.
     pub workers_ready: bool,
-    /// Tokenizer-autoload gate: every healthy gRPC worker's tokenizer is
+    /// Tokenizer-autoload gate: every healthy gRPC/ZMQ worker's tokenizer is
     /// registered (`true` when autoload is disabled — the gateway does not
     /// manage tokenizers at all then).
     pub tokenizers_ready: bool,
@@ -190,18 +190,19 @@ impl ProbeState {
         };
 
         // A worker reports healthy (engine SERVING) as soon as its process is
-        // up, but the gateway autoloads each gRPC worker's tokenizer
+        // up, but the gateway autoloads each gRPC-pipeline worker's tokenizer
         // asynchronously afterward (`SubmitTokenizerJobStep`,
         // fire-and-forget). Until that lands, generation requests fail with
         // `tokenizer_not_found`, so `/readiness` must not report ready yet.
-        // Hold readiness until every healthy gRPC worker's tokenizer is
-        // registered. HTTP/proxy workers never autoload a local tokenizer
-        // and are exempt; when autoload is disabled the gateway does not
-        // manage tokenizers at all.
+        // Hold readiness until every healthy gRPC and ZMQ worker's tokenizer
+        // is registered — both ride the gRPC pipeline and speak tokens on the
+        // wire. HTTP/proxy workers never autoload a local tokenizer and are
+        // exempt; when autoload is disabled the gateway does not manage
+        // tokenizers at all.
         let tokenizers_ready = router_config.disable_tokenizer_autoload
             || healthy_workers
                 .iter()
-                .filter(|w| matches!(w.connection_mode(), ConnectionMode::Grpc))
+                .filter(|w| w.connection_mode().uses_grpc_pipeline())
                 .all(|w| tokenizer_registered(w.model_id()));
 
         self.readiness.store(Arc::new(ReadinessSnapshot {
@@ -483,7 +484,7 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
-    use crate::worker::{BasicWorkerBuilder, ModelCard, Worker};
+    use crate::worker::{BasicWorkerBuilder, ConnectionMode, ModelCard, Worker};
 
     fn worker(
         url: &str,
@@ -689,6 +690,39 @@ mod tests {
         };
         state.recompute_with(&registry, &no_autoload, |_| false);
         assert!(state.readiness().tokenizers_ready);
+    }
+
+    /// ZMQ workers ride the same gRPC pipeline and the same fire-and-forget
+    /// tokenizer autoload, and their wire is token-only, so they must gate
+    /// readiness exactly like gRPC workers.
+    #[test]
+    fn zmq_workers_gate_readiness_on_tokenizer_registration() {
+        let state = probe_state();
+        let registry = WorkerRegistry::new();
+        let router_config = regular_config();
+
+        registry
+            .register(worker(
+                "ipc:///tmp/smg-z1",
+                "llama-3",
+                WorkerType::Regular,
+                ConnectionMode::Zmq,
+                WorkerStatus::Ready,
+            ))
+            .unwrap();
+
+        state.recompute_with(&registry, &router_config, |_| false);
+        let snapshot = state.readiness();
+        assert!(snapshot.workers_ready);
+        assert!(!snapshot.tokenizers_ready);
+        assert_eq!(
+            state.readiness_response().status(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+
+        state.recompute_with(&registry, &router_config, |model_id| model_id == "llama-3");
+        assert!(state.readiness().tokenizers_ready);
+        assert_eq!(state.readiness_response().status(), StatusCode::OK);
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

The audit finding **"/readiness tokenizer gate exempts ZMQ workers from the tokenizer-registration race it exists to close"** (`model_gateway/src/health.rs:204`).

The readiness snapshot holds not-ready until every healthy worker's tokenizer is registered, because the gateway autoloads tokenizers asynchronously via the fire-and-forget `SubmitTokenizerJobStep` after a worker reports healthy. But the gate filtered on `ConnectionMode::Grpc` alone. `SubmitTokenizerJobStep` skips only `ConnectionMode::Http`, so ZMQ workers get the same async `AddTokenizer` job — and the ZMQ wire is token-only, so every request depends on the router tokenizer for tokenization, stop resolution, and detokenization. A ZMQ-only deployment therefore reported ready as soon as the handshake completed, and requests routed before the tokenizer job landed failed with `tokenizer_not_found` — exactly the failure class the gate was added to prevent.

### Solution

The tokenizer gate now filters with `ConnectionMode::uses_grpc_pipeline()` (`Grpc | Zmq`), so a ZMQ deployment stays not-ready until its tokenizer is registered. HTTP/proxy workers stay exempt, and `disable_tokenizer_autoload` still short-circuits the gate.

## Changes

- `model_gateway/src/health.rs`: the tokenizer gate now filters with `ConnectionMode::uses_grpc_pipeline()` (`Grpc | Zmq`) instead of `matches!(.., ConnectionMode::Grpc)`. HTTP/proxy workers stay exempt, and `disable_tokenizer_autoload` still short-circuits the gate. Comments and the `ReadinessSnapshot::tokenizers_ready` doc updated to match.
- Added `zmq_workers_gate_readiness_on_tokenizer_registration`, mirroring the existing gRPC test: a healthy ZMQ worker with no registered tokenizer must report `503`, and flip to `200` once the tokenizer registers.
- Moved the now test-only `ConnectionMode` import into the test module.

## Test Plan

- `CARGO_TARGET_DIR=… cargo test -p smg --lib health::` — 13 passed, 0 failed (including the new ZMQ test and the existing gRPC/HTTP gate tests).
- `CARGO_TARGET_DIR=… cargo clippy -p smg --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all` — clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
