### PR TITLE
fix(zmq): tolerate trailing wire fields and fail fast on persistent decode errors

### DIFF
--- a/crates/engine_zmq_client/src/codec/mod.rs
+++ b/crates/engine_zmq_client/src/codec/mod.rs
@@ -4,10 +4,13 @@
 //! Engine-agnostic wire primitives: msgpack (de)serialization, numpy dtype
 //! handling, and the zero-copy tensor aux-frame codec.
 
-use std::{any::type_name, io::Cursor};
+use std::{any::type_name, fmt, io::Cursor, marker::PhantomData};
 
 use rmpv::Value;
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{value::SeqAccessDeserializer, IgnoredAny, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
 
 use crate::error::{Error, Result};
 
@@ -18,11 +21,60 @@ pub mod tensor;
 /// yet strongly typed.
 pub type OpaqueValue = Value;
 
+/// Decode adapter for msgspec `array_like` structs. Upstream grows those
+/// structs by appending fields, so a newer engine sends a longer positional
+/// array than this client knows about — and `rmp-serde` rejects an array with
+/// unconsumed elements, which would fail the whole message. This wrapper
+/// consumes the elements `T` declares and discards the trailing remainder.
+pub struct TrailingTolerant<T>(pub T);
+
+impl<'de, T> Deserialize<'de> for TrailingTolerant<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TupleVisitor<T>(PhantomData<T>);
+
+        impl<'de, T: Deserialize<'de>> Visitor<'de> for TupleVisitor<T> {
+            type Value = TrailingTolerant<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "a positional array for `{}`", type_name::<T>())
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let value = T::deserialize(SeqAccessDeserializer::new(&mut seq))?;
+                while seq.next_element::<IgnoredAny>()?.is_some() {}
+                Ok(TrailingTolerant(value))
+            }
+        }
+
+        deserializer.deserialize_seq(TupleVisitor(PhantomData))
+    }
+}
+
+/// Deserialize a sequence of `array_like` structs, tolerating trailing wire
+/// fields in each element. Use as `#[serde(deserialize_with = ...)]`.
+pub fn deserialize_tolerant_seq<'de, D, T>(deserializer: D) -> std::result::Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let items = Vec::<TrailingTolerant<T>>::deserialize(deserializer)?;
+    Ok(items.into_iter().map(|item| item.0).collect())
+}
+
 /// Encode a Rust value into msgpack using named fields (map encoding for
 /// structs; positional arrays come from `serde_tuple`-derived types).
 pub fn encode_msgpack<T>(value: &T) -> Result<Vec<u8>>
 where
