### PR TITLE
test(zmq): cover gateway integration, job_queue, and mock lockstep gaps

### DIFF
--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -1425,4 +1425,72 @@ mod tests {
             other => panic!("independent rank expected only its Add, got {other:?}"),
         }
     }
+
+    /// A rank that took a request for an already-drained wave asks the client
+    /// to start the next one (vLLM `start_wave`). Without a DP coordinator
+    /// nobody else answers that request, so the client must broadcast the wake
+    /// itself — to EVERY rank, at a wave the asking rank will still accept.
+    #[tokio::test]
+    async fn a_ranks_start_wave_request_wakes_the_whole_group() {
+        let (_client, mut engines, _ns) = connect_ranks(2, true).await;
+
+        // The rank is ahead of the client's clock (it self-incremented on its
+        // way out of the last wave), which is exactly the stale-wake trap.
+        let requested = 7;
+        engines[0]
+            .send_output(wave_control(0, DpControlMessage::StartWave(requested)))
+            .await
+            .unwrap();
+
+        assert!(next_wake(&mut engines[0]).await >= requested);
+        assert!(next_wake(&mut engines[1]).await >= requested);
+    }
+
+    /// A drain notification is bookkeeping, not a wake: `wave_complete` folds
+    /// into the clock but must NOT restart the group, or the ranks would never
+    /// stay parked and an idle group would spin.
+    #[tokio::test]
+    async fn wave_complete_updates_the_clock_without_waking() {
+        let (client, mut engines, _ns) = connect_ranks(2, true).await;
+
+        engines[0]
+            .send_output(wave_control(0, DpControlMessage::WaveComplete(3)))
+            .await
+            .unwrap();
+        tokio::time::timeout(TIMEOUT, async {
+            while *client.inner.wave.as_ref().unwrap().lock() <= 3 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the drained wave never reached the clock");
+
+        // The next submit is the first thing that may wake the group, and it
+        // must clear the wave the ranks parked on.
+        let _stream = client.submit(request_for("req-1", 1)).await.unwrap();
+        assert!(next_wake(&mut engines[0]).await > 3);
+    }
+
+    /// Independent ranks keep no wave clock, so a stray wave notification (a
+    /// mislabeled engine, say) must be ignored rather than panic or start
+    /// waking ranks that never park.
+    #[tokio::test]
+    async fn wave_notifications_from_independent_ranks_are_ignored() {
+        let (client, mut engines, _ns) = connect_ranks(2, false).await;
+
+        engines[0]
+            .send_output(wave_control(0, DpControlMessage::StartWave(2)))
+            .await
+            .unwrap();
+
+        let _stream = client.submit(request_for("req-1", 0)).await.unwrap();
+        match engines[0].recv().await.unwrap() {
+            EngineInbound::Add(request) => assert_eq!(request.request_id, "req-1"),
+            other => panic!("independent rank expected only its Add, got {other:?}"),
+        }
+        assert!(
+            client.inner.wave.is_none(),
+            "no clock for independent ranks"
+        );
+    }
 }

--- a/crates/mock_worker/src/zmq.rs
+++ b/crates/mock_worker/src/zmq.rs
@@ -350,4 +350,66 @@ mod tests {
         assert!(finished, "stream should reach a terminal output");
         assert_eq!(tokens.len(), 4, "canned mode emits output_tokens tokens");
     }
+
+    /// Two mock ranks dial one socket set — the grouped-worker topology the
+    /// gateway registers for `--zmq-engine-count`. Each rank must complete its
+    /// own rank-pinned request off the shared output socket, tagging its
+    /// outputs with its own engine index.
+    #[tokio::test]
+    async fn two_ranks_share_one_socket_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let endpoint = |name: &str| format!("ipc://{}", dir.path().join(name).display());
+        let (handshake, input, output) = (
+            endpoint("hs.sock"),
+            endpoint("in.sock"),
+            endpoint("out.sock"),
+        );
+
+        let cfg = Arc::new(test_config());
+        for rank in 0..2 {
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "serve loops until the test drops its handles"
+            )]
+            let _engine = tokio::spawn(serve(cfg.clone(), handshake.clone(), rank));
+        }
+
+        let transport = connect_handshake(
+            &handshake,
+            2,
+            "127.0.0.1",
+            Some(&input),
+            Some(&output),
+            Duration::from_secs(10),
+        )
+        .await
+        .expect("frontend handshake");
+        let client = EngineCoreClient::new(transport);
+        assert_eq!(client.engines().len(), 2);
+
+        for rank in 0..2u32 {
+            let mut stream = client
+                .submit(EngineCoreRequest {
+                    request_id: format!("rank-{rank}"),
+                    prompt_token_ids: Some(vec![1, 2, 3]),
+                    data_parallel_rank: Some(rank),
+                    ..Default::default()
+                })
+                .await
+                .expect("submit");
+
+            let mut tokens = Vec::new();
+            let mut finished = false;
+            while let Some(item) = stream.next().await {
+                let output = item.expect("output ok");
+                tokens.extend(output.new_token_ids.clone());
+                if output.finished() {
+                    finished = true;
+                    break;
+                }
+            }
+            assert!(finished, "rank {rank} should reach a terminal output");
+            assert_eq!(tokens.len(), 4, "rank {rank} emits output_tokens tokens");
+        }
+    }
 }

