### PR TITLE
fix(mesh): keep host-local ZMQ workers out of cross-node sync

### DIFF
--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -4,9 +4,10 @@
 //! stream that publishes every locally-owned worker's state under
 //! `worker:{worker_id}` (and a tombstone on removal). Mesh-imported
 //! workers are filtered out by their registration origin so a peer's
-//! state is never re-published. On broadcast lag the loop re-publishes
-//! all local workers and tombstones any it published that no longer
-//! exist.
+//! state is never re-published, and `Zmq` workers are filtered out as
+//! host-local capacity (their `ipc://` endpoint is unreachable off this
+//! machine). On broadcast lag the loop re-publishes all local workers
+//! and tombstones any it published that no longer exist.
 //!
 //! Inbound: `start` also spawns a task that subscribes to the
 //! namespace, routes each non-tombstone update through
@@ -35,7 +36,9 @@ use smg_mesh::{CrdtNamespace, WorkerState};
 use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
 
-use crate::worker::{event::WorkerEvent, registry::WorkerId, Worker, WorkerOrigin, WorkerRegistry};
+use crate::worker::{
+    event::WorkerEvent, registry::WorkerId, ConnectionMode, Worker, WorkerOrigin, WorkerRegistry,
+};
 
 const PREFIX: &str = "worker:";
 
