### PR TITLE
refactor(router): close ZMQ dialect dispatch behind one seam

### DIFF
--- a/model_gateway/src/routers/grpc/backend_client.rs
+++ b/model_gateway/src/routers/grpc/backend_client.rs
@@ -27,7 +27,7 @@ use crate::{
             finish_tokenspeed_request, finish_vllm_request, ProtoEmbedComplete, ProtoEmbedRequest,
             ProtoGenerateRequest, ProtoStream,
         },
-        zmq_client::{fold_tokenizer_eos_backstop, ZmqEngineClient},
+        zmq_client::{fold_tokenizer_eos_backstop, ZmqDialect, ZmqEngineClient},
         MultimodalData,
     },
     worker::RuntimeType,
@@ -40,6 +40,45 @@ pub enum BackendClient {
     Grpc(GrpcClient),
     Zmq(ZmqEngineClient),
 }
+
+/// The native request builders of both ZMQ dialects for one request kind — the
+/// only thing that differs between the ZMQ build surfaces, so the dialect
+/// dispatch itself lives once in [`build_zmq_request`]/[`build_zmq_plain_request`].
+struct ZmqBuilders<V, T> {
+    vllm: V,
+    tokenspeed: T,
+}
+
+/// A vLLM builder for a request kind carrying multimodal inputs and tool
+/// constraints (chat, messages).
+type VllmMmBuilder<B> = fn(
+    String,
+    &B,
+    String,
+    Vec<u32>,
+    Option<vllm_proto::MultimodalInputs>,
+    Option<(String, String)>,
+) -> Result<vllm_proto::GenerateRequest, String>;
+
+/// The TokenSpeed counterpart of [`VllmMmBuilder`].
+type TokenSpeedMmBuilder<B> = fn(
+    String,
+    &B,
+    String,
+    Vec<u32>,
+    Option<tokenspeed_proto::MultimodalInputs>,
+    Option<(String, String)>,
+) -> Result<tokenspeed_proto::GenerateRequest, String>;
+
+/// A vLLM builder for a request kind with neither multimodal inputs nor tool
+/// constraints (completion, plain generate); `T` is the builder's text
+/// parameter.
+type VllmPlainBuilder<B, T> =
+    fn(String, &B, T, Vec<u32>) -> Result<vllm_proto::GenerateRequest, String>;
+
+/// The TokenSpeed counterpart of [`VllmPlainBuilder`].
+type TokenSpeedPlainBuilder<B, T> =
+    fn(String, &B, T, Vec<u32>) -> Result<tokenspeed_proto::GenerateRequest, String>;
 
 impl BackendClient {
     /// Runtime type backing this client.
@@ -72,12 +111,12 @@ impl BackendClient {
     ) -> Vec<String> {
         let token_only_wire = self.is_zmq();
         let router_stops = helpers::resolve_string_stops(request, tokenizer, token_only_wire);
-        if let Self::Zmq(client) = self {
+        if token_only_wire {
             // EngineCore has no tokenizer, so stopping at EOS is this
-            // frontend's job; TokenSpeed's scheduler stops at EOS itself.
-            if client.runtime() != RuntimeType::TokenSpeed {
-                fold_tokenizer_eos_backstop(request, tokenizer);
-            }
+            // frontend's job; TokenSpeed's scheduler stops at EOS itself, and
+            // its requests are a different proto variant — the fold's own
+            // variant match is the single dispatch point.
+            fold_tokenizer_eos_backstop(request, tokenizer);
         }
         router_stops
     }
@@ -229,39 +268,20 @@ impl BackendClient {
                 client.build_chat_request(request_id, body, processed_text, token_ids, options)
             }
             // A ZMQ backend speaks vLLM EngineCore or TokenSpeed directly; build
-            // the native request for its runtime, mirroring the gRPC per-engine
+            // the native request for its dialect, mirroring the gRPC per-engine
             // dispatch in `GrpcClient::build_chat_request`.
-            Self::Zmq(client) => match client.runtime() {
-                RuntimeType::TokenSpeed => {
-                    let tokenspeed_mm = zmq_tokenspeed_mm(options.multimodal_inputs)?;
-                    finish_tokenspeed_request(tokenspeed_mm, |mm| {
-                        TokenSpeedSchedulerClient::build_generate_request_from_chat(
-                            request_id,
-                            body,
-                            processed_text,
-                            token_ids,
-                            mm,
-                            options.tool_constraints,
-                        )
-                    })
-                }
-                RuntimeType::Vllm => {
-                    let vllm_mm = zmq_vllm_mm(options.multimodal_inputs)?;
-                    finish_vllm_request(vllm_mm, |mm| {
-                        VllmEngineClient::build_generate_request_from_chat(
-                            request_id,
-                            body,
-                            processed_text,
-                            token_ids,
-                            mm,
-                            options.tool_constraints,
-                        )
-                    })
-                }
-                other => Err(format!(
-                    "ZMQ backend reports unsupported runtime {other:?}; expected vLLM or TokenSpeed"
-                )),
-            },
+            Self::Zmq(client) => build_zmq_request(
+                client.dialect(),
+                request_id,
+                body,
+                processed_text,
+                token_ids,
+                options,
+                ZmqBuilders {
+                    vllm: VllmEngineClient::build_generate_request_from_chat,
+                    tokenspeed: TokenSpeedSchedulerClient::build_generate_request_from_chat,
+                },
+            ),
         }
     }
 
