### PR TITLE
fix(router): poll backend loads for pressure-configured cache_aware

### DIFF
--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -625,19 +625,26 @@ impl AppContextBuilder {
             .client
             .as_ref()
             .ok_or_else(|| "client must be set before load monitor".to_string())?;
-        self.worker_monitor = Some(Arc::new(WorkerMonitor::new(
+        let policy_registry = self
+            .policy_registry
+            .as_ref()
+            .ok_or_else(|| "policy_registry must be set before load monitor".to_string())?
+            .clone();
+        let monitor = Arc::new(WorkerMonitor::new(
             self.worker_registry
                 .as_ref()
                 .ok_or_else(|| "worker_registry must be set before load monitor".to_string())?
                 .clone(),
-            self.policy_registry
-                .as_ref()
-                .ok_or_else(|| "policy_registry must be set before load monitor".to_string())?
-                .clone(),
+            Arc::clone(&policy_registry),
             client.clone(),
             config.load_monitor_interval_secs,
             config.engine_metrics,
-        )));
+        ));
+        // Wire the backend load-snapshot feed into every policy that consumes
+        // it; the monitor itself only polls while some policy reports needing
+        // the data.
+        policy_registry.set_load_receiver(Some(monitor.subscribe()));
+        self.worker_monitor = Some(monitor);
         Ok(self)
     }
 
@@ -739,12 +746,6 @@ impl AppContextBuilder {
             // and any other existing cache-aware policies.
             if let Some(ref registry) = self.policy_registry {
                 registry.set_kv_event_monitor(Some(Arc::clone(&monitor)));
-                // Wire the backend load snapshot so cache-aware policies can use
-                // the KV-usage imbalance trigger. `with_worker_monitor` ran
-                // earlier in the build chain, so this is already set.
-                if let Some(ref worker_monitor) = self.worker_monitor {
-                    registry.set_load_receiver(Some(worker_monitor.subscribe()));
-                }
             }
 
             self.kv_event_monitor = Some(monitor);
@@ -870,6 +871,45 @@ mod tests {
             .with_kv_event_monitor(&config)
             .kv_event_monitor
             .is_some()
+    }
+
+    /// The load-snapshot feed must be wired whenever the worker monitor is
+    /// built — without a KV-event monitor in the chain — so HTTP-only
+    /// cache-aware deployments get waiting-prefill and KV-usage data.
+    #[test]
+    fn worker_monitor_wires_load_receiver_into_policies() {
+        use crate::policies::CacheAwarePolicy;
+
+        let config = config_with_policy(PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 32,
+            balance_rel_threshold: 1.1,
+            eviction_interval_secs: 0,
+            max_tree_size: 1000,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+            overlap_decay: 1.0,
+            selection_temperature: 0.0,
+        });
+        let builder = AppContextBuilder::new()
+            .with_client(&config, 5)
+            .expect("client builds")
+            .with_worker_registry()
+            .with_policy_registry(&config)
+            .with_worker_monitor(&config)
+            .expect("worker monitor builds");
+
+        let policy = builder
+            .policy_registry
+            .as_ref()
+            .expect("policy registry set")
+            .get_default_policy();
+        let cache_aware = policy
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .expect("default policy is cache-aware");
+        assert!(cache_aware.has_load_receiver_for_test());
     }
 
     /// The #1794-relevant guarantee: passthrough never starts the KV-event

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -409,6 +409,11 @@ impl CacheAwarePolicy {
         *self.load_rx.write() = rx;
     }
 
+    #[cfg(test)]
+    pub(crate) fn has_load_receiver_for_test(&self) -> bool {
+        self.load_rx.read().is_some()
+    }
+
     /// True when backend KV pressure demands abandoning cache affinity.
     ///
     /// Two triggers, OR'd together, both requiring a backend `token_usage`
