### PR TITLE
fix(worker): close ZMQ lifecycle state-machine holes

### DIFF
--- a/model_gateway/src/routers/grpc/backend_client.rs
+++ b/model_gateway/src/routers/grpc/backend_client.rs
@@ -111,11 +111,19 @@ impl BackendClient {
     ) -> Vec<String> {
         let token_only_wire = self.is_zmq();
         let router_stops = helpers::resolve_string_stops(request, tokenizer, token_only_wire);
-        if token_only_wire {
+        if let Self::Zmq(client) = self {
             // EngineCore has no tokenizer, so stopping at EOS is this
             // frontend's job; TokenSpeed's scheduler stops at EOS itself, and
             // its requests are a different proto variant — the fold's own
             // variant match is the single dispatch point.
+            //
+            // The primary id must also ride the request's `_eos_token_id`, not
+            // just the stop set, or an EOS finish surfaces as a matched_stop
+            // token id. That field is filled from the client's own EOS set, so
+            // hand it the tokenizer's ids for the deployments where the
+            // connect-time model-dir lookup found none (the adopted set is
+            // likewise only read by the vLLM translation).
+            client.adopt_tokenizer_eos(tokenizer);
             fold_tokenizer_eos_backstop(request, tokenizer);
         }
         router_stops

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -13,7 +13,7 @@
 use std::{
     collections::{BTreeSet, HashMap},
     path::Path,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -85,6 +85,10 @@ struct ZmqConnectionMeta {
     /// EOS ids attached to every vLLM request (the engine can't stop at EOS
     /// without them).
     eos: EosTokenIds,
+    /// Tokenizer-derived EOS ids, adopted once when `eos` came back empty
+    /// (the model id is a repo id, not a local directory). Lives here rather
+    /// than on the client so every clone shares the one adoption.
+    tokenizer_eos: OnceLock<EosTokenIds>,
 }
 
 /// The model's EOS stop set, resolved from its local directory. EngineCore
@@ -102,6 +106,20 @@ pub struct EosTokenIds {
 impl EosTokenIds {
     pub fn new(primary: Option<u32>, extra: Vec<u32>) -> Self {
         Self { primary, extra }
+    }
+
+    /// Build from the tokenizer's merged EOS set (same ordering as
+    /// [`Self::from_model_dir`]: config first, generation config after).
+    fn from_ids(ids: &[u32]) -> Self {
+        let mut ids = ids.iter().copied();
+        Self {
+            primary: ids.next(),
+            extra: ids.collect(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.primary.is_none() && self.extra.is_empty()
     }
 
     /// Resolve from `config.json` + `generation_config.json` in a local model
@@ -224,6 +242,9 @@ fn derive_handshake_port(path: &str) -> u16 {
 /// band), so setting the override to that value pairs a bare
 /// `ts serve --headless` with a manually registered worker.
 /// Returns `(handshake, input, output)`.
+///
+/// [`zmq_handshake_address`] exposes just the handshake half, for collision
+/// checks at registration time.
 fn zmq_socket_addresses(
     base_url: &str,
     handshake_override: Option<&str>,
@@ -246,6 +267,17 @@ fn zmq_socket_addresses(
     let input = format!("ipc://{path}-in.sock");
     let output = format!("ipc://{path}-out.sock");
     Ok((handshake, input, output))
+}
+
+/// The TCP handshake address a ZMQ worker will bind, or `None` when the URL is
+/// not a usable `ipc://` base (connect reports that with its own error).
+pub(crate) fn zmq_handshake_address(
+    base_url: &str,
+    handshake_override: Option<&str>,
+) -> Option<String> {
+    zmq_socket_addresses(base_url, handshake_override)
+        .ok()
+        .map(|(handshake, _, _)| handshake)
 }
 
 /// Create the parent directory for a worker's `ipc://` sockets. Kept off the
@@ -450,8 +482,38 @@ impl ZmqEngineClient {
         };
         Ok(Self {
             backend,
-            meta: Arc::new(ZmqConnectionMeta { model_id, eos }),
+            meta: Arc::new(ZmqConnectionMeta {
+                model_id,
+                eos,
+                tokenizer_eos: OnceLock::new(),
+            }),
         })
+    }
+
+    /// Adopt the tokenizer's EOS ids when the connect-time model-dir lookup
+    /// found none (the worker's model id is a repo id, not a local path).
+    ///
+    /// Without this the primary EOS id would only ride `stop_token_ids`, and
+    /// an EOS finish would be reported as `matched_stop = <eos id>` — so the
+    /// same model would answer differently depending on whether its files
+    /// happen to be local.
+    pub(crate) fn adopt_tokenizer_eos(&self, tokenizer: Option<&Arc<dyn Tokenizer>>) {
+        if !self.meta.eos.is_empty() || self.meta.tokenizer_eos.get().is_some() {
+            return;
+        }
+        let Some(ids) = tokenizer
+            .map(|t| t.eos_token_ids())
+            .filter(|ids| !ids.is_empty())
+        else {
+            return;
+        };
+        let _ = self.meta.tokenizer_eos.set(EosTokenIds::from_ids(ids));
+    }
+
+    /// The EOS set attached to requests: the connect-time set, or the adopted
+    /// tokenizer set when that one was empty.
+    fn effective_eos(&self) -> &EosTokenIds {
+        self.meta.tokenizer_eos.get().unwrap_or(&self.meta.eos)
     }
 
     /// The wire protocol chosen at connect time.
@@ -519,7 +581,7 @@ impl ZmqEngineClient {
                 let mut streams = SelectAll::new();
                 for (index, sub) in fan_out_requests(*req).into_iter().enumerate() {
                     let request =
-                        translate_request(sub, max_model_len, model_dtype, &self.meta.eos)
+                        translate_request(sub, max_model_len, model_dtype, self.effective_eos())
                             .map_err(tonic::Status::invalid_argument)?;
                     // The engine returns the sampled/prompt token's logprob
                     // plus the requested ranked candidates per position; carry
@@ -1658,6 +1720,54 @@ mod tests {
         let mut req = eos_request(vec![999], false);
         fold_tokenizer_eos_backstop(&mut req, Some(&tokenizer));
         assert_eq!(eos_stop_ids(&req), &[999]);
+    }
+
+    /// A connected client over a throwaway ipc endpoint. The mock engine is
+    /// dropped on return: these tests only inspect request-side EOS state.
+    async fn connected_client(dir: &Path, prefix: &str, eos: EosTokenIds) -> ZmqEngineClient {
+        let ep = |name: &str| format!("ipc://{}", dir.join(format!("{prefix}-{name}")).display());
+        let (handshake, input, output) = (ep("hs.sock"), ep("in.sock"), ep("out.sock"));
+        let (client, engine) = tokio::join!(
+            ZmqEngineClient::connect(
+                &handshake,
+                &input,
+                &output,
+                1,
+                "org/repo".to_string(),
+                eos,
+                RuntimeType::Vllm,
+                Duration::from_secs(10)
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        engine.expect("mock engine");
+        client.expect("adapter connect")
+    }
+
+    #[tokio::test]
+    async fn tokenizer_eos_is_adopted_when_the_model_dir_is_not_local() {
+        // MockTokenizer's EOS set is {999}. With no local model dir the
+        // connect-time set is empty, so the primary id must come from the
+        // tokenizer — otherwise EOS rides `stop_token_ids` alone and an EOS
+        // finish is reported as `matched_stop = 999`.
+        let dir = tempfile::tempdir().unwrap();
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
+
+        let client = connected_client(dir.path(), "empty", EosTokenIds::default()).await;
+        assert_eq!(client.effective_eos(), &EosTokenIds::default());
+        client.adopt_tokenizer_eos(Some(&tokenizer));
+        assert_eq!(client.effective_eos(), &EosTokenIds::new(Some(999), vec![]));
+
+        // A connect-time set resolved from a local model dir wins: adoption is
+        // a backstop, not an override.
+        let resolved = EosTokenIds::new(Some(5), vec![7]);
+        let client = connected_client(dir.path(), "resolved", resolved.clone()).await;
+        client.adopt_tokenizer_eos(Some(&tokenizer));
+        assert_eq!(client.effective_eos(), &resolved);
     }
 
     #[test]

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -355,7 +355,9 @@ async fn run_health_loop(
             () = tokio::time::sleep_until(sleep_until) => {}
             signal = recv_connect_signal(&mut connect_rx) => {
                 match signal {
-                    Some(connected) => apply_connect_signal(&registry, connected),
+                    Some(connected) => {
+                        apply_connect_signal(&registry, connected, &mut next_check, &config);
+                    }
                     // Every sender lives on the registry (Arc), so recv() only
                     // returns None if the registry itself is gone. Drop the
                     // branch so the loop stops polling a dead channel.
@@ -597,7 +599,12 @@ async fn recv_connect_signal(
 /// for its next scheduled poll. Resolves the URL to a live worker id and flips
 /// the status through the revision-checked setter, so a signal that lost a race
 /// with a same-URL replacement — or a worker already removed — is discarded.
-fn apply_connect_signal(registry: &Arc<WorkerRegistry>, connected: WorkerConnected) {
+fn apply_connect_signal(
+    registry: &Arc<WorkerRegistry>,
+    connected: WorkerConnected,
+    next_check: &mut HashMap<WorkerId, tokio::time::Instant>,
+    config: &WorkerManagerConfig,
+) {
     let WorkerConnected { url, revision } = connected;
     let Some(worker_id) = registry.get_id_by_url(&url) else {
         debug!(worker_url = %url, "Connect signal for an unknown worker; ignoring");
@@ -606,6 +613,20 @@ fn apply_connect_signal(registry: &Arc<WorkerRegistry>, connected: WorkerConnect
     match registry.transition_status_if_revision(&worker_id, revision, WorkerStatus::Ready) {
         Some((old, new)) => {
             debug!(worker_url = %url, ?old, ?new, "Promoted worker on connect signal");
+            // A Failed worker was dropped from the schedule; a promoted one is
+            // serving traffic, so it must be probed again — otherwise a later
+            // engine death would leave it Ready with a dead client forever.
+            if let Some(worker) = registry.get(&worker_id) {
+                schedule_worker_at(
+                    next_check,
+                    worker_id,
+                    new,
+                    &worker.metadata().health_config,
+                    config,
+                    tokio::time::Instant::now(),
+                    false,
+                );
+            }
         }
         None => {
             // No transition: already Ready (idempotent), or a stale revision
@@ -1184,6 +1205,13 @@ mod tests {
         )
     }
 
+    fn test_config() -> WorkerManagerConfig {
+        WorkerManagerConfig {
+            default_check_interval_secs: 5,
+            remove_unhealthy: false,
+        }
+    }
+
     fn make_zmq_worker(url: &str) -> Arc<dyn Worker> {
         Arc::new(
             BasicWorkerBuilder::new(url)
@@ -1343,18 +1371,50 @@ mod tests {
         let revision = worker.revision();
         registry.register(worker.clone()).unwrap();
 
+        let mut next_check = HashMap::new();
         apply_connect_signal(
             &registry,
             WorkerConnected {
                 url: "http://w:1".to_string(),
                 revision,
             },
+            &mut next_check,
+            &test_config(),
         );
 
         assert_eq!(
             worker.status(),
             WorkerStatus::Ready,
             "a matching connect signal must promote a Pending worker immediately"
+        );
+    }
+
+    #[test]
+    fn apply_connect_signal_reschedules_a_promoted_worker() {
+        // A worker that hit the Pending cap is dropped from the schedule. A
+        // late handshake promotes it to Ready, so it must re-enter the probe
+        // schedule — otherwise it would serve traffic unmonitored forever.
+        let registry = Arc::new(WorkerRegistry::new());
+        let worker = make_worker("http://w:1", 2, 3);
+        worker.set_status(WorkerStatus::Failed);
+        let revision = worker.revision();
+        let worker_id = registry.register(worker.clone()).unwrap();
+
+        let mut next_check = HashMap::new();
+        apply_connect_signal(
+            &registry,
+            WorkerConnected {
+                url: "http://w:1".to_string(),
+                revision,
+            },
+            &mut next_check,
+            &test_config(),
+        );
+
+        assert_eq!(worker.status(), WorkerStatus::Ready);
+        assert!(
+            next_check.contains_key(&worker_id),
+            "a promoted worker must be probed again"
         );
     }
 
@@ -1379,6 +1439,8 @@ mod tests {
                 url: "http://w:1".to_string(),
                 revision: stale_revision,
             },
+            &mut HashMap::new(),
+            &test_config(),
         );
 
         assert_eq!(
@@ -1399,6 +1461,8 @@ mod tests {
                 url: "http://ghost:1".to_string(),
                 revision: 0,
             },
+            &mut HashMap::new(),
+            &test_config(),
         );
     }
 

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -632,6 +632,7 @@ impl WorkerRegistry {
         let mut decode_count = 0;
         let mut http_count = 0;
         let mut grpc_count = 0;
+        let mut zmq_count = 0;
         let mut cb_open_count = 0;
         let mut cb_half_open_count = 0;
 
@@ -652,7 +653,8 @@ impl WorkerRegistry {
 
             match worker.connection_mode() {
                 ConnectionMode::Http => http_count += 1,
-                ConnectionMode::Grpc | ConnectionMode::Zmq => grpc_count += 1,
+                ConnectionMode::Grpc => grpc_count += 1,
+                ConnectionMode::Zmq => zmq_count += 1,
             }
 
             match worker.circuit_breaker_state() {
@@ -674,6 +676,7 @@ impl WorkerRegistry {
             decode_workers: decode_count,
             http_workers: http_count,
             grpc_workers: grpc_count,
+            zmq_workers: zmq_count,
             circuit_breaker_open: cb_open_count,
             circuit_breaker_half_open: cb_half_open_count,
         }
@@ -1903,6 +1906,8 @@ pub struct WorkerRegistryStats {
     pub http_workers: usize,
     /// Number of gRPC-connected workers
     pub grpc_workers: usize,
+    /// Number of ZMQ-connected workers (direct-backend transport)
+    pub zmq_workers: usize,
     /// Number of workers with circuit breaker in Open state (not accepting requests)
     pub circuit_breaker_open: usize,
     /// Number of workers with circuit breaker in HalfOpen state (testing recovery)
@@ -2104,6 +2109,34 @@ mod tests {
         assert_eq!(stats.decode_workers, 0);
         assert_eq!(stats.regular_workers, 0);
         assert_eq!(stats.grpc_workers, 1);
+        assert_eq!(stats.zmq_workers, 0);
+    }
+
+    #[test]
+    fn test_stats_counts_zmq_workers_separately_from_grpc() {
+        // ZMQ rides the gRPC request pipeline but is its own transport;
+        // folding it into grpc_workers hid it from observability output.
+        let registry = WorkerRegistry::new();
+
+        for (url, mode) in [
+            ("grpc://worker:8080", ConnectionMode::Grpc),
+            ("ipc:///tmp/smg-zmq/engine.ipc", ConnectionMode::Zmq),
+            ("http://worker:8080", ConnectionMode::Http),
+        ] {
+            let worker: Arc<dyn Worker> = Arc::new(
+                BasicWorkerBuilder::new(url)
+                    .worker_type(WorkerType::Regular)
+                    .connection_mode(mode)
+                    .build(),
+            );
+            registry.register(worker).unwrap();
+        }
+
+        let stats = registry.stats();
+        assert_eq!(stats.total_workers, 3);
+        assert_eq!(stats.http_workers, 1);
+        assert_eq!(stats.grpc_workers, 1);
+        assert_eq!(stats.zmq_workers, 1);
     }
 
     #[test]

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -6,16 +6,17 @@ use async_trait::async_trait;
 use openai_protocol::{
     model_card::ModelCard,
     model_type::ModelType,
-    worker::{WorkerSpec, WorkerType},
+    worker::{HealthCheckConfig, WorkerSpec, WorkerType},
 };
-use tracing::debug;
+use tracing::{debug, warn};
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
 use crate::{
+    routers::grpc::zmq_client::zmq_handshake_address,
     worker::{
         circuit_breaker::CircuitBreakerConfig, http_client::build_worker_http_client,
         resilience::resolve_resilience, worker::RuntimeType, BasicWorkerBuilder, ConnectionMode,
-        Worker, UNKNOWN_MODEL_ID,
+        Worker, WorkerRegistry, UNKNOWN_MODEL_ID,
     },
     workflow::data::{WorkerKind, WorkerRegistrationMode, WorkerWorkflowData},
 };
@@ -174,6 +175,17 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
         // Normalize URL
         let url = normalize_url(&config.url, *connection_mode);
 
+        validate_zmq_handshake_collision(
+            &app_context.worker_registry,
+            &url,
+            config.zmq_handshake_address.as_deref(),
+            *connection_mode,
+        )
+        .map_err(|message| WorkflowError::StepFailed {
+            step_id: StepId::new("create_worker"),
+            message,
+        })?;
+
         // Build workers — resolve per-worker resilience and HTTP client
         let base_retry = app_context.router_config.effective_retry_config();
         let base_cb_cfg = app_context.router_config.effective_circuit_breaker_config();
@@ -199,7 +211,8 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
         })?;
 
         let health_base = app_context.router_config.health_check.to_protocol_config();
-        let health_config = config.health.apply_to(&health_base);
+        let health_config =
+            resolve_zmq_health_config(config.health.apply_to(&health_base), *connection_mode, &url);
         let health_endpoint = &app_context.router_config.health_check.endpoint;
 
         let dp_ranks: Vec<Option<(usize, usize)>> = if app_context.router_config.dp_aware {
@@ -311,7 +324,7 @@ fn resolve_model_id<'a>(config: &'a WorkerSpec, labels: &'a HashMap<String, Stri
 fn warn_on_conflicting_parser_overrides(
     card: &ModelCard,
     worker_url: &str,
-    registry: &crate::worker::WorkerRegistry,
+    registry: &WorkerRegistry,
 ) {
     for existing in registry.get_by_model(&card.id).iter() {
         let Some(existing_card) = existing.metadata().spec.models.find(&card.id) else {
@@ -523,6 +536,74 @@ fn validate_zmq_handshake_override(
     Ok(())
 }
 
+/// Reject a ZMQ worker whose TCP handshake address is already claimed.
+///
+/// The handshake port is a hash of the ipc path, so a collision between two
+/// worker URLs is deterministic and permanent: the second worker's handshake
+/// bind fails on every connect attempt with a bare transport error, hours
+/// after registration. Detect it here, where the fix can be named.
+fn validate_zmq_handshake_collision(
+    registry: &WorkerRegistry,
+    url: &str,
+    handshake_override: Option<&str>,
+    connection_mode: ConnectionMode,
+) -> Result<(), String> {
+    if connection_mode != ConnectionMode::Zmq {
+        return Ok(());
+    }
+    // An unparsable URL fails later with its own message; nothing to compare.
+    let Some(handshake) = zmq_handshake_address(url, handshake_override) else {
+        return Ok(());
+    };
+    for existing in registry.get_all() {
+        let metadata = existing.metadata();
+        // Sockets are bound against the base URL (a dp-expanded worker carries
+        // a `@rank` suffix on `spec.url` but binds the base).
+        let existing_url = metadata.base_url();
+        if *existing.connection_mode() != ConnectionMode::Zmq || existing_url == url {
+            continue;
+        }
+        if zmq_handshake_address(existing_url, metadata.spec.zmq_handshake_address.as_deref())
+            .as_deref()
+            == Some(handshake.as_str())
+        {
+            return Err(format!(
+                "ZMQ worker {url} would bind handshake address {handshake}, already claimed by \
+                 worker {existing_url}: the derived port is a hash of the ipc path, so rename \
+                 this worker's ipc path or set zmq_handshake_address to a free tcp:// address"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Keep health checking on for a ZMQ worker.
+///
+/// The ZMQ probe is not a network call — it peeks a local liveness flag — and
+/// it is the only path that evicts a client whose engine died and rebinds the
+/// sockets for a replacement engine to dial into (ZMQ liveness is latched: a
+/// dead client never recovers in place). With probing off the first handshake
+/// still runs, since a request kicks the background connect driver, but an
+/// engine restart leaves the worker pinned to that dead client until the
+/// gateway restarts. Honor the transport over the flag and say so.
+fn resolve_zmq_health_config(
+    health_config: HealthCheckConfig,
+    connection_mode: ConnectionMode,
+    url: &str,
+) -> HealthCheckConfig {
+    if connection_mode != ConnectionMode::Zmq || !health_config.disable_health_check {
+        return health_config;
+    }
+    warn!(
+        "Ignoring disabled health checks for ZMQ worker {url}: the ZMQ probe is a local liveness \
+         check and the only path that reconnects a restarted engine, so it stays enabled"
+    );
+    HealthCheckConfig {
+        disable_health_check: false,
+        ..health_config
+    }
+}
+
 fn normalize_url(url: &str, connection_mode: ConnectionMode) -> String {
     if url.starts_with("http://")
         || url.starts_with("https://")
@@ -602,7 +683,6 @@ fn validate_zmq_dp(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::worker::WorkerRegistry;
 
     #[test]
     fn normalize_url_preserves_existing_schemes() {
@@ -719,6 +799,80 @@ mod tests {
         let card = build_model_card("GLM-5.2", &spec, &HashMap::new(), &aliases);
 
         assert!(card.aliases.is_empty());
+    }
+
+    fn zmq_worker(url: &str, handshake_override: Option<&str>) -> Arc<dyn Worker> {
+        let mut spec = WorkerSpec::new(url);
+        spec.connection_mode = ConnectionMode::Zmq;
+        spec.zmq_handshake_address = handshake_override.map(str::to_string);
+        Arc::new(BasicWorkerBuilder::from_spec(spec).build())
+    }
+
+    #[test]
+    fn zmq_handshake_collision_is_rejected_at_registration() {
+        // Two ipc paths hashing to the same derived port would leave the second
+        // worker's handshake bind failing forever with a bare transport error.
+        let registry = WorkerRegistry::new();
+        let first = "ipc:///tmp/smg-zmq/a.ipc";
+        let handshake = zmq_handshake_address(first, None).expect("derived handshake address");
+        registry.register(zmq_worker(first, None)).unwrap();
+
+        // Same derived address reached through an explicit override.
+        let err = validate_zmq_handshake_collision(
+            &registry,
+            "ipc:///tmp/smg-zmq/b.ipc",
+            Some(&handshake),
+            ConnectionMode::Zmq,
+        )
+        .expect_err("a colliding handshake address must be rejected");
+        assert!(err.contains(&handshake), "message was: {err}");
+        assert!(err.contains(first), "message was: {err}");
+
+        // A distinct path derives a distinct address; re-registering the same
+        // URL (update path) is not a collision with itself.
+        validate_zmq_handshake_collision(
+            &registry,
+            "ipc:///tmp/smg-zmq/b.ipc",
+            None,
+            ConnectionMode::Zmq,
+        )
+        .expect("a distinct ipc path must be accepted");
+        validate_zmq_handshake_collision(&registry, first, None, ConnectionMode::Zmq)
+            .expect("re-registering the same worker URL must be accepted");
+        validate_zmq_handshake_collision(
+            &registry,
+            "grpc://worker:8080",
+            None,
+            ConnectionMode::Grpc,
+        )
+        .expect("non-ZMQ workers are not affected");
+    }
+
+    #[test]
+    fn zmq_workers_keep_health_checks_enabled() {
+        // The ZMQ probe drives the handshake and evicts dead clients, so
+        // disabling it would brick the worker on engine restart.
+        let disabled = HealthCheckConfig {
+            disable_health_check: true,
+            ..Default::default()
+        };
+
+        let resolved = resolve_zmq_health_config(
+            disabled.clone(),
+            ConnectionMode::Zmq,
+            "ipc:///tmp/smg-zmq/a.ipc",
+        );
+        assert!(!resolved.disable_health_check);
+        assert_eq!(
+            resolved.check_interval_secs, disabled.check_interval_secs,
+            "only the disable flag is overridden"
+        );
+
+        assert!(
+            resolve_zmq_health_config(disabled, ConnectionMode::Http, "http://w:1")
+                .disable_health_check,
+            "other transports keep the operator's choice"
+        );
     }
 
     #[test]

--- a/model_gateway/src/workflow/steps/local/discover_dp.rs
+++ b/model_gateway/src/workflow/steps/local/discover_dp.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use openai_protocol::worker::WorkerSpec;
 use tracing::{debug, warn};
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
@@ -49,7 +50,15 @@ pub fn dp_info_from_labels(labels: &HashMap<String, String>) -> Result<DpInfo, S
         .filter(|&n| n > 0)
         .ok_or_else(|| "no positive dp_size in discovered metadata".to_string())?;
 
-    let model_id = labels
+    Ok(DpInfo {
+        dp_size,
+        model_id: model_id_from_labels(labels),
+    })
+}
+
+/// Best-effort model identity from discovered metadata labels.
+fn model_id_from_labels(labels: &HashMap<String, String>) -> String {
+    labels
         .get("model_id")
         .or_else(|| labels.get("served_model_name"))
         .filter(|s| !s.is_empty())
@@ -60,9 +69,19 @@ pub fn dp_info_from_labels(labels: &HashMap<String, String>) -> Result<DpInfo, S
                 .and_then(|p| p.split('/').rfind(|s| !s.is_empty()))
                 .map(str::to_string)
         })
-        .unwrap_or_else(|| UNKNOWN_MODEL_ID.to_string());
+        .unwrap_or_else(|| UNKNOWN_MODEL_ID.to_string())
+}
 
-    Ok(DpInfo { dp_size, model_id })
+/// DP info for a ZMQ worker. There is nothing to discover — the engines dial
+/// in later and EngineCore serves no metadata endpoint — so the spec's own
+/// `dp_size` (a grouped worker: one socket set, N engines) is the answer.
+/// Reporting it keeps a ZMQ worker registrable under `--dp-aware`, where an
+/// absent `dp_info` used to fail create_worker with an internal error.
+fn zmq_dp_info(config: &WorkerSpec, labels: &HashMap<String, String>) -> DpInfo {
+    DpInfo {
+        dp_size: config.dp_size.unwrap_or(1).max(1),
+        model_id: model_id_from_labels(labels),
+    }
 }
 
 /// Step 2b: Discover DP (Data Parallel) information (only for DP-aware workers).
@@ -103,6 +122,11 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverDPInfoStep {
                     step_id: StepId::new("discover_dp_info"),
                     message: format!("Failed to get DP info for {}: {e}", config.url),
                 })?,
+            // A ZMQ worker has no metadata endpoint to discover from: its DP
+            // shape is the spec's own `dp_size` (a grouped worker awaiting N
+            // engines on one socket set). Report it so create_worker can
+            // validate the shape instead of failing on a missing dp_info.
+            Some(ConnectionMode::Zmq) => zmq_dp_info(config, &context.data.discovered_labels),
             _ => {
                 // HTTP DP discovery uses SGLang's /server_info which exposes
                 // dp_size — other runtimes don't expose DP info this way
@@ -171,6 +195,23 @@ mod tests {
     fn dp_info_from_labels_unknown_model_when_absent() {
         let info = dp_info_from_labels(&labels(&[("dp_size", "2")])).unwrap();
         assert_eq!(info.model_id, UNKNOWN_MODEL_ID);
+    }
+
+    #[test]
+    fn zmq_dp_info_uses_the_spec_dp_size() {
+        // Nothing to discover over ZMQ: an ungrouped worker is dp_size 1 and a
+        // grouped one reports its spec size, so create_worker gets a dp_info
+        // to validate under --dp-aware instead of an internal error.
+        let mut spec = WorkerSpec::new("ipc:///tmp/smg-zmq/engine.ipc");
+        let info = zmq_dp_info(&spec, &labels(&[("model_id", "m")]));
+        assert_eq!(info.dp_size, 1);
+        assert_eq!(info.model_id, "m");
+
+        spec.dp_size = Some(4);
+        assert_eq!(zmq_dp_info(&spec, &HashMap::new()).dp_size, 4);
+
+        spec.dp_size = Some(0);
+        assert_eq!(zmq_dp_info(&spec, &HashMap::new()).dp_size, 1);
     }
 
     #[test]

--- a/model_gateway/src/workflow/steps/shared/update_policies.rs
+++ b/model_gateway/src/workflow/steps/shared/update_policies.rs
@@ -20,6 +20,27 @@ use crate::{
 pub struct UpdatePoliciesStep;
 
 impl UpdatePoliciesStep {
+    /// Say so when cache_aware routing runs degraded.
+    ///
+    /// The raw ZMQ wire carries no KV-event stream, so a ZMQ worker under a
+    /// cache_aware policy is routed by the approximate radix tree alone. That
+    /// is the intended behavior, but silently degrading a policy the operator
+    /// asked for deserves a line in the log.
+    fn warn_on_cache_aware_without_kv_events(
+        model_id: &str,
+        worker: &Arc<dyn Worker>,
+        cache_aware: bool,
+    ) {
+        if cache_aware && *worker.connection_mode() == ConnectionMode::Zmq {
+            warn!(
+                "cache_aware policy for model {model_id} includes ZMQ worker {}: the ZMQ \
+                 transport has no KV-event stream, so cache tracking for it falls back to the \
+                 approximate prefix tree",
+                worker.url()
+            );
+        }
+    }
+
     /// Check for conflicts between prefill and decode worker configurations for a model.
     fn check_worker_conflicts(model_id: &str, workers: &[Arc<dyn Worker>]) {
         let prefill_workers: Vec<_> = workers
@@ -122,24 +143,26 @@ impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for UpdatePolicie
 
             // Check for configuration conflicts between prefill and decode
             Self::check_worker_conflicts(&model_id, &all_workers);
-            if let Some(policy) = app_context.policy_registry.get_policy(&model_id) {
-                if policy.name() == "cache_aware" {
-                    app_context
-                        .policy_registry
-                        .init_cache_aware_policy(&model_id, &all_workers);
-                }
+            let cache_aware = app_context
+                .policy_registry
+                .get_policy(&model_id)
+                .is_some_and(|policy| policy.name() == "cache_aware");
+            if cache_aware {
+                app_context
+                    .policy_registry
+                    .init_cache_aware_policy(&model_id, &all_workers);
             }
 
             // Start KV event subscription for gRPC workers with cache_aware policy
-            if let Some(ref monitor) = app_context.kv_event_monitor {
-                if let Some(policy) = app_context.policy_registry.get_policy(&model_id) {
-                    if policy.name() == "cache_aware"
-                        && *worker.connection_mode() == ConnectionMode::Grpc
-                    {
+            if cache_aware {
+                if let Some(ref monitor) = app_context.kv_event_monitor {
+                    if *worker.connection_mode() == ConnectionMode::Grpc {
                         monitor.on_worker_added(worker).await;
                     }
                 }
             }
+
+            Self::warn_on_cache_aware_without_kv_events(&model_id, worker, cache_aware);
 
             if !updated_models.contains(&model_id) {
                 updated_models.push(model_id);


### PR DESCRIPTION
## Description

### Problem

Seven audit findings on the ZMQ direct-backend lifecycle, all registration- or state-machine-level:

- **`--dp-aware` gateway cannot register any ZMQ worker: `dp_info` never set, `create_worker` fails with an internal error** — `discover_dp` dropped ZMQ into the HTTP arm, warned about "HTTP workers", and returned Success without `dp_info`; `create_worker` then failed with `ContextValueNotFound("dp_info")` before `validate_zmq_dp` could run.
- **Late connect signal promotes a Failed ZMQ worker to Ready but never re-enters it in the probe schedule** — the promoted worker served traffic and was never health-checked again, so a later engine death left it Ready with a dead client.
- **ZMQ dead-client eviction/reconnect lives only in the health probe, so `disable_health_check` permanently bricks the worker on engine restart**.
- **Deterministic handshake-port hash can collide between workers with no detection or diagnostic**.
- **`cache_aware` policy over ZMQ workers silently runs without KV events**.
- **EOS finish reported as `matched_stop` token id when the model dir is not local**.
- **Registry stats count ZMQ workers as `grpc_workers`**.

### Solution

Close each hole at its own layer: a real ZMQ arm in DP discovery, rescheduling on connect-signal promotion, ZMQ-specific health-config and handshake-collision validation at registration, tokenizer-EOS adoption when the model dir is not local, a `cache_aware`-over-ZMQ warning, and a separate `zmq_workers` stat.

`get_backend_client` and the detached handshake driver are deliberately untouched (owned by a separate PR).

## Changes

- `workflow/steps/local/discover_dp.rs`: new `ConnectionMode::Zmq` arm returning `zmq_dp_info` — the spec's own `dp_size` (a grouped ZMQ worker is one worker with N engines on one socket set), so single-engine ZMQ registers under `--dp-aware` and a grouped one gets the curated "configure a grouped ZMQ worker" rejection instead of an internal error. Model-id extraction factored into `model_id_from_labels`.
- `worker/manager.rs`: `apply_connect_signal` now reschedules a worker it promotes to Ready (a Failed worker has been dropped from `next_check`), so it re-enters the probe schedule.
- `workflow/steps/local/create_worker.rs`:
  - `resolve_zmq_health_config` keeps health checking on for ZMQ workers and logs that `disable_health_check` is ignored — the ZMQ probe is not a network call, it drives the handshake and evicts dead clients.
  - `validate_zmq_handshake_collision` rejects a ZMQ worker whose TCP handshake address (derived from the ipc path, or the explicit override) is already claimed by another registered ZMQ worker, naming the fix.
- `routers/grpc/zmq_client.rs`: `zmq_handshake_address` helper for the collision check; `ZmqEngineClient::adopt_tokenizer_eos` takes the tokenizer's EOS set once when the connect-time model-dir lookup found none, so the primary id rides `_eos_token_id` and an EOS finish is a plain stop instead of `matched_stop = <eos id>`.
- `routers/grpc/backend_client.rs`: call the adoption where the tokenizer EOS backstop is already folded in.
- `workflow/steps/shared/update_policies.rs`: warn when a `cache_aware` policy covers a ZMQ worker (no KV-event stream on that transport); the repeated policy lookups collapse into one.
- `worker/registry.rs`: `WorkerRegistryStats::zmq_workers`, mirroring `FlushCacheResult`.

## Test Plan

Run from the worktree against a private copy of the shared target dir (concurrent agents sharing `/Users/…/smg/target` clobber the `smg` lib-test binary, which silently produced stale results):

```
cargo +nightly fmt --all
cargo clippy -p smg --all-targets -- -D warnings   # clean
cargo test -p smg --lib                            # 1564 passed; 0 failed; 5 ignored
```

New tests: `zmq_dp_info_uses_the_spec_dp_size`, `apply_connect_signal_reschedules_a_promoted_worker`, `zmq_handshake_collision_is_rejected_at_registration`, `zmq_workers_keep_health_checks_enabled`, `tokenizer_eos_is_adopted_when_the_model_dir_is_not_local`, `test_stats_counts_zmq_workers_separately_from_grpc`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
