### PR TITLE
fix(router): reject ZMQ workers from PD prefill/decode pools

### DIFF
--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -295,11 +295,11 @@ impl WorkerSelectionStage {
             Some(model_id)
         };
 
-        // gRPC + direct-ZMQ workers both ride the gRPC router pipeline.
+        // Filtered to gRPC below: PD legs cannot ride the ZMQ transport.
         let all_workers = self.worker_registry.get_workers_filtered(
             model_filter,
             None,
-            None, // grpc + zmq, filtered below
+            None, // filtered below
             None, // any runtime type
             false,
         );
@@ -308,7 +308,12 @@ impl WorkerSelectionStage {
             all_workers
                 .into_iter()
                 .fold((Vec::new(), Vec::new()), |mut acc, w| {
-                    if w.connection_mode().uses_grpc_pipeline() && w.is_available() {
+                    // Only gRPC legs, not every grpc-pipeline mode: the ZMQ
+                    // wire carries no KV-transfer rendezvous, so a ZMQ leg
+                    // would silently drop the PD bootstrap info. Registration
+                    // rejects such workers; this keeps any that slipped in
+                    // (remote/service-discovery paths) out of PD pairs.
+                    if *w.connection_mode() == ConnectionMode::Grpc && w.is_available() {
                         match w.metadata().spec.worker_type {
                             WorkerType::Prefill => acc.0.push(w),
                             WorkerType::Decode => acc.1.push(w),
@@ -442,11 +447,11 @@ impl WorkerSelectionStage {
             Some(model_id)
         };
 
-        // gRPC + direct-ZMQ workers both ride the gRPC router pipeline.
+        // Filtered to gRPC below: no EPD leg can ride the ZMQ transport.
         let all_workers = self.worker_registry.get_workers_filtered(
             model_filter,
             None,
-            None, // grpc + zmq, filtered below
+            None, // filtered below
             None, // any runtime type
             false,
         );
@@ -454,16 +459,12 @@ impl WorkerSelectionStage {
         let (all_encode, all_prefill, all_decode): (Vec<_>, Vec<_>, Vec<_>) = all_workers
             .into_iter()
             .fold((Vec::new(), Vec::new(), Vec::new()), |mut acc, w| {
-                if w.connection_mode().uses_grpc_pipeline() && w.is_available() {
+                // Only gRPC legs: encode dispatch is a gRPC encoder RPC the
+                // direct-ZMQ worker has no path for, and the ZMQ wire carries
+                // no KV-transfer rendezvous for the prefill/decode legs.
+                if *w.connection_mode() == ConnectionMode::Grpc && w.is_available() {
                     match w.metadata().spec.worker_type {
-                        // Encode dispatch is a gRPC encoder RPC sent to the
-                        // worker's URL; a direct-ZMQ worker has no encode
-                        // path, so only gRPC workers qualify for this pool.
-                        WorkerType::Encode => {
-                            if *w.connection_mode() == ConnectionMode::Grpc {
-                                acc.0.push(w);
-                            }
-                        }
+                        WorkerType::Encode => acc.0.push(w),
                         WorkerType::Prefill => acc.1.push(w),
                         WorkerType::Decode => acc.2.push(w),
                         WorkerType::Regular => {}
@@ -845,5 +846,49 @@ mod tests {
             &prefill_hits,
             &decode_hits,
         );
+    }
+
+    #[test]
+    fn select_pd_pair_ignores_zmq_legs() {
+        // The ZMQ wire carries no KV-transfer rendezvous, so ZMQ prefill/decode
+        // workers must never be paired even if they reach the registry.
+        let model_id = "test-model-zmq";
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        for (port, worker_type) in [(9000, WorkerType::Prefill), (9100, WorkerType::Decode)] {
+            worker_registry
+                .register(Arc::new(
+                    BasicWorkerBuilder::new(format!("ipc:///tmp/smg-zmq/{port}.ipc"))
+                        .model(ModelCard::new(model_id))
+                        .worker_type(worker_type)
+                        .connection_mode(ConnectionMode::Zmq)
+                        .health_config(no_health_check())
+                        .build(),
+                ))
+                .unwrap();
+        }
+
+        let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin));
+        policy_registry
+            .set_prefill_policy(PolicyFactory::create_from_config(&PolicyConfig::RoundRobin));
+        policy_registry
+            .set_decode_policy(PolicyFactory::create_from_config(&PolicyConfig::RoundRobin));
+        let stage = WorkerSelectionStage::new(
+            Arc::clone(&worker_registry),
+            Arc::clone(&policy_registry),
+            WorkerSelectionMode::PrefillDecode,
+        );
+
+        assert!(
+            stage.select_pd_pair(model_id, None, None, None).is_none(),
+            "ZMQ-only PD pools must not yield a pair"
+        );
+
+        // Adding gRPC legs makes selection succeed, and it never picks the ZMQ ones.
+        let (prefill_urls, decode_urls) = register_pd_workers(&worker_registry, model_id, 4);
+        let (prefill, decode, _) = stage
+            .select_pd_pair(model_id, None, None, None)
+            .expect("gRPC PD pair should be selected");
+        assert!(prefill_urls.contains(&prefill.url().to_string()));
+        assert!(decode_urls.contains(&decode.url().to_string()));
     }
 }

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -546,22 +546,28 @@ fn normalize_url(url: &str, connection_mode: ConnectionMode) -> String {
 /// `EngineCoreRequest` nor the TokenSpeed `TokenizedGenerateReqInput` has a
 /// field for the bootstrap info PD injects, so a ZMQ prefill/decode leg would
 /// silently drop it and degrade to a decode-side recompute or a stalled KV
-/// wait. Reject at registration so the ZMQ lane never serves disaggregated
-/// requests.
+/// wait. Encode fares no better: encode dispatch is a gRPC encoder RPC a
+/// direct-ZMQ worker has no path for. `Regular` is therefore the only role the
+/// ZMQ lane serves, and every disaggregated leg is rejected at registration —
+/// matching the gRPC-only PD/EPD selection folds, which would otherwise leave
+/// such a worker registered but never selected.
 fn validate_zmq_worker_type(
     connection_mode: ConnectionMode,
     worker_type: WorkerType,
     url: &str,
 ) -> Result<(), WorkflowError> {
     if connection_mode == ConnectionMode::Zmq
-        && matches!(worker_type, WorkerType::Prefill | WorkerType::Decode)
+        && matches!(
+            worker_type,
+            WorkerType::Prefill | WorkerType::Decode | WorkerType::Encode
+        )
     {
         return Err(WorkflowError::StepFailed {
             step_id: StepId::new("create_worker"),
             message: format!(
                 "ZMQ worker {url} cannot serve worker type {worker_type}: the direct-ZMQ \
-                 backend carries no KV-transfer metadata, so prefill/decode disaggregation \
-                 requires a gRPC worker"
+                 backend carries no KV-transfer metadata and has no encode path, so \
+                 encode/prefill/decode disaggregation requires a gRPC worker"
             ),
         });
     }
@@ -717,13 +723,13 @@ mod tests {
 
     #[test]
     fn zmq_disaggregated_legs_are_rejected_as_a_create_worker_failure() {
-        for worker_type in [WorkerType::Prefill, WorkerType::Decode] {
+        for worker_type in [WorkerType::Prefill, WorkerType::Decode, WorkerType::Encode] {
             let err = validate_zmq_worker_type(
                 ConnectionMode::Zmq,
                 worker_type,
                 "ipc:///tmp/smg-zmq/ts0.ipc",
             )
-            .expect_err("ZMQ prefill/decode must be rejected");
+            .expect_err("ZMQ encode/prefill/decode must be rejected");
             match err {
                 WorkflowError::StepFailed { step_id, message } => {
                     assert_eq!(step_id, StepId::new("create_worker"));
@@ -736,8 +742,8 @@ mod tests {
             }
         }
 
-        // Regular and encode workers over ZMQ, and any worker type over the
-        // other transports, stay accepted.
+        // Regular is the one role the ZMQ lane serves; every worker type over
+        // the other transports stays accepted.
         validate_zmq_worker_type(
             ConnectionMode::Zmq,
             WorkerType::Regular,

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -3,7 +3,11 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use openai_protocol::{model_card::ModelCard, model_type::ModelType, worker::WorkerSpec};
+use openai_protocol::{
+    model_card::ModelCard,
+    model_type::ModelType,
+    worker::{WorkerSpec, WorkerType},
+};
 use tracing::debug;
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
@@ -156,6 +160,8 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
                 ),
             });
         }
+
+        validate_zmq_worker_type(*connection_mode, config.worker_type, &config.url)?;
 
         // A grouped ZMQ worker (`dp_size: N` on the spec) awaits N engines on
         // one socket set. Both ZMQ runtimes route per rank: vLLM by in-request
@@ -534,6 +540,34 @@ fn normalize_url(url: &str, connection_mode: ConnectionMode) -> String {
     }
 }
 
+/// Reject a disaggregated leg the ZMQ path cannot serve.
+///
+/// The ZMQ wire carries no KV-transfer rendezvous: neither the vLLM
+/// `EngineCoreRequest` nor the TokenSpeed `TokenizedGenerateReqInput` has a
+/// field for the bootstrap info PD injects, so a ZMQ prefill/decode leg would
+/// silently drop it and degrade to a decode-side recompute or a stalled KV
+/// wait. Reject at registration so the ZMQ lane never serves disaggregated
+/// requests.
+fn validate_zmq_worker_type(
+    connection_mode: ConnectionMode,
+    worker_type: WorkerType,
+    url: &str,
+) -> Result<(), WorkflowError> {
+    if connection_mode == ConnectionMode::Zmq
+        && matches!(worker_type, WorkerType::Prefill | WorkerType::Decode)
+    {
+        return Err(WorkflowError::StepFailed {
+            step_id: StepId::new("create_worker"),
+            message: format!(
+                "ZMQ worker {url} cannot serve worker type {worker_type}: the direct-ZMQ \
+                 backend carries no KV-transfer metadata, so prefill/decode disaggregation \
+                 requires a gRPC worker"
+            ),
+        });
+    }
+    Ok(())
+}
+
 /// Reject a data-parallel worker the ZMQ path cannot serve.
 ///
 /// dp-aware expansion creates one rank-pinned worker per DP rank, but each
@@ -679,6 +713,43 @@ mod tests {
         let card = build_model_card("GLM-5.2", &spec, &HashMap::new(), &aliases);
 
         assert!(card.aliases.is_empty());
+    }
+
+    #[test]
+    fn zmq_disaggregated_legs_are_rejected_as_a_create_worker_failure() {
+        for worker_type in [WorkerType::Prefill, WorkerType::Decode] {
+            let err = validate_zmq_worker_type(
+                ConnectionMode::Zmq,
+                worker_type,
+                "ipc:///tmp/smg-zmq/ts0.ipc",
+            )
+            .expect_err("ZMQ prefill/decode must be rejected");
+            match err {
+                WorkflowError::StepFailed { step_id, message } => {
+                    assert_eq!(step_id, StepId::new("create_worker"));
+                    assert!(
+                        message.contains(&worker_type.to_string()),
+                        "message was: {message}"
+                    );
+                }
+                other => panic!("expected StepFailed, got {other:?}"),
+            }
+        }
+
+        // Regular and encode workers over ZMQ, and any worker type over the
+        // other transports, stay accepted.
+        validate_zmq_worker_type(
+            ConnectionMode::Zmq,
+            WorkerType::Regular,
+            "ipc:///tmp/smg-zmq/ts0.ipc",
+        )
+        .expect("ZMQ regular workers are the supported case");
+        for mode in [ConnectionMode::Http, ConnectionMode::Grpc] {
+            for worker_type in [WorkerType::Prefill, WorkerType::Decode, WorkerType::Encode] {
+                validate_zmq_worker_type(mode, worker_type, "grpc://worker:8080")
+                    .expect("non-ZMQ transports serve every worker type");
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

The audit finding **"PD routing admits ZMQ prefill/decode legs but the ZMQ wire silently drops all KV-transfer metadata"**.

`select_pd_pair` pooled any worker passing `uses_grpc_pipeline()` (gRPC *or* ZMQ) into prefill/decode legs, but the ZMQ wire cannot carry PD rendezvous: `EngineCoreRequest` has no KV-transfer field, so the params injected by `execute_sequential_pd` vanished silently — degrading to full decode-side recompute or a stalled KV wait.

### Solution

Reject ZMQ Prefill/Decode workers at registration and pool only gRPC workers into PD legs. `proto_wrapper.rs` already asserts "the ZMQ lane does not serve disaggregated requests"; this makes that true by construction.

## Changes

- `workflow/steps/local/create_worker.rs`: new `validate_zmq_worker_type` rejects `ConnectionMode::Zmq` + `WorkerType::Prefill/Decode` at registration (a `StepFailed`, right after the existing ZMQ runtime check).
- `routers/grpc/common/stages/worker_selection.rs`: `select_pd_pair` pools only `ConnectionMode::Grpc` workers, as defense in depth.
- Same gRPC-only filter applied to `select_encode_prefill_decode_workers` — its prefill/decode legs had the identical defect (the new outer condition subsumes the per-encode gRPC check that already existed).

## Test Plan

- `cargo test -p smg --lib -- zmq pd_ worker_selection select_pd` → 125 passed / 0 failed (includes both new tests)
- `cargo clippy -p smg --all-targets -- -D warnings` → clean
- `cargo +nightly fmt --all -- --check` → clean

## Follow-up (not in this PR)

`router_manager.rs:284-292` still counts ZMQ Prefill/Decode workers toward PD router activation, and `pd_tests::pd_debug_counts_include_zmq_workers` still asserts they appear in debug counts. Both are unreachable via create_worker registration after this change.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