@@ -1021,6 +1026,14 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
 
     fn needs_request_text(&self) -> bool {
         true // Cache-aware policy needs request text for cache affinity
+    }
+
+    /// Backend loads feed the KV-usage gate and the waiting-prefill decay;
+    /// both are disabled by default, so only configured policies poll.
+    fn needs_backend_loads(&self) -> bool {
+        self.config.overlap_decay > 0.0
+            || self.config.balance_token_usage_threshold < 1.0
+            || self.config.overload_token_usage_threshold < 1.0
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/model_gateway/src/policies/least_load.rs
+++ b/model_gateway/src/policies/least_load.rs
@@ -325,6 +325,10 @@ impl LoadBalancingPolicy for LeastLoadPolicy {
         }
     }
 
+    fn needs_backend_loads(&self) -> bool {
+        true
+    }
+
     fn remove_worker(&self, url: &str) {
         if let Ok(mut cached) = self.cached_loads.write() {
             cached.remove(url);

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -78,6 +78,13 @@ pub trait LoadBalancingPolicy: Send + Sync + Debug {
         // Default: no-op for policies that don't use load information
     }
 
+    /// Whether routing consumes backend load snapshots, pushed via
+    /// [`Self::update_loads`] or read from the monitor's watch feed. The
+    /// `WorkerMonitor` skips backend load polling while no policy needs it.
+    fn needs_backend_loads(&self) -> bool {
+        false
+    }
+
     /// Drop any cached per-worker state for a removed worker.
     ///
     /// Called when a worker leaves the registry so load-aware policies don't

--- a/model_gateway/src/policies/power_of_two.rs
+++ b/model_gateway/src/policies/power_of_two.rs
@@ -119,6 +119,10 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
         }
     }
 
