### PR TITLE
fix(worker): keep ZMQ handshake off request paths and abort the driver on removal

### DIFF
--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -306,8 +306,8 @@ async fn unlink_stale_socket(address: &str) -> Result<(), String> {
 }
 
 /// Bind the SMG-side ZMQ sockets and complete the handshake with the
-/// engine(s): the single connect path for a worker's `ipc://` URL, shared by
-/// the lazy client accessor and the background handshake driver. `model_id` is
+/// engine(s): the single connect path for a worker's `ipc://` URL, driven only
+/// by the worker's background handshake driver. `model_id` is
 /// the config-resolved served model (EngineCore reports none). `engine_count`
 /// is the number of DP engines that will dial this worker's sockets (1 for an
 /// ungrouped worker). Errors are plain reasons; the worker layer wraps them in

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, ArcSwapOption};
 use openai_protocol::{
     model_card::ModelCard,
     worker::{HealthCheckConfig, WorkerModels, WorkerSpec, WorkerStatus},
@@ -335,6 +335,7 @@ impl BasicWorkerBuilder {
             metadata,
             backend_client,
             zmq_connect_started: Arc::new(AtomicBool::new(false)),
+            zmq_connect_abort: Arc::new(ArcSwapOption::empty()),
             connect_signal_tx: self.connect_signal_tx,
             models_override: Arc::new(ArcSwap::from_pointee(WorkerModels::Wildcard)),
             http_client,

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -905,6 +905,11 @@ impl WorkerRegistry {
         // Overwrite worker object atomically
         self.workers.insert(worker_id.clone(), new_worker.clone());
 
+        // The replacement carries its own backend-client slot, so the old
+        // instance's ZMQ handshake driver can now only hold its socket binds
+        // against the new worker's connect.
+        old_worker.abort_background_tasks();
+
         // Diff model indexes: remove stale, add new
         for removed_model in old_models.difference(&new_models) {
             self.remove_worker_from_model_index(removed_model, old_worker.url());
@@ -1199,6 +1204,11 @@ impl WorkerRegistry {
                 worker.set_status(WorkerStatus::NotReady);
             }
             Metrics::remove_worker_metrics(worker.url());
+
+            // Release background work owned by this instance — notably the ZMQ
+            // handshake driver, whose bound sockets would otherwise block a
+            // re-registration at the same URL until it times out.
+            worker.abort_background_tasks();
 
             // Mesh tombstoning rides the `Removed` event below: the
             // outbound sync loop deletes `worker:{id}` for local workers.
@@ -3473,6 +3483,72 @@ mod tests {
         assert!(
             registry.get_hash_ring(UNKNOWN_MODEL_ID).is_none(),
             "an empty registry has no ring to route against"
+        );
+    }
+
+    /// A ZMQ worker whose handshake driver is in flight, holding the socket
+    /// binds derived from `dir`.
+    async fn connecting_zmq_worker(dir: &std::path::Path) -> Arc<crate::worker::BasicWorker> {
+        let worker = Arc::new(
+            BasicWorkerBuilder::new(format!("ipc://{}", dir.join("ts0.ipc").display()))
+                .connection_mode(ConnectionMode::Zmq)
+                .health_config(no_health_check())
+                .build(),
+        );
+        assert!(
+            !worker.zmq_health_check().await.unwrap(),
+            "worker is not ready until the handshake lands"
+        );
+        assert!(
+            worker.zmq_connect_abort.load_full().is_some(),
+            "probe must start the background handshake driver"
+        );
+        worker
+    }
+
+    /// A removed worker's ZMQ handshake driver must not outlive its registry
+    /// entry: it holds the worker's socket binds until it lands, which would
+    /// fail a re-registration at the same URL.
+    #[tokio::test]
+    async fn remove_aborts_the_zmq_handshake_driver() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = WorkerRegistry::new();
+        let worker = connecting_zmq_worker(dir.path()).await;
+
+        let id = registry
+            .register(worker.clone() as Arc<dyn Worker>)
+            .unwrap();
+        registry.remove(&id).expect("worker removed");
+
+        assert!(
+            worker.zmq_connect_abort.load_full().is_none(),
+            "removal must abort the in-flight handshake driver"
+        );
+    }
+
+    /// Same for a replacement: it brings its own backend-client slot, so the
+    /// old instance's driver could only collide with the new worker's connect.
+    #[tokio::test]
+    async fn replace_aborts_the_replaced_workers_zmq_handshake_driver() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = WorkerRegistry::new();
+        let worker = connecting_zmq_worker(dir.path()).await;
+        let url = worker.url().to_string();
+
+        let id = registry
+            .register(worker.clone() as Arc<dyn Worker>)
+            .unwrap();
+        let replacement: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new(url)
+                .connection_mode(ConnectionMode::Zmq)
+                .health_config(no_health_check())
+                .build(),
+        );
+        assert!(registry.replace(&id, replacement));
+
+        assert!(
+            worker.zmq_connect_abort.load_full().is_none(),
+            "replacement must abort the replaced worker's handshake driver"
         );
     }
 }

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, ArcSwapOption};
 use async_trait::async_trait;
 use axum::body::Body;
 // Re-export protocol types as the canonical types for the gateway