-    T: Serialize + std::fmt::Debug,
+    T: Serialize + fmt::Debug,
 {
     rmp_serde::to_vec_named(value).map_err(|error| Error::Encode {
         target_type: type_name::<T>(),

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -618,6 +618,14 @@ const ENGINE_SEND_TIMEOUT: Duration = Duration::from_secs(10);
 /// removed: without it a killed engine hangs its requests forever.
 const ENGINE_SILENCE_DEATH_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Consecutive undecodable output messages tolerated before the client is
+/// declared dead. One corrupt message is survivable, but an engine whose wire
+/// schema this client cannot read never recovers: every dropped batch strands
+/// the requests it carried, and the silence watchdog never fires because other
+/// traffic keeps arriving. Failing those requests is strictly better than
+/// hanging them.
+const MAX_CONSECUTIVE_DECODE_ERRORS: u32 = 3;
+
 /// Route decoded outputs to per-request streams and forward auto-abort requests
 /// to their engines. Runs until the output channel closes or the engine dies.
 async fn run_dispatcher<P: EngineProtocol>(
@@ -625,11 +633,13 @@ async fn run_dispatcher<P: EngineProtocol>(
     mut abort_rx: mpsc::UnboundedReceiver<(EngineId, String)>,
     inner: Arc<ClientInner<P>>,
 ) {
+    let mut consecutive_decode_errors = 0;
     loop {
         tokio::select! {
             output = out_rx.recv() => {
                 match output {
                     Some(Ok(batch)) => {
+                        consecutive_decode_errors = 0;
                         if let Some(load) = batch.load {
                             inner.routing.lock().load.insert(batch.engine_index, load);
                         }
@@ -658,7 +668,20 @@ async fn run_dispatcher<P: EngineProtocol>(
                             inner.routing.lock().inflight.clear();
                             return;
                         }
-                        // A per-message decode error is non-fatal; keep going.
+                        // A single decode error is non-fatal; a run of them means
+                        // this client cannot read the engine, so fail rather than
+                        // silently drop every output the requests are waiting for.
+                        consecutive_decode_errors += 1;
+                        if consecutive_decode_errors >= MAX_CONSECUTIVE_DECODE_ERRORS {
+                            warn!(
+                                %error,
+                                consecutive_decode_errors,
+                                "engine output undecodable repeatedly; failing all in-flight requests"
+                            );
+                            inner.registry.lock().fail_all(Arc::new(error));
+                            inner.routing.lock().inflight.clear();
+                            return;
+                        }
                         warn!(%error, "ignoring undecodable engine output");
                     }
                     None => break,
@@ -1339,6 +1362,31 @@ mod tests {
         assert!(matches!(result, Err(Error::Shared(_))));
     }
 
+    #[tokio::test]
+    async fn persistent_decode_errors_fail_inflight_requests() {
+        let (client, mut engine, _ns) = connect().await;
+        let mut stream = client
+            .submit(EngineCoreRequest {
+                request_id: "r".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        engine.recv_request().await.unwrap();
+
+        // One bad message is tolerated; a run of them is a schema mismatch the
+        // client cannot recover from, so the request fails instead of hanging.
+        for _ in 0..MAX_CONSECUTIVE_DECODE_ERRORS {
+            engine
+                .send_output(vec![Bytes::from_static(b"\xc1")])
+                .await
+                .unwrap();
+        }
+
+        let result = stream.next().await.expect("an error item");
+        assert!(matches!(result, Err(Error::Shared(_))), "{result:?}");
+    }
+
     /// The generic connector drives the TokenSpeed protocol over the same shared
     /// transport: it frames a tagged `TokenizedGenerateReqInput` and streams
     /// `BatchTokenIDOutSlim` batches back until a finish reason is seen.
@@ -1515,7 +1563,7 @@ mod tests {
                     exclude_engine_index,
                 } => {
                     // No rank is excluded: the whole group shares one wave.
-                    assert_eq!(exclude_engine_index, u32::MAX);
+                    assert_eq!(exclude_engine_index, None);
                     return wave;
                 }
                 EngineInbound::Add(_) => continue,

--- a/crates/engine_zmq_client/src/mock_engine.rs
+++ b/crates/engine_zmq_client/src/mock_engine.rs
@@ -95,10 +95,10 @@ pub enum EngineInbound {
     /// An abort for the given request ids (`EngineCoreRequestType::Abort`).
     Abort(Vec<String>),
     /// A lockstep-group wake (`EngineCoreRequestType::StartDpWave`): start this
-    /// wave unless this engine is the excluded one.
+    /// wave unless this engine is the excluded one (`None` excludes no rank).
     StartDpWave {
         wave: u64,
-        exclude_engine_index: u32,
+        exclude_engine_index: Option<u32>,
     },
     /// Any other request type byte (Utility), unhandled here.
     Other(u8),

--- a/crates/engine_zmq_client/src/protocol/vllm/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/mod.rs
@@ -95,9 +95,10 @@ impl EngineProtocol for VllmProtocol {
 
     fn encode_start_wave(wave: u64) -> Result<Option<(Bytes, Vec<u8>)>> {
         // Python decodes this with the generic msgpack decoder and unpacks it
-        // positionally as `new_wave, exclude_eng_index`. The sentinel matches
-        // no rank, so every rank adopts `wave`.
-        const NO_EXCLUDED_RANK: u32 = u32::MAX;
+        // positionally as `new_wave, exclude_eng_index`. `nil` excludes no
+        // rank — the same encoding vLLM's own DP coordinator emits — so every
+        // rank adopts `wave`.
+        const NO_EXCLUDED_RANK: Option<u32> = None;
         Ok(Some((
             EngineCoreRequestType::StartDpWave.to_frame(),
             encode_msgpack(&(wave, NO_EXCLUDED_RANK))?,
@@ -129,5 +130,23 @@ impl EngineProtocol for VllmProtocol {
             }),
             EngineCoreOutputs::Utility(_) => Ok(EngineBatch::default()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rmpv::Value;
+
+    use super::*;
+    use crate::codec::decode_value;
+
+    #[test]
+    fn start_wave_encodes_a_nil_excluded_rank() {
+        let (frame, payload) = VllmProtocol::encode_start_wave(9).unwrap().unwrap();
+        assert_eq!(frame.as_ref(), b"\x02");
+        assert_eq!(
+            decode_value(&payload).unwrap(),
+            Value::Array(vec![Value::from(9), Value::Nil])
+        );
     }
 }

--- a/crates/engine_zmq_client/src/protocol/vllm/output.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/output.rs
@@ -13,7 +13,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::{
-    codec::{decode_msgpack, OpaqueValue},
+    codec::{decode_msgpack, deserialize_tolerant_seq, OpaqueValue, TrailingTolerant},
     error::{Error, Result},
     protocol::vllm::{
         logprobs::{Logprobs, WireLogprobs},
@@ -89,6 +89,11 @@ pub struct EngineCoreOutput {
     pub routed_experts: Option<OpaqueValue>,
     /// Number of NaNs seen in logits. Values above zero indicate corruption.
     pub num_nans_in_logits: u32,
+    /// Multimodal hashes the engine's receiver cache missed, so the frontend
+    /// resends those inputs.
+    pub mm_cache_miss_hashes: Option<Vec<String>>,
+    /// Updated sampling mask (untyped for now).
+    pub new_sampling_mask: Option<OpaqueValue>,
 }
 
 impl EngineCoreOutput {
@@ -120,6 +125,8 @@ impl Serialize for EngineCoreOutput {
             prefill_stats: self.prefill_stats.as_ref(),
             routed_experts: self.routed_experts.as_ref(),
             num_nans_in_logits: self.num_nans_in_logits,
+            mm_cache_miss_hashes: self.mm_cache_miss_hashes.as_deref(),
+            new_sampling_mask: self.new_sampling_mask.as_ref(),
         }
         .serialize(serializer)
     }
@@ -167,6 +174,13 @@ struct WireEngineCoreOutput {
     routed_experts: Option<OpaqueValue>,
     #[serde(default)]
     num_nans_in_logits: u32,
+    /// Multimodal hashes the engine's receiver cache missed, so the frontend
+    /// resends those inputs.
+    #[serde(default)]
+    mm_cache_miss_hashes: Option<Vec<String>>,
+    /// Updated sampling mask (untyped for now).
+    #[serde(default)]
+    new_sampling_mask: Option<OpaqueValue>,
 }
 
 impl WireEngineCoreOutput {
@@ -193,6 +207,8 @@ impl WireEngineCoreOutput {
             prefill_stats: self.prefill_stats,
             routed_experts: self.routed_experts,
             num_nans_in_logits: self.num_nans_in_logits,
+            mm_cache_miss_hashes: self.mm_cache_miss_hashes,
+            new_sampling_mask: self.new_sampling_mask,
         })
     }
 }
@@ -215,6 +231,8 @@ struct WireEngineCoreOutputRef<'a> {
     prefill_stats: Option<&'a PrefillStats>,
     routed_experts: Option<&'a OpaqueValue>,
     num_nans_in_logits: u32,
+    mm_cache_miss_hashes: Option<&'a [String]>,
+    new_sampling_mask: Option<&'a OpaqueValue>,
 }
 
 /// Raw Python/msgpack engine-core output envelope. Mirrors Python
@@ -224,7 +242,7 @@ struct WireEngineCoreOutputs {
     #[serde(default)]
     engine_index: u32,
     /// Outputs grouped for this client in the current engine tick.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_seq")]
     outputs: Vec<WireEngineCoreOutput>,
     #[serde(default)]
     scheduler_stats: Option<Box<SchedulerStats>>,
@@ -451,7 +469,11 @@ pub fn decode_engine_core_outputs(frames: &[Bytes]) -> Result<EngineCoreOutputs>
         message: "missing output frame".to_string(),
     })?;
 
-    decode_msgpack::<WireEngineCoreOutputs>(first_frame)?.into_semantic(frames)
+    // Decoded through `TrailingTolerant` so an envelope a newer engine grew
+    // past this struct still yields the fields this client knows.
+    decode_msgpack::<TrailingTolerant<WireEngineCoreOutputs>>(first_frame)?
+        .0
+        .into_semantic(frames)
 }
 
 #[cfg(test)]
@@ -459,7 +481,7 @@ mod tests {
     use super::*;
     use crate::{
         codec::{
-            encode_msgpack,
+            decode_value, encode_msgpack,
             tensor::{WireArrayData, WireNdArray},
         },
         protocol::vllm::logprobs::{PositionLogprobs, TokenLogprob},
@@ -643,6 +665,48 @@ mod tests {
         };
         let error = wire.into_semantic(&[]).unwrap_err();
         assert!(error.to_string().contains("invalid wire shape"), "{error}");
+    }
+
+    /// The positional array a value encodes to.
+    fn wire_array<T: Serialize + std::fmt::Debug>(value: &T) -> Vec<rmpv::Value> {
+        match decode_value(&encode_msgpack(value).unwrap()).unwrap() {
+            rmpv::Value::Array(array) => array,
+            other => panic!("expected array, got {other:?}"),
+        }
+    }
+
+    fn encode_value(value: &rmpv::Value) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        rmpv::encode::write_value(&mut bytes, value).unwrap();
+        bytes
+    }
+
+    #[test]
+    fn decode_tolerates_wire_arrays_longer_than_the_struct() {
+        // A newer engine appends fields to both the envelope and each output;
+        // the elements this client knows must still decode.
+        let mut output = wire_array(&EngineCoreOutput {
+            request_id: "req-1".to_string(),
+            new_token_ids: vec![7],
+            mm_cache_miss_hashes: Some(vec!["hash-1".to_string()]),
+            ..Default::default()
+        });
+        output.push(rmpv::Value::from("appended by a newer engine"));
+
+        let mut envelope = wire_array(&batch(Vec::new()));
+        envelope[1] = rmpv::Value::Array(vec![rmpv::Value::Array(output)]);
+        envelope.push(rmpv::Value::from(true));
+
+        let frame = Bytes::from(encode_value(&rmpv::Value::Array(envelope)));
+        let decoded = decode_engine_core_outputs(&[frame])
+            .unwrap()
+            .into_request_batch()
+            .expect("request batch");
+        assert_eq!(decoded.outputs[0].new_token_ids, vec![7]);
+        assert_eq!(
+            decoded.outputs[0].mm_cache_miss_hashes,
+            Some(vec!["hash-1".to_string()])
+        );
     }
 
     #[test]

--- a/crates/engine_zmq_client/src/protocol/vllm/request.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/request.rs
@@ -61,7 +61,7 @@ pub struct ReasoningParserKwargs {
 /// Engine-core add-request payload sent from frontend to engine.
 ///
 /// This is a msgspec `array_like=True` struct: it serializes as a positional
-/// msgpack array of exactly 20 elements. **Field order is the wire contract** —
+/// msgpack array of exactly 21 elements. **Field order is the wire contract** —
 /// do not reorder. Mirrors Python `EngineCoreRequest`.
 #[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple, DefaultFromSerde)]
 pub struct EngineCoreRequest {
@@ -112,6 +112,9 @@ pub struct EngineCoreRequest {
     /// connector-side cleanup runs via the standard `request_finished` hook.
     #[serde(default)]
     pub abort_immediately: bool,
+    /// Stable session identity shared by related requests.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 impl EngineCoreRequest {
@@ -175,8 +178,8 @@ mod tests {
             other => panic!("expected array, got {other:?}"),
         };
 
-        // 20-element positional tuple; spot-check the wire positions.
-        assert_eq!(array.len(), 20);
+        // 21-element positional tuple; spot-check the wire positions.
+        assert_eq!(array.len(), 21);
         assert_eq!(array[0], Value::from("req-1"));
         assert_eq!(array[2], Value::Nil); // mm_features
         assert_eq!(array[4], Value::Nil); // pooling_params


### PR DESCRIPTION
## Description

### Problem

Four audit findings against the ZMQ engine client's vLLM wire protocol:

- **EngineCoreOutput drops upstream's trailing tuple fields, so decode fails when a newer engine populates them** — `EngineCoreOutput` ended at `num_nans_in_logits`, while upstream appends `mm_cache_miss_hashes` and `new_sampling_mask`. Because the struct is `Serialize_tuple`/`Deserialize_tuple` and rmp-serde rejects an array with unconsumed elements, a 15/16-element array from the engine failed the whole batch (latent until the engine populates those fields: mm receiver-cache misses, sampling-mask flows).
- **Dispatcher swallows decode errors that upstream treats as fatal, turning schema mismatch into silent request hangs** — every undecodable message was logged and ignored, so a persistent mismatch dropped the affected requests' outputs on every tick; their streams never received a terminal item and the 300s silence watchdog never fired because other traffic kept arriving.
- **START_DP_WAVE encodes exclude_engine_index as u32::MAX where the Python-compatible wire uses None**.
- **EngineCoreRequest drops upstream's trailing session_id field**.

### Solution

Make the decoder tolerate trailing fields a newer engine appends, re-add the two upstream fields that were dropped, fail in-flight requests instead of hanging them once decode errors persist, and encode `START_DP_WAVE` the way vLLM's own coordinator does.

## Changes

- `codec`: `TrailingTolerant<T>` decode wrapper plus a `deserialize_tolerant_seq` helper — they consume the positional elements the struct declares and discard any trailing ones a newer engine appended. Applied to the `EngineCoreOutputs` envelope and to each `EngineCoreOutput` inside it, so appending a field upstream can no longer break decoding wholesale.
- `protocol/vllm/output.rs`: re-add `mm_cache_miss_hashes: Option<Vec<String>>` and `new_sampling_mask: Option<OpaqueValue>` in upstream's field order, both `#[serde(default)]`.
- `protocol/vllm/request.rs`: re-add the trailing `session_id: Option<String>`; the add-request tuple is 21 elements again.
- `connector.rs`: decode-error policy — a single undecodable message is still tolerated, but three consecutive ones fail all in-flight requests (the same path as `EngineCoreDead`) and stop the dispatcher. Any successfully decoded batch resets the counter. Failing requests is strictly better than hanging them.
- `protocol/vllm/mod.rs`: `START_DP_WAVE` now encodes `(wave, nil)` — the encoding vLLM's own `DPCoordinatorProc` emits — instead of a `u32::MAX` sentinel; the mock engine's `EngineInbound::StartDpWave.exclude_engine_index` is `Option<u32>` to match.

## Test Plan

`cargo test -p engine-zmq-client` → `test result: ok. 80 passed; 0 failed`, including the three new tests:

- `protocol::vllm::output::tests::decode_tolerates_wire_arrays_longer_than_the_struct` — an envelope and a per-request output both carrying an extra appended element still decode, and the new `mm_cache_miss_hashes` field round-trips.
- `protocol::vllm::tests::start_wave_encodes_a_nil_excluded_rank` — the wake payload is `[wave, nil]` behind the `\x02` type frame.
- `connector::tests::persistent_decode_errors_fail_inflight_requests` — three undecodable output messages fail the in-flight request instead of leaving its stream hanging.

`cargo clippy -p engine-zmq-client --all-targets -- -D warnings` → clean; `cargo +nightly fmt --all` → no diff.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