@@ -278,38 +298,19 @@ impl BackendClient {
                 client.build_messages_request(request_id, body, processed_text, token_ids, options)
             }
             // Mirrors the gRPC per-engine dispatch: build the request natively for
-            // the ZMQ backend's runtime (vLLM EngineCore or TokenSpeed).
-            Self::Zmq(client) => match client.runtime() {
-                RuntimeType::TokenSpeed => {
-                    let tokenspeed_mm = zmq_tokenspeed_mm(options.multimodal_inputs)?;
-                    finish_tokenspeed_request(tokenspeed_mm, |mm| {
-                        TokenSpeedSchedulerClient::build_generate_request_from_messages(
-                            request_id,
-                            body,
-                            processed_text,
-                            token_ids,
-                            mm,
-                            options.tool_constraints,
-                        )
-                    })
-                }
-                RuntimeType::Vllm => {
-                    let vllm_mm = zmq_vllm_mm(options.multimodal_inputs)?;
-                    finish_vllm_request(vllm_mm, |mm| {
-                        VllmEngineClient::build_generate_request_from_messages(
-                            request_id,
-                            body,
-                            processed_text,
-                            token_ids,
-                            mm,
-                            options.tool_constraints,
-                        )
-                    })
-                }
-                other => Err(format!(
-                    "ZMQ backend reports unsupported runtime {other:?}; expected vLLM or TokenSpeed"
-                )),
-            },
+            // the ZMQ backend's dialect (vLLM EngineCore or TokenSpeed).
+            Self::Zmq(client) => build_zmq_request(
+                client.dialect(),
+                request_id,
+                body,
+                processed_text,
+                token_ids,
+                options,
+                ZmqBuilders {
+                    vllm: VllmEngineClient::build_generate_request_from_messages,
+                    tokenspeed: TokenSpeedSchedulerClient::build_generate_request_from_messages,
+                },
+            ),
         }
     }
 
@@ -324,29 +325,17 @@ impl BackendClient {
             Self::Grpc(client) => {
                 client.build_completion_request(request_id, body, original_text, token_ids)
             }
-            Self::Zmq(client) => match client.runtime() {
-                RuntimeType::TokenSpeed => {
-                    let req = TokenSpeedSchedulerClient::build_generate_request_from_completion(
-                        request_id,
-                        body,
-                        original_text,
-                        token_ids,
-                    )?;
-                    Ok(ProtoGenerateRequest::TokenSpeed(Box::new(req)))
-                }
-                RuntimeType::Vllm => {
-                    let req = VllmEngineClient::build_generate_request_from_completion(
-                        request_id,
-                        body,
-                        original_text,
-                        token_ids,
-                    )?;
-                    Ok(ProtoGenerateRequest::Vllm(Box::new(req)))
-                }
-                other => Err(format!(
-                    "ZMQ backend reports unsupported runtime {other:?}; expected vLLM or TokenSpeed"
-                )),
-            },
+            Self::Zmq(client) => build_zmq_plain_request(
+                client.dialect(),
+                request_id,
+                body,
+                original_text,
+                token_ids,
+                ZmqBuilders {
+                    vllm: VllmEngineClient::build_generate_request_from_completion,
+                    tokenspeed: TokenSpeedSchedulerClient::build_generate_request_from_completion,
+                },
+            ),
         }
     }
 