@@ -21,6 +21,7 @@ use openai_protocol::{
 use smg_grpc_client::common_proto;
 use tokio::{
     sync::{mpsc, OnceCell},
+    task::AbortHandle,
     time,
 };
 
@@ -553,6 +554,15 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
     async fn reset_grpc_client(&self) -> WorkerResult<()> {
         Ok(())
     }
+
+    /// Release background work owned by this worker instance.
+    ///
+    /// Called by the registry when the worker leaves it (removal) or is
+    /// superseded by a replacement. `BasicWorker` aborts the detached ZMQ
+    /// handshake driver: it holds the handshake and data-plane socket binds
+    /// until it lands, so an orphaned driver would keep them for up to the
+    /// connect timeout and collide with a same-URL re-registration.
+    fn abort_background_tasks(&self) {}
     async fn grpc_health_check(&self) -> WorkerResult<bool>;
     /// Liveness check for a ZMQ worker. Unlike gRPC there is no health RPC on
     /// the raw wire: liveness is local (handshake completed and the engine has
@@ -1032,6 +1042,10 @@ pub struct BasicWorker {
     /// never cancels a long (model-load) handshake. Self-clears on failure to
     /// allow a retry. Unused for HTTP/gRPC.
     pub zmq_connect_started: Arc<AtomicBool>,
+    /// Abort handle for that driver, so removing or replacing the worker
+    /// releases the sockets the in-flight handshake has bound instead of
+    /// leaving them held until it times out. `None` until a driver is spawned.
+    pub zmq_connect_abort: Arc<ArcSwapOption<AbortHandle>>,
     /// Wakes the manager the instant the ZMQ handshake completes so it can
     /// promote the worker without waiting for the next health poll. Set only
     /// for ZMQ workers built through the registration path; `None` elsewhere
@@ -1055,6 +1069,7 @@ impl Clone for BasicWorker {
             circuit_breaker: ArcSwap::from(self.circuit_breaker.load_full()),
             backend_client: Arc::clone(&self.backend_client),
             zmq_connect_started: Arc::clone(&self.zmq_connect_started),
+            zmq_connect_abort: Arc::clone(&self.zmq_connect_abort),
             connect_signal_tx: self.connect_signal_tx.clone(),
             models_override: Arc::clone(&self.models_override),
             http_client: self.http_client.clone(),
@@ -1084,6 +1099,70 @@ impl BasicWorker {
 
     fn shared_runtime(&self) -> Arc<WorkerRuntime> {
         self.runtime.load_full()
+    }
+
+    /// Start the one-shot background ZMQ handshake driver for `cell` unless one
+    /// is already in flight.
+    ///
+    /// The handshake is never driven inline: it can take as long as a model
+    /// load, so any caller awaiting it (request pipeline, load monitor, health
+    /// probe) would block far past its own deadline. Callers peek the cell and
+    /// report unavailable until the driver lands.
+    fn spawn_zmq_connect_driver(&self, cell: &Arc<OnceCell<Arc<BackendClient>>>) {
+        if self.zmq_connect_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let cell = Arc::clone(cell);
+        let started = Arc::clone(&self.zmq_connect_started);
+        let base_url = self.metadata.base_url().to_string();
+        let model_id = self.metadata.model_id().to_string();
+        let url = self.metadata.spec.url.clone();
+        let runtime = self.metadata.spec.runtime_type;
+        let handshake_override = self.metadata.spec.zmq_handshake_address.clone();
+        let engine_count = self.metadata.zmq_engine_count();
+        // Capture the readiness signal and the revision at hand-off. The
+        // manager only promotes if this revision still matches, so a
+        // same-URL replacement racing the handshake is discarded.
+        let signal_tx = self.connect_signal_tx.clone();
+        let revision = self.revision();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "detached one-shot handshake driver; the OnceCell dedupes with the request path and the guard self-clears on failure to allow a retry"
+        )]
+        // Detached: only the AbortHandle is kept, so the task keeps running
+        // until it completes or the worker leaves the registry.
+        let handle = tokio::spawn(async move {
+            match cell
+                .get_or_try_init(|| {
+                    connect_zmq_backend(
+                        base_url,
+                        model_id,
+                        runtime,
+                        handshake_override,
+                        engine_count,
+                    )
+                })
+                .await
+            {
+                Ok(_) => {
+                    // Handshake landed: wake the manager to promote now
+                    // rather than on the next poll. A dropped signal (no
+                    // manager, or receiver gone) is harmless — polling
+                    // still promotes on the success threshold.
+                    if let Some(tx) = &signal_tx {
+                        let _ = tx.send(WorkerConnected { url, revision });
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "ZMQ backend handshake failed for {url}: {e}; will retry on the next health probe"
+                    );
+                    started.store(false, Ordering::SeqCst);
+                }
+            }
+        });
+        self.zmq_connect_abort
+            .store(Some(Arc::new(handle.abort_handle())));
     }
 
     fn install_shared_state_from_basic(&self, other: &BasicWorker) {
@@ -1344,28 +1423,21 @@ impl Worker for BasicWorker {
             }
             ConnectionMode::Zmq => {
                 // SMG binds the handshake + data-plane sockets; the
-                // operator-launched engine dials them. The first acquisition
-                // completes the handshake (a liveness signal in itself). The
-                // model id comes from config — EngineCore reports none on the
-                // wire (see create_worker).
-                let base_url = self.metadata.base_url().to_string();
-                let model_id = self.metadata.model_id().to_string();
-                let runtime = self.metadata.spec.runtime_type;
-                let handshake_override = self.metadata.spec.zmq_handshake_address.clone();
-                let engine_count = self.metadata.zmq_engine_count();
+                // operator-launched engine dials them. Peek only: the handshake
+                // is owned by the background driver (it can outlast any
+                // caller's deadline — see spawn_zmq_connect_driver), so fail
+                // fast instead of blocking a request or a load poll behind it.
+                // Kicking the driver off here also covers workers whose health
+                // checks are disabled, where no probe ever runs.
                 let cell = self.backend_client.load_full();
-                let client = cell
-                    .get_or_try_init(|| {
-                        connect_zmq_backend(
-                            base_url,
-                            model_id,
-                            runtime,
-                            handshake_override,
-                            engine_count,
-                        )
-                    })
-                    .await?;
-                Ok(Some(Arc::clone(client)))
+                if let Some(client) = cell.get() {
+                    return Ok(Some(Arc::clone(client)));
+                }
+                self.spawn_zmq_connect_driver(&cell);
+                Err(WorkerError::ConnectionFailed {
+                    url: self.metadata.spec.url.clone(),
+                    reason: "ZMQ backend handshake has not completed yet".to_string(),
+                })
             }
         }
     }
@@ -1446,56 +1518,17 @@ impl Worker for BasicWorker {
             self.zmq_connect_started.store(false, Ordering::SeqCst);
             return Ok(false);
         }
-        if !self.zmq_connect_started.swap(true, Ordering::SeqCst) {
-            let started = Arc::clone(&self.zmq_connect_started);
-            let base_url = self.metadata.base_url().to_string();
-            let model_id = self.metadata.model_id().to_string();
-            let url = self.metadata.spec.url.clone();
-            let runtime = self.metadata.spec.runtime_type;
-            let handshake_override = self.metadata.spec.zmq_handshake_address.clone();
-            let engine_count = self.metadata.zmq_engine_count();
-            // Capture the readiness signal and the revision at hand-off. The
-            // manager only promotes if this revision still matches, so a
-            // same-URL replacement racing the handshake is discarded.
-            let signal_tx = self.connect_signal_tx.clone();
-            let revision = self.revision();
-            #[expect(
-                clippy::disallowed_methods,
-                reason = "detached one-shot handshake driver; the OnceCell dedupes with the request path and the guard self-clears on failure to allow a retry"
-            )]
-            // Detached: dropping the handle at scope end leaves the task running.
-            let _handle = tokio::spawn(async move {
-                match cell
-                    .get_or_try_init(|| {
-                        connect_zmq_backend(
-                            base_url,
-                            model_id,
-                            runtime,
-                            handshake_override,
-                            engine_count,
-                        )
-                    })
-                    .await
-                {
-                    Ok(_) => {
-                        // Handshake landed: wake the manager to promote now
-                        // rather than on the next poll. A dropped signal (no
-                        // manager, or receiver gone) is harmless — polling
-                        // still promotes on the success threshold.
-                        if let Some(tx) = &signal_tx {
-                            let _ = tx.send(WorkerConnected { url, revision });
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "ZMQ backend handshake failed for {url}: {e}; will retry on the next health probe"
-                        );
-                        started.store(false, Ordering::SeqCst);
-                    }
-                }
-            });
-        }
+        self.spawn_zmq_connect_driver(&cell);
         Ok(false)
