### PR TITLE
fix(workflow): preserve ZMQ state across worker property updates

### DIFF
--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -1098,6 +1098,31 @@ impl BasicWorker {
         if other_cb.config() == existing_cb.config() {
             self.circuit_breaker.store(other_cb);
         }
+
+        self.adopt_backend_client_from(other);
+    }
+
+    /// Adopt the replaced worker's backend-client cell so a same-URL
+    /// replacement (a metadata-only update, say) keeps talking over the
+    /// connection the old worker already established. Decisive for ZMQ: SMG
+    /// binds the sockets and the engine handshakes only at its own startup, so
+    /// a replacement starting from an empty cell would unbind the live sockets,
+    /// rebind, and wait for a HELLO that never arrives.
+    ///
+    /// `zmq_connect_started` is deliberately left cleared rather than copied:
+    /// the shared cell already dedupes a handshake in flight, and a cleared
+    /// guard lets the replacement retry (and signal under its own revision) if
+    /// that handshake fails.
+    fn adopt_backend_client_from(&self, other: &BasicWorker) {
+        // A transport or runtime change means a different wire protocol, and a
+        // replacement that arrived with its own client keeps it.
+        if self.metadata.spec.connection_mode != other.metadata.spec.connection_mode
+            || self.metadata.spec.runtime_type != other.metadata.spec.runtime_type
+            || self.backend_client.load().get().is_some()
+        {
+            return;
+        }
+        self.backend_client.store(other.backend_client.load_full());
     }
 }
 
@@ -2608,6 +2633,34 @@ mod tests {
         assert!(worker.supports_model("text-embedding-3-small"));
         assert!(!worker.supports_model("non-existent-model"));
         assert!(worker.has_models_discovered());
+    }
+
+    #[test]
+    fn replacement_adopts_the_backend_client_only_on_a_matching_transport() {
+        // The cell object itself is the connection: sharing it is what keeps a
+        // replaced ZMQ worker talking to the engine that already handshook.
+        let build = |mode: ConnectionMode| {
+            BasicWorkerBuilder::new("ipc:///tmp/w.ipc")
+                .connection_mode(mode)
+                .health_config(no_health_check())
+                .build()
+        };
+
+        let old = build(ConnectionMode::Zmq);
+        let new = build(ConnectionMode::Zmq);
+        assert!(new.inherit_shared_state_from(&old));
+        assert!(Arc::ptr_eq(
+            &new.backend_client.load_full(),
+            &old.backend_client.load_full()
+        ));
+
+        // A transport change means a different wire protocol — no adoption.
+        let retyped = build(ConnectionMode::Http);
+        assert!(retyped.inherit_shared_state_from(&old));
+        assert!(!Arc::ptr_eq(
+            &retyped.backend_client.load_full(),
+            &old.backend_client.load_full()
+        ));
     }
 
     /// A ZMQ client whose engine dies must be evicted by the health probe (the

--- a/model_gateway/src/workflow/steps/local/update_worker_properties.rs
+++ b/model_gateway/src/workflow/steps/local/update_worker_properties.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info, warn};
 use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
 use crate::{
-    worker::{BasicWorkerBuilder, Worker},
+    worker::{BasicWorkerBuilder, ConnectionMode, Worker},
     workflow::data::WorkerUpdateWorkflowData,
 };
 
@@ -117,6 +117,23 @@ impl StepExecutor<WorkerUpdateWorkflowData> for UpdateWorkerPropertiesStep {
                         "DP-aware worker is missing dp_rank or dp_size; skipping DP config"
                     );
                 }
+            } else if let Some(size) = worker.dp_size() {
+                // Grouped ZMQ worker: `dp_size` with no rank. Dropping it would
+                // shrink the handshake's engine count to 1 on the next connect.
+                builder = builder.zmq_engine_group(size);
+            }
+
+            // ZMQ transport state must survive a metadata-only update: the
+            // handshake address defines the socket this worker's engines dialed
+            // into, and the connect signal is how the manager learns a handshake
+            // landed. The live backend client itself is adopted from the
+            // replaced worker by `inherit_shared_state_from` below.
+            if let Some(address) = worker.metadata().spec.zmq_handshake_address.clone() {
+                builder = builder.zmq_handshake_address(address);
+            }
+            if *worker.connection_mode() == ConnectionMode::Zmq {
+                builder =
+                    builder.connect_signal_tx(app_context.worker_registry.connect_signal_sender());
             }
 
             let new_worker: Arc<dyn Worker> = Arc::new(builder.build());