@@ -199,8 +202,8 @@ impl WorkerSyncAdapter {
                 // gone cluster-wide and peers dropped their imports, so
                 // re-assert the authoritative state — otherwise the worker
                 // stays delisted everywhere until its next status change.
-                if self.worker_registry.origin_of(&id) == Some(WorkerOrigin::Local) {
-                    if let Some(worker) = self.worker_registry.get(&id) {
+                if let Some(worker) = self.worker_registry.get(&id) {
+                    if self.is_publishable(&id, &worker) {
                         warn!(
                             worker_id,
                             "re-publishing locally-owned worker after foreign tombstone"
@@ -215,6 +218,16 @@ impl WorkerSyncAdapter {
                 }
             }
         }
+    }
+
+    /// Whether this node should export the worker to the cluster. Only
+    /// locally-owned workers are ours to publish, and a `Zmq` worker is
+    /// host-local by construction — its `ipc://` endpoint names a socket on
+    /// this machine only, so a peer that imported it would route to a path
+    /// that resolves to nothing on its own host.
+    fn is_publishable(&self, worker_id: &WorkerId, worker: &Arc<dyn Worker>) -> bool {
+        self.worker_registry.origin_of(worker_id) == Some(WorkerOrigin::Local)
+            && *worker.connection_mode() != ConnectionMode::Zmq
     }
 
     fn apply_incoming(&self, worker_id: &str, bytes: &[u8]) {
@@ -235,7 +248,7 @@ impl WorkerSyncAdapter {
         loop {
             match events.recv().await {
                 Ok(WorkerEvent::Registered { worker_id, worker }) => {
-                    if self.worker_registry.origin_of(&worker_id) == Some(WorkerOrigin::Local) {
+                    if self.is_publishable(&worker_id, &worker) {
                         self.on_worker_changed(
                             worker_id.as_str(),
                             &worker_state_of(&worker_id, &worker),
@@ -248,18 +261,23 @@ impl WorkerSyncAdapter {
                 // claimed by register_or_replace — starts publishing from its
                 // next mutation.
                 Ok(WorkerEvent::Replaced { worker_id, new, .. }) => {
-                    if self.worker_registry.origin_of(&worker_id) == Some(WorkerOrigin::Local) {
+                    if self.is_publishable(&worker_id, &new) {
                         self.on_worker_changed(
                             worker_id.as_str(),
                             &worker_state_of(&worker_id, &new),
                         );
                         published.insert(worker_id);
+                    } else if published.remove(&worker_id) {
+                        // The replacement is no longer exportable (e.g. the
+                        // endpoint moved to a host-local ZMQ transport):
+                        // withdraw the key peers already imported.
+                        self.on_worker_removed(worker_id.as_str());
                     }
                 }
                 Ok(WorkerEvent::StatusChanged {
                     worker_id, worker, ..
                 }) => {
-                    if self.worker_registry.origin_of(&worker_id) == Some(WorkerOrigin::Local) {
+                    if self.is_publishable(&worker_id, &worker) {
                         self.on_worker_changed(
                             worker_id.as_str(),
                             &worker_state_of(&worker_id, &worker),
@@ -294,7 +312,7 @@ impl WorkerSyncAdapter {
     fn resync_local(&self, published: &mut HashSet<WorkerId>) {
         let mut current = HashSet::new();
         for (id, worker) in self.worker_registry.get_all_with_ids() {
-            if self.worker_registry.origin_of(&id) == Some(WorkerOrigin::Local) {
+            if self.is_publishable(&id, &worker) {
                 let state = worker_state_of(&id, &worker);
                 if !self.store_matches(&id, &state) {
                     self.on_worker_changed(id.as_str(), &state);
@@ -640,6 +658,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn outbound_never_publishes_local_zmq_worker() {
+        // ZMQ workers are host-local capacity: their `ipc://` endpoint is
+        // meaningless off this machine, so they stay out of the mesh.
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+        adapter.start();
+
+        let zmq: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("ipc:///tmp/smg-local.sock")
+                .model(ModelCard::new("llama-3"))
+                .connection_mode(ConnectionMode::Zmq)
+                .build(),
+        );
+        let zmq_id = registry.register(zmq).unwrap();
+        registry
+            .get(&zmq_id)
+            .unwrap()
+            .set_status(WorkerStatus::Ready);
+
+        // A published HTTP worker is the ordering fence: once its key is in
+        // the store the outbound loop has drained past the ZMQ events.
+        let http_id = registry
+            .register(local_worker("http://local:8080"))
+            .unwrap();
+        assert!(
+            wait_for(|| ns.get(&format!("worker:{}", http_id.as_str())).is_some()).await,
+            "local HTTP registration was not published"
+        );
+        assert!(
+            ns.get(&format!("worker:{}", zmq_id.as_str())).is_none(),
+            "a ZMQ worker must never be published to the mesh"
+        );
+
+        // The resync/lag path takes the same gate.
+        let mut published = HashSet::new();
+        adapter.resync_local(&mut published);
+        assert!(
+            ns.get(&format!("worker:{}", zmq_id.as_str())).is_none(),
+            "resync must not publish a ZMQ worker"
+        );
+        assert!(published.contains(&http_id) && !published.contains(&zmq_id));
+    }
+
+    #[tokio::test]
     async fn outbound_never_republishes_mesh_imported_worker() {
         let mesh = MeshKV::new("node-a".into());
         let ns = worker_namespace(&mesh);
@@ -760,7 +824,7 @@ mod tests {
         let worker: Arc<dyn Worker> = Arc::new(
             BasicWorkerBuilder::new("grpc://remote:9000")
                 .model(ModelCard::new("llama-3"))
-                .connection_mode(crate::worker::ConnectionMode::Grpc)
+                .connection_mode(ConnectionMode::Grpc)
                 .worker_type(crate::worker::WorkerType::Decode)
                 .build(),
         );
@@ -773,7 +837,7 @@ mod tests {
         let imported = sub_registry.get_by_url("grpc://remote:9000").unwrap();
         assert_eq!(
             *imported.connection_mode(),
-            crate::worker::ConnectionMode::Grpc,
+            ConnectionMode::Grpc,
             "connection mode must survive the spec round trip"
         );
         assert_eq!(

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -1734,6 +1734,18 @@ impl WorkerRegistry {
     pub fn on_remote_worker_state(&self, state: &smg_mesh::WorkerState) {
         use openai_protocol::model_card::ModelCard;
 
+        // ZMQ is a same-host transport: its `ipc://` endpoint names a socket
+        // on the publisher's machine, so importing it here would advertise a
+        // route that can never reach the engine. Publishers filter these out;
+        // this guard also covers peers running older builds.
+        if ConnectionMode::from_url(&state.url) == Some(ConnectionMode::Zmq) {
+            tracing::debug!(
+                url = %state.url,
+                "Ignoring mesh state for host-local ZMQ worker"
+            );
+            return;
+        }
+
         // If worker already exists at this URL, update its health
         // status from the mesh state. Don't re-register — the existing
         // worker has full config from its creation workflow.
@@ -1798,6 +1810,15 @@ impl WorkerRegistry {
         } else {
             match serde_json::from_slice::<openai_protocol::worker::WorkerSpec>(&state.spec) {
                 Ok(spec) => {
+                    // Same-host transport declared by the spec rather than by
+                    // the URL scheme — not routable from this node.
+                    if spec.connection_mode == ConnectionMode::Zmq {
+                        tracing::debug!(
+                            url = %state.url,
+                            "Ignoring mesh state for host-local ZMQ worker"
+                        );
+                        return;
+                    }
                     spec_applied = true;
                     super::builder::BasicWorkerBuilder::from_spec(spec).build()
                 }
@@ -2124,6 +2145,41 @@ mod tests {
             registry.get_id_by_url("http://remote:8080"),
             Some(WorkerId::from_string("peer-w1".to_string())),
             "import keys under the publisher's id so its tombstone resolves"
+        );
+    }
+
+    #[test]
+    fn mesh_state_for_zmq_worker_is_never_imported() {
+        // ZMQ is same-host: an `ipc://` endpoint published by a peer names a
+        // socket path on that peer's machine, so importing it would advertise
+        // an unroutable worker.
+        let registry = WorkerRegistry::new();
+        registry.on_remote_worker_state(&remote_state(
+            "peer-w1",
+            "ipc:///tmp/smg-peer.sock",
+            true,
+            vec![],
+        ));
+        assert!(
+            registry.get_by_url("ipc:///tmp/smg-peer.sock").is_none(),
+            "a host-local ZMQ worker must not be imported from the mesh"
+        );
+
+        // Same rejection when the transport is declared only by the spec.
+        let spec: openai_protocol::worker::WorkerSpec = serde_json::from_value(serde_json::json!({
+            "url": "http://remote:8080",
+            "connection_mode": "zmq"
+        }))
+        .unwrap();
+        registry.on_remote_worker_state(&remote_state(
+            "peer-w2",
+            "http://remote:8080",
+            true,
+            serde_json::to_vec(&spec).unwrap(),
+        ));
+        assert!(
+            registry.get_by_url("http://remote:8080").is_none(),
+            "a spec-declared ZMQ worker must not be imported from the mesh"
         );
     }
 

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -1784,6 +1784,38 @@ impl WorkerRegistry {
             }
         }
 
+        // Decode the spec (and run the transport gate it declares) BEFORE
+        // touching any index: a rejected state must leave no trace, or the
+        // id reservation below would outlive it and a legitimate worker
+        // later arriving at this URL would silently inherit the rejected
+        // publisher's id — breaking tombstone routing for it.
+        let spec = if state.spec.is_empty() {
+            None
+        } else {
+            match serde_json::from_slice::<openai_protocol::worker::WorkerSpec>(&state.spec) {
+                Ok(spec) => {
+                    // Same-host transport declared by the spec rather than by
+                    // the URL scheme — not routable from this node.
+                    if spec.connection_mode == ConnectionMode::Zmq {
+                        tracing::debug!(
+                            url = %state.url,
+                            "Ignoring mesh state for host-local ZMQ worker"
+                        );
+                        return;
+                    }
+                    Some(spec)
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        url = %state.url,
+                        %err,
+                        "undecodable WorkerSpec in mesh state; importing minimal worker"
+                    );
+                    None
+                }
+            }
+        };
+
         // Adopt the publisher's worker id for the import so a later
         // tombstone for `worker:{id}` (which carries no value, only the
         // key) resolves to this worker. A pre-existing reservation for
@@ -1797,40 +1829,14 @@ impl WorkerRegistry {
                 .or_insert_with(|| WorkerId::from_string(state.worker_id.clone()));
         }
 
-        // New worker — build from the full WorkerSpec (JSON) if available,
+        // New worker — build from the full WorkerSpec if it decoded,
         // otherwise fall back to the minimal builder.
-        let minimal = || {
-            super::builder::BasicWorkerBuilder::new(&state.url)
+        let spec_applied = spec.is_some();
+        let worker = match spec {
+            Some(spec) => super::builder::BasicWorkerBuilder::from_spec(spec).build(),
+            None => super::builder::BasicWorkerBuilder::new(&state.url)
                 .model(ModelCard::new(&state.model_id))
-                .build()
-        };
-        let mut spec_applied = false;
-        let worker = if state.spec.is_empty() {
-            minimal()
-        } else {
-            match serde_json::from_slice::<openai_protocol::worker::WorkerSpec>(&state.spec) {
-                Ok(spec) => {
-                    // Same-host transport declared by the spec rather than by
-                    // the URL scheme — not routable from this node.
-                    if spec.connection_mode == ConnectionMode::Zmq {
-                        tracing::debug!(
-                            url = %state.url,
-                            "Ignoring mesh state for host-local ZMQ worker"
-                        );
-                        return;
-                    }
-                    spec_applied = true;
-                    super::builder::BasicWorkerBuilder::from_spec(spec).build()
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        url = %state.url,
-                        %err,
-                        "undecodable WorkerSpec in mesh state; importing minimal worker"
-                    );
-                    minimal()
-                }
-            }
+                .build(),
         };
 
         // An explicitly-unhealthy import must not be routable: the builder
@@ -2181,6 +2187,60 @@ mod tests {
             registry.get_by_url("http://remote:8080").is_none(),
             "a spec-declared ZMQ worker must not be imported from the mesh"
         );
+    }
+
+    #[test]
+    fn rejected_zmq_state_leaves_no_url_to_id_residue() {
+        // Both transport gates run before the id reservation. A leftover
+        // `url_to_id` entry would be invisible to `get_id_by_url` (which
+        // skips ids with no live worker) yet still win the `Entry::Occupied`
+        // arm in `register_inner`, handing the next legitimate worker at
+        // this URL the rejected publisher's id — so a peer tombstone for
+        // that id would delete a worker that never came from the mesh.
+        let registry = WorkerRegistry::new();
+
+        // Rejected by the URL scheme.
+        registry.on_remote_worker_state(&remote_state(
+            "peer-w1",
+            "ipc:///tmp/smg-peer.sock",
+            true,
+            vec![],
+        ));
+        assert!(
+            registry.url_to_id.get("ipc:///tmp/smg-peer.sock").is_none(),
+            "a URL-scheme rejection must not reserve an id"
+        );
+
+        // Rejected by the spec's declared connection mode.
+        let spec: openai_protocol::worker::WorkerSpec = serde_json::from_value(serde_json::json!({
+            "url": "http://remote:8080",
+            "connection_mode": "zmq"
+        }))
+        .unwrap();
+        registry.on_remote_worker_state(&remote_state(
+            "peer-w2",
+            "http://remote:8080",
+            true,
+            serde_json::to_vec(&spec).unwrap(),
+        ));
+        assert!(
+            registry.url_to_id.get("http://remote:8080").is_none(),
+            "a spec rejection must not reserve an id"
+        );
+
+        // A legitimate worker later arriving at the same URL gets its own id.
+        let local: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://remote:8080")
+                .model(ModelCard::new("llama-3"))
+                .build(),
+        );
+        let local_id = registry.register(local).expect("registers");
+        assert_ne!(
+            local_id,
+            WorkerId::from_string("peer-w2".to_string()),
+            "a later worker must not inherit the rejected publisher's id"
+        );
+        assert_eq!(registry.get_id_by_url("http://remote:8080"), Some(local_id));
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

The audit finding **"Mesh sync imports peer ZMQ worker specs as locally routable workers with no transport gating"**.

`worker_state_of` serialized the full `WorkerSpec` — `connection_mode: zmq` and the `ipc://` URL included — for every locally-owned worker, and the outbound loop published all of them. On the importing node, `on_remote_worker_state` rebuilt the spec verbatim and set the worker `Ready` from the published health flag. ZMQ is a same-host transport (the `ipc://` endpoint names a socket on the publisher's machine), so the peer routed to a black hole until its own probe demoted it — after `connect_for_worker` had created the socket dir, unlinked whatever sat at that path locally, and waited for an engine that could never dial in.

### Solution

Gate ZMQ workers out of mesh sync on both ends: never publish a host-local ZMQ worker outbound, and skip inbound state that classifies as ZMQ. This mirrors the transport-identity gating added in a976d82a for the metrics/admin/PD paths.

## Changes

- `model_gateway/src/mesh/adapters/worker_sync.rs`: new `is_publishable` gate (locally-owned **and** not `ConnectionMode::Zmq`) applied to the `Registered`/`Replaced`/`StatusChanged` publish paths, the `resync_local` lag/bootstrap pass, and the re-publish-after-foreign-tombstone path. A `Replaced` event that turns a published worker into a ZMQ one now tombstones the key peers already imported. Module doc updated.
- `model_gateway/src/worker/registry.rs`: `on_remote_worker_state` skips inbound state whose URL scheme classifies as ZMQ, and skips a decoded spec that declares `connection_mode: zmq` — defensive coverage for peers running older builds.

## Test Plan

Test binary built from this worktree and run directly (the shared cargo target dir is contended by sibling agents):

- `cargo test -p smg --lib` → `worker::registry::tests::mesh_state_for_zmq_worker_is_never_imported ... ok`, `mesh::adapters::worker_sync::tests::outbound_never_publishes_local_zmq_worker ... ok`
- Module suites: `worker::registry::` 54 passed, `mesh::` 85 passed, `worker::manager` 28 passed, 0 failed
- `cargo clippy -p smg --all-targets -- -D warnings` → clean
- `cargo +nightly fmt --all` → clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
