### PR TITLE
perf(zmq): remove avoidable copies on protocol and codec paths

### DIFF
--- a/crates/engine_zmq_client/src/codec/tensor.rs
+++ b/crates/engine_zmq_client/src/codec/tensor.rs
@@ -279,14 +279,7 @@ pub struct DecodedArray2<T> {
 
 /// Resolve an array payload to raw bytes, following an aux-frame index into
 /// `frames` (frame 0 is the primary msgpack, so indices are one-based).
-pub fn resolve_array_bytes<Frame>(
-    value: WireArrayData,
-    field: &str,
-    frames: &[Frame],
-) -> Result<Bytes>
-where
-    Frame: AsRef<[u8]>,
-{
+pub fn resolve_array_bytes(value: WireArrayData, field: &str, frames: &[Bytes]) -> Result<Bytes> {
     match value {
         WireArrayData::RawView(bytes) => Ok(bytes),
         WireArrayData::AuxIndex(index) => {
@@ -299,7 +292,8 @@ where
                     ),
                 )
             })?;
-            Ok(Bytes::copy_from_slice(frame.as_ref()))
+            // Aux frames are refcounted buffers off the wire: share, do not copy.
+            Ok(frame.clone())
         }
     }
 }
@@ -325,15 +319,12 @@ pub fn validate_byte_length(
     Ok(())
 }
 