@@ -154,5 +171,197 @@ impl StepExecutor<WorkerUpdateWorkflowData> for UpdateWorkerPropertiesStep {
 
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, time::Duration};
+
+    use engine_zmq_client::{
+        mock_engine::{connect_to_frontend, default_ready_response},
+        EngineId,
+    };
+    use openai_protocol::worker::{HealthCheckConfig, WorkerUpdateRequest};
+    use wfaas::WorkflowInstanceId;
+
+    use super::*;
+    use crate::{
+        app_context::AppContext,
+        routers::grpc::{
+            backend_client::BackendClient,
+            zmq_client::{EosTokenIds, ZmqEngineClient},
+        },
+        worker::{BasicWorker, RuntimeType},
+    };
+
+    fn make_app_context(workers: &[Arc<dyn Worker>]) -> Arc<AppContext> {
+        use crate::{
+            config::RouterConfig,
+            middleware::TokenBucket,
+            observability::inflight_tracker::InFlightRequestTracker,
+            routers::{
+                common::{openai_bridge, realtime::RealtimeRegistry},
+                grpc::multimodal::MultimodalConfigRegistry,
+            },
+            worker::{WorkerRegistry, WorkerService},
+        };
+
+        let router_config = RouterConfig::builder()
+            .worker_startup_timeout_secs(1)
+            .build_unchecked();
+        let registry = Arc::new(WorkerRegistry::new());
+        for w in workers {
+            registry.register(Arc::clone(w)).unwrap();
+        }
+        let job_queue = Arc::new(std::sync::OnceLock::new());
+
+        Arc::new(AppContext {
+            client: reqwest::Client::new(),
+            router_config: router_config.clone(),
+            rate_limiter: Some(Arc::new(TokenBucket::new(1000, 1000))),
+            rate_limit_manager: None,
+            worker_registry: Arc::clone(&registry),
+            policy_registry: Arc::new(crate::policies::PolicyRegistry::new(
+                router_config.policy.clone(),
+            )),
+            reasoning_parser_factory: None,
+            tool_parser_factory: None,
+            router_manager: None,
+            response_storage: Arc::new(smg_data_connector::MemoryResponseStorage::new()),
+            conversation_storage: Arc::new(smg_data_connector::MemoryConversationStorage::new()),
+            conversation_item_storage: Arc::new(
+                smg_data_connector::MemoryConversationItemStorage::new(),
+            ),
+            worker_monitor: None,
+            configured_reasoning_parser: None,
+            configured_tool_parser: None,
+            worker_job_queue: Arc::clone(&job_queue),
+            workflow_engines: Arc::new(std::sync::OnceLock::new()),
+            mcp_orchestrator: Arc::new(std::sync::OnceLock::new()),
+            mcp_format_registry: openai_bridge::FormatRegistry::new(),
+            tokenizer_registry: Arc::new(llm_tokenizer::registry::TokenizerRegistry::new()),
+            multimodal_config_registry: Arc::new(MultimodalConfigRegistry::new()),
+            wasm_manager: None,
+            worker_service: Arc::new(WorkerService::new(registry, job_queue, router_config)),
+            inflight_tracker: InFlightRequestTracker::new(),
+            kv_event_monitor: None,
+            realtime_registry: Arc::new(RealtimeRegistry::new()),
+            webrtc_bind_addr: None,
+            webrtc_stun_server: None,
+        })
+    }
+
+    fn make_context(
+        app_context: Arc<AppContext>,
+        worker: Arc<dyn Worker>,
+        labels: HashMap<String, String>,
+    ) -> WorkflowContext<WorkerUpdateWorkflowData> {
+        let data = WorkerUpdateWorkflowData {
+            config: WorkerUpdateRequest {
+                priority: None,
+                cost: None,
+                labels: Some(labels),
+                api_key: None,
+                health: None,
+            },
+            worker_url: worker.url().to_string(),
+            dp_aware: false,
+            app_context: Some(app_context),
+            workers_to_update: Some(vec![worker]),
+            updated_workers: None,
+        };
+        WorkflowContext::new(WorkflowInstanceId::new(), data)
+    }
+
+    /// A label-only PATCH must not disturb a ZMQ worker's transport: the engine
+    /// handshakes once at its own startup, so losing the connected client (or
+    /// the addresses and engine count that define the sockets) would black-hole
+    /// every request until the engine group is restarted.
+    #[tokio::test]
+    async fn zmq_update_preserves_transport_state_and_the_live_client() {
+        let dir = tempfile::tempdir().unwrap();
+        let ep = |name: &str| format!("ipc://{}", dir.path().join(name).display());
+        let (handshake, input, output) = (ep("hs.sock"), ep("in.sock"), ep("out.sock"));
+
+        let (client, engine) = tokio::join!(
+            ZmqEngineClient::connect(
+                &handshake,
+                &input,
+                &output,
+                1,
+                "m".to_string(),
+                EosTokenIds::default(),
+                RuntimeType::Vllm,
+                Duration::from_secs(10)
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        let _engine = engine.expect("mock engine");
+        let client = Arc::new(BackendClient::Zmq(client.expect("adapter connect")));
+
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new(ep("ts0.ipc"))
+                .connection_mode(ConnectionMode::Zmq)
+                .runtime_type(RuntimeType::Vllm)
+                .zmq_handshake_address(handshake.clone())
+                .zmq_engine_group(2)
+                .health_config(HealthCheckConfig::default())
+                .status(WorkerStatus::Ready)
+                .build(),
+        );
+        let old = worker
+            .as_any()
+            .downcast_ref::<BasicWorker>()
+            .expect("BasicWorker");
+        old.backend_client
+            .load_full()
+            .set(Arc::clone(&client))
+            .ok()
+            .expect("cell empty");
+
+        let app_ctx = make_app_context(std::slice::from_ref(&worker));
+        let mut ctx = make_context(
+            Arc::clone(&app_ctx),
+            Arc::clone(&worker),
+            HashMap::from([("tier".to_string(), "gold".to_string())]),
+        );
+
+        let result = UpdateWorkerPropertiesStep.execute(&mut ctx).await.unwrap();
+        assert_eq!(result, StepResult::Success);
+
+        let updated = ctx.data.updated_workers.as_ref().expect("updated workers");
+        assert_eq!(updated.len(), 1);
+        let new = updated[0]
+            .as_any()
+            .downcast_ref::<BasicWorker>()
+            .expect("BasicWorker");
+
+        assert_eq!(
+            new.metadata().spec.labels.get("tier"),
+            Some(&"gold".to_string())
+        );
+        assert_eq!(
+            new.metadata().spec.zmq_handshake_address.as_deref(),
+            Some(handshake.as_str())
+        );
+        assert_eq!(new.metadata().zmq_engine_count(), 2);
+        assert!(
+            new.connect_signal_tx.is_some(),
+            "ZMQ promotion stays event-driven after an update"
+        );
+
+        let adopted = new
+            .backend_client
+            .load_full()
+            .get()
+            .cloned()
+            .expect("replacement must inherit the connected client");
+        assert!(Arc::ptr_eq(&adopted, &client));
+        assert_eq!(new.status(), WorkerStatus::Ready);
     }
 }