+    fn needs_backend_loads(&self) -> bool {
+        true
+    }
+
     fn remove_worker(&self, url: &str) {
         if let Ok(mut cached) = self.cached_loads.write() {
             cached.remove(url);

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -512,16 +512,14 @@ impl PolicyRegistry {
 
     /// Get all load-aware policies that need periodic load updates (lock-free).
     ///
-    /// These are policies whose routing depends on the worker load monitor:
-    /// `power_of_two` and `least_load`.
+    /// Membership is policy-reported via
+    /// [`LoadBalancingPolicy::needs_backend_loads`]: `power_of_two` and
+    /// `least_load` always consume load reports; `cache_aware` does when its
+    /// pressure knobs are configured.
     pub fn get_all_load_aware_policies(&self) -> Vec<Arc<dyn LoadBalancingPolicy>> {
-        fn is_load_aware(name: &str) -> bool {
-            name == "power_of_two" || name == "least_load"
-        }
-
         let mut policies = Vec::new();
 
-        if is_load_aware(self.default_policy.name()) {
+        if self.default_policy.needs_backend_loads() {
             policies.push(Arc::clone(&self.default_policy));
         }
 
@@ -531,13 +529,13 @@ impl PolicyRegistry {
         let encode_policy_opt = self.encode_policy.get();
 
         if let Some(policy) = prefill_policy_opt {
-            if is_load_aware(policy.name()) && !Arc::ptr_eq(policy, &self.default_policy) {
+            if policy.needs_backend_loads() && !Arc::ptr_eq(policy, &self.default_policy) {
                 policies.push(Arc::clone(policy));
             }
         }
 
         if let Some(policy) = decode_policy_opt {
-            if is_load_aware(policy.name())
+            if policy.needs_backend_loads()
                 && !Arc::ptr_eq(policy, &self.default_policy)
                 && !prefill_policy_opt.is_some_and(|p| Arc::ptr_eq(p, policy))
             {
@@ -546,7 +544,7 @@ impl PolicyRegistry {
         }
 
         if let Some(policy) = encode_policy_opt {
-            if is_load_aware(policy.name())
+            if policy.needs_backend_loads()
                 && !Arc::ptr_eq(policy, &self.default_policy)
                 && !prefill_policy_opt.is_some_and(|p| Arc::ptr_eq(p, policy))
                 && !decode_policy_opt.is_some_and(|p| Arc::ptr_eq(p, policy))
@@ -557,7 +555,7 @@ impl PolicyRegistry {
 
         for entry in self.model_policies.iter() {
             let policy = entry.value();
-            if is_load_aware(policy.name()) {
+            if policy.needs_backend_loads() {
                 let already_added = policies.iter().any(|p| Arc::ptr_eq(p, policy));
                 if !already_added {
                     policies.push(Arc::clone(policy));
@@ -625,12 +623,12 @@ impl PolicyRegistry {
         }
     }
 
-    /// Drop a removed worker's cached load report from all load-aware policies
-    /// (`power_of_two`, `least_load`).
+    /// Drop a removed worker's cached load report from all load-aware
+    /// policies.
     ///
-    /// These policies cache per-worker load reports keyed by URL; without this
-    /// their caches would grow unbounded under worker churn. Called on worker
-    /// removal alongside the cache-aware cleanup above.
+    /// Push-model policies cache per-worker load reports keyed by URL;
+    /// without this their caches would grow unbounded under worker churn.
+    /// Called on worker removal alongside the cache-aware cleanup above.
     pub fn remove_worker_from_load_aware(&self, worker_url: &str) {
         for policy in self.get_all_load_aware_policies() {
             policy.remove_worker(worker_url);
@@ -879,6 +877,44 @@ mod tests {
         let registry = PolicyRegistry::new(PolicyConfig::Passthrough);
         registry.on_worker_added("m", Some("passthrough"));
         assert!(registry.get_all_load_aware_policies().is_empty());
+    }
+
+    #[test]
+    fn cache_aware_is_load_aware_only_when_pressure_configured() {
+        fn cache_aware(
+            overlap_decay: f32,
+            balance_token_usage_threshold: f32,
+            overload_token_usage_threshold: f32,
+        ) -> PolicyConfig {
+            PolicyConfig::CacheAware {
+                cache_threshold: 0.5,
+                balance_abs_threshold: 32,
+                balance_rel_threshold: 1.1,
+                eviction_interval_secs: 0,
+                max_tree_size: 4096,
+                block_size: 16,
+                balance_token_usage_threshold,
+                overload_token_usage_threshold,
+                overlap_decay,
+                selection_temperature: 0.0,
+            }
+        }
+
+        // Plain cache_aware consumes no backend loads — the monitor must
+        // keep skipping load polling for it.
+        let plain = PolicyRegistry::new(cache_aware(0.0, 1.0, 1.0));
+        assert!(plain.get_all_load_aware_policies().is_empty());
+
+        // Any pressure knob makes it load-aware: waiting-prefill decay,
+        // KV-usage balance spread, or the KV-usage overload ceiling.
+        for pressured in [
+            cache_aware(1.0, 1.0, 1.0),
+            cache_aware(0.0, 0.5, 1.0),
+            cache_aware(0.0, 1.0, 0.9),
+        ] {
+            let registry = PolicyRegistry::new(pressured);
+            assert_eq!(registry.get_all_load_aware_policies().len(), 1);
+        }
     }
 
     #[test]

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -1479,7 +1479,10 @@ mod native_loads_tests {
     use openai_protocol::{model_card::ModelCard, worker::HealthCheckConfig};
 
     use super::*;
-    use crate::worker::{BasicWorkerBuilder, ConnectionMode, WorkerType};
+    use crate::{
+        config::types::PolicyConfig,
+        worker::{BasicWorkerBuilder, ConnectionMode, WorkerType},
+    };
 
     const VLLM_METRICS: &str = "vllm:num_requests_running{m=\"a\"} 7.0\n\
          vllm:num_requests_waiting{m=\"a\"} 11.0\n\
@@ -1544,6 +1547,76 @@ mod native_loads_tests {
                 })
                 .build(),
         )
+    }
+
+    fn cache_aware_policy_config(overlap_decay: f32) -> PolicyConfig {
+        PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 32,
+            balance_rel_threshold: 1.1,
+            eviction_interval_secs: 0,
+            max_tree_size: 4096,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+            overlap_decay,
+            selection_temperature: 0.0,
+        }
+    }
+
+    fn monitor_with_policy(config: PolicyConfig) -> (Arc<WorkerRegistry>, Arc<WorkerMonitor>) {
+        let registry = Arc::new(WorkerRegistry::new());
+        let policy_registry = Arc::new(PolicyRegistry::new(config));
+        let monitor = Arc::new(WorkerMonitor::new(
+            registry.clone(),
+            policy_registry,
+            reqwest::Client::new(),
+            1,
+            false,
+        ));
+        (registry, monitor)
+    }
+
+    #[tokio::test]
+    async fn pressure_configured_cache_aware_starts_load_polling() {
+        let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
+        let (registry, monitor) = monitor_with_policy(cache_aware_policy_config(1.0));
+        let worker = vllm_worker(&stub.url);
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(worker).unwrap();
+        monitor.start_event_loop();
+
+        let mut rx = monitor.subscribe();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let waiting = rx
+                    .borrow()
+                    .get(&stub.url)
+                    .map(|load| load.total_waiting_uncached_tokens());
+                if let Some(waiting) = waiting {
+                    assert_eq!(waiting, 900);
+                    break;
+                }
+                rx.changed().await.expect("watch sender alive");
+            }
+        })
+        .await
+        .expect("cache_aware with overlap_decay must trigger load polling");
+    }
+
+    #[tokio::test]
+    async fn default_cache_aware_skips_load_polling() {
+        let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
+        let (registry, monitor) = monitor_with_policy(cache_aware_policy_config(0.0));
+        let worker = vllm_worker(&stub.url);
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(worker).unwrap();
+        monitor.start_event_loop();
+
+        // Covers the immediate first tick plus one full 1s interval.
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        assert_eq!(stub.probes.load(Ordering::SeqCst), 0);
+        assert!(monitor.load_rx.borrow().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

### Problem

The `cache_aware` pressure knobs — `--overlap-decay`, `--balance-token-usage-threshold`, and `--overload-token-usage-threshold` — were silent no-ops. They read backend load snapshots that never arrived, for two independent reasons:

1. `PolicyRegistry::get_all_load_aware_policies` name-matched only `power_of_two` and `least_load`, so under a pure `cache_aware` deployment the `WorkerMonitor` group loop skipped backend load polling entirely (`monitor.rs` gate).
2. `set_load_receiver` was only wired inside the KV-event-monitor branch of the builder, so HTTP-only deployments never received the load watch feed even when polling ran for another policy.

With both gaps, `waiting_prefill_snapshot` and `backend_token_usage_bounds` always returned `None`: waiting-prefill decay and the KV-usage gates could never act.

### Solution

Make load-awareness policy-reported instead of name-matched. `LoadBalancingPolicy` gains `needs_backend_loads()` (default `false`): `power_of_two` and `least_load` return `true`; `cache_aware` returns `true` exactly when a pressure knob is configured (`overlap_decay > 0` or a token-usage threshold `< 1.0`). The registry's load-aware set keys off the trait method, and `with_worker_monitor` wires the load receiver whenever the monitor is constructed. Default `cache_aware` (knobs off) keeps skipping load polling, so existing deployments see no new backend traffic.

## Changes

- `policies/mod.rs`: add `LoadBalancingPolicy::needs_backend_loads`, default `false`
- `policies/power_of_two.rs`, `policies/least_load.rs`: return `true`
- `policies/cache_aware.rs`: return `true` when a pressure knob is configured
- `policies/registry.rs`: `get_all_load_aware_policies` membership via the trait method instead of policy-name matching
- `app_context.rs`: `with_worker_monitor` wires `set_load_receiver(monitor.subscribe())` at monitor construction; drop the KV-event-branch-only wiring

## Test Plan

- `cargo test -p smg` — full suite green (lib + all integration binaries)
- New tests:
  - `cache_aware_is_load_aware_only_when_pressure_configured` — membership matrix over the three knobs, plain cache_aware stays out
  - `pressure_configured_cache_aware_starts_load_polling` — end-to-end: monitor polls a loopback `/v1/loads` engine and the waiting-uncached token count lands in the watch feed
  - `default_cache_aware_skips_load_polling` — plain cache_aware never probes the engine
  - `worker_monitor_wires_load_receiver_into_policies` — builder wires the feed with no KV-event monitor in the chain
- `cargo +nightly fmt --check`, `cargo clippy -p smg --all-targets` — clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
