### PR TITLE
fix(zmq): connector and error-surface cleanups

### DIFF
--- a/crates/engine_zmq_client/Cargo.toml
+++ b/crates/engine_zmq_client/Cargo.toml
@@ -34,7 +34,6 @@ half.workspace = true
 # Transport + async runtime.
 zeromq.workspace = true
 tokio = { workspace = true, features = ["rt", "sync", "time", "net", "macros"] }
-tokio-util.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
 

--- a/crates/engine_zmq_client/examples/live_probe.rs
+++ b/crates/engine_zmq_client/examples/live_probe.rs
@@ -51,16 +51,9 @@ async fn main() {
     let timeout = Duration::from_secs(600);
 
     eprintln!("[probe] binding sockets; waiting for engine to connect on {handshake}");
-    let transport = connect_handshake(
-        &handshake,
-        1,
-        "127.0.0.1",
-        Some(&input),
-        Some(&output),
-        timeout,
-    )
-    .await
-    .expect("handshake with engine");
+    let transport = connect_handshake(&handshake, 1, &input, &output, timeout)
+        .await
+        .expect("handshake with engine");
 
     let engine = &transport.engines[0];
     eprintln!(

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -8,7 +8,12 @@
 //   `data_parallel_rank` remains authoritative.
 // - No DP coordinator process: for a lockstep engine group the connector plays
 //   the wake role itself, over the input socket each rank already listens on.
-// - No utility RPC (deferred).
+// - No utility RPC. Upstream's `call_utility` and its management wrappers
+//   (LoRA add/remove, prefix-cache reset, sleep/wake, profiling, weight
+//   updates) are out of scope: none of them is wired through SMG's ZMQ router
+//   path, so utility outputs decode to an empty batch the dispatcher ignores.
+//   Re-porting them means restoring upstream's call-id registry (u64 sequence
+//   numbers) alongside the request registry below.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -44,6 +49,14 @@ pub type TokenSpeedClient = Client<TokenSpeedProtocol>;
 /// The per-request output stream for the TokenSpeed connector.
 pub type TokenSpeedStream = RequestStream<TokenSpeedProtocol>;
 
+/// Per-request output channels are unbounded on purpose. The dispatcher fans
+/// one engine tick out to every request in it while holding the registry lock,
+/// so a bounded channel would let one slow consumer stall delivery for every
+/// other request on the transport — and backpressuring further, into the
+/// output PULL socket, would wedge the engine itself. Unboundedness is not
+/// unbounded memory: a request's queue is capped by its own generation
+/// (`max_tokens` outputs), a dropped stream auto-aborts it on the engine, and
+/// the buffer is freed with the stream.
 type OutputSender<O> = mpsc::UnboundedSender<Result<O>>;
 type OutputReceiver<O> = mpsc::UnboundedReceiver<Result<O>>;
 
@@ -80,16 +93,35 @@ impl<O: EngineOutput> RequestRegistry<O> {
     }
 
     /// Deliver one output to its request stream; drop the entry when terminal.
+    ///
+    /// The lookup key stays borrowed from the output, so the hot path — a
+    /// non-terminal token batch — never allocates one.
     fn route(&mut self, output: O) {
-        let request_id = output.request_id().to_string();
-        let Some(sender) = self.requests.get(&request_id) else {
-            trace!(%request_id, "output for unknown/finished request; dropping");
+        if output.finished() {
+            // Terminal: retire the entry before handing the output over, while
+            // its request id is still borrowable.
+            match self.requests.remove(output.request_id()) {
+                Some(sender) => {
+                    let _ = sender.send(Ok(output));
+                }
+                None => trace!(
+                    request_id = output.request_id(),
+                    "output for unknown/finished request; dropping"
+                ),
+            }
+            return;
+        }
+        let Some(sender) = self.requests.get(output.request_id()) else {
+            trace!(
+                request_id = output.request_id(),
+                "output for unknown/finished request; dropping"
+            );
             return;
         };
-        let finished = output.finished();
-        if sender.send(Ok(output)).is_err() || finished {
-            // Receiver gone (stream dropped) or request finished — stop tracking.
-            self.requests.remove(&request_id);
+        // A failed send hands the output back, so the receiver-gone (stream
+        // dropped) path retires the entry without an owned key either.
+        if let Err(mpsc::error::SendError(Ok(undelivered))) = sender.send(Ok(output)) {
+            self.requests.remove(undelivered.request_id());
         }
     }
 
@@ -472,7 +504,8 @@ impl<P: EngineProtocol> Client<P> {
     }
 
     /// Submit a request and return a stream of its outputs. The request is
-    /// routed by `data_parallel_rank` (SMG-pinned) or to the sole engine.
+    /// routed by `data_parallel_rank` (SMG-pinned) or, unpinned, to the
+    /// least-loaded engine (see [`ClientInner::select_engine`]).
     /// Dropping the returned stream before it finishes aborts the request.
     pub async fn submit(&self, request: P::Request) -> Result<RequestStream<P>> {
         P::validate(&request)?;
@@ -553,12 +586,6 @@ impl<P: EngineProtocol> Drop for Client<P> {
     }
 }
 
-/// If the engine emits no output for this long while requests are in flight, the
-/// dispatcher treats it as dead. A hard engine death (SIGKILL/OOM) sends no
-/// `ENGINE_CORE_DEAD` sentinel, and a bound PULL socket never errors when its
-/// PUSH peer vanishes — so silence is the only available death signal. Generous
-/// so a slow first token never trips it, while still bounding an otherwise
-/// infinite hang.
 /// Maximum time to wait for a single request frame to be accepted by an engine's
 /// input socket before treating the engine as wedged. A healthy engine drains its
 /// input continuously; a send that blocks this long means its event loop is stuck.
@@ -566,6 +593,19 @@ impl<P: EngineProtocol> Drop for Client<P> {
 /// [`ClientInner::send_to_engine`]).
 const ENGINE_SEND_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// If the engine emits no output for this long while requests are in flight, the
+/// dispatcher treats it as dead. A hard engine death (SIGKILL/OOM) sends no
+/// `ENGINE_CORE_DEAD` sentinel, and a bound PULL socket never errors when its
+/// PUSH peer vanishes — so silence is the only available death signal. Generous
+/// so a slow first token never trips it, while still bounding an otherwise
+/// infinite hang.
+///
+/// The window is deliberately fixed rather than derived from context length:
+/// any single request whose first token takes longer than this — a lone
+/// million-token prefill on an otherwise idle transport — is failed as if the
+/// engine had died. Deployments that can prefill for minutes with no other
+/// traffic need this raised (per-worker configuration), not the watchdog
+/// removed: without it a killed engine hangs its requests forever.
 const ENGINE_SILENCE_DEATH_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Route decoded outputs to per-request streams and forward auto-abort requests
@@ -588,11 +628,8 @@ async fn run_dispatcher<P: EngineProtocol>(
                         }
                         // Unique finished ids: a terminal output and the
                         // out-of-band finished list may name the same request.
-                        let mut finished: HashSet<String> = batch
-                            .finished_request_ids
-                            .iter()
-                            .cloned()
-                            .collect();
+                        let mut finished: HashSet<String> =
+                            batch.finished_request_ids.into_iter().collect();
                         let mut registry = inner.registry.lock();
                         for output in batch.outputs {
                             if output.finished() {
@@ -600,7 +637,7 @@ async fn run_dispatcher<P: EngineProtocol>(
                             }
                             registry.route(output);
                         }
-                        registry.remove_all(&batch.finished_request_ids);
+                        registry.remove_all(&finished);
                         drop(registry);
                         inner.release(batch.engine_index, &finished);
                     }
@@ -697,9 +734,16 @@ impl<P: EngineProtocol> Stream for RequestStream<P> {
                 self.finished = true;
                 Poll::Ready(Some(Err(error)))
             }
+            // The sender was dropped without a terminal output — the client was
+            // dropped out from under the stream, or the dispatcher stopped
+            // tracking the request. Surface it as an error: a clean end here is
+            // indistinguishable from a completed generation, and a truncated
+            // response must not look complete to the caller.
             Poll::Ready(None) => {
                 self.finished = true;
-                Poll::Ready(None)
+                Poll::Ready(Some(Err(Error::RequestStreamClosed {
+                    request_id: self.request_id.clone(),
+                })))
             }
             Poll::Pending => Poll::Pending,
         }
@@ -755,14 +799,7 @@ mod tests {
             ns.output_endpoint(),
         );
         let (transport, engine) = tokio::join!(
-            connect_handshake(
-                &handshake,
-                1,
-                "127.0.0.1",
-                Some(&input),
-                Some(&output),
-                TIMEOUT
-            ),
+            connect_handshake(&handshake, 1, &input, &output, TIMEOUT),
             connect_to_frontend(
                 &handshake,
                 EngineId::from_engine_index(0),
@@ -799,14 +836,7 @@ mod tests {
             connect_to_frontend(&handshake, EngineId::from_engine_index(rank), ready(rank))
         });
         let (transport, engines) = tokio::join!(
-            connect_handshake(
-                &handshake,
-                engine_count,
-                "127.0.0.1",
-                Some(&input),
-                Some(&output),
-                TIMEOUT
-            ),
+            connect_handshake(&handshake, engine_count, &input, &output, TIMEOUT),
             futures::future::join_all(engines),
         );
         let engines = engines.into_iter().map(Result::unwrap).collect();
@@ -895,6 +925,35 @@ mod tests {
         assert_eq!(second.new_token_ids, vec![11]);
         assert!(second.finished());
         // Terminal output ends the stream.
+        assert!(stream.next().await.is_none());
+    }
+
+    /// A stream that outlives its client is truncated, not complete: it must
+    /// report the truncation rather than end like a finished generation.
+    #[tokio::test]
+    async fn dropping_the_client_errors_live_streams() {
+        let (client, mut engine, _ns) = connect().await;
+        let mut stream = client
+            .submit(EngineCoreRequest {
+                request_id: "orphan".into(),
+                prompt_token_ids: Some(vec![1, 2, 3]),
+                ..EngineCoreRequest::default()
+            })
+            .await
+            .unwrap();
+        engine.recv_request().await.unwrap();
+
+        drop(client);
+
+        let error = stream
+            .next()
+            .await
+            .expect("a terminal error item")
+            .expect_err("truncation is not a clean end of stream");
+        assert!(
+            matches!(&error, Error::RequestStreamClosed { request_id } if request_id == "orphan"),
+            "unexpected error: {error}"
+        );
         assert!(stream.next().await.is_none());
     }
 
@@ -1236,16 +1295,10 @@ mod tests {
             ns.input_endpoint(),
             ns.output_endpoint(),
         );
-        std::mem::forget(ns);
+        // Held for the test duration so the ipc files outlive the client.
+        let _ns = ns;
         let (transport, engine) = tokio::join!(
-            connect_handshake(
-                &handshake,
-                1,
-                "127.0.0.1",
-                Some(&input),
-                Some(&output),
-                TIMEOUT
-            ),
+            connect_handshake(&handshake, 1, &input, &output, TIMEOUT),
             connect_to_frontend(
                 &handshake,
                 EngineId::from_engine_index(0),

--- a/crates/engine_zmq_client/src/error.rs
+++ b/crates/engine_zmq_client/src/error.rs
@@ -25,12 +25,10 @@ pub enum Error {
     ValueDecode(#[from] rmpv::decode::Error),
     #[error("messagepack ext value decode failed: {message}")]
     ExtValueDecode { message: String },
-    #[error("io error")]
+    #[error("io error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("transport error")]
+    #[error("transport error: {0}")]
     Transport(#[from] zeromq::ZmqError),
-    #[error("ZMQ runtime task failed")]
-    ZmqRuntimeTask(#[from] tokio::task::JoinError),
     #[error("engine core reported fatal failure")]
     EngineCoreDead,
     #[error("startup handshake timed out while waiting for {stage} after {timeout:?}")]
@@ -40,12 +38,8 @@ pub enum Error {
     },
     #[error("engine input registration timed out after {timeout:?}")]
     InputRegistrationTimeout { timeout: Duration },
-    #[error("unexpected engine id in startup handshake: expected {expected:?}, got {actual:?}")]
-    UnexpectedHandshakeIdentity { expected: Vec<u8>, actual: Vec<u8> },
     #[error("unexpected startup handshake message: {message}")]
     UnexpectedHandshakeMessage { message: String },
-    #[error("unsupported auxiliary frame(s): expected {expected} frame(s), got {frame_count}")]
-    UnsupportedAuxFrames { expected: usize, frame_count: usize },
     #[error("unsupported field `{field}` in {context}")]
     UnsupportedField {
         context: &'static str,
@@ -59,8 +53,6 @@ pub enum Error {
     InvalidDataParallelRank { rank: u32, num_engines: u32 },
     #[error("request output stream for `{request_id}` closed unexpectedly")]
     RequestStreamClosed { request_id: String },
-    #[error("engine-core output dispatcher closed: {message}")]
-    DispatcherClosed { message: String },
     #[error("engine ZMQ client is closed: {message}")]
     ClientClosed { message: String },
 

--- a/crates/engine_zmq_client/src/lib.rs
+++ b/crates/engine_zmq_client/src/lib.rs
@@ -33,12 +33,10 @@ pub mod transport;
 #[cfg(any(test, feature = "mock-engine"))]
 pub mod mock_engine;
 
+// Crate-root shortcuts for what consumers actually build against; everything
+// else stays reachable through its own module path.
 pub use connector::{
     Client, EngineCoreClient, EngineCoreStream, RequestStream, TokenSpeedClient, TokenSpeedStream,
 };
 pub use error::{Error, Result};
-pub use protocol::{EngineBatch, EngineOutput, EngineProtocol};
-pub use transport::{
-    connect_handshake, run_output_loop, send_message, ConnectedEngine, ConnectedTransport,
-    EngineId, ENGINE_CORE_DEAD_SENTINEL,
-};
+pub use transport::{connect_handshake, ConnectedEngine, EngineId, ENGINE_CORE_DEAD_SENTINEL};

--- a/crates/engine_zmq_client/src/protocol/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/mod.rs
@@ -64,7 +64,10 @@ pub struct EngineBatch<O> {
     pub engine_index: u32,
     /// Per-request outputs produced in this tick.
     pub outputs: Vec<O>,
-    /// Request ids the engine reported finished out-of-band.
+    /// Request ids finished in this tick, including ones the connector could
+    /// derive from a terminal output: a protocol without an out-of-band finish
+    /// channel may list them here too. The connector unions both sources, so
+    /// the overlap is harmless.
     pub finished_request_ids: Vec<String>,
     /// Per-rank load signal, when the protocol carries it (`None` otherwise).
     pub load: Option<EngineLoad>,

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/mod.rs
@@ -120,7 +120,7 @@ impl EngineProtocol for TokenSpeedProtocol {
         // The abort payload is a positional msgpack array of request-id strings,
         // decoded by the engine's `decode_abort` (a `msgspec.msgpack.Decoder(
         // list[str])`) into abort requests. A single-element array aborts one rid.
-        encode_msgpack(&[request_id.to_string()])
+        encode_msgpack(&[request_id])
     }
 
     fn encode_start_wave(_wave: u64) -> Result<Option<(Bytes, Vec<u8>)>> {
@@ -151,6 +151,9 @@ impl EngineProtocol for TokenSpeedProtocol {
             kv_cache_usage: batch.kv_active_pages as f64 / batch.kv_total_pages as f64,
         });
         let outputs = batch.into_outputs()?;
+        // TokenSpeed has no out-of-band finish channel: every finish is carried
+        // by its own output. Reporting them here anyway keeps the batch shape
+        // self-describing for consumers that only read the finished list.
         let finished_request_ids = outputs
             .iter()
             .filter(|output| output.finish_reason.is_some())

--- a/crates/engine_zmq_client/src/protocol/vllm/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/mod.rs
@@ -9,9 +9,6 @@
 //! features are typed fully. Pooling params and prompt embeds are carried as
 //! [`crate::codec::OpaqueValue`] — they serialize as `nil` on supported paths.
 
-// The startup handshake is engine-neutral (TokenSpeed speaks the same
-// protocol); re-exported here so existing `vllm::handshake` paths keep working.
-pub use crate::protocol::handshake;
 pub mod logprobs;
 pub mod lora;
 pub mod multimodal;
@@ -93,7 +90,7 @@ impl EngineProtocol for VllmProtocol {
     }
 
     fn encode_abort(request_id: &str) -> Result<Vec<u8>> {
-        encode_msgpack(&[request_id.to_string()])
+        encode_msgpack(&[request_id])
     }
 
     fn encode_start_wave(wave: u64) -> Result<Option<(Bytes, Vec<u8>)>> {

--- a/crates/engine_zmq_client/src/transport.rs
+++ b/crates/engine_zmq_client/src/transport.rs
@@ -72,7 +72,13 @@ impl EngineId {
     }
 
     /// Construct an engine id from the Python-compatible engine index encoding.
+    /// The identity is two bytes, so an index above [`u16::MAX`] cannot be
+    /// represented — it would alias another rank's identity.
     pub fn from_engine_index(value: u32) -> Self {
+        debug_assert!(
+            value <= u32::from(u16::MAX),
+            "engine index {value} does not fit the 2-byte engine identity"
+        );
         Self(Bytes::copy_from_slice(&(value as u16).to_le_bytes()))
     }
 }
@@ -157,9 +163,8 @@ fn unexpected_handshake(message: impl Into<String>) -> Error {
 pub async fn connect_handshake(
     handshake_address: &str,
     engine_count: usize,
-    local_host: &str,
-    local_input_address: Option<&str>,
-    local_output_address: Option<&str>,
+    local_input_address: &str,
+    local_output_address: &str,
     ready_timeout: Duration,
 ) -> Result<ConnectedTransport> {
     if engine_count == 0 {
@@ -174,7 +179,7 @@ pub async fn connect_handshake(
     // 1. Bind shared input/output sockets first so every engine receives the
     //    same data-plane addresses during handshake.
     let (input_address, mut input_socket, output_address, output_socket) =
-        bind_local_sockets(local_host, local_input_address, local_output_address).await?;
+        bind_local_sockets(local_input_address, local_output_address).await?;
     info!(%input_address, %output_address, "bound local transport sockets");
 
     // 2. Bind the shared handshake socket. All engines connect here with their
@@ -281,24 +286,17 @@ pub async fn connect_handshake(
     })
 }
 
-/// Bind the shared input (ROUTER) and output (PULL) sockets. `ipc://` is
-/// supported via explicit addresses; otherwise an ephemeral `tcp://host:0` is used.
+/// Bind the shared input (ROUTER) and output (PULL) sockets to the given
+/// addresses (`ipc://` on the same host, `tcp://` otherwise).
 async fn bind_local_sockets(
-    local_host: &str,
-    local_input_address: Option<&str>,
-    local_output_address: Option<&str>,
+    local_input_address: &str,
+    local_output_address: &str,
 ) -> Result<(String, RouterSocket, String, PullSocket)> {
     let mut input_socket = RouterSocket::new();
-    let input_bind = local_input_address
-        .map(str::to_owned)
-        .unwrap_or_else(|| format!("tcp://{local_host}:0"));
-    let input_address = input_socket.bind(&input_bind).await?.to_string();
+    let input_address = input_socket.bind(local_input_address).await?.to_string();
 
     let mut output_socket = PullSocket::new();
-    let output_bind = local_output_address
-        .map(str::to_owned)
-        .unwrap_or_else(|| format!("tcp://{local_host}:0"));
-    let output_address = output_socket.bind(&output_bind).await?.to_string();
+    let output_address = output_socket.bind(local_output_address).await?.to_string();
 
     Ok((input_address, input_socket, output_address, output_socket))
 }
@@ -490,13 +488,10 @@ mod tests {
     #[tokio::test]
     async fn bind_local_sockets_supports_ipc() {
         let ns = IpcNamespace::new().unwrap();
-        let (input_address, _in, output_address, _out) = bind_local_sockets(
-            "127.0.0.1",
-            Some(&ns.input_endpoint()),
-            Some(&ns.output_endpoint()),
-        )
-        .await
-        .unwrap();
+        let (input_address, _in, output_address, _out) =
+            bind_local_sockets(&ns.input_endpoint(), &ns.output_endpoint())
+                .await
+                .unwrap();
         assert!(input_address.starts_with("ipc://"));
         assert!(output_address.starts_with("ipc://"));
     }
@@ -512,14 +507,7 @@ mod tests {
 
         // Frontend binds + drives handshake; mock engine (index 0) connects in.
         let (transport, engine) = tokio::join!(
-            connect_handshake(
-                &handshake,
-                1,
-                "127.0.0.1",
-                Some(&input),
-                Some(&output),
-                TIMEOUT
-            ),
+            connect_handshake(&handshake, 1, &input, &output, TIMEOUT),
             connect_to_frontend(
                 &handshake,
                 EngineId::from_engine_index(0),
@@ -617,14 +605,7 @@ mod tests {
         );
 
         let (transport, engine) = tokio::join!(
-            connect_handshake(
-                &handshake,
-                1,
-                "127.0.0.1",
-                Some(&input),
-                Some(&output),
-                TIMEOUT
-            ),
+            connect_handshake(&handshake, 1, &input, &output, TIMEOUT),
             connect_to_frontend(
                 &handshake,
                 EngineId::from_engine_index(0),

--- a/crates/mock_worker/src/zmq.rs
+++ b/crates/mock_worker/src/zmq.rs
@@ -315,16 +315,9 @@ mod tests {
         )]
         let _engine = tokio::spawn(serve(cfg, handshake.clone(), 0));
 
-        let transport = connect_handshake(
-            &handshake,
-            1,
-            "127.0.0.1",
-            Some(&input),
-            Some(&output),
-            Duration::from_secs(10),
-        )
-        .await
-        .expect("frontend handshake");
+        let transport = connect_handshake(&handshake, 1, &input, &output, Duration::from_secs(10))
+            .await
+            .expect("frontend handshake");
         let client = EngineCoreClient::new(transport);
         assert_eq!(client.engines()[0].ready_response.data_parallel_rank, 0);
 

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -411,9 +411,8 @@ impl ZmqEngineClient {
         let transport = connect_handshake(
             handshake_address,
             engine_count,
-            ZMQ_LOOPBACK_HOST,
-            Some(input_address),
-            Some(output_address),
+            input_address,
+            output_address,
             timeout,
         )
         .await?;


### PR DESCRIPTION
## Description

### Problem

Audit cleanups on `engine-zmq-client`, the direct-ZMQ engine connector. Findings fixed:

- *Client drop silently truncates live request streams as clean end-of-stream; `RequestStreamClosed` variant is dead code*
- *Source-less Display strings on Io/Transport/JoinError variants erase all diagnostic context in logs*
- *Five error variants are never constructed anywhere*
- *connect_handshake carries dead configurability: Option-al data-plane addresses and a local_host parameter no caller ever exercises*
- *Several crate-root re-exports have no consumer anywhere in the repo*
- *Dead compat re-export: vllm::handshake alias has zero users*
- *Unused dependency: tokio-util*
- *Doc comment for ENGINE_SILENCE_DEATH_TIMEOUT is attached to ENGINE_SEND_TIMEOUT* (reported three times)
- *submit() doc claims routing to 'the sole engine' but unpinned requests are load-balanced across ranks*
- *Per-request output channels are unbounded; no backpressure between dispatcher and stream consumers* (reported twice)
- *300s silence watchdog can falsely kill an engine mid-long-prefill*
- *Entire utility-RPC surface dropped; utility outputs decoded then discarded*
- *Avoidable per-output String allocations in the dispatch hot path*
- *encode_abort allocates a String where a &str serializes identically*
- *EngineId::from_engine_index silently truncates u32 to u16*
- *TokenSpeed decode_batch fills the 'out-of-band finished ids' field with in-band ids*
- *`std::mem::forget(ns)` in a test leaks the IPC tempdir on every run*

### Solution

The one behavior change is the stream-truncation fix; the rest removes dead surface or records decisions the code could not express. Changes are grouped by kind below.

## Changes

**Behavior**

- `RequestStream::poll_next` yields `Error::RequestStreamClosed` once when its channel closes before a terminal output, instead of a clean `None`. Dropping the `Client` out from under a live stream, or the engine retiring a request out-of-band without a terminal output, no longer looks like a completed generation to the caller.

**API**

- `connect_handshake` takes `local_input_address: &str` / `local_output_address: &str`; the never-taken `tcp://{local_host}:0` fallback and the `local_host` parameter are gone (every caller passed `Some(..), Some(..), "127.0.0.1"`).
- Deleted the four never-constructed error variants (`UnexpectedHandshakeIdentity`, `DispatcherClosed`, `UnsupportedAuxFrames`, `ZmqRuntimeTask`); `Io`/`Transport` now interpolate their `#[from]` source into Display, so `error=transport error` becomes the actual `ZmqError`.
- Crate-root re-exports trimmed to what consumers import (`run_output_loop`, `send_message`, `ConnectedTransport`, `EngineBatch`, `EngineOutput`, `EngineProtocol` remain reachable via their module paths); dropped the unused `vllm::handshake` compat alias and the unused `tokio-util` dependency.

**Docs / notes (no behavior change)**

- Moved the silence-watchdog paragraph onto `ENGINE_SILENCE_DEATH_TIMEOUT` and recorded the fixed-window tradeoff (a lone multi-minute prefill on an idle transport is failed as a death) plus what raising it would require.
- Documented why per-request output channels are unbounded (a bounded channel would stall the shared dispatcher; growth is bounded by the request's own generation and freed with the stream).
- Documented the utility-RPC scope decision and what re-porting it costs.
- Corrected the `submit` doc for unpinned DP load balancing, and reworded `EngineBatch::finished_request_ids` so TokenSpeed's in-band population matches the contract.

**Cleanups**

- `RequestRegistry::route` looks up by `&str` and retires entries without building an owned key, and the dispatcher consumes `finished_request_ids` instead of cloning it.
- `encode_abort` serializes the borrowed id; `EngineId::from_engine_index` debug-asserts the index fits the 2-byte identity.
- The TokenSpeed connector test holds its `IpcNamespace` instead of `mem::forget`ing it (which leaked the socket tempdir every run).

## Test Plan

- `cargo test -p engine-zmq-client` — 78 passed, 0 failed (includes the new `dropping_the_client_errors_live_streams`).
- `cargo test -p mock-worker zmq` — 1 passed (`end_to_end_generate_over_ipc`).
- `cargo test -p smg --lib zmq_client` — 32 passed, 0 failed.
- `cargo clippy -p engine-zmq-client -p mock-worker --all-targets -- -D warnings` — clean.
- `cargo clippy -p smg --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