### PR DESCRIPTION
## Description

### Problem

The audit finding **"Worker-update workflow silently bricks a live ZMQ worker: rebuilds it without client continuity, grouped dp_size, or handshake override"**.

`UpdateWorkerPropertiesStep` rebuilds each worker through `BasicWorkerBuilder` and re-registers it. For a ZMQ worker the rebuild dropped every piece of transport state:

- the connected backend client — `inherit_shared_state_from` adopted only the shared runtime and circuit breaker, so the replacement stayed `Ready` with an empty `OnceCell`; the next probe re-ran `connect_zmq_backend`, unbinding the live ipc sockets and waiting for a HELLO that only arrives at engine startup;
- `spec.zmq_handshake_address`, so the connect path silently fell back to the address derived from the URL;
- the grouped engine count — the `is_dp_aware()` guard requires `dp_rank`, which grouped ZMQ workers do not have, so `zmq_engine_count()` degraded from N to 1;
- `connect_signal_tx`, losing event-driven promotion.

A routine `PATCH` of labels or priority therefore black-holed a healthy ZMQ worker until its engine group was restarted.

### Solution

Carry the ZMQ transport state through the rebuild — handshake address, grouped `dp_size`, and the connect-readiness sender — and let the replacement adopt the replaced worker's backend-client cell so a same-URL replacement keeps talking over the established connection.

## Changes

- `update_worker_properties.rs`: carry `zmq_handshake_address`, the grouped `dp_size` (`dp_size` with no rank → `zmq_engine_group`), and — for ZMQ workers — the registry's connect-readiness sender into the rebuilt worker.
- `worker.rs`: `install_shared_state_from_basic` now also adopts the replaced worker's backend-client cell, so a same-URL replacement keeps talking over the established connection. Adoption is skipped when the connection mode or runtime type differs, or when the replacement already carries its own client. `zmq_connect_started` is deliberately left cleared: the shared cell already dedupes a handshake in flight, and a cleared guard lets the replacement retry (and signal under its own revision) if that handshake fails.

## Test Plan

`cargo test -p smg --lib -- zmq_update_preserves replacement_adopts_the_backend_client` — 2 passed. New tests:

- `update_worker_properties::tests::zmq_update_preserves_transport_state_and_the_live_client`: a label-only update against a registered grouped ZMQ worker holding a live client (mock engine over ipc) — asserts the rebuilt worker keeps the handshake address, `zmq_engine_count() == 2`, a connect signal sender, its `Ready` status, and the *same* `Arc<BackendClient>`.
- `worker::worker::tests::replacement_adopts_the_backend_client_only_on_a_matching_transport`: the client cell is shared on a same-transport replacement and not shared across a transport change.

`cargo test -p smg --lib -- worker:: workflow::` — 318 passed, 0 failed, 4 ignored.
`cargo clippy -p smg --all-targets -- -D warnings` — clean.
`cargo +nightly fmt --all -- --check` — clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