@@ -361,30 +350,83 @@ impl BackendClient {
             Self::Grpc(client) => {
                 client.build_generate_request(request_id, body, original_text, token_ids)
             }
-            Self::Zmq(client) => match client.runtime() {
-                RuntimeType::TokenSpeed => {
-                    let req = TokenSpeedSchedulerClient::build_plain_generate_request(
-                        request_id,
-                        body,
-                        original_text,
-                        token_ids,
-                    )?;
-                    Ok(ProtoGenerateRequest::TokenSpeed(Box::new(req)))
-                }
-                RuntimeType::Vllm => {
-                    let req = VllmEngineClient::build_plain_generate_request(
-                        request_id,
-                        body,
-                        original_text,
-                        token_ids,
-                    )?;
-                    Ok(ProtoGenerateRequest::Vllm(Box::new(req)))
-                }
-                other => Err(format!(
-                    "ZMQ backend reports unsupported runtime {other:?}; expected vLLM or TokenSpeed"
-                )),
-            },
+            Self::Zmq(client) => build_zmq_plain_request(
+                client.dialect(),
+                request_id,
+                body,
+                original_text,
+                token_ids,
+                ZmqBuilders {
+                    vllm: VllmEngineClient::build_plain_generate_request,
+                    tokenspeed: TokenSpeedSchedulerClient::build_plain_generate_request,
+                },
+            ),
         }
+    }
+}
+
+/// Build a multimodal-carrying request (chat, messages) for a ZMQ backend: one
+/// dispatch over the closed [`ZmqDialect`], converting the assembled multimodal
+/// data to the dialect's proto and finishing through its SHM-cleanup wrapper.
+fn build_zmq_request<B>(
+    dialect: ZmqDialect,
+    request_id: String,
+    body: &B,
+    processed_text: String,
+    token_ids: Vec<u32>,
+    options: GenerateRequestBuildOptions,
+    builders: ZmqBuilders<VllmMmBuilder<B>, TokenSpeedMmBuilder<B>>,
+) -> Result<ProtoGenerateRequest, String> {
+    let ZmqBuilders { vllm, tokenspeed } = builders;
+    match dialect {
+        ZmqDialect::Vllm => {
+            let vllm_mm = zmq_vllm_mm(options.multimodal_inputs)?;
+            finish_vllm_request(vllm_mm, |mm| {
+                vllm(
+                    request_id,
+                    body,
+                    processed_text,
+                    token_ids,
+                    mm,
+                    options.tool_constraints,
+                )
+            })
+        }
+        ZmqDialect::TokenSpeed => {
+            let tokenspeed_mm = zmq_tokenspeed_mm(options.multimodal_inputs)?;
+            finish_tokenspeed_request(tokenspeed_mm, |mm| {
+                tokenspeed(
+                    request_id,
+                    body,
+                    processed_text,
+                    token_ids,
+                    mm,
+                    options.tool_constraints,
+                )
+            })
+        }
+    }
+}
+
+/// Build a request kind with no multimodal or tool inputs (completion, plain
+/// generate) for a ZMQ backend. `text` is the builders' shared text parameter
+/// (`String` for completion, `Option<String>` for plain generate).
+fn build_zmq_plain_request<B, T>(
+    dialect: ZmqDialect,
+    request_id: String,
+    body: &B,
+    text: T,
+    token_ids: Vec<u32>,
+    builders: ZmqBuilders<VllmPlainBuilder<B, T>, TokenSpeedPlainBuilder<B, T>>,
+) -> Result<ProtoGenerateRequest, String> {
+    let ZmqBuilders { vllm, tokenspeed } = builders;
+    match dialect {
+        ZmqDialect::Vllm => Ok(ProtoGenerateRequest::Vllm(Box::new(vllm(
+            request_id, body, text, token_ids,
+        )?))),
+        ZmqDialect::TokenSpeed => Ok(ProtoGenerateRequest::TokenSpeed(Box::new(tokenspeed(
+            request_id, body, text, token_ids,
+        )?))),
     }
 }
 

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -5,21 +5,19 @@ use axum::response::Response;
 use smg_grpc_client::{SglangGenerateRequestOptions, TokenSpeedSchedulerClient, VllmEngineClient};
 use tracing::{debug, error};
 