+    }
+
+    fn abort_background_tasks(&self) {
+        if let Some(handle) = self.zmq_connect_abort.swap(None) {
+            handle.abort();
+            // The bound sockets are released with the cancelled future; reset
+            // the guard so any instance still sharing this state can retry.
+            self.zmq_connect_started.store(false, Ordering::SeqCst);
+        }
     }
 
     async fn http_health_check(&self) -> WorkerResult<bool> {
@@ -2698,6 +2731,112 @@ mod tests {
         assert!(
             !worker.zmq_connect_started.load(Ordering::SeqCst),
             "handshake guard must reset to allow a reconnect"
+        );
+    }
+
+    /// Build a ZMQ worker whose sockets no engine will ever dial, plus the
+    /// data-plane socket path its handshake driver binds.
+    fn unattended_zmq_worker(dir: &std::path::Path) -> (BasicWorker, std::path::PathBuf) {
+        let worker = BasicWorkerBuilder::new(format!("ipc://{}", dir.join("ts0.ipc").display()))
+            .connection_mode(ConnectionMode::Zmq)
+            .health_config(no_health_check())
+            .build();
+        (worker, dir.join("ts0.ipc-in.sock"))
+    }
+
+    /// Poll `cond` until it holds, up to five seconds.
+    async fn wait_for(cond: impl Fn() -> bool) -> bool {
+        time::timeout(Duration::from_secs(5), async {
+            while !cond() {
+                time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    /// The ZMQ handshake can run as long as a model load, so acquisition on a
+    /// request or load-monitor path must hand it to the background driver and
+    /// fail fast instead of awaiting it inline.
+    #[tokio::test]
+    async fn zmq_get_backend_client_hands_the_handshake_to_the_background_driver() {
+        let base = tempfile::tempdir().unwrap();
+        let (worker, input_socket) = unattended_zmq_worker(base.path());
+
+        let acquired = time::timeout(Duration::from_secs(5), worker.get_backend_client())
+            .await
+            .expect("acquisition must not await the handshake");
+        assert!(
+            matches!(acquired, Err(WorkerError::ConnectionFailed { .. })),
+            "acquisition must report the backend as not connected yet"
+        );
+        assert!(
+            worker.backend_client.load().get().is_none(),
+            "no client can be cached before the handshake lands"
+        );
+
+        let handle = worker
+            .zmq_connect_abort
+            .load_full()
+            .expect("acquisition must start the background handshake driver");
+        assert!(
+            wait_for(|| input_socket.exists()).await,
+            "driver never bound the data-plane sockets"
+        );
+        assert!(
+            !handle.is_finished(),
+            "driver must still be waiting for the engine"
+        );
+
+        // A second acquisition rides the in-flight driver instead of spawning
+        // another one (which would rebind the same sockets).
+        assert!(worker.get_backend_client().await.is_err());
+        assert!(Arc::ptr_eq(
+            &handle,
+            &worker
+                .zmq_connect_abort
+                .load_full()
+                .expect("driver still recorded")
+        ));
+
+        worker.abort_background_tasks();
+    }
+
+    /// The driver holds the ipc data-plane and TCP handshake binds until it
+    /// lands, so worker removal/replacement must abort it — otherwise a
+    /// same-URL re-registration collides with an orphan for up to the connect
+    /// timeout.
+    #[tokio::test]
+    async fn abort_background_tasks_cancels_the_zmq_handshake_driver() {
+        let base = tempfile::tempdir().unwrap();
+        let (worker, input_socket) = unattended_zmq_worker(base.path());
+
+        assert!(
+            !worker.zmq_health_check().await.unwrap(),
+            "worker is not ready until the handshake lands"
+        );
+        let handle = worker
+            .zmq_connect_abort
+            .load_full()
+            .expect("probe must start the background handshake driver");
+        assert!(
+            wait_for(|| input_socket.exists()).await,
+            "driver never bound the data-plane sockets"
+        );
+
+        worker.abort_background_tasks();
+
+        assert!(
+            wait_for(|| handle.is_finished()).await,
+            "abort must cancel the in-flight handshake"
+        );
+        assert!(
+            worker.zmq_connect_abort.load_full().is_none(),
+            "the aborted driver must not stay recorded"
+        );
+        assert!(
+            !worker.zmq_connect_started.load(Ordering::SeqCst),
+            "handshake guard must reset so a later probe can retry"
         );
     }
 }


### PR DESCRIPTION
## Description

### Problem

Two coupled ZMQ worker lifecycle findings from the audit:

- **"ZMQ client acquisition on request/monitor paths can drive the full 600s handshake inline"** (and its consequence, **"Load monitor can initiate and block on a 600s inline ZMQ handshake for an evicted-but-still-Ready worker"**). `get_backend_client` ran `get_or_try_init(connect_zmq_backend)` inline for `ConnectionMode::Zmq`, and `connect_for_worker` waits `ZMQ_CONNECT_TIMEOUT` = 600s. Every non-probe caller connected inline: the request pipeline, the load monitor (awaited via `join_all`, so one hung worker stalled the whole group's load tick) and the KV-event subscriber. After the health probe evicts a dead client the worker stays `Ready` until the failure threshold demotes it, so requests routed in that window bound fresh sockets and blocked for up to ten minutes on a dead engine.

- **"Detached ZMQ handshake driver outlives worker removal, holding socket binds up to 600s"**. The background handshake task was fully detached with no handle stored on `BasicWorker`, and registry removal/replacement aborted nothing. `connect_handshake` binds the ipc data-plane sockets and the TCP handshake listener *before* waiting, so an orphaned driver held them for up to 600s after the worker was gone — a same-URL re-registration then unlinked the orphan's live socket files (violating `unlink_stale_socket`'s "stale by construction" premise) and failed to bind the handshake port, and an engine dialing meanwhile completed its handshake into a client nobody owns.

### Solution

Keep the handshake off request paths by making ZMQ client acquisition peek-only and handing the connect to a one-shot background driver, and store the driver's abort handle on the worker so removal and replacement release the socket binds deterministically.

## Changes

- `worker.rs`: extracted the one-shot handshake driver into `BasicWorker::spawn_zmq_connect_driver`, used by both the health probe and acquisition. The ZMQ arm of `get_backend_client` is now peek-only: it returns the cached client, or starts the driver and fails fast with `ConnectionFailed` ("handshake has not completed yet"). Starting the driver from acquisition also covers ZMQ workers with health checks disabled, where no probe ever runs.
- `worker.rs`: `BasicWorker` stores the driver's `AbortHandle` (`zmq_connect_abort`), and a new `Worker::abort_background_tasks` (default no-op) aborts it and resets the one-shot guard.
- `registry.rs`: `remove_inner` and `replace_inner` call `abort_background_tasks` on the departing worker, so the socket binds are released deterministically.
- `zmq_client.rs`: doc comment updated — `connect_for_worker` is now driven only by the background driver.

Callers already degrade correctly on the new fast failure: the load monitor skips the sample, the KV-event subscriber retries with backoff, and the request pipeline surfaces an error instead of hanging.

## Test Plan

- `cargo test -p smg --lib` — 1562 passed, 0 failed, 5 ignored. New tests:
  - `worker::worker::tests::zmq_get_backend_client_hands_the_handshake_to_the_background_driver` — acquisition returns without awaiting the handshake, leaves the cell empty, and a second acquisition rides the same driver.
  - `worker::worker::tests::abort_background_tasks_cancels_the_zmq_handshake_driver` — after the driver has bound its data-plane sockets, the abort finishes the task and resets the guard.
  - `worker::registry::tests::remove_aborts_the_zmq_handshake_driver`
  - `worker::registry::tests::replace_aborts_the_replaced_workers_zmq_handshake_driver`
- `cargo clippy -p smg --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all --check` — clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