--- a/model_gateway/src/workflow/job_queue.rs
+++ b/model_gateway/src/workflow/job_queue.rs
@@ -565,26 +565,7 @@ impl JobQueue {
                     spec.worker_type = proto_worker_type;
                     spec.api_key.clone_from(&api_key);
                     spec.bootstrap_port = bootstrap_port;
-                    // ZMQ startup workers carry the runtime pinned by
-                    // `--backend` (the shared handshake cannot be probed for a
-                    // wire protocol); `None` — HTTP/gRPC or no `--backend` —
-                    // keeps auto-detection in detect_backend.
-                    if let Some(runtime) = router_config.startup_worker_runtime_type {
-                        spec.runtime_type = runtime;
-                    }
-                    // Grouped ZMQ worker: the handshake awaits this many DP
-                    // engines on one socket set. Only ZMQ URLs — dp_size on an
-                    // HTTP/gRPC startup worker would misread as dp-awareness.
-                    if let Some(count) = router_config.zmq_engine_count.filter(|&n| n > 1) {
-                        if ConnectionMode::from_url(&spec.url) == Some(ConnectionMode::Zmq) {
-                            spec.dp_size = Some(count);
-                        }
-                    }
-                    // Health config is resolved at worker build time from router
-                    // defaults + per-worker overrides (spec.health). No need to
-                    // set spec.health here since these workers have no overrides.
-                    spec.max_connection_attempts =
-                        router_config.health_check.success_threshold.max(1) * 10;
+                    apply_startup_worker_config(&mut spec, router_config);
                     let config = spec;
 
                     let job = Job::AddWorker {
@@ -766,6 +747,31 @@ impl JobQueue {
     }
 }
 
+/// Stamp the router-config-derived fields onto a startup worker's spec: the
+/// pinned runtime, the grouped-ZMQ engine count, and the connection budget.
+/// Identity fields (url, worker type, api key, bootstrap port) are the
+/// caller's.
+fn apply_startup_worker_config(spec: &mut WorkerSpec, router_config: &RouterConfig) {
+    // ZMQ startup workers carry the runtime pinned by `--backend` (the shared
+    // handshake cannot be probed for a wire protocol); `None` — HTTP/gRPC or no
+    // `--backend` — keeps auto-detection in detect_backend.
+    if let Some(runtime) = router_config.startup_worker_runtime_type {
+        spec.runtime_type = runtime;
+    }
+    // Grouped ZMQ worker: the handshake awaits this many DP engines on one
+    // socket set. Only ZMQ URLs — dp_size on an HTTP/gRPC startup worker would
+    // misread as dp-awareness.
+    if let Some(count) = router_config.zmq_engine_count.filter(|&n| n > 1) {
+        if ConnectionMode::from_url(&spec.url) == Some(ConnectionMode::Zmq) {
+            spec.dp_size = Some(count);
+        }
+    }
+    // Health config is resolved at worker build time from router defaults +
+    // per-worker overrides (spec.health). No need to set spec.health here since
+    // these workers have no overrides.
+    spec.max_connection_attempts = router_config.health_check.success_threshold.max(1) * 10;
+}
+
 /// Submit AddWorker jobs for external provider endpoints (OpenAI/Anthropic/Gemini).
 async fn submit_external_worker_jobs(
     worker_urls: &[String],
@@ -821,4 +827,85 @@ fn build_external_worker_config(
     // set spec.health here since these workers have no overrides.
     spec.max_connection_attempts = router_config.health_check.success_threshold.max(1) * 10;
     spec
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec_for(url: &str, router_config: &RouterConfig) -> WorkerSpec {
+        let mut spec = WorkerSpec::new(url);
+        apply_startup_worker_config(&mut spec, router_config);
+        spec
+    }
+
+    /// A grouped-ZMQ fleet stamps `dp_size` only on the `ipc://` workers:
+    /// `dp_size` on an HTTP/gRPC worker means rank-aware DP routing, a
+    /// different topology entirely.
+    #[test]
+    fn engine_count_only_reaches_zmq_workers_in_a_mixed_fleet() {
+        let config = RouterConfig {
+            zmq_engine_count: Some(4),
+            ..RouterConfig::default()
+        };
+
+        assert_eq!(spec_for("ipc:///tmp/smg/engine", &config).dp_size, Some(4));
+        assert_eq!(spec_for("grpc://127.0.0.1:30000", &config).dp_size, None);
+        assert_eq!(spec_for("http://127.0.0.1:8000", &config).dp_size, None);
+    }
+
+    /// One engine is an ungrouped worker, not a group of one: the ZMQ client
+    /// awaits a single engine by default, and `Some(1)` must not turn the
+    /// worker into a dp-aware one.
+    #[test]
+    fn a_single_engine_leaves_dp_size_unset() {
+        let mut config = RouterConfig {
+            zmq_engine_count: Some(1),
+            ..RouterConfig::default()
+        };
+        assert_eq!(spec_for("ipc:///tmp/smg/engine", &config).dp_size, None);
+
+        config.zmq_engine_count = None;
+        assert_eq!(spec_for("ipc:///tmp/smg/engine", &config).dp_size, None);
+    }
+
+    /// `--backend` pins the ZMQ wire protocol (the handshake can't be probed);
+    /// without it the spec keeps its default so `detect_backend` can probe.
+    #[test]
+    fn startup_runtime_is_pinned_only_when_configured() {
+        let default_runtime = WorkerSpec::new("ipc:///tmp/smg/engine").runtime_type;
+
+        let mut config = RouterConfig {
+            startup_worker_runtime_type: Some(RuntimeType::Vllm),
+            ..RouterConfig::default()
+        };
+        assert_eq!(
+            spec_for("ipc:///tmp/smg/engine", &config).runtime_type,
+            RuntimeType::Vllm
+        );
+
+        config.startup_worker_runtime_type = None;
+        assert_eq!(
+            spec_for("ipc:///tmp/smg/engine", &config).runtime_type,
+            default_runtime
+        );
+    }
+
+    /// The connection budget scales with the health-check success threshold,
+    /// and a zero threshold must not collapse it to zero attempts.
+    #[test]
+    fn connection_attempts_scale_with_the_success_threshold_floor() {
+        let mut config = RouterConfig::default();
+        config.health_check.success_threshold = 0;
+        assert_eq!(
+            spec_for("http://127.0.0.1:8000", &config).max_connection_attempts,
+            10
+        );
+
+        config.health_check.success_threshold = 3;
+        assert_eq!(
+            spec_for("http://127.0.0.1:8000", &config).max_connection_attempts,
+            30
+        );
+    }
 }

--- a/model_gateway/tests/zmq_backend_test.rs
+++ b/model_gateway/tests/zmq_backend_test.rs
@@ -1,0 +1,279 @@
+//! Gateway-level integration test for the direct ZMQ backend
+//! (`routers/grpc/zmq_client.rs`), driven against a real in-process mock
+//! EngineCore (`mock-worker`'s `zmq` mode) over `ipc://` data-plane sockets.
+//!
+//! Everything below the router is real: the worker's lazy ZMQ connect binds
+//! the frontend sockets, completes the vLLM handshake with the mock engine(s),
+//! and streams `EngineCoreOutputs` back through the shared gRPC request
+//! pipeline (`ConnectionMode::Zmq` rides `uses_grpc_pipeline`). Before this
+//! suite, that whole path had CPU coverage only inside `engine-zmq-client`;
+//! the gateway half was exercised only on GPU e2e lanes.
+//!
+//! Determinism relies on `mock-worker`'s canned (non-`realistic`) ZMQ mode: it
+//! emits exactly `output_tokens` synthetic token ids then a `stop`-terminated
+//! output, regardless of the prompt. The ids are outside `MockTokenizer`'s tiny
+//! vocab, so decoded text is empty by construction -- the assertions are on
+//! token accounting and stream shape, not on text.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use std::{sync::Arc, time::Duration};
+
+use llm_tokenizer::{traits::Tokenizer, MockTokenizer, TokenizerRegistry};
+use openai_protocol::{
+    generate::GenerateRequest, model_card::ModelCard, worker::HealthCheckConfig,
+};
+use portpicker::pick_unused_port;
+use smg::{
+    config::RouterConfig,
+    middleware::{RouteRequestMeta, TenantKey},
+    routers::{RouterFactory, RouterTrait},
+    worker::{BasicWorkerBuilder, ConnectionMode, RuntimeType, WorkerType},
+};
+
+const MODEL: &str = "zmq-backend-test-model";
+/// Canned tokens the mock engine emits per request.
+const OUTPUT_TOKENS: u32 = 4;
+
+/// A ZMQ frontend under test: the gateway's worker URL plus the TCP handshake
+/// address the mock engines dial. The tempdir backs the `ipc://` data plane and
+/// must stay alive for the test's whole body.
+struct ZmqFixture {
+    worker_url: String,
+    handshake: String,
+    _dir: tempfile::TempDir,
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+fn zmq_fixture() -> ZmqFixture {
+    let dir = tempfile::tempdir().expect("tempdir for ipc sockets");
+    // The gateway derives `<path>-in.sock` / `-out.sock` from this base path.
+    let worker_url = format!("ipc://{}", dir.path().join("engine").display());
+    // Pin the handshake port rather than letting the gateway derive it from the
+    // socket path: the derived port is a hash of a tempdir path, so it could
+    // collide with anything else on the runner.
+    let port = pick_unused_port().expect("no free port for the zmq handshake");
+    ZmqFixture {
+        worker_url,
+        handshake: format!("tcp://127.0.0.1:{port}"),
+        _dir: dir,
+    }
+}
+
+/// Spawn `count` mock EngineCore ranks dialing `handshake`, canned mode.
+/// Each rank runs until the test process exits.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test helper - the mock engine tasks are fire-and-forget for the test process's lifetime"
+)]
+fn start_mock_zmq_engines(handshake: &str, count: u16) {
+    let cfg = Arc::new(mock_worker::config::Config {
+        host: "127.0.0.1".to_string(),
+        http_base_port: 0,
+        http_count: 0,
+        grpc_base_port: 0,
+        grpc_count: 0,
+        zmq_handshake: Some(handshake.to_string()),
+        zmq_count: count,
+        zmq_start_index: 0,
+        model_id: MODEL.to_string(),
+        tokenizer_path: MODEL.to_string(),
+        gen_delay: Duration::ZERO,
+        output_tokens: OUTPUT_TOKENS,
+        realistic: false,
+        engine: mock_worker::engine::EngineParams::default(),
+    });
+    for rank in 0..u32::from(count) {
+        tokio::spawn(mock_worker::zmq::serve(
+            cfg.clone(),
+            handshake.to_string(),
+            rank,
+        ));
+    }
+}
+
+/// Build a real gRPC-pipeline router with a single ZMQ worker registered
+/// against `fixture`. `engine_count > 1` registers a grouped worker: one
+/// worker, one socket set, N engines dialing in.
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+async fn build_router(fixture: &ZmqFixture, engine_count: usize) -> Box<dyn RouterTrait> {
+    let mut config = RouterConfig::builder()
+        .grpc_connection()
+        .regular_mode(vec![])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .max_concurrent_requests(64)
+        .queue_timeout_secs(60)
+        .build_unchecked();
+    config.health_check.disable_health_check = true;
+
+    let tokenizer_registry = Arc::new(TokenizerRegistry::new());
+    let tokenizer = Arc::new(MockTokenizer::new()) as Arc<dyn Tokenizer>;
+    tokenizer_registry
+        .load(
+            "tokenizer-id",
+            MODEL,
+            "test",
+            || async move { Ok(tokenizer) },
+        )
+        .await
+        .unwrap();
+
+    let app_context =
+        common::create_test_context_with_tokenizer_registry(config, tokenizer_registry).await;
+
+    let mut builder = BasicWorkerBuilder::new(fixture.worker_url.clone())
+        .worker_type(WorkerType::Regular)
+        .connection_mode(ConnectionMode::Zmq)
+        .runtime_type(RuntimeType::Vllm)
+        .zmq_handshake_address(fixture.handshake.clone())
+        .model(ModelCard::new(MODEL))
+        .health_config(HealthCheckConfig {
+            disable_health_check: true,
+            ..Default::default()
+        });
+    if engine_count > 1 {
+        builder = builder.zmq_engine_group(engine_count);
+    }
+    app_context
+        .worker_registry
+        .register(Arc::new(builder.build()))
+        .unwrap();
+
+    RouterFactory::create_router(&app_context)
+        .await
+        .expect("router should build over a ZMQ worker")
+}
+
+#[expect(
+    clippy::unwrap_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+fn generate_request(stream: bool) -> GenerateRequest {
+    serde_json::from_value(serde_json::json!({
+        "model": MODEL,
+        "text": "Hello world",
+        "stream": stream,
+        "sampling_params": { "max_new_tokens": OUTPUT_TOKENS },
+    }))
+    .unwrap()
+}
+
+fn test_meta() -> RouteRequestMeta {
+    RouteRequestMeta::new(TenantKey::from("zmq-backend-test"))
+}
+
+/// The full gateway path over ZMQ: router -> lazy handshake -> mock EngineCore
+/// -> streamed outputs -> assembled non-streaming response. A regression
+/// anywhere in the ipc:// bind, handshake, or output translation fails here on
+/// CPU, without an H100 e2e lane.
+#[tokio::test]
+async fn non_streaming_generate_over_zmq() {
+    let fixture = zmq_fixture();
+    start_mock_zmq_engines(&fixture.handshake, 1);
+    let router = build_router(&fixture, 1).await;
+
+    let response = router
+        .route_generate(None, &test_meta(), &generate_request(false), MODEL)
+        .await;
+    assert_eq!(response.status(), http::StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+    let usage = json
+        .pointer("/0/meta_info/completion_tokens")
+        .or_else(|| json.pointer("/meta_info/completion_tokens"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_else(|| panic!("no completion token count in {json}"));
+    assert_eq!(
+        usage,
+        u64::from(OUTPUT_TOKENS),
+        "canned mock engine emits exactly {OUTPUT_TOKENS} tokens"
+    );
+}
+
+/// The streaming half of the same path: every engine output must reach the
+/// client as its own SSE event, terminated by `[DONE]`. Non-streaming assembly
+/// buffers the same outputs, so a stream that stalls mid-generation would pass
+/// the test above and fail here.
+#[tokio::test]
+async fn streaming_generate_over_zmq() {
+    let fixture = zmq_fixture();
+    start_mock_zmq_engines(&fixture.handshake, 1);
+    let router = build_router(&fixture, 1).await;
+
+    let response = router
+        .route_generate(None, &test_meta(), &generate_request(true), MODEL)
+        .await;
+    assert_eq!(response.status(), http::StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    let text = String::from_utf8(body.to_vec()).expect("utf8 sse body");
+    assert!(
+        text.contains("data: [DONE]"),
+        "stream must terminate with [DONE]: {text}"
+    );
+    assert_eq!(
+        text.matches("\"finish_reason\":null").count(),
+        OUTPUT_TOKENS as usize,
+        "one in-flight chunk per canned engine token: {text}"
+    );
+    assert_eq!(
+        text.matches("\"finish_reason\":\"stop\"").count(),
+        1,
+        "exactly one terminal chunk: {text}"
+    );
+}
+
+/// Two concurrent requests over one ZMQ transport must not cross-talk: the
+/// connector demultiplexes outputs by request id off a single shared output
+/// socket, so a mix-up here would show as a request never terminating.
+#[tokio::test]
+async fn concurrent_requests_share_one_zmq_transport() {
+    let fixture = zmq_fixture();
+    start_mock_zmq_engines(&fixture.handshake, 1);
+    let router = build_router(&fixture, 1).await;
+
+    let (first_meta, second_meta) = (test_meta(), test_meta());
+    let (first_request, second_request) = (generate_request(false), generate_request(false));
+    let (first, second) = tokio::join!(
+        router.route_generate(None, &first_meta, &first_request, MODEL),
+        router.route_generate(None, &second_meta, &second_request, MODEL),
+    );
+    assert_eq!(first.status(), http::StatusCode::OK);
+    assert_eq!(second.status(), http::StatusCode::OK);
+}
+
+/// A grouped ZMQ worker: two engines dial one socket set and the connector
+/// balances across them. This is the `dp_size`-on-one-worker topology
+/// `zmq_engine_group` builds, exercised end-to-end through the router.
+#[tokio::test]
+async fn grouped_zmq_worker_serves_requests_from_either_rank() {
+    let fixture = zmq_fixture();
+    start_mock_zmq_engines(&fixture.handshake, 2);
+    let router = build_router(&fixture, 2).await;
+
+    for _ in 0..4 {
+        let response = router
+            .route_generate(None, &test_meta(), &generate_request(false), MODEL)
+            .await;
+        assert_eq!(response.status(), http::StatusCode::OK);
+    }
+}


### PR DESCRIPTION
## Description

### Problem

The CPU-side coverage gaps the ZMQ audit flagged:

- **"No gateway-level ZMQ integration test; mock_worker's zmq mode is dead in CI"** — the full `config → worker handshake → zmq_client streaming` path was exercised only on GPU e2e lanes, and `crates/mock_worker/src/zmq.rs` was reachable only through the standalone binary.
- **"Grouped-worker spec derivation in job_queue has no direct unit test"** — the `zmq_engine_count` branch (n>1 filter + per-URL `ConnectionMode` guard) had coverage only downstream in `worker/builder.rs` and in GPU e2e.
- **"Coordinator dropped entirely: DP>1 lockstep wave handling reimplemented client-side, validated only against mocks"** — partially addressed: the mock harness now pins the wave paths the previous tests left open. Validation against a real Python lockstep DP group remains out of tree (see the CI lane suggestions below).

### Solution

Test-only PR: add a CPU gateway-level ZMQ integration test driving the real gRPC-pipeline router against an in-process mock worker, unit-test the job_queue grouped-worker spec derivation, and add connector and mock wave tests for the DP lockstep paths.

## Changes

**`model_gateway/tests/zmq_backend_test.rs` (new)** — boots `mock_worker::zmq::serve` in-process behind an `ipc://` worker URL with a pinned `tcp://` handshake override, registers a real `ConnectionMode::Zmq` worker, and drives the real gRPC-pipeline router:

- `non_streaming_generate_over_zmq` — asserts the assembled response reports the canned engine's exact completion-token count.
- `streaming_generate_over_zmq` — one SSE chunk per engine token plus exactly one terminal `stop` chunk and `[DONE]`.
- `concurrent_requests_share_one_zmq_transport` — two in-flight requests demultiplexed off one output socket.
- `grouped_zmq_worker_serves_requests_from_either_rank` — two engines dialing one socket set (`zmq_engine_group`).

**`model_gateway/src/workflow/job_queue.rs`** — extracted the startup-worker stamping into `apply_startup_worker_config` (behavior unchanged; the logic was inline in a `match` arm and untestable) and added the file's first `mod tests`:

- `dp_size` set only on the `ipc://` worker in a mixed `ipc://` + `grpc://` + `http://` fleet;
- `zmq_engine_count` of `Some(1)` / `None` leaves `dp_size` unset;
- `--backend` pins `runtime_type` only when configured;
- the `max_connection_attempts` floor survives a zero success threshold.

**`crates/engine_zmq_client/src/connector.rs`** — three wave tests beyond the existing submit-path ones:

- a rank's `start_wave` request wakes *every* rank at a wave the asking rank will accept (the coordinator-replacement path, previously untested);
- `wave_complete` folds into the clock without waking, and the next submit still outranks the parked ranks;
- a wave notification on an independent (dense DP) group is ignored and leaves no clock.

**`crates/mock_worker/src/zmq.rs`** — `two_ranks_share_one_socket_set`: two mock ranks behind one transport, each completing its own rank-pinned request.

## Test Plan

- `cargo test -p smg --test zmq_backend_test` → 13 passed (4 new ZMQ tests + shared `common/` unit tests).
- `cargo test -p smg --lib workflow::job_queue` → 4 passed.
- `cargo test -p engine-zmq-client wave` → 5 passed (3 new).
- `cargo test -p mock-worker zmq` → 2 passed (1 new).
- `cargo clippy -p smg -p mock-worker -p engine-zmq-client --all-targets -- -D warnings` → clean.
- `cargo +nightly fmt --all` → clean.

## CI lane suggestions (not wired here — `.github/workflows` is owned by a sibling PR)

- `model_gateway/tests/zmq_backend_test.rs` runs on CPU and needs no runner changes; it is picked up by the existing `cargo test -p smg` lane.
- **Non-chat ZMQ e2e** (audit finding "Only the chat-completions suite runs over ZMQ"): both ZMQ lanes pin `test_dirs: e2e_test/chat_completions` (`pr-test-rust.yml:581,624`). The lane's collection filter (`e2e_test/fixtures/hooks.py`) is dir-agnostic, so extending coverage is purely a `test_dirs` change — no markers or parametrization needed in `e2e_test/`. Suggested: add `e2e_test/completions` to the 1-GPU ZMQ lane. Left as a follow-up rather than adding dead markers here.
- **Real lockstep DP validation** remains a follow-up: whether a real vLLM DP>1 lockstep group emits `wave_complete`/`start_wave` on the frontend output socket with no coordinator addresses is still unverified in-tree; only the mock asserts it.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