-use crate::{
-    routers::{
-        error,
-        grpc::{
-            backend_client::BackendClient,
-            client::GrpcClient,
-            common::stages::{helpers, PipelineStage},
-            context::{
-                ClientSelection, ExecutionPlan, ExecutionPlanKind, PreparationOutput,
-                RequestContext, RequestType,
-            },
-            proto_wrapper::ProtoGenerateRequest,
+use crate::routers::{
+    error,
+    grpc::{
+        backend_client::BackendClient,
+        client::GrpcClient,
+        common::stages::{helpers, PipelineStage},
+        context::{
+            ClientSelection, ExecutionPlan, ExecutionPlanKind, PreparationOutput, RequestContext,
+            RequestType,
         },
+        proto_wrapper::ProtoGenerateRequest,
+        zmq_client::ZmqDialect,
     },
-    worker::RuntimeType,
 };
 
 /// Harmony Request Building stage: Convert Harmony tokens to gRPC request
@@ -151,18 +149,12 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             token_ids,
             tool_constraints,
         )
-        .map_err(|e| match e {
-            HarmonyBuildError::Request(e) => {
-                error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build Harmony generate request");
-                error::bad_request(
-                    "invalid_request_parameters",
-                    format!("Invalid request parameters: {e}"),
-                )
-            }
-            HarmonyBuildError::Wiring(e) => {
-                error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Harmony backend wiring bug");
-                error::internal_error("unsupported_backend_runtime", e)
-            }
+        .map_err(|e| {
+            error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build Harmony generate request");
+            error::bad_request(
+                "invalid_request_parameters",
+                format!("Invalid request parameters: {e}"),
+            )
         })?;
 
         // Inject the Harmony stop ids (<|return|> and <|call|>) so the model
@@ -217,23 +209,12 @@ enum HarmonyBody<'a> {
     Responses(&'a openai_protocol::responses::ResponsesRequest),
 }
 
-/// Build failure classes: a bad request (builder rejected the parameters,
-/// HTTP 400) vs. a wiring bug (a backend/runtime pairing that cannot exist,
-/// HTTP 500).
-enum HarmonyBuildError {
-    Request(String),
-    Wiring(String),
-}
-
-impl From<String> for HarmonyBuildError {
-    fn from(reason: String) -> Self {
-        Self::Request(reason)
-    }
-}
-
 /// One (backend x request-kind) dispatch for Harmony request building: every
 /// arm is just the engine's builder call. vLLM and TokenSpeed build through
-/// static translators, so one arm each covers both gRPC and direct-ZMQ.
+/// static translators, so a direct-ZMQ backend routes into the same builders
+/// as its gRPC counterpart via its [`ZmqDialect`] — leaving the match
+/// exhaustive over transports and engines, with no unrepresentable pairing to
+/// error on.
 fn build_harmony_proto(
     client: &BackendClient,
     body: HarmonyBody<'_>,
@@ -241,9 +222,8 @@ fn build_harmony_proto(
     text: String,
     token_ids: Vec<u32>,
     tool_constraints: Option<(String, String)>,
-) -> Result<ProtoGenerateRequest, HarmonyBuildError> {
+) -> Result<ProtoGenerateRequest, String> {
     use HarmonyBody::{Chat, Responses};
-    let runtime = client.runtime_type();
     Ok(match (client, body) {
         (BackendClient::Grpc(GrpcClient::Sglang(c)), Chat(b)) => {
             ProtoGenerateRequest::Sglang(Box::new(c.build_generate_request_from_chat(
@@ -298,67 +278,76 @@ fn build_harmony_proto(
                 tool_constraints,
             )?))
         }
-        (BackendClient::Grpc(GrpcClient::Vllm(_)) | BackendClient::Zmq(_), Chat(b))
-            if runtime == RuntimeType::Vllm =>
-        {
-            ProtoGenerateRequest::Vllm(Box::new(
-                VllmEngineClient::build_generate_request_from_chat(
-                    request_id,
-                    b,
-                    text,
-                    token_ids,
-                    None, // No multimodal in the Harmony pipeline
-                    tool_constraints,
-                )?,
-            ))
+        (BackendClient::Grpc(GrpcClient::Vllm(_)), body) => {
+            build_vllm(body, request_id, text, token_ids, tool_constraints)?
         }
-        (BackendClient::Grpc(GrpcClient::Vllm(_)) | BackendClient::Zmq(_), Responses(b))
-            if runtime == RuntimeType::Vllm =>
-        {
-            ProtoGenerateRequest::Vllm(Box::new(
-                VllmEngineClient::build_generate_request_from_responses(
-                    request_id,
-                    b,
-                    text,
-                    token_ids,
-                    tool_constraints,
-                )?,
-            ))
+        (BackendClient::Grpc(GrpcClient::TokenSpeed(_)), body) => {
+            build_tokenspeed(body, request_id, text, token_ids, tool_constraints)?
         }
-        (BackendClient::Grpc(GrpcClient::TokenSpeed(_)) | BackendClient::Zmq(_), Chat(b))
-            if runtime == RuntimeType::TokenSpeed =>
-        {
-            ProtoGenerateRequest::TokenSpeed(Box::new(
-                TokenSpeedSchedulerClient::build_generate_request_from_chat(
-                    request_id,
-                    b,
-                    text,
-                    token_ids,
-                    None, // Harmony path: multimodal not yet wired
-                    tool_constraints,
-                )?,
-            ))
-        }
-        (BackendClient::Grpc(GrpcClient::TokenSpeed(_)) | BackendClient::Zmq(_), Responses(b))
-            if runtime == RuntimeType::TokenSpeed =>
-        {
-            ProtoGenerateRequest::TokenSpeed(Box::new(
-                TokenSpeedSchedulerClient::build_generate_request_from_responses(
-                    request_id,
-                    b,
-                    text,
-                    token_ids,
-                    tool_constraints,
-                )?,
-            ))
-        }
-        // Guards above keep the match non-exhaustive to the compiler; the only
-        // real way here is a ZMQ client reporting a runtime it cannot have
-        // (connect() admits vLLM/TokenSpeed only) - a wiring bug, so error out.
-        _ => {
-            return Err(HarmonyBuildError::Wiring(format!(
-                "unsupported backend runtime {runtime:?} for Harmony requests"
-            )))
-        }
+        (BackendClient::Zmq(zmq), body) => match zmq.dialect() {
+            ZmqDialect::Vllm => build_vllm(body, request_id, text, token_ids, tool_constraints)?,
+            ZmqDialect::TokenSpeed => {
+                build_tokenspeed(body, request_id, text, token_ids, tool_constraints)?
+            }
+        },
     })
+}
+
+/// vLLM Harmony builders, shared by the gRPC and direct-ZMQ vLLM backends.
+fn build_vllm(
+    body: HarmonyBody<'_>,
+    request_id: String,
+    text: String,
+    token_ids: Vec<u32>,
+    tool_constraints: Option<(String, String)>,
+) -> Result<ProtoGenerateRequest, String> {
+    let request = match body {
+        HarmonyBody::Chat(b) => VllmEngineClient::build_generate_request_from_chat(
+            request_id,
+            b,
+            text,
+            token_ids,
+            None, // No multimodal in the Harmony pipeline
+            tool_constraints,
+        )?,
+        HarmonyBody::Responses(b) => VllmEngineClient::build_generate_request_from_responses(
+            request_id,
+            b,
+            text,
+            token_ids,
+            tool_constraints,
+        )?,
+    };
+    Ok(ProtoGenerateRequest::Vllm(Box::new(request)))
+}
+
+/// TokenSpeed Harmony builders, shared by the gRPC and direct-ZMQ TokenSpeed
+/// backends.
+fn build_tokenspeed(
+    body: HarmonyBody<'_>,
+    request_id: String,
+    text: String,
+    token_ids: Vec<u32>,
+    tool_constraints: Option<(String, String)>,
+) -> Result<ProtoGenerateRequest, String> {
+    let request = match body {
+        HarmonyBody::Chat(b) => TokenSpeedSchedulerClient::build_generate_request_from_chat(
+            request_id,
+            b,
+            text,
+            token_ids,
+            None, // Harmony path: multimodal not yet wired
+            tool_constraints,
+        )?,
+        HarmonyBody::Responses(b) => {
+            TokenSpeedSchedulerClient::build_generate_request_from_responses(
+                request_id,
+                b,
+                text,
+                token_ids,
+                tool_constraints,
+            )?
+        }
+    };
+    Ok(ProtoGenerateRequest::TokenSpeed(Box::new(request)))
 }

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -54,14 +54,25 @@ use crate::{
 /// binds). Shared with the worker-side socket derivation.
 pub(crate) const ZMQ_LOOPBACK_HOST: &str = "127.0.0.1";
 
-/// The engine protocol a ZMQ backend speaks. Both share the transport and
+/// The engine protocol a ZMQ backend speaks — a closed set: the transport has
+/// an adapter for exactly these two engines. Resolved once at connect time and
+/// exposed by [`ZmqEngineClient::dialect`] so every per-engine dispatch on the
+/// ZMQ lane (request building, multimodal, EOS) matches on the same two
+/// variants with no unreachable arm.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ZmqDialect {
+    /// vLLM EngineCore.
+    Vllm,
+    /// TokenSpeed.
+    TokenSpeed,
+}
+
+/// The connected client for a [`ZmqDialect`]. Both share the transport and
 /// handshake; only the request/output struct shapes and the translation to/from
 /// SMG proto differ.
 #[derive(Clone)]
 enum ZmqBackend {
-    /// vLLM EngineCore.
     Vllm(Arc<EngineCoreClient>),
-    /// TokenSpeed.
     TokenSpeed(Arc<TokenSpeedClient>),
 }
 
@@ -135,8 +146,9 @@ fn eos_ids_from_value(value: Option<&serde_json::Value>) -> Vec<u32> {
 /// model id is a repo id rather than a local path, so the tokenizer's merged
 /// EOS set is folded into `stop_token_ids` here as the always-available
 /// backstop; without it an uncapped request generates to the full context
-/// window. Not needed for TokenSpeed (its scheduler stops at EOS itself) —
-/// the caller gates on runtime.
+/// window. Not needed for TokenSpeed (its scheduler stops at EOS itself), and
+/// a TokenSpeed backend builds a TokenSpeed request variant — so the variant
+/// match below is the single dispatch point for this policy.
 pub(crate) fn fold_tokenizer_eos_backstop(
     request: &mut ProtoGenerateRequest,
     tokenizer: Option<&Arc<dyn Tokenizer>>,
@@ -394,19 +406,22 @@ impl ZmqEngineClient {
         runtime: RuntimeType,
         timeout: Duration,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        // No silent fallback: any other runtime has no ZMQ engine adapter.
-        // Reject before the handshake — no such engine ever dials in, so the
-        // handshake would just block for the full timeout.
-        if !matches!(
-            runtime,
-            RuntimeType::Vllm | RuntimeType::TokenSpeed | RuntimeType::Unspecified
-        ) {
-            return Err(format!(
-                "ZMQ direct backend has no engine implementation for runtime \
-                 {runtime}; only vllm and tokenspeed are supported"
-            )
-            .into());
-        }
+        // Resolve the dialect before the handshake: no silent fallback for a
+        // runtime with no ZMQ engine adapter, and no such engine ever dials in,
+        // so the handshake would just block for the full timeout.
+        let dialect = match runtime {
+            // vLLM EngineCore is the default ZMQ wire; an unspecified runtime
+            // maps to it for backward compatibility (see `detect_backend`).
+            RuntimeType::Vllm | RuntimeType::Unspecified => ZmqDialect::Vllm,
+            RuntimeType::TokenSpeed => ZmqDialect::TokenSpeed,
+            other => {
+                return Err(format!(
+                    "ZMQ direct backend has no engine implementation for runtime \
+                     {other}; only vllm and tokenspeed are supported"
+                )
+                .into())
+            }
+        };
 
         let transport = connect_handshake(
             handshake_address,
@@ -417,14 +432,11 @@ impl ZmqEngineClient {
             timeout,
         )
         .await?;
-        let backend = match runtime {
-            RuntimeType::TokenSpeed => {
+        let backend = match dialect {
+            ZmqDialect::Vllm => ZmqBackend::Vllm(Arc::new(EngineCoreClient::new(transport))),
+            ZmqDialect::TokenSpeed => {
                 ZmqBackend::TokenSpeed(Arc::new(TokenSpeedClient::new(transport)))
             }
-            // vLLM EngineCore is the default ZMQ wire; an unspecified runtime maps
-            // to it for backward compatibility (see `detect_backend`). All other
-            // runtimes were rejected before the handshake.
-            _ => ZmqBackend::Vllm(Arc::new(EngineCoreClient::new(transport))),
         };
         Ok(Self {
             backend,
@@ -433,12 +445,20 @@ impl ZmqEngineClient {
         })
     }
 
-    /// The engine runtime behind this connection (the wire protocol chosen at
-    /// connect time).
-    pub fn runtime(&self) -> RuntimeType {
+    /// The wire protocol chosen at connect time.
+    pub fn dialect(&self) -> ZmqDialect {
         match &self.backend {
-            ZmqBackend::Vllm(_) => RuntimeType::Vllm,
-            ZmqBackend::TokenSpeed(_) => RuntimeType::TokenSpeed,
+            ZmqBackend::Vllm(_) => ZmqDialect::Vllm,
+            ZmqBackend::TokenSpeed(_) => ZmqDialect::TokenSpeed,
+        }
+    }
+
+    /// The engine runtime behind this connection, widened to the open
+    /// [`RuntimeType`] for callers that report it alongside gRPC backends.
+    pub fn runtime(&self) -> RuntimeType {
+        match self.dialect() {
+            ZmqDialect::Vllm => RuntimeType::Vllm,
+            ZmqDialect::TokenSpeed => RuntimeType::TokenSpeed,
         }
     }
 
@@ -1616,6 +1636,53 @@ mod tests {
         let mut req = eos_request(vec![7], true);
         fold_tokenizer_eos_backstop(&mut req, Some(&tokenizer));
         assert_eq!(eos_stop_ids(&req), &[7]);
+    }
+
+    /// The variant match is the only gate on the fold: a TokenSpeed request
+    /// (whose scheduler stops at EOS itself) is left untouched.
+    #[test]
+    fn eos_backstop_leaves_tokenspeed_requests_untouched() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
+        let mut req =
+            ProtoGenerateRequest::TokenSpeed(Box::new(tokenspeed_proto::GenerateRequest {
+                sampling_params: Some(tokenspeed_proto::SamplingParams {
+                    stop_token_ids: vec![7],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }));
+        fold_tokenizer_eos_backstop(&mut req, Some(&tokenizer));
+        let ProtoGenerateRequest::TokenSpeed(req) = req else {
+            panic!("expected TokenSpeed request");
+        };
+        assert_eq!(req.sampling_params.unwrap().stop_token_ids, vec![7]);
+    }
+
+    /// The dialect is resolved before the handshake, so a runtime with no ZMQ
+    /// adapter fails immediately instead of blocking for the connect timeout
+    /// (this test would hang on the generous timeout otherwise).
+    #[tokio::test]
+    async fn connect_rejects_a_runtime_without_a_zmq_adapter_before_the_handshake() {
+        let dir = tempfile::tempdir().unwrap();
+        let ep = |name: &str| format!("ipc://{}", dir.path().join(name).display());
+        let Err(error) = ZmqEngineClient::connect(
+            &ep("hs.sock"),
+            &ep("in.sock"),
+            &ep("out.sock"),
+            1,
+            "m".to_string(),
+            EosTokenIds::default(),
+            RuntimeType::Sglang,
+            ZMQ_CONNECT_TIMEOUT,
+        )
+        .await
+        else {
+            panic!("SGLang has no ZMQ engine adapter");
+        };
+        assert!(
+            error.to_string().contains("no engine implementation"),
+            "{error}"
+        );
     }
 
     fn batch(


### PR DESCRIPTION
## Description

### Problem

Four architecture findings from the audit, all on the ZMQ engine-dialect decision:

- **ZMQ dialect dispatch leaks out of `ZmqEngineClient` via a lossy `RuntimeType` round-trip, forcing four near-identical match blocks with impossible arms** (`backend_client.rs`)
- **Harmony introduces a third dispatch style for the same vLLM/TokenSpeed decision: tuple matches with runtime guards and a catch-all wiring error** (`harmony/stages/request_building.rs`)
- **EOS-backstop dispatch is double-encoded: runtime gate at the caller plus a silent variant no-op in the callee** (`zmq_client.rs`)
- **Runtime-to-backend mapping in `connect()` is split between an allowlist guard and a defaulting match, so a future allowlist addition silently becomes vLLM** (`zmq_client.rs`)

### Solution

Close the decision behind a single seam: `ZmqEngineClient` now exposes the closed two-variant `ZmqDialect` it already tracked privately, and every ZMQ dispatch matches on it — the impossible states become unrepresentable, so no arm has to report them. Pure refactor: behavior is unchanged.

## Changes

- `zmq_client.rs`: new public `ZmqDialect` (Vllm/TokenSpeed); `connect()` resolves it once *before* the handshake (preserving the early reject of runtimes with no ZMQ adapter) and builds the backend from it, replacing the allowlist guard + defaulting `_` arm; `dialect()` accessor added, `runtime()` kept as the widened view for callers that report alongside gRPC backends.
- `backend_client.rs`: the four `build_chat/messages/completion/generate` ZMQ arms now go through `build_zmq_request` / `build_zmq_plain_request`, parameterized by the per-dialect builder pair (`ZmqBuilders`). The four `other => Err("unsupported runtime …")` arms are gone.
- `backend_client.rs`: `finalize_generate_request` no longer gates the EOS backstop on the runtime — the callee's request-variant match is the single dispatch point (a TokenSpeed backend builds a TokenSpeed request variant, so the outcome is identical).
- `harmony/stages/request_building.rs`: the `(backend, body)` match loses its runtime guards and catch-all; a ZMQ backend routes into the same vLLM/TokenSpeed builders as its gRPC counterpart via `dialect()`. The match is exhaustive again, and `HarmonyBuildError` (whose `Wiring` class only existed for the unreachable arm) is removed.

## Test Plan

- `CARGO_TARGET_DIR=… cargo test -p smg --lib routers::grpc` → `259 passed; 0 failed; 1 ignored` (existing tests unmodified; two new zmq_client tests).
- `CARGO_TARGET_DIR=… cargo clippy -p smg --all-targets -- -D warnings` → clean.
- `cargo +nightly fmt --all` → clean.

New tests: `eos_backstop_leaves_tokenspeed_requests_untouched` (pins the callee's variant match now that the caller's gate is gone) and `connect_rejects_a_runtime_without_a_zmq_adapter_before_the_handshake` (pins the pre-handshake dialect resolution — the test would hang on the 600 s connect timeout if the reject moved after the handshake).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
