### PR TITLE
perf(router): trim per-request allocations on the ZMQ path

### DIFF
--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -65,6 +65,16 @@ enum ZmqBackend {
     TokenSpeed(Arc<TokenSpeedClient>),
 }
 
+/// Per-connection constants of a [`ZmqEngineClient`], fixed at connect time.
+struct ZmqConnectionMeta {
+    /// Model id advertised for metadata (the engine does not report it on the
+    /// wire; it is configured at worker registration).
+    model_id: String,
+    /// EOS ids attached to every vLLM request (the engine can't stop at EOS
+    /// without them).
+    eos: EosTokenIds,
+}
+
 /// The model's EOS stop set, resolved from its local directory. EngineCore
 /// has no tokenizer or model config — stopping at EOS is the frontend's job
 /// (the ids ride each request), and without them generation only ends at
@@ -85,9 +95,9 @@ impl EosTokenIds {
     /// Resolve from `config.json` + `generation_config.json` in a local model
     /// directory: primary = the model config's first id, extras = every other
     /// listed id. Missing files or fields degrade to fewer ids.
-    pub fn from_model_dir(dir: &Path) -> Self {
-        let model_ids = eos_ids_from_file(&dir.join("config.json"));
-        let gen_ids = eos_ids_from_file(&dir.join("generation_config.json"));
+    pub async fn from_model_dir(dir: &Path) -> Self {
+        let model_ids = eos_ids_from_file(&dir.join("config.json")).await;
+        let gen_ids = eos_ids_from_file(&dir.join("generation_config.json")).await;
         let primary = (model_ids.first().or_else(|| gen_ids.first())).copied();
         let mut extra = Vec::new();
         for id in model_ids.into_iter().chain(gen_ids) {
@@ -106,8 +116,8 @@ impl EosTokenIds {
 /// that exists but holds corrupt JSON is worth a `warn!`: it runs once at
 /// connect time, and losing the EOS ids here silently manifests later as
 /// generation running to `max_tokens`.
-fn eos_ids_from_file(path: &Path) -> Vec<u32> {
-    let Ok(text) = std::fs::read_to_string(path) else {
+async fn eos_ids_from_file(path: &Path) -> Vec<u32> {
+    let Ok(text) = tokio::fs::read_to_string(path).await else {
         return Vec::new();
     };
     match serde_json::from_str::<serde_json::Value>(&text) {
@@ -332,8 +342,11 @@ pub(crate) async fn connect_for_worker(
     // config); resolve the EOS ids from the local model dir so every request
     // carries them.
     let model_dir = Path::new(&model_id);
-    let eos = if model_dir.is_dir() {
-        EosTokenIds::from_model_dir(model_dir)
+    let is_model_dir = tokio::fs::metadata(model_dir)
+        .await
+        .is_ok_and(|meta| meta.is_dir());
+    let eos = if is_model_dir {
+        EosTokenIds::from_model_dir(model_dir).await
     } else {
         tracing::warn!(
             "ZMQ worker model id '{model_id}' is not a local model directory; connect-time \
@@ -364,12 +377,9 @@ pub(crate) async fn connect_for_worker(
 #[derive(Clone)]
 pub struct ZmqEngineClient {
     backend: ZmqBackend,
-    /// Model id advertised for metadata (the engine does not report it on the
-    /// wire; it is configured at worker registration).
-    model_id: String,
-    /// EOS ids attached to every vLLM request (the engine can't stop at EOS
-    /// without them).
-    eos: EosTokenIds,
+    /// Connection-constant metadata, shared so cloning the client (once per
+    /// request, via `BackendClient`) stays a pointer bump.
+    meta: Arc<ZmqConnectionMeta>,
 }
 
 impl ZmqEngineClient {
@@ -428,8 +438,7 @@ impl ZmqEngineClient {
         };
         Ok(Self {
             backend,
-            model_id,
-            eos,
+            meta: Arc::new(ZmqConnectionMeta { model_id, eos }),
         })
     }
 
@@ -489,8 +498,9 @@ impl ZmqEngineClient {
                     .ok_or_else(|| tonic::Status::unavailable("no connected ZMQ engine"))?;
                 let mut streams = SelectAll::new();
                 for (index, sub) in fan_out_requests(*req).into_iter().enumerate() {
-                    let request = translate_request(sub, max_model_len, model_dtype, &self.eos)
-                        .map_err(tonic::Status::invalid_argument)?;
+                    let request =
+                        translate_request(sub, max_model_len, model_dtype, &self.meta.eos)
+                            .map_err(tonic::Status::invalid_argument)?;
                     // The engine returns the sampled/prompt token's logprob
                     // plus the requested ranked candidates per position; carry
                     // the counts so the stream can shape both `top_logprobs`
@@ -602,18 +612,18 @@ impl ZmqEngineClient {
             .unwrap_or(0);
         match &self.backend {
             ZmqBackend::Vllm(_) => ModelInfo::Vllm(vllm::GetModelInfoResponse {
-                model_path: self.model_id.clone(),
-                served_model_name: self.model_id.clone(),
-                tokenizer_path: self.model_id.clone(),
+                model_path: self.meta.model_id.clone(),
+                served_model_name: self.meta.model_id.clone(),
+                tokenizer_path: self.meta.model_id.clone(),
                 is_generation: true,
                 max_context_length: u32::try_from(max_context_length).unwrap_or(u32::MAX),
                 ..Default::default()
             }),
             ZmqBackend::TokenSpeed(_) => {
                 ModelInfo::TokenSpeed(Box::new(tokenspeed_proto::GetModelInfoResponse {
-                    model_path: self.model_id.clone(),
-                    served_model_name: self.model_id.clone(),
-                    tokenizer_path: self.model_id.clone(),
+                    model_path: self.meta.model_id.clone(),
+                    served_model_name: self.meta.model_id.clone(),
+                    tokenizer_path: self.meta.model_id.clone(),
                     max_context_length: i32::try_from(max_context_length).unwrap_or(i32::MAX),
                     ..Default::default()
                 }))
@@ -948,30 +958,34 @@ impl VllmGenerateStream {
         if self.state.prompt_logprobs.is_empty() {
             return;
         }
-        let input_logprobs = vllm::InputLogProbs {
-            token_logprobs: self.state.prompt_logprobs.clone(),
-            token_ids: self.state.prompt_token_ids.clone(),
-            top_logprobs: self.state.prompt_top_logprobs.clone(),
+        // Built per attachment site rather than up front: with
+        // `prompt_logprobs` requested this runs on every decode tick, and the
+        // common tick (a later chunk) attaches nothing.
+        let state = &self.state;
+        let build = || vllm::InputLogProbs {
+            token_logprobs: state.prompt_logprobs.clone(),
+            token_ids: state.prompt_token_ids.clone(),
+            top_logprobs: state.prompt_top_logprobs.clone(),
         };
         if let Some(vllm::generate_response::Response::Complete(parked)) = self
             .pending
             .as_mut()
             .and_then(|pending| pending.response.as_mut())
         {
-            parked.input_logprobs = Some(input_logprobs.clone());
+            parked.input_logprobs = Some(build());
         }
         match response.response.as_mut() {
             Some(vllm::generate_response::Response::Chunk(chunk))
                 if !self.input_logprobs_emitted && !chunk.token_ids.is_empty() =>
             {
-                chunk.input_logprobs = Some(input_logprobs);
+                chunk.input_logprobs = Some(build());
                 self.input_logprobs_emitted = true;
             }
             // Later chunks never repeat them (the proto carries them in the
             // first chunk only), and neither do token-less prefill chunks.
             Some(vllm::generate_response::Response::Chunk(_)) => {}
             Some(vllm::generate_response::Response::Complete(complete)) => {
-                complete.input_logprobs = Some(input_logprobs);
+                complete.input_logprobs = Some(build());
             }
             None => {}
         }
@@ -1134,18 +1148,21 @@ fn fan_out_requests(req: vllm::GenerateRequest) -> Vec<vllm::GenerateRequest> {
 
 /// Shared n>1 fan-out scaffolding: clone the request into `n` subs and let
 /// `per_sub` apply the engine-specific rid suffix and sampling tweaks. An
-/// `n <= 1` request passes through untouched.
-fn fan_out_n<R: Clone>(req: R, n: u32, mut per_sub: impl FnMut(&mut R, u32)) -> Vec<R> {
+/// `n <= 1` request passes through untouched. The last sub reuses `req`
+/// itself, so a multimodal payload is copied `n - 1` times, not `n`.
+fn fan_out_n<R: Clone>(mut req: R, n: u32, mut per_sub: impl FnMut(&mut R, u32)) -> Vec<R> {
     if n <= 1 {
         return vec![req];
     }
-    (0..n)
-        .map(|i| {
-            let mut sub = req.clone();
-            per_sub(&mut sub, i);
-            sub
-        })
-        .collect()
+    let mut subs = Vec::with_capacity(n as usize);
+    for i in 0..n - 1 {
+        let mut sub = req.clone();
+        per_sub(&mut sub, i);
+        subs.push(sub);
+    }
+    per_sub(&mut req, n - 1);
+    subs.push(req);
+    subs
 }
 
 /// Split an `n > 1` TokenSpeed proto request into `n` single-sample
@@ -2509,8 +2526,8 @@ mod tests {
         assert_eq!(sp.all_stop_token_ids, BTreeSet::from([5, 7, 9]));
     }
 
-    #[test]
-    fn eos_token_ids_resolve_from_model_dir() {
+    #[tokio::test]
+    async fn eos_token_ids_resolve_from_model_dir() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("config.json"), r#"{"eos_token_id": 5}"#).unwrap();
         std::fs::write(
@@ -2519,14 +2536,14 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            EosTokenIds::from_model_dir(dir.path()),
+            EosTokenIds::from_model_dir(dir.path()).await,
             EosTokenIds::new(Some(5), vec![7, 9]),
         );
 
         // Missing files degrade to no ids, not an error.
         let empty = tempfile::tempdir().expect("tempdir");
         assert_eq!(
-            EosTokenIds::from_model_dir(empty.path()),
+            EosTokenIds::from_model_dir(empty.path()).await,
             EosTokenIds::default(),
         );
     }

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -12,8 +12,8 @@ use super::{
     event::WorkerConnected,
     resilience::ResolvedResilience,
     worker::{
-        BasicWorker, ConnectionMode, RuntimeType, WorkerMetadata, WorkerRuntime, WorkerType,
-        DEFAULT_WORKER_HTTP_TIMEOUT_SECS,
+        BasicWorker, ConnectionMode, LazyHttpClient, RuntimeType, WorkerMetadata, WorkerRuntime,
+        WorkerType,
     },
 };
 use crate::{observability::metrics::Metrics, routers::grpc::backend_client::BackendClient};
@@ -314,14 +314,9 @@ impl BasicWorkerBuilder {
                 });
         Metrics::set_worker_health(&metadata.spec.url, initial_status == WorkerStatus::Ready);
 
-        let http_client = self.http_client.unwrap_or_else(|| {
-            reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(
-                    DEFAULT_WORKER_HTTP_TIMEOUT_SECS,
-                ))
-                .pool_max_idle_per_host(8)
-                .build()
-                .unwrap_or_default()
+        let http_client = Arc::new(match self.http_client {
+            Some(client) => LazyHttpClient::ready(client),
+            None => LazyHttpClient::deferred(),
         });
 
         let resilience = self.resilience.unwrap_or_default();
@@ -409,6 +404,29 @@ mod tests {
             .connection_mode(ConnectionMode::Zmq)
             .build();
         assert_eq!(worker.metadata().zmq_engine_count(), 1);
+    }
+
+    #[test]
+    fn http_client_is_deferred_until_first_use_and_shared_across_clones() {
+        // A ZMQ worker never issues an HTTP request, so nothing is built at
+        // construction; asking for it materializes one usable client, and a
+        // clone keeps pointing at the same lazy slot.
+        let worker = BasicWorkerBuilder::new("ipc:///tmp/w.ipc")
+            .connection_mode(ConnectionMode::Zmq)
+            .build();
+        assert!(worker.http_client.cell_is_empty());
+        let clone = worker.clone();
+        let client = worker.http_client();
+        assert!(!worker.http_client.cell_is_empty());
+        assert!(std::ptr::eq(client, clone.http_client()));
+    }
+
+    #[test]
+    fn provided_http_client_is_used_as_is() {
+        let worker = BasicWorkerBuilder::new("http://localhost:8080")
+            .http_client(reqwest::Client::new())
+            .build();
+        assert!(!worker.http_client.cell_is_empty());
     }
 
     #[test]

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -3,7 +3,7 @@ use std::{
     fmt,
     sync::{
         atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering},
-        Arc,
+        Arc, OnceLock,
     },
     time::Duration,
 };
@@ -38,6 +38,57 @@ use crate::{
 
 /// Default HTTP client timeout for worker requests (in seconds)
 pub const DEFAULT_WORKER_HTTP_TIMEOUT_SECS: u64 = 30;
+
+/// Per-worker HTTP client with an isolated connection pool, materialized on
+/// first use.
+///
+/// A worker whose connection mode never speaks HTTP (ZMQ: local health check,
+/// admin ops rejected up front) would otherwise pay for a connector and idle
+/// pool it can never use, so the fallback client is built only when a caller
+/// actually asks for it.
+pub struct LazyHttpClient {
+    cell: OnceLock<reqwest::Client>,
+}
+
+impl LazyHttpClient {
+    /// Wrap an already-built client (the registration paths hand one in).
+    pub fn ready(client: reqwest::Client) -> Self {
+        let cell = OnceLock::new();
+        let _ = cell.set(client);
+        Self { cell }
+    }
+
+    /// Defer construction until [`Self::client`] is first called.
+    pub fn deferred() -> Self {
+        Self {
+            cell: OnceLock::new(),
+        }
+    }
+
+    /// Whether the client is still unbuilt (test-only observation of laziness).
+    #[cfg(test)]
+    pub(crate) fn cell_is_empty(&self) -> bool {
+        self.cell.get().is_none()
+    }
+
+    /// The client, building the default one on first use.
+    pub fn client(&self) -> &reqwest::Client {
+        self.cell.get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(DEFAULT_WORKER_HTTP_TIMEOUT_SECS))
+                .pool_max_idle_per_host(8)
+                .build()
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "failed to build the default per-worker HTTP client; \
+                         falling back to reqwest defaults (no request timeout)"
+                    );
+                    reqwest::Client::new()
+                })
+        })
+    }
+}
 
 /// Timeout for worker HTTP `flush_cache` requests. Matches the gRPC
 /// client's local flush deadline.
@@ -1041,8 +1092,9 @@ pub struct BasicWorker {
     /// When not `Wildcard`, overrides metadata.models for routing decisions.
     /// Uses `ArcSwap` for lock-free reads on the hot path (`supports_model`).
     pub models_override: Arc<ArcSwap<WorkerModels>>,
-    /// Per-worker HTTP client with isolated connection pool.
-    pub http_client: reqwest::Client,
+    /// Per-worker HTTP client with isolated connection pool, built on first
+    /// use (see [`LazyHttpClient`]).
+    pub http_client: Arc<LazyHttpClient>,
     /// Resolved resilience config (retry + circuit breaker settings).
     pub resilience: ResolvedResilience,
 }
@@ -1057,7 +1109,7 @@ impl Clone for BasicWorker {
             zmq_connect_started: Arc::clone(&self.zmq_connect_started),
             connect_signal_tx: self.connect_signal_tx.clone(),
             models_override: Arc::clone(&self.models_override),
-            http_client: self.http_client.clone(),
+            http_client: Arc::clone(&self.http_client),
             resilience: self.resilience.clone(),
         }
     }
@@ -1266,7 +1318,7 @@ impl Worker for BasicWorker {
     }
 
     fn http_client(&self) -> &reqwest::Client {
-        &self.http_client
+        self.http_client.client()
     }
 
     fn supports_model(&self, model_id: &str) -> bool {
@@ -1503,7 +1555,7 @@ impl Worker for BasicWorker {
 
         let health_url = format!("{}{}", self.base_url(), self.metadata.health_endpoint);
 
-        let mut req = self.http_client.get(&health_url).timeout(timeout);
+        let mut req = self.http_client.client().get(&health_url).timeout(timeout);
         if let Some(api_key) = &self.metadata.spec.api_key {
             req = req.bearer_auth(api_key);
         }


### PR DESCRIPTION
## Description

### Problem

Five allocation-shaped audit findings on the direct-ZMQ gateway path:

- *attach_input_logprobs clones full prompt-logprob vectors on every tick, then usually discards them*
- *BackendClient deep-cloned per request; ZmqEngineClient's owned String/Vec make the clone allocate*
- *fan_out_n clones the request n times including the last; multimodal payloads copied per sub*
- *Blocking std::fs I/O inside async connect path, inconsistent with the file's own async-fs rationale*
- *Every ZMQ worker builds a reqwest HTTP client and pool it can never use*

### Solution

Each path drops its avoidable allocation: prompt-logprob vectors are built per attachment site, the per-request `BackendClient` clone becomes a pointer bump behind an `Arc`, `fan_out_n` moves the original request into the last sub, the connect-path file reads move to `tokio::fs`, and the per-worker reqwest client is built lazily on first use. Per-file detail below.

## Changes

- `zmq_client.rs`: `attach_input_logprobs` builds `InputLogProbs` per attachment site instead of once up front, so a mid-stream chunk (the common decode tick with `prompt_logprobs` requested) no longer pays an O(prompt_len) clone that is thrown away.
- `zmq_client.rs`: `ZmqEngineClient`'s `model_id`/`eos` move behind an `Arc<ZmqConnectionMeta>`, so the per-request `BackendClient` clone in client acquisition is a pointer bump rather than a `String` + `Vec<u32>` copy. (`ClientSelection` keeps holding the client by value — the change makes that clone cheap instead of reshaping the pipeline's ownership.)
- `zmq_client.rs`: `fan_out_n` moves the original request into the last sub, so an `n > 1` request clones `n - 1` times — one fewer copy of any inline multimodal tensor payload.
- `zmq_client.rs`: the connect-time model-dir probe and `eos_token_id` config reads use `tokio::fs`, matching `ensure_ipc_socket_dir`'s stated reason for being async.
- `worker/{worker,builder}.rs`: new `LazyHttpClient` holds the per-worker reqwest client in a `OnceLock`, built on first use. A worker built without an explicit client (ZMQ: local health check, admin ops rejected up front) never materializes a connector and idle pool. The old `unwrap_or_default()` now logs a warning before falling back.

## Test Plan

- `cargo test -p smg --lib zmq_client::` — 32 passed (includes the fan-out, prompt-logprob, and EOS model-dir tests, the last now `#[tokio::test]`).
- `cargo test -p smg --lib worker::` — 272 passed, including the two new builder tests covering deferred construction/clone sharing and the pre-built client path.
- `cargo clippy -p smg --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
