### PR TITLE
refactor(router): make ZMQ stream chunk semantics explicit

### DIFF
--- a/model_gateway/src/routers/grpc/common/response_formatting.rs
+++ b/model_gateway/src/routers/grpc/common/response_formatting.rs
@@ -42,9 +42,9 @@ pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
 
 /// Tracks per-index completion token counts across streaming chunks.
 ///
-/// Handles the vLLM vs SGLang difference:
-/// - vLLM sends delta token counts per chunk (must accumulate)
-/// - SGLang sends cumulative counts in the Complete message
+/// Handles the two chunk conventions (`ChunkSemantics`):
+/// - delta streams send per-chunk token counts (must accumulate)
+/// - cumulative streams send the count in the Complete message
 pub(crate) struct CompletionTokenTracker {
     tokens: HashMap<u32, u32>,
 }
@@ -57,20 +57,20 @@ impl CompletionTokenTracker {
     }
 
     /// Record tokens from a streaming chunk.
-    /// For vLLM, accumulates the chunk's token count.
-    /// For SGLang/TRT-LLM, this is a no-op (they report in Complete).
+    /// Delta streams accumulate the chunk's token count; cumulative streams
+    /// report it in Complete instead, so this is a no-op for them.
     pub fn record_chunk(&mut self, chunk: &ProtoGenerateStreamChunk) {
-        if chunk.is_vllm() {
+        if chunk.chunk_semantics().is_delta() {
             *self.tokens.entry(chunk.index()).or_insert(0) += chunk.token_ids().len() as u32;
         }
     }
 
     /// Record the final count from a Complete message.
-    /// For vLLM, preserves the accumulated count.
-    /// For SGLang/TRT-LLM, uses the cumulative value from Complete.
+    /// Delta streams keep the count accumulated from their chunks; cumulative
+    /// streams take the value from Complete.
     pub fn record_complete(&mut self, complete: &ProtoGenerateComplete) {
         let index = complete.index();
-        if complete.is_vllm() {
+        if complete.chunk_semantics().is_delta() {
             // Keep accumulated count; ensure entry exists
             self.tokens.entry(index).or_insert(0);
         } else {
@@ -86,7 +86,7 @@ impl CompletionTokenTracker {
 
 #[cfg(test)]
 mod tests {
-    use smg_grpc_client::tokenspeed_proto as tokenspeed;
+    use smg_grpc_client::{tokenspeed_proto as tokenspeed, vllm_proto as vllm};
 
     use super::*;
 
@@ -120,6 +120,41 @@ mod tests {
         assert_eq!(
             usage.completion_tokens, 10,
             "each choice generates its own completion -- must be summed"
+        );
+    }
+
+    #[test]
+    fn completion_token_tracker_follows_chunk_semantics() {
+        // Delta stream (the vLLM shape, which the ZMQ lane also emits for
+        // TokenSpeed workers): the chunks carry the counts.
+        let mut tracker = CompletionTokenTracker::new();
+        tracker.record_chunk(&ProtoGenerateStreamChunk::Vllm(vllm::GenerateStreamChunk {
+            token_ids: vec![1, 2, 3],
+            ..Default::default()
+        }));
+        tracker.record_complete(&ProtoGenerateComplete::Vllm(vllm::GenerateComplete {
+            completion_tokens: 99,
+            ..Default::default()
+        }));
+        assert_eq!(
+            tracker.total(),
+            3,
+            "delta stream keeps the accumulated count"
+        );
+
+        // Cumulative stream: chunks are not accumulated, Complete is the count.
+        let mut tracker = CompletionTokenTracker::new();
+        tracker.record_chunk(&ProtoGenerateStreamChunk::TokenSpeed(
+            tokenspeed::GenerateStreamChunk {
+                token_ids: vec![1, 2, 3],
+                ..Default::default()
+            },
+        ));
+        tracker.record_complete(&complete(0, 0, 7));
+        assert_eq!(
+            tracker.total(),
+            7,
+            "cumulative stream reports it in Complete"
         );
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -799,9 +799,9 @@ impl HarmonyStreamingProcessor {
 
             match response.into_response() {
                 ProtoResponseVariant::Chunk(chunk_wrapper) => {
-                    // Track token counts for vLLM (vLLM sends deltas)
-                    // For SGLang, skip (SGLang sends cumulative values in Complete)
-                    if chunk_wrapper.is_vllm() {
+                    // Track token counts on delta streams; cumulative streams
+                    // report them in Complete instead.
+                    if chunk_wrapper.chunk_semantics().is_delta() {
                         completion_tokens += chunk_wrapper.token_ids().len() as u32;
                     }
 
@@ -1028,9 +1028,9 @@ impl HarmonyStreamingProcessor {
                     prompt_tokens = complete_wrapper.prompt_tokens();
                     // Combine decode-stream cached_tokens with any prefill cached_tokens
                     cached_tokens = cached_tokens.saturating_add(complete_wrapper.cached_tokens());
-                    // For vLLM, use accumulated count (we tracked deltas above)
-                    // For SGLang, use complete value (already cumulative)
-                    if !complete_wrapper.is_vllm() {
+                    // Delta streams keep the count accumulated above;
+                    // cumulative streams take it from Complete.
+                    if !complete_wrapper.chunk_semantics().is_delta() {
                         completion_tokens = complete_wrapper.completion_tokens();
                     }
 

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -1562,11 +1562,6 @@ impl ProtoGenerateStreamChunk {
         matches!(self, Self::Sglang(_))
     }
 
-    /// Check if this is vLLM
-    pub fn is_vllm(&self) -> bool {
-        matches!(self, Self::Vllm(_))
-    }
-
     /// Check if this is TensorRT-LLM
     pub fn is_trtllm(&self) -> bool {
         matches!(self, Self::Trtllm(_))
@@ -1759,11 +1754,6 @@ impl ProtoGenerateComplete {
     /// Check if this is SGLang
     pub fn is_sglang(&self) -> bool {
         matches!(self, Self::Sglang(_))
-    }
-
-    /// Check if this is vLLM
-    pub fn is_vllm(&self) -> bool {
-        matches!(self, Self::Vllm(_))
     }
 
     /// Check if this is TensorRT-LLM

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -41,6 +41,31 @@ use smg_mm_rdma::RdmaExporter;
 
 use crate::routers::grpc::{multimodal::mm_rdma_exporter, zmq_client::ZmqGenerateStream};
 
+/// How a streaming response's per-token payloads (token ids, sampled
+/// logprobs, token counts) relate across the responses of one stream.
+///
+/// This is a property of the response *shape*, not of the engine behind it: a
+/// TokenSpeed worker reached over ZMQ emits vLLM-shaped responses and so
+/// carries `Delta` semantics, while the same engine reached over gRPC carries
+/// `Cumulative`. Response-side accumulation must key on this, never on the
+/// engine variant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChunkSemantics {
+    /// Each chunk carries only what is new since the previous one, so the
+    /// consumer accumulates; the terminal `Complete` repeats the totals.
+    Delta,
+    /// Each chunk carries the run's totals so far, so the consumer replaces;
+    /// the terminal `Complete` is authoritative.
+    Cumulative,
+}
+
+impl ChunkSemantics {
+    /// Whether chunks must be accumulated rather than replaced.
+    pub fn is_delta(self) -> bool {
+        matches!(self, Self::Delta)
+    }
+}
+
 /// Backend-neutral encode->prefill bootstrap info for one multimodal item.
 ///
 /// Backend wrappers translate this into their own proto shape when supported.
@@ -1557,6 +1582,17 @@ impl ProtoGenerateStreamChunk {
         matches!(self, Self::TokenSpeed(_))
     }
 
+    /// How this chunk's payloads relate to the preceding ones — see
+    /// [`ChunkSemantics`].
+    pub fn chunk_semantics(&self) -> ChunkSemantics {
+        match self {
+            Self::Vllm(_) => ChunkSemantics::Delta,
+            Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => {
+                ChunkSemantics::Cumulative
+            }
+        }
+    }
+
     /// Get token IDs from chunk (common field)
     pub fn token_ids(&self) -> &[u32] {
         match self {
@@ -1743,6 +1779,18 @@ impl ProtoGenerateComplete {
     /// Check if this is TokenSpeed
     pub fn is_tokenspeed(&self) -> bool {
         matches!(self, Self::TokenSpeed(_))
+    }
+
+    /// Chunk semantics of the stream this `Complete` terminates — see
+    /// [`ChunkSemantics`]. `Delta` streams already accumulated their counts
+    /// chunk by chunk; `Cumulative` streams report them here.
+    pub fn chunk_semantics(&self) -> ChunkSemantics {
+        match self {
+            Self::Vllm(_) => ChunkSemantics::Delta,
+            Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => {
+                ChunkSemantics::Cumulative
+            }
+        }
     }
 
     /// Get token IDs from either backend (output_ids in proto)
@@ -2005,7 +2053,9 @@ impl ProtoStream {
             // `vllm::GenerateResponse`, so variant checks like
             // `is_tokenspeed()` on a response are unreliable for ZMQ-backed
             // streams. Key response-side engine logic on the worker's
-            // `runtime_type()`, never on the response variant.
+            // `runtime_type()`, never on the response variant; key
+            // accumulation on `chunk_semantics()`, which the vLLM shape
+            // (delta chunks, cumulative `Complete`) defines for this lane.
             Self::Zmq(stream) => stream
                 .next()
                 .await
@@ -2420,5 +2470,39 @@ mod tests {
         // Missing sampling params: untouched, no panic.
         let mut req = ProtoGenerateRequest::TokenSpeed(Box::default());
         req.extend_stop_token_ids(&ids);
+    }
+
+    #[test]
+    fn chunk_semantics_follow_the_response_shape() {
+        // The vLLM shape is the delta contract — the ZMQ lane emits it for
+        // every engine it fronts, TokenSpeed included.
+        assert!(
+            ProtoGenerateStreamChunk::Vllm(vllm::GenerateStreamChunk::default())
+                .chunk_semantics()
+                .is_delta()
+        );
+        assert!(
+            ProtoGenerateComplete::Vllm(vllm::GenerateComplete::default())
+                .chunk_semantics()
+                .is_delta()
+        );
+
+        // Every other shape reports running totals.
+        for chunk in [
+            ProtoGenerateStreamChunk::Sglang(sglang::GenerateStreamChunk::default()),
+            ProtoGenerateStreamChunk::Trtllm(trtllm::GenerateStreamChunk::default()),
+            ProtoGenerateStreamChunk::Mlx(mlx::GenerateStreamChunk::default()),
+            ProtoGenerateStreamChunk::TokenSpeed(tokenspeed::GenerateStreamChunk::default()),
+        ] {
+            assert_eq!(chunk.chunk_semantics(), ChunkSemantics::Cumulative);
+        }
+        for complete in [
+            ProtoGenerateComplete::Sglang(sglang::GenerateComplete::default()),
+            ProtoGenerateComplete::Trtllm(trtllm::GenerateComplete::default()),
+            ProtoGenerateComplete::Mlx(mlx::GenerateComplete::default()),
+            ProtoGenerateComplete::TokenSpeed(tokenspeed::GenerateComplete::default()),
+        ] {
+            assert_eq!(complete.chunk_semantics(), ChunkSemantics::Cumulative);
+        }
     }
 }

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -1183,13 +1183,12 @@ impl StreamingProcessor {
                     let accumulated_text = accumulated_texts.entry(index).or_default();
                     accumulated_text.push_str(&chunk_text);
 
-                    // Handle output logprobs based on backend behavior:
-                    // - SGLang sends cumulative logprobs (replace is correct)
-                    // - vLLM sends delta logprobs (need to extend/accumulate)
+                    // Handle output logprobs by the stream's chunk semantics:
+                    // cumulative chunks replace, delta chunks accumulate.
                     if let Some(ref output_logprobs) = chunk.output_logprobs() {
                         let converted = utils::convert_generate_output_logprobs(output_logprobs);
-                        if chunk.is_vllm() {
-                            // vLLM sends delta - extend existing logprobs
+                        if chunk.chunk_semantics().is_delta() {
+                            // Delta - extend existing logprobs
                             if let Some(v) = accumulated_output_logprobs
                                 .entry(index)
                                 .or_insert_with(|| Some(Vec::new()))
@@ -1198,7 +1197,7 @@ impl StreamingProcessor {
                                 v.extend(converted);
                             }
                         } else {
-                            // SGLang sends cumulative - replace
+                            // Cumulative - replace
                             accumulated_output_logprobs.insert(index, Some(converted));
                         }
                     }

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -834,6 +834,44 @@ impl StreamState {
     }
 }
 
+/// The per-dialect half of a ZMQ generate stream: the wire stream, the parked
+/// terminal `Complete`, and the mapping from one wire output to a vLLM-proto
+/// response. [`poll_mapped`] writes the `Stream` machinery once for every
+/// dialect that implements this.
+trait MappedGenerateStream {
+    /// One tick of engine output on this dialect's wire.
+    type Output;
+    /// The wire stream carrying those ticks.
+    type Inner: Stream<Item = Result<Self::Output, engine_zmq_client::Error>> + Unpin;
+
+    fn inner(&mut self) -> &mut Self::Inner;
+
+    /// Terminal `Complete` held back when the finish tick also carried new
+    /// tokens; yielded before the wire stream is polled again.
+    fn pending(&mut self) -> &mut Option<vllm::GenerateResponse>;
+
+    fn map_output(&mut self, output: Self::Output)
+        -> Result<vllm::GenerateResponse, tonic::Status>;
+}
+
+/// `Stream::poll_next` for any [`MappedGenerateStream`]: drain the parked
+/// `Complete` first, otherwise poll the wire and map the tick.
+fn poll_mapped<S: MappedGenerateStream>(
+    stream: &mut S,
+    cx: &mut std::task::Context<'_>,
+) -> std::task::Poll<Option<Result<vllm::GenerateResponse, tonic::Status>>> {
+    use std::task::Poll;
+    if let Some(pending) = stream.pending().take() {
+        return Poll::Ready(Some(Ok(pending)));
+    }
+    match std::pin::Pin::new(stream.inner()).poll_next(cx) {
+        Poll::Ready(Some(Ok(output))) => Poll::Ready(Some(stream.map_output(output))),
+        Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(zmq_status(error)))),
+        Poll::Ready(None) => Poll::Ready(None),
+        Poll::Pending => Poll::Pending,
+    }
+}
+
 /// Streaming generate output for one vLLM EngineCore sub-request, mapping each
 /// `EngineCoreOutput` to a vLLM-proto `GenerateResponse` (chunks until the
 /// terminal output, then a complete), tagged with this sub's choice `index`.
@@ -878,6 +916,61 @@ impl VllmGenerateStream {
             input_logprobs_emitted: false,
             pending: None,
         }
+    }
+
+    /// Attach the accumulated prompt logprobs: once on the first token-bearing
+    /// chunk (the proto puts them in the first chunk only) and on every
+    /// `Complete`, including one parked in `pending`. Prefill precedes the
+    /// first sampled token, so the set is whole by the time a chunk carries
+    /// tokens.
+    fn attach_input_logprobs(&mut self, response: &mut vllm::GenerateResponse) {
+        if self.state.prompt_logprobs.is_empty() {
+            return;
+        }
+        // Built per attachment site rather than up front: with
+        // `prompt_logprobs` requested this runs on every decode tick, and the
+        // common tick (a later chunk) attaches nothing.
+        let state = &self.state;
+        let build = || vllm::InputLogProbs {
+            token_logprobs: state.prompt_logprobs.clone(),
+            token_ids: state.prompt_token_ids.clone(),
+            top_logprobs: state.prompt_top_logprobs.clone(),
+        };
+        if let Some(vllm::generate_response::Response::Complete(parked)) = self
+            .pending
+            .as_mut()
+            .and_then(|pending| pending.response.as_mut())
+        {
+            parked.input_logprobs = Some(build());
+        }
+        match response.response.as_mut() {
+            Some(vllm::generate_response::Response::Chunk(chunk))
+                if !self.input_logprobs_emitted && !chunk.token_ids.is_empty() =>
+            {
+                chunk.input_logprobs = Some(build());
+                self.input_logprobs_emitted = true;
+            }
+            // Later chunks never repeat them (the proto carries them in the
+            // first chunk only), and neither do token-less prefill chunks.
+            Some(vllm::generate_response::Response::Chunk(_)) => {}
+            Some(vllm::generate_response::Response::Complete(complete)) => {
+                complete.input_logprobs = Some(build());
+            }
+            None => {}
+        }
+    }
+}
+
+impl MappedGenerateStream for VllmGenerateStream {
+    type Output = EngineCoreOutput;
+    type Inner = EngineCoreStream;
+
+    fn inner(&mut self) -> &mut Self::Inner {
+        &mut self.inner
+    }
+
+    fn pending(&mut self) -> &mut Option<vllm::GenerateResponse> {
+        &mut self.pending
     }
 
     fn map_output(
@@ -981,48 +1074,6 @@ impl VllmGenerateStream {
         self.attach_input_logprobs(&mut response);
         Ok(response)
     }
-
-    /// Attach the accumulated prompt logprobs: once on the first token-bearing
-    /// chunk (the proto puts them in the first chunk only) and on every
-    /// `Complete`, including one parked in `pending`. Prefill precedes the
-    /// first sampled token, so the set is whole by the time a chunk carries
-    /// tokens.
-    fn attach_input_logprobs(&mut self, response: &mut vllm::GenerateResponse) {
-        if self.state.prompt_logprobs.is_empty() {
-            return;
-        }
-        // Built per attachment site rather than up front: with
-        // `prompt_logprobs` requested this runs on every decode tick, and the
-        // common tick (a later chunk) attaches nothing.
-        let state = &self.state;
-        let build = || vllm::InputLogProbs {
-            token_logprobs: state.prompt_logprobs.clone(),
-            token_ids: state.prompt_token_ids.clone(),
-            top_logprobs: state.prompt_top_logprobs.clone(),
-        };
-        if let Some(vllm::generate_response::Response::Complete(parked)) = self
-            .pending
-            .as_mut()
-            .and_then(|pending| pending.response.as_mut())
-        {
-            parked.input_logprobs = Some(build());
-        }
-        match response.response.as_mut() {
-            Some(vllm::generate_response::Response::Chunk(chunk))
-                if !self.input_logprobs_emitted && !chunk.token_ids.is_empty() =>
-            {
-                chunk.input_logprobs = Some(build());
-                self.input_logprobs_emitted = true;
-            }
-            // Later chunks never repeat them (the proto carries them in the
-            // first chunk only), and neither do token-less prefill chunks.
-            Some(vllm::generate_response::Response::Chunk(_)) => {}
-            Some(vllm::generate_response::Response::Complete(complete)) => {
-                complete.input_logprobs = Some(build());
-            }
-            None => {}
-        }
-    }
 }
 
 impl Stream for VllmGenerateStream {
@@ -1032,17 +1083,7 @@ impl Stream for VllmGenerateStream {
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        use std::task::Poll;
-        let this = self.get_mut();
-        if let Some(pending) = this.pending.take() {
-            return Poll::Ready(Some(Ok(pending)));
-        }
-        match std::pin::Pin::new(&mut this.inner).poll_next(cx) {
-            Poll::Ready(Some(Ok(output))) => Poll::Ready(Some(this.map_output(output))),
-            Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(zmq_status(error)))),
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
+        poll_mapped(self.get_mut(), cx)
     }
 }
 
@@ -1069,6 +1110,19 @@ impl TokenSpeedGenerateStream {
             index,
             pending: None,
         }
+    }
+}
+
+impl MappedGenerateStream for TokenSpeedGenerateStream {
+    type Output = TokenSpeedOutput;
+    type Inner = TokenSpeedStream;
+
+    fn inner(&mut self) -> &mut Self::Inner {
+        &mut self.inner
+    }
+
+    fn pending(&mut self) -> &mut Option<vllm::GenerateResponse> {
+        &mut self.pending
     }
 
     fn map_output(
@@ -1137,17 +1191,7 @@ impl Stream for TokenSpeedGenerateStream {
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        use std::task::Poll;
-        let this = self.get_mut();
-        if let Some(pending) = this.pending.take() {
-            return Poll::Ready(Some(Ok(pending)));
-        }
-        match std::pin::Pin::new(&mut this.inner).poll_next(cx) {
-            Poll::Ready(Some(Ok(output))) => Poll::Ready(Some(this.map_output(output))),
-            Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(zmq_status(error)))),
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
+        poll_mapped(self.get_mut(), cx)
     }
 }
 


### PR DESCRIPTION
## Description

### Problem

Two audit findings on the gRPC/ZMQ response path:

- **"ZMQ streams erase engine identity on the response path: TokenSpeed-over-ZMQ yields `ProtoGenerateResponse::Vllm`, splitting response-side dialect dispatch into two competing conventions"** — the ZMQ adapter wraps every engine's output (TokenSpeed included) as a vLLM-proto response, so downstream `is_vllm()` checks were really asking "does this stream send delta chunks?" while reading as an engine check, correct only by convention.
- **"`VllmGenerateStream` and `TokenSpeedGenerateStream` duplicate identical `Stream` scaffolding verbatim"** (reported twice) — the two `poll_next` bodies are token-for-token identical.

### Solution

The property is now named: `ChunkSemantics` (`Delta` / `Cumulative`), fixed by the response shape a stream is constructed with, and the duplicated `poll_next` bodies collapse into one shared helper.

Behavior-preserving: the semantics mapping reproduces the previous variant checks one for one (vLLM shape → `Delta`, every other shape → `Cumulative`).

## Changes

- `proto_wrapper.rs`: new `ChunkSemantics` enum with `is_delta()`, plus `chunk_semantics()` on `ProtoGenerateStreamChunk` and `ProtoGenerateComplete`; the ZMQ-wrapping comment in `ProtoStream::next` now points accumulation at `chunk_semantics()`.
- `common/response_formatting.rs`, `regular/streaming.rs`, `harmony/streaming.rs`: completion-token and output-logprob accumulation keyed on `chunk_semantics().is_delta()` instead of `is_vllm()`; comments updated to talk about stream conventions rather than engine names.
- `zmq_client.rs`: `MappedGenerateStream` trait (wire stream + parked `Complete` + per-dialect `map_output`) and a shared `poll_mapped`; both `impl Stream` bodies reduce to one call, leaving only the dialect-specific mapping.
- Tests: `chunk_semantics_follow_the_response_shape` (every wrapper variant) and `completion_token_tracker_follows_chunk_semantics` (delta stream accumulates chunks and ignores the `Complete` count; cumulative stream does the reverse).

## Test Plan

- `cargo test -p smg --lib -- chunk_semantics response_formatting` → 3 passed, 0 failed.
- `cargo clippy -p smg --all-targets -- -D warnings` → clean.
- `cargo +nightly fmt --all -- --check` → clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