-fn decode_array_metadata<Frame>(
+fn decode_array_metadata(
     value: WireNdArray,
     field: &str,
-    frames: &[Frame],
+    frames: &[Bytes],
     expected_scalars: &[ScalarType],
-) -> Result<(Vec<usize>, Bytes, ScalarType, Endianness)>
-where
-    Frame: AsRef<[u8]>,
-{
+) -> Result<(Vec<usize>, Bytes, ScalarType, Endianness)> {
     let WireNdArray { dtype, shape, data } = value;
     let (scalar, endianness) = parse_dtype(&dtype, field)?;
     if !expected_scalars.contains(&scalar) {
@@ -348,14 +339,11 @@ where
 }
 
 /// Decode a rank-2 integer array (i32/i64) to `u32` rows.
-pub fn decode_array2_u32<Frame>(
+pub fn decode_array2_u32(
     value: WireNdArray,
     field: &str,
-    frames: &[Frame],
-) -> Result<DecodedArray2<u32>>
-where
-    Frame: AsRef<[u8]>,
-{
+    frames: &[Bytes],
+) -> Result<DecodedArray2<u32>> {
     let (shape, bytes, scalar, endianness) =
         decode_array_metadata(value, field, frames, &[ScalarType::I32, ScalarType::I64])?;
     if shape.len() != 2 {
@@ -373,14 +361,7 @@ where
 }
 
 /// Decode a rank-1 integer array (i32/i64) to a `Vec<u32>`.
-pub fn decode_array1_u32<Frame>(
-    value: WireNdArray,
-    field: &str,
-    frames: &[Frame],
-) -> Result<Vec<u32>>
-where
-    Frame: AsRef<[u8]>,
-{
+pub fn decode_array1_u32(value: WireNdArray, field: &str, frames: &[Bytes]) -> Result<Vec<u32>> {
     let (shape, bytes, scalar, endianness) =
         decode_array_metadata(value, field, frames, &[ScalarType::I32, ScalarType::I64])?;
     if shape.len() != 1 {
@@ -393,14 +374,11 @@ where
 }
 
 /// Decode a rank-2 float32 array.
-pub fn decode_array2_f32<Frame>(
+pub fn decode_array2_f32(
     value: WireNdArray,
     field: &str,
-    frames: &[Frame],
-) -> Result<DecodedArray2<f32>>
-where
-    Frame: AsRef<[u8]>,
-{
+    frames: &[Bytes],
+) -> Result<DecodedArray2<f32>> {
     let (shape, bytes, _, endianness) =
         decode_array_metadata(value, field, frames, &[ScalarType::F32])?;
     if shape.len() != 2 {
@@ -517,6 +495,15 @@ mod tests {
             decode_array1_u32(via_aux, "ids", &framed).unwrap(),
             vec![10, 20, 30]
         );
+    }
+
+    #[test]
+    fn resolve_array_bytes_shares_the_aux_frame() {
+        let frame = Bytes::from(vec![1_u8, 2, 3, 4]);
+        let frames = vec![Bytes::new(), frame.clone()];
+        let resolved = resolve_array_bytes(WireArrayData::AuxIndex(1), "ids", &frames).unwrap();
+        // Zero-copy: the resolved payload aliases the received frame.
+        assert_eq!(resolved.as_ptr(), frame.as_ptr());
     }
 
     #[test]

--- a/crates/engine_zmq_client/src/protocol/vllm/logprobs.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/logprobs.rs
@@ -2,7 +2,8 @@
 // (vllm-project/vllm): protocol/logprobs.rs + protocol/logprobs/wire.rs.
 // The numpy-array decoders live in `crate::codec::tensor`.
 
-use serde::{Deserialize, Deserializer, Serialize};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::{
@@ -88,27 +89,27 @@ impl Logprobs {
 /// aux-frame references and raw-view payloads are resolved. Mirrors Python
 /// `vllm/v1/outputs.py`.
 #[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
-pub struct WireLogprobs {
+pub(crate) struct WireLogprobs {
     /// Wire array with shape `[num_positions, max_num_logprobs + 1]`.
-    pub logprob_token_ids: WireNdArray,
+    pub(crate) logprob_token_ids: WireNdArray,
     /// Wire array with shape `[num_positions, max_num_logprobs + 1]`.
-    pub logprobs: WireNdArray,
+    pub(crate) logprobs: WireNdArray,
     /// Wire array with shape `[num_positions]`. Python names it
     /// `sampled_token_ranks` (sample logprobs) / `selected_token_ranks` (prompt
     /// logprobs); one neutral field here since both share the wire shape.
-    pub token_ranks: WireNdArray,
+    pub(crate) token_ranks: WireNdArray,
     /// Preserved only for wire compatibility with batch-level Python tensors.
     /// Scheduler-sliced per-request outputs emit `None`; any other value is
     /// rejected by the semantic decoder.
     #[serde(default)]
-    pub cu_num_generated_tokens: Option<Vec<usize>>,
+    pub(crate) cu_num_generated_tokens: Option<Vec<usize>>,
 }
 
 impl WireLogprobs {
     /// Convert semantic per-position logprobs into the Python wire tuple shape.
     /// Exists mainly so tests can inject semantic logprobs without hand-building
     /// ndarray raw-view tuples.
-    fn from_direct(value: &Logprobs) -> std::result::Result<Self, String> {
+    pub(crate) fn from_direct(value: &Logprobs) -> std::result::Result<Self, String> {
         let rows = value.positions.len();
         let cols = value
             .positions
@@ -160,10 +161,7 @@ impl WireLogprobs {
 
     /// Resolve wire-format logprobs into semantic [`Logprobs`] by decoding the
     /// three arrays (via aux frames as needed) and grouping each row.
-    fn resolve<Frame>(self, frames: &[Frame], field_prefix: &str) -> Result<Logprobs>
-    where
-        Frame: AsRef<[u8]>,
-    {
+    pub(crate) fn resolve(self, frames: &[Bytes], field_prefix: &str) -> Result<Logprobs> {
         if let Some(indices) = self.cu_num_generated_tokens {
             return Err(Error::ExtValueDecode {
                 message: format!(
@@ -237,68 +235,8 @@ impl WireLogprobs {
     }
 }
 
-/// Output field wrapper deserialized from the Python wire shape, then resolved
-/// into [`Logprobs`] before the decoded message is returned to callers.
-#[derive(Clone, PartialEq, Debug)]
-pub enum MaybeWireLogprobs {
-    /// Still in wire format; needs [`MaybeWireLogprobs::resolve`]. Internal use
-    /// only during deserialization.
-    Wire(Box<WireLogprobs>),
-    /// The decoded logprobs value.
-    Direct(Logprobs),
-}
-
-impl MaybeWireLogprobs {
-    /// The decoded logprobs, if already resolved.
-    pub fn as_direct(&self) -> Option<&Logprobs> {
-        match self {
-            Self::Direct(value) => Some(value),
-            Self::Wire(_) => None,
-        }
-    }
-
-    /// Resolve the wire representation into decoded logprobs, looking up aux
-    /// frames and decoding raw views as needed.
-    pub(crate) fn resolve<Frame>(self, frames: &[Frame], field_prefix: &str) -> Result<Self>
-    where
-        Frame: AsRef<[u8]>,
-    {
-        match self {
-            Self::Direct(value) => Ok(Self::Direct(value)),
-            Self::Wire(value) => value.resolve(frames, field_prefix).map(Self::Direct),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for MaybeWireLogprobs {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // On the wire it is always the wire form.
-        WireLogprobs::deserialize(deserializer).map(|v| Self::Wire(Box::new(v)))
-    }
-}
-
-impl Serialize for MaybeWireLogprobs {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        // Test-only: we never actually serialize into aux frames on the send path.
-        match self {
-            Self::Wire(value) => value.serialize(serializer),
-            Self::Direct(value) => WireLogprobs::from_direct(value)
-                .map_err(serde::ser::Error::custom)?
-                .serialize(serializer),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
-
     use super::*;
 
     fn direct(positions: Vec<Vec<(u32, f32, u32)>>) -> Logprobs {
@@ -350,17 +288,13 @@ mod tests {
     }
 
     #[test]
-    fn maybe_wire_logprobs_deserializes_as_wire_then_resolves() {
+    fn wire_logprobs_deserialize_then_resolve() {
         let bytes = rmp_serde::to_vec_named(
             &WireLogprobs::from_direct(&direct(vec![vec![(7, -0.2, 3)]])).unwrap(),
         )
         .unwrap();
-        let maybe: MaybeWireLogprobs = rmp_serde::from_slice(&bytes).unwrap();
-        assert!(maybe.as_direct().is_none()); // still wire
-        let resolved = maybe.resolve(&[Bytes::new()], "lp").unwrap();
-        assert_eq!(
-            resolved.as_direct().unwrap().positions[0].entries[0].token_id,
-            7
-        );
+        let wire: WireLogprobs = rmp_serde::from_slice(&bytes).unwrap();
+        let resolved = wire.resolve(&[Bytes::new()], "lp").unwrap();
+        assert_eq!(resolved.positions[0].entries[0].token_id, 7);
     }
 }

--- a/crates/engine_zmq_client/src/protocol/vllm/output.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/output.rs
@@ -6,7 +6,8 @@
 
 use std::collections::BTreeSet;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize, Serializer};
 use serde_default::DefaultFromSerde;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
@@ -15,7 +16,7 @@ use crate::{
     codec::{decode_msgpack, OpaqueValue},
     error::{Error, Result},
     protocol::vllm::{
-        logprobs::MaybeWireLogprobs,
+        logprobs::{Logprobs, WireLogprobs},
         stats::{PrefillStats, SchedulerStats},
     },
 };
@@ -63,38 +64,30 @@ pub struct EngineCoreEvent {
 
 /// Engine-core output for a single request. Mirrors Python `EngineCoreOutput`
 /// (`array_like` — field order is the wire contract).
-#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple, DefaultFromSerde)]
+///
+/// Logprobs are resolved out of their wire form (aux frames, raw views) by
+/// [`decode_engine_core_outputs`], so this type only ever carries decoded
+/// [`Logprobs`].
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EngineCoreOutput {
     pub request_id: String,
     pub new_token_ids: Vec<u32>,
     /// Decoded sample logprobs for the newly generated positions.
-    #[serde(default)]
-    pub new_logprobs: Option<MaybeWireLogprobs>,
+    pub new_logprobs: Option<Logprobs>,
     /// Decoded prompt logprobs for the scored prompt positions.
-    #[serde(default)]
-    pub new_prompt_logprobs_tensors: Option<MaybeWireLogprobs>,
-    #[serde(default)]
+    pub new_prompt_logprobs_tensors: Option<Logprobs>,
     pub pooling_output: Option<OpaqueValue>,
-    #[serde(default)]
     pub finish_reason: Option<EngineCoreFinishReason>,
-    #[serde(default)]
     pub stop_reason: Option<StopReason>,
-    #[serde(default)]
     pub events: Option<Vec<EngineCoreEvent>>,
-    #[serde(default)]
     pub kv_transfer_params: Option<serde_json::Value>,
-    #[serde(default)]
     pub ec_transfer_params: Option<serde_json::Value>,
-    #[serde(default)]
     pub trace_headers: Option<OpaqueValue>,
     /// Breakdown of the scheduled prefill computation, set on the first output
     /// of a newly scheduled prefill and elided for subsequent decode outputs.
-    #[serde(default)]
     pub prefill_stats: Option<PrefillStats>,
-    #[serde(default)]
     pub routed_experts: Option<OpaqueValue>,
     /// Number of NaNs seen in logits. Values above zero indicate corruption.
-    #[serde(default)]
     pub num_nans_in_logits: u32,
 }
 
@@ -103,35 +96,136 @@ impl EngineCoreOutput {
     pub fn finished(&self) -> bool {
         self.finish_reason.is_some()
     }
+}
 
-    /// Resolve wire-format logprobs in-place using the aux frames.
-    fn resolve_in_place<Frame>(&mut self, frames: &[Frame]) -> Result<()>
+impl Serialize for EngineCoreOutput {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
-        Frame: AsRef<[u8]>,
+        S: Serializer,
     {
-        self.new_logprobs = self
-            .new_logprobs
-            .take()
-            .map(|value| value.resolve(frames, "new_logprobs"))
-            .transpose()?;
-        self.new_prompt_logprobs_tensors = self
-            .new_prompt_logprobs_tensors
-            .take()
-            .map(|value| value.resolve(frames, "new_prompt_logprobs_tensors"))
-            .transpose()?;
-        Ok(())
+        let new_logprobs = wire_logprobs(self.new_logprobs.as_ref())?;
+        let new_prompt_logprobs_tensors = wire_logprobs(self.new_prompt_logprobs_tensors.as_ref())?;
+        WireEngineCoreOutputRef {
+            request_id: &self.request_id,
+            new_token_ids: &self.new_token_ids,
+            new_logprobs: new_logprobs.as_ref(),
+            new_prompt_logprobs_tensors: new_prompt_logprobs_tensors.as_ref(),
+            pooling_output: self.pooling_output.as_ref(),
+            finish_reason: self.finish_reason,
+            stop_reason: self.stop_reason.as_ref(),
+            events: self.events.as_deref(),
+            kv_transfer_params: self.kv_transfer_params.as_ref(),
+            ec_transfer_params: self.ec_transfer_params.as_ref(),
+            trace_headers: self.trace_headers.as_ref(),
+            prefill_stats: self.prefill_stats.as_ref(),
+            routed_experts: self.routed_experts.as_ref(),
+            num_nans_in_logits: self.num_nans_in_logits,
+        }
+        .serialize(serializer)
     }
+}
+
+/// Encode decoded logprobs back into their wire arrays (send path only: the
+/// mock engine and tests).
+fn wire_logprobs<E: serde::ser::Error>(
+    logprobs: Option<&Logprobs>,
+) -> std::result::Result<Option<WireLogprobs>, E> {
+    logprobs
+        .map(WireLogprobs::from_direct)
+        .transpose()
+        .map_err(serde::ser::Error::custom)
+}
+
+/// Raw Python/msgpack per-request output. Logprobs arrive here in wire form
+/// (inline raw views or aux-frame indices) and are resolved before the public
+/// [`EngineCoreOutput`] is built.
+#[derive(Debug, Clone, PartialEq, Deserialize_tuple, DefaultFromSerde)]
+struct WireEngineCoreOutput {
+    request_id: String,
+    new_token_ids: Vec<u32>,
+    #[serde(default)]
+    new_logprobs: Option<Box<WireLogprobs>>,
+    #[serde(default)]
+    new_prompt_logprobs_tensors: Option<Box<WireLogprobs>>,
+    #[serde(default)]
+    pooling_output: Option<OpaqueValue>,
+    #[serde(default)]
+    finish_reason: Option<EngineCoreFinishReason>,
+    #[serde(default)]
+    stop_reason: Option<StopReason>,
+    #[serde(default)]
+    events: Option<Vec<EngineCoreEvent>>,
+    #[serde(default)]
+    kv_transfer_params: Option<serde_json::Value>,
+    #[serde(default)]
+    ec_transfer_params: Option<serde_json::Value>,
+    #[serde(default)]
+    trace_headers: Option<OpaqueValue>,
+    #[serde(default)]
+    prefill_stats: Option<PrefillStats>,
+    #[serde(default)]
+    routed_experts: Option<OpaqueValue>,
+    #[serde(default)]
+    num_nans_in_logits: u32,
+}
+
+impl WireEngineCoreOutput {
+    /// Resolve the wire-format logprobs using the aux frames.
+    fn resolve(self, frames: &[Bytes]) -> Result<EngineCoreOutput> {
+        Ok(EngineCoreOutput {
+            request_id: self.request_id,
+            new_token_ids: self.new_token_ids,
+            new_logprobs: self
+                .new_logprobs
+                .map(|value| value.resolve(frames, "new_logprobs"))
+                .transpose()?,
+            new_prompt_logprobs_tensors: self
+                .new_prompt_logprobs_tensors
+                .map(|value| value.resolve(frames, "new_prompt_logprobs_tensors"))
+                .transpose()?,
+            pooling_output: self.pooling_output,
+            finish_reason: self.finish_reason,
+            stop_reason: self.stop_reason,
+            events: self.events,
+            kv_transfer_params: self.kv_transfer_params,
+            ec_transfer_params: self.ec_transfer_params,
+            trace_headers: self.trace_headers,
+            prefill_stats: self.prefill_stats,
+            routed_experts: self.routed_experts,
+            num_nans_in_logits: self.num_nans_in_logits,
+        })
+    }
+}
+
+/// Borrowed send-side view of [`WireEngineCoreOutput`]; keeps the wire field
+/// order without cloning the output being encoded.
+#[derive(Serialize_tuple)]
+struct WireEngineCoreOutputRef<'a> {
+    request_id: &'a str,
+    new_token_ids: &'a [u32],
+    new_logprobs: Option<&'a WireLogprobs>,
+    new_prompt_logprobs_tensors: Option<&'a WireLogprobs>,
+    pooling_output: Option<&'a OpaqueValue>,
+    finish_reason: Option<EngineCoreFinishReason>,
+    stop_reason: Option<&'a StopReason>,
+    events: Option<&'a [EngineCoreEvent]>,
+    kv_transfer_params: Option<&'a serde_json::Value>,
+    ec_transfer_params: Option<&'a serde_json::Value>,
+    trace_headers: Option<&'a OpaqueValue>,
+    prefill_stats: Option<&'a PrefillStats>,
+    routed_experts: Option<&'a OpaqueValue>,
+    num_nans_in_logits: u32,
 }
 
 /// Raw Python/msgpack engine-core output envelope. Mirrors Python
 /// `EngineCoreOutputs` (`array_like`).
-#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple, DefaultFromSerde)]
+#[derive(Debug, Clone, PartialEq, Deserialize_tuple, DefaultFromSerde)]
 struct WireEngineCoreOutputs {
     #[serde(default)]
     engine_index: u32,
     /// Outputs grouped for this client in the current engine tick.
     #[serde(default)]
-    outputs: Vec<EngineCoreOutput>,
+    outputs: Vec<WireEngineCoreOutput>,
     #[serde(default)]
     scheduler_stats: Option<Box<SchedulerStats>>,
     #[serde(default)]
@@ -209,19 +303,6 @@ impl EngineCoreOutputs {
             _ => None,
         }
     }
-
-    /// Resolve wire-format fields in-place using the aux frames.
-    fn resolve_in_place<Frame>(&mut self, frames: &[Frame]) -> Result<()>
-    where
-        Frame: AsRef<[u8]>,
-    {
-        if let Self::RequestBatch(batch) = self {
-            for output in &mut batch.outputs {
-                output.resolve_in_place(frames)?;
-            }
-        }
-        Ok(())
-    }
 }
 
 impl From<RequestBatchOutputs> for EngineCoreOutputs {
@@ -242,11 +323,11 @@ impl From<DpControlOutput> for EngineCoreOutputs {
     }
 }
 
-/// Classify the raw wire message into the semantic Rust enum.
-impl TryFrom<WireEngineCoreOutputs> for EngineCoreOutputs {
-    type Error = Error;
-
-    fn try_from(value: WireEngineCoreOutputs) -> Result<Self> {
+impl WireEngineCoreOutputs {
+    /// Classify into the semantic enum, resolving per-request wire logprobs
+    /// against the aux `frames`.
+    fn into_semantic(self, frames: &[Bytes]) -> Result<EngineCoreOutputs> {
+        let value = self;
         let has_request_payload = !value.outputs.is_empty()
             || value.scheduler_stats.is_some()
             || value.finished_requests.is_some();
@@ -259,7 +340,11 @@ impl TryFrom<WireEngineCoreOutputs> for EngineCoreOutputs {
         ) {
             (true, None, None, None) => Ok(RequestBatchOutputs {
                 engine_index: value.engine_index,
-                outputs: value.outputs,
+                outputs: value
+                    .outputs
+                    .into_iter()
+                    .map(|output| output.resolve(frames))
+                    .collect::<Result<Vec<_>>>()?,
                 scheduler_stats: value.scheduler_stats,
                 timestamp: value.timestamp,
                 finished_requests: value.finished_requests,
@@ -291,22 +376,46 @@ impl TryFrom<WireEngineCoreOutputs> for EngineCoreOutputs {
     }
 }
 
-impl From<EngineCoreOutputs> for WireEngineCoreOutputs {
-    fn from(value: EngineCoreOutputs) -> Self {
+/// Borrowed send-side view of [`WireEngineCoreOutputs`]; keeps the wire field
+/// order without cloning the batch being encoded.
+#[derive(Serialize_tuple)]
+struct WireEngineCoreOutputsRef<'a> {
+    engine_index: u32,
+    outputs: &'a [EngineCoreOutput],
+    scheduler_stats: Option<&'a SchedulerStats>,
+    timestamp: f64,
+    utility_output: Option<&'a OpaqueValue>,
+    finished_requests: Option<&'a BTreeSet<String>>,
+    wave_complete: Option<u64>,
+    start_wave: Option<u64>,
+}
+
+impl<'a> From<&'a EngineCoreOutputs> for WireEngineCoreOutputsRef<'a> {
+    fn from(value: &'a EngineCoreOutputs) -> Self {
+        let empty = Self {
+            engine_index: 0,
+            outputs: &[],
+            scheduler_stats: None,
+            timestamp: 0.0,
+            utility_output: None,
+            finished_requests: None,
+            wave_complete: None,
+            start_wave: None,
+        };
         match value {
             EngineCoreOutputs::RequestBatch(batch) => Self {
                 engine_index: batch.engine_index,
-                outputs: batch.outputs,
-                scheduler_stats: batch.scheduler_stats,
+                outputs: &batch.outputs,
+                scheduler_stats: batch.scheduler_stats.as_deref(),
                 timestamp: batch.timestamp,
-                finished_requests: batch.finished_requests,
-                ..Default::default()
+                finished_requests: batch.finished_requests.as_ref(),
+                ..empty
             },
             EngineCoreOutputs::Utility(utility) => Self {
                 engine_index: utility.engine_index,
                 timestamp: utility.timestamp,
-                utility_output: utility.output,
-                ..Default::default()
+                utility_output: utility.output.as_ref(),
+                ..empty
             },
             EngineCoreOutputs::DpControl(control) => {
                 let (wave_complete, start_wave) = match control.control {
@@ -318,7 +427,7 @@ impl From<EngineCoreOutputs> for WireEngineCoreOutputs {
                     timestamp: control.timestamp,
                     wave_complete,
                     start_wave,
-                    ..Default::default()
+                    ..empty
                 }
             }
         }
@@ -330,78 +439,154 @@ impl Serialize for EngineCoreOutputs {
     where
         S: Serializer,
     {
-        WireEngineCoreOutputs::from(self.clone()).serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for EngineCoreOutputs {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        WireEngineCoreOutputs::deserialize(deserializer)?
-            .try_into()
-            .map_err(serde::de::Error::custom)
+        WireEngineCoreOutputsRef::from(self).serialize(serializer)
     }
 }
 
 /// Decode one ordinary or multipart engine-core output message into the typed
 /// public protocol shape. Frame 0 is the primary msgpack; `frames[1..]` are the
 /// ordered aux tensor frames.
-pub fn decode_engine_core_outputs<Frame>(frames: &[Frame]) -> Result<EngineCoreOutputs>
-where
-    Frame: AsRef<[u8]>,
-{
+pub fn decode_engine_core_outputs(frames: &[Bytes]) -> Result<EngineCoreOutputs> {
     let first_frame = frames.first().ok_or_else(|| Error::ExtValueDecode {
         message: "missing output frame".to_string(),
     })?;
 
-    let mut outputs: EngineCoreOutputs = decode_msgpack(first_frame.as_ref())?;
-    outputs.resolve_in_place(frames)?;
-    Ok(outputs)
+    decode_msgpack::<WireEngineCoreOutputs>(first_frame)?.into_semantic(frames)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::{decode_msgpack, encode_msgpack};
+    use crate::{
+        codec::{
+            encode_msgpack,
+            tensor::{WireArrayData, WireNdArray},
+        },
+        protocol::vllm::logprobs::{PositionLogprobs, TokenLogprob},
+    };
+
+    fn batch(outputs: Vec<EngineCoreOutput>) -> EngineCoreOutputs {
+        EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
+            outputs,
+            finished_requests: Some(BTreeSet::from(["req-1".to_string()])),
+            ..Default::default()
+        })
+    }
+
+    fn encoded_frame(outputs: &EngineCoreOutputs) -> Vec<Bytes> {
+        vec![Bytes::from(encode_msgpack(outputs).unwrap())]
+    }
 
     #[test]
     fn engine_core_outputs_roundtrip_finished_fields() {
-        let outputs = WireEngineCoreOutputs {
-            outputs: vec![EngineCoreOutput {
+        let outputs = batch(vec![EngineCoreOutput {
+            request_id: "req-1".to_string(),
+            new_token_ids: vec![42],
+            finish_reason: Some(EngineCoreFinishReason::Length),
+            stop_reason: Some(StopReason::Text("stop".to_string())),
+            ..Default::default()
+        }]);
+
+        let decoded = decode_engine_core_outputs(&encoded_frame(&outputs)).unwrap();
+
+        assert_eq!(decoded, outputs);
+    }
+
+    #[test]
+    fn engine_core_outputs_roundtrip_logprobs() {
+        let logprobs = Logprobs {
+            positions: vec![PositionLogprobs {
+                entries: vec![
+                    TokenLogprob {
+                        token_id: 5,
+                        logprob: -0.25,
+                        rank: 3,
+                    },
+                    TokenLogprob {
+                        token_id: 6,
+                        logprob: -1.5,
+                        rank: 1,
+                    },
+                ],
+            }],
+        };
+        let outputs = batch(vec![EngineCoreOutput {
+            request_id: "req-1".to_string(),
+            new_token_ids: vec![5],
+            new_logprobs: Some(logprobs.clone()),
+            ..Default::default()
+        }]);
+
+        let decoded = decode_engine_core_outputs(&encoded_frame(&outputs)).unwrap();
+
+        assert_eq!(
+            decoded.as_request_batch().unwrap().outputs[0].new_logprobs,
+            Some(logprobs)
+        );
+    }
+
+    #[test]
+    fn decode_resolves_logprobs_from_aux_frames() {
+        // Aux frames carry the three logprob arrays; frame 0 is the primary.
+        let token_ids = Bytes::from(
+            [7_i64, 8]
+                .into_iter()
+                .flat_map(i64::to_le_bytes)
+                .collect::<Vec<_>>(),
+        );
+        let logprobs = Bytes::from(
+            [-0.5_f32, -2.0]
+                .into_iter()
+                .flat_map(f32::to_le_bytes)
+                .collect::<Vec<_>>(),
+        );
+        let ranks = Bytes::from(2_i64.to_le_bytes().to_vec());
+        let aux = |index| WireNdArray {
+            dtype: "<i8".to_string(),
+            shape: vec![1, 2],
+            data: WireArrayData::AuxIndex(index),
+        };
+        let wire = WireEngineCoreOutputs {
+            outputs: vec![WireEngineCoreOutput {
                 request_id: "req-1".to_string(),
-                new_token_ids: vec![42],
-                finish_reason: Some(EngineCoreFinishReason::Length),
-                stop_reason: Some(StopReason::Text("stop".to_string())),
+                new_token_ids: vec![7],
+                new_logprobs: Some(Box::new(WireLogprobs {
+                    logprob_token_ids: aux(1),
+                    logprobs: WireNdArray {
+                        dtype: "<f4".to_string(),
+                        shape: vec![1, 2],
+                        data: WireArrayData::AuxIndex(2),
+                    },
+                    token_ranks: WireNdArray {
+                        dtype: "<i8".to_string(),
+                        shape: vec![1],
+                        data: WireArrayData::AuxIndex(3),
+                    },
+                    cu_num_generated_tokens: None,
+                })),
                 ..Default::default()
             }],
-            finished_requests: Some(BTreeSet::from(["req-1".to_string()])),
             ..Default::default()
         };
 
-        let encoded = encode_msgpack(&outputs).unwrap();
-        let decoded: WireEngineCoreOutputs = decode_msgpack(&encoded).unwrap();
+        let frames = vec![Bytes::new(), token_ids, logprobs, ranks];
+        let decoded = wire.into_semantic(&frames).unwrap();
 
-        assert_eq!(decoded.outputs.len(), 1);
-        assert_eq!(
-            decoded.outputs[0].finish_reason,
-            Some(EngineCoreFinishReason::Length)
-        );
-        assert_eq!(
-            decoded.outputs[0].stop_reason,
-            Some(StopReason::Text("stop".to_string()))
-        );
-        assert_eq!(
-            decoded.finished_requests,
-            Some(BTreeSet::from(["req-1".to_string()]))
-        );
+        let entries = &decoded.as_request_batch().unwrap().outputs[0]
+            .new_logprobs
+            .as_ref()
+            .unwrap()
+            .positions[0]
+            .entries;
+        assert_eq!(entries[0].token_id, 7);
+        assert_eq!(entries[0].rank, 2);
+        assert_eq!(entries[1].logprob, -2.0);
     }
 
     #[test]
     fn classify_request_batch() {
         let wire = WireEngineCoreOutputs {
-            outputs: vec![EngineCoreOutput {
+            outputs: vec![WireEngineCoreOutput {
                 request_id: "req-1".to_string(),
                 new_token_ids: vec![7],
                 ..Default::default()
@@ -409,7 +594,7 @@ mod tests {
             finished_requests: Some(BTreeSet::from(["req-1".to_string()])),
             ..Default::default()
         };
-        let classified = EngineCoreOutputs::try_from(wire).unwrap();
+        let classified = wire.into_semantic(&[]).unwrap();
         let batch = classified.as_request_batch().expect("request batch");
         assert_eq!(batch.outputs[0].new_token_ids, vec![7]);
         assert_eq!(
@@ -424,7 +609,7 @@ mod tests {
             utility_output: Some(rmpv::Value::from(42u32)),
             ..Default::default()
         };
-        let classified = EngineCoreOutputs::try_from(wire).unwrap();
+        let classified = wire.into_semantic(&[]).unwrap();
         assert!(matches!(classified, EngineCoreOutputs::Utility(_)));
     }
 
@@ -434,7 +619,7 @@ mod tests {
             start_wave: Some(3),
             ..Default::default()
         };
-        let classified = EngineCoreOutputs::try_from(wire).unwrap();
+        let classified = wire.into_semantic(&[]).unwrap();
         assert_eq!(
             classified,
             EngineCoreOutputs::DpControl(DpControlOutput {
@@ -448,7 +633,7 @@ mod tests {
     #[test]
     fn classify_rejects_mixed_shape() {
         let wire = WireEngineCoreOutputs {
-            outputs: vec![EngineCoreOutput {
+            outputs: vec![WireEngineCoreOutput {
                 request_id: "req-1".to_string(),
                 new_token_ids: vec![7],
                 ..Default::default()
@@ -456,22 +641,18 @@ mod tests {
             utility_output: Some(rmpv::Value::from(1u32)),
             ..Default::default()
         };
-        let error = EngineCoreOutputs::try_from(wire).unwrap_err();
+        let error = wire.into_semantic(&[]).unwrap_err();
         assert!(error.to_string().contains("invalid wire shape"), "{error}");
     }
 
     #[test]
     fn decode_engine_core_outputs_from_single_frame() {
-        let wire = WireEngineCoreOutputs {
-            outputs: vec![EngineCoreOutput {
-                request_id: "req-1".to_string(),
-                new_token_ids: vec![1, 2, 3],
-                ..Default::default()
-            }],
+        let outputs = batch(vec![EngineCoreOutput {
+            request_id: "req-1".to_string(),
+            new_token_ids: vec![1, 2, 3],
             ..Default::default()
-        };
-        let bytes = encode_msgpack(&wire).unwrap();
-        let decoded = decode_engine_core_outputs(&[bytes]).unwrap();
+        }]);
+        let decoded = decode_engine_core_outputs(&encoded_frame(&outputs)).unwrap();
         assert_eq!(
             decoded.as_request_batch().unwrap().outputs[0].new_token_ids,
             vec![1, 2, 3]

--- a/crates/engine_zmq_client/src/protocol/vllm/structured_outputs.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/structured_outputs.rs
@@ -126,8 +126,7 @@ fn is_false(v: &bool) -> bool {
 /// fields is present. This client exposes [`StructuredOutputsParams`] as an
 /// enum-backed domain type instead, while using this private wire type for
 /// ser/de.
-#[serde_with::skip_serializing_none]
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default)]
 struct WireStructuredOutputsParams {
     json: Option<Value>,
@@ -135,9 +134,7 @@ struct WireStructuredOutputsParams {
     choice: Option<Vec<String>>,
     grammar: Option<String>,
     json_object: Option<bool>,
-    #[serde(skip_serializing_if = "is_false")]
     disable_any_whitespace: bool,
-    #[serde(skip_serializing_if = "is_false")]
     disable_additional_properties: bool,
     whitespace_pattern: Option<String>,
     structural_tag: Option<String>,
@@ -146,6 +143,26 @@ struct WireStructuredOutputsParams {
         rename = "_backend",
         deserialize_with = "serde_with::rust::deserialize_ignore_any"
     )]
+    backend: StructuredOutputBackend,
+}
+
+/// Borrowed send-side view of [`WireStructuredOutputsParams`]; keeps the wire
+/// shape without cloning the constraint (JSON schemas can be large).
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Serialize)]
+struct WireStructuredOutputsParamsRef<'a> {
+    json: Option<&'a Value>,
+    regex: Option<&'a str>,
+    choice: Option<&'a [String]>,
+    grammar: Option<&'a str>,
+    json_object: Option<bool>,
+    #[serde(skip_serializing_if = "is_false")]
+    disable_any_whitespace: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    disable_additional_properties: bool,
+    whitespace_pattern: Option<&'a str>,
+    structural_tag: Option<&'a str>,
+    #[serde(rename = "_backend")]
     backend: StructuredOutputBackend,
 }
 
@@ -206,24 +223,29 @@ impl TryFrom<WireStructuredOutputsParams> for StructuredOutputsParams {
     }
 }
 
-impl From<StructuredOutputsParams> for WireStructuredOutputsParams {
-    fn from(params: StructuredOutputsParams) -> Self {
+impl<'a> From<&'a StructuredOutputsParams> for WireStructuredOutputsParamsRef<'a> {
+    fn from(params: &'a StructuredOutputsParams) -> Self {
         let mut raw = Self {
+            json: None,
+            regex: None,
+            choice: None,
+            grammar: None,
+            json_object: None,
             disable_any_whitespace: params.options.disable_any_whitespace,
             disable_additional_properties: params.options.disable_additional_properties,
-            whitespace_pattern: params.options.whitespace_pattern,
+            whitespace_pattern: params.options.whitespace_pattern.as_deref(),
+            structural_tag: None,
             backend: params.backend,
-            ..Self::default()
         };
 
-        match params.constraint {
+        match &params.constraint {
             StructuredOutputConstraint::Json(json) => raw.json = Some(json),
-            StructuredOutputConstraint::Regex(regex) => raw.regex = Some(regex),
-            StructuredOutputConstraint::Choice(choice) => raw.choice = Some(choice),
-            StructuredOutputConstraint::Grammar(grammar) => raw.grammar = Some(grammar),
+            StructuredOutputConstraint::Regex(regex) => raw.regex = Some(regex.as_str()),
+            StructuredOutputConstraint::Choice(choice) => raw.choice = Some(choice.as_slice()),
+            StructuredOutputConstraint::Grammar(grammar) => raw.grammar = Some(grammar.as_str()),
             StructuredOutputConstraint::JsonObject => raw.json_object = Some(true),
             StructuredOutputConstraint::StructuralTag(structural_tag) => {
-                raw.structural_tag = Some(structural_tag);
+                raw.structural_tag = Some(structural_tag.as_str());
             }
         }
 
@@ -236,7 +258,7 @@ impl Serialize for StructuredOutputsParams {
     where
         S: Serializer,
     {
-        WireStructuredOutputsParams::from(self.clone()).serialize(serializer)
+        WireStructuredOutputsParamsRef::from(self).serialize(serializer)
     }
 }
 
@@ -280,6 +302,23 @@ mod tests {
         let value = serde_json::to_value(params).unwrap();
         assert_eq!(value["_backend"], "xgrammar");
         assert_eq!(value["structural_tag"], r#"{"format":{}}"#);
+    }
+
+    #[test]
+    fn structured_outputs_json_roundtrips_through_wire_shape() {
+        let mut params = StructuredOutputsParams::json(serde_json::json!({"type": "object"}));
+        params.options.disable_any_whitespace = true;
+        params.options.whitespace_pattern = Some(" ".to_string());
+
+        let value = serde_json::to_value(&params).unwrap();
+        assert_eq!(value["json"], serde_json::json!({"type": "object"}));
+        assert_eq!(value["disable_any_whitespace"], true);
+        assert_eq!(value["whitespace_pattern"], " ");
+        assert!(value.get("disable_additional_properties").is_none());
+        assert_eq!(
+            serde_json::from_value::<StructuredOutputsParams>(value).unwrap(),
+            params
+        );
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -843,12 +843,7 @@ impl VllmGenerateStream {
         let mut tick_logprobs_val = Vec::new();
         let mut tick_logprobs_idx = Vec::new();
         let mut tick_top_logprobs = Vec::new();
-        if let Some(logprobs) = &output.new_logprobs {
-            let decoded = logprobs.as_direct().ok_or_else(|| {
-                // The protocol layer resolves wire logprobs during decode, so
-                // an unresolved payload here is a protocol bug — fail loudly.
-                tonic::Status::internal("unresolved wire logprobs in engine output")
-            })?;
+        if let Some(decoded) = &output.new_logprobs {
             for position in &decoded.positions {
                 let Some(sampled) = position.entries.first() else {
                     continue;
@@ -880,10 +875,7 @@ impl VllmGenerateStream {
         // them incrementally); entry 0 per position is the actual prompt
         // token. The API contract reports the first prompt token with a null
         // logprob, so seed it once before the first scored position.
-        if let Some(prompt_logprobs) = &output.new_prompt_logprobs_tensors {
-            let decoded = prompt_logprobs.as_direct().ok_or_else(|| {
-                tonic::Status::internal("unresolved wire prompt logprobs in engine output")
-            })?;
+        if let Some(decoded) = &output.new_prompt_logprobs_tensors {
             if state.prompt_logprobs.is_empty() && !decoded.positions.is_empty() {
                 if let Some(first) = self.first_prompt_token {
                     state
@@ -1459,7 +1451,7 @@ mod tests {
     use engine_zmq_client::{
         mock_engine::{connect_to_frontend, default_ready_response, EngineInbound},
         protocol::vllm::{
-            logprobs::{Logprobs, MaybeWireLogprobs, PositionLogprobs, TokenLogprob},
+            logprobs::{Logprobs, PositionLogprobs, TokenLogprob},
             output::{EngineCoreOutputs, RequestBatchOutputs},
         },
         EngineId,
@@ -1625,16 +1617,14 @@ mod tests {
         finish: Option<EngineCoreFinishReason>,
     ) -> EngineCoreOutputs {
         let finished = finish.map(|_| BTreeSet::from([request_id.to_string()]));
-        let new_logprobs = logprob.map(|lp| {
-            MaybeWireLogprobs::Direct(Logprobs {
-                positions: vec![PositionLogprobs {
-                    entries: vec![TokenLogprob {
-                        token_id: token,
-                        logprob: lp,
-                        rank: 1,
-                    }],
+        let new_logprobs = logprob.map(|lp| Logprobs {
+            positions: vec![PositionLogprobs {
+                entries: vec![TokenLogprob {
+                    token_id: token,
+                    logprob: lp,
+                    rank: 1,
                 }],
-            })
+            }],
         });
         EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
             engine_index: 0,
@@ -1826,9 +1816,9 @@ mod tests {
             outputs: vec![EngineCoreOutput {
                 request_id: "r1".to_string(),
                 new_token_ids: vec![10],
-                new_logprobs: Some(MaybeWireLogprobs::Direct(Logprobs {
+                new_logprobs: Some(Logprobs {
                     positions: vec![position],
-                })),
+                }),
                 finish_reason: Some(EngineCoreFinishReason::Length),
                 ..Default::default()
             }],
@@ -1940,7 +1930,7 @@ mod tests {
 
         // Prompt position for input token 2 (the engine scores every prompt
         // token but the first), with one ranked candidate behind it.
-        let prompt_tensors = MaybeWireLogprobs::Direct(Logprobs {
+        let prompt_tensors = Logprobs {
             positions: vec![PositionLogprobs {
                 entries: vec![
                     TokenLogprob {
@@ -1955,7 +1945,7 @@ mod tests {
                     },
                 ],
             }],
-        });
+        };
         let prefill = EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
             engine_index: 0,
             outputs: vec![EngineCoreOutput {


### PR DESCRIPTION
## Description

### Problem

Three verified audit findings in `engine-zmq-client`, all on hot or semi-hot paths:

- **Serialize impls clone the entire value to reuse owned `From` conversions** (`structured_outputs.rs:239`) — every guided-decoding submit deep-cloned the constraint, including a potentially large JSON schema `serde_json::Value`.
- **Generic `Frame: AsRef<[u8]>` forces a full copy of aux frames that are already `Bytes`** (`codec/tensor.rs:302`) — production callers pass `&[Bytes]` from `ZmqMessage::into_vec()`, so each logprob/tensor array was copied per message.
- **`MaybeWireLogprobs` leaks its internal `Wire` state past the boundary that guarantees resolution** (`logprobs.rs:246`, reported by two reviewers) — the router had to synthesize `tonic::Status::internal` for a state the protocol layer already made impossible.

### Solution

Each path loses its copy: the serialize impls go through borrowed wire types instead of cloning to reuse owned conversions, aux-frame decoding takes `&[Bytes]` and shares payloads by refcount, and the unresolved-logprobs state is deleted so the wire type never escapes the protocol layer.

## Changes

- `structured_outputs.rs`: added `WireStructuredOutputsParamsRef<'a>` (borrowed fields, same wire field order and `skip_serializing_none`/`skip_serializing_if` behavior). `Serialize` now goes through it; the owned wire type is deserialize-only and its unused owned `From` conversion is gone.
- `codec/tensor.rs`: `resolve_array_bytes`, `decode_array_metadata`, `decode_array{1,2}_*` now take `&[Bytes]` and return `frame.clone()` for aux-frame payloads (refcount bump, no memcpy).
- `logprobs.rs`: deleted `MaybeWireLogprobs`; `WireLogprobs` is now `pub(crate)` and resolves straight to `Logprobs`.
- `output.rs`: split wire from semantic. Private `WireEngineCoreOutput`/`WireEngineCoreOutputs` deserialize the msgpack tuples and `into_semantic(frames)` resolves logprobs against the aux frames; public `EngineCoreOutput` carries `Option<Logprobs>`. The send path serializes through `WireEngineCoreOutputRef`/`WireEngineCoreOutputsRef`, removing the `self.clone()` in `Serialize for EngineCoreOutputs`.
- `model_gateway/src/routers/grpc/zmq_client.rs`: consumes `&Logprobs` directly; the two "unresolved wire logprobs" internal errors are gone.
- Tests: new aux-frame sharing assertion in `tensor.rs`, a JSON-constraint round-trip in `structured_outputs.rs`, and in `output.rs` a full encode/decode round-trip with logprobs plus an aux-frame resolution case (classification tests now drive `into_semantic`).

Wire format is byte-identical: tuple field order and sparse map keys are unchanged.

## Test Plan

- `cargo test -p engine-zmq-client` → `ok. 81 passed; 0 failed`
- `cargo test -p smg --lib routers::grpc::zmq_client` → `ok. 32 passed; 0 failed`
- `cargo clippy -p engine-zmq-client -p smg --all-targets -- -D warnings` → clean
- `cargo +nightly fmt --all`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
