### PR TITLE
feat(gateway): add routed worker ID header

### DIFF
--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -10,6 +10,7 @@ use http::header::HeaderName;
 static HEADER_TARGET_WORKER: HeaderName = HeaderName::from_static("x-smg-target-worker");
 static HEADER_ROUTING_KEY: HeaderName = HeaderName::from_static("x-smg-routing-key");
 static HEADER_MCP: HeaderName = HeaderName::from_static("x-smg-mcp");
+pub(crate) static HEADER_WORKER_ID: HeaderName = HeaderName::from_static("x-smg-worker-id");
 
 fn extract_header_value<'a>(headers: Option<&'a HeaderMap>, name: &HeaderName) -> Option<&'a str> {
     headers
@@ -64,6 +65,16 @@ pub fn preserve_response_headers(reqwest_headers: &HeaderMap) -> HeaderMap {
     }
 
     headers
+}
+
+/// Stamp a response with the opaque ID of the worker that served it.
+///
+/// Call this after [`preserve_response_headers`] so the gateway's value wins
+/// over any value supplied by an upstream worker.
+pub(crate) fn insert_worker_id(headers: &mut HeaderMap, worker_id: &str) {
+    if let Ok(value) = HeaderValue::from_str(worker_id) {
+        headers.insert(HEADER_WORKER_ID.clone(), value);
+    }
 }
 
 /// Determine if a header should be forwarded without allocating (case-insensitive)

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -10,7 +10,7 @@ use http::header::HeaderName;
 static HEADER_TARGET_WORKER: HeaderName = HeaderName::from_static("x-smg-target-worker");
 static HEADER_ROUTING_KEY: HeaderName = HeaderName::from_static("x-smg-routing-key");
 static HEADER_MCP: HeaderName = HeaderName::from_static("x-smg-mcp");
-pub(crate) static HEADER_WORKER_ID: HeaderName = HeaderName::from_static("x-smg-worker-id");
+static HEADER_ROUTED_WORKER_ID: HeaderName = HeaderName::from_static("x-smg-routed-worker-id");
 
 fn extract_header_value<'a>(headers: Option<&'a HeaderMap>, name: &HeaderName) -> Option<&'a str> {
     headers
@@ -67,13 +67,18 @@ pub fn preserve_response_headers(reqwest_headers: &HeaderMap) -> HeaderMap {
     headers
 }
 
-/// Stamp a response with the opaque ID of the worker that served it.
+/// Stamp the response with the id of the worker that served the request — the
+/// worker URL as the gateway knows it, including the `@<rank>` suffix for
+/// dp-aware workers.
 ///
-/// Call this after [`preserve_response_headers`] so the gateway's value wins
-/// over any value supplied by an upstream worker.
-pub(crate) fn insert_worker_id(headers: &mut HeaderMap, worker_id: &str) {
-    if let Ok(value) = HeaderValue::from_str(worker_id) {
-        headers.insert(HEADER_WORKER_ID.clone(), value);
+/// Lets a client see which replica answered: which pod to pull logs from, and
+/// whether retries landed somewhere new. Call after
+/// [`preserve_response_headers`] so the gateway's value wins over anything an
+/// upstream set under the same name. Skipped if the URL isn't representable as
+/// a header value.
+pub fn insert_routed_worker_id(headers: &mut HeaderMap, worker_url: &str) {
+    if let Ok(value) = HeaderValue::from_str(worker_url) {
+        headers.insert(HEADER_ROUTED_WORKER_ID.clone(), value);
     }
 }
 

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -759,8 +759,9 @@ impl PDRouter {
                 None
             };
 
-            let response_headers =
+            let mut response_headers =
                 header_utils::preserve_response_headers(decode_response.headers());
+            header_utils::insert_routed_worker_id(&mut response_headers, decode.url());
 
             self.create_streaming_response(
                 decode_response.bytes_stream(),
@@ -773,7 +774,7 @@ impl PDRouter {
             )
         } else {
             // Non-streaming response
-            if context.return_logprob {
+            let mut response = if context.return_logprob {
                 self.process_non_streaming_response(
                     decode_response,
                     status,
@@ -798,7 +799,12 @@ impl PDRouter {
                         error::internal_error("read_response_failed", "Failed to read response")
                     }
                 }
-            }
+            };
+
+            // The decode worker is the one that produced the body the client
+            // sees, on both the merged-logprob and passthrough paths.
+            header_utils::insert_routed_worker_id(response.headers_mut(), decode.url());
+            response
         }
     }
 

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -1052,6 +1052,9 @@ impl Router {
     ) -> Response {
         let api_key = worker.api_key().cloned();
         let endpoint_url = worker.endpoint_url(route);
+        // Capture the ID before the request so a concurrent worker removal
+        // cannot make an already-routed response lose its attribution.
+        let worker_id = self.worker_registry.get_id_by_url(worker.url());
 
         let body = match serialize_request_body(typed_req, canonical_model, worker) {
             Ok(body) => body,
@@ -1101,6 +1104,9 @@ impl Router {
         if is_stream {
             // Preserve headers for streaming response
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
+            if let Some(worker_id) = worker_id.as_ref() {
+                header_utils::insert_worker_id(&mut response_headers, worker_id.as_str());
+            }
             // Ensure we set the correct content-type for SSE
             response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
 
@@ -1156,7 +1162,7 @@ impl Router {
 
             // Cap the buffered read at the ingress payload limit; this is the
             // point where an upstream body is first pulled into memory.
-            let response = match Self::read_worker_body_capped(
+            let mut response = match Self::read_worker_body_capped(
                 res.bytes_stream(),
                 self.max_payload_size,
             )
@@ -1170,6 +1176,9 @@ impl Router {
                 }
                 Err(error_response) => error_response,
             };
+            if let Some(worker_id) = worker_id.as_ref() {
+                header_utils::insert_worker_id(response.headers_mut(), worker_id.as_str());
+            }
 
             // load_guard dropped here automatically after response body is read
             response
@@ -1192,7 +1201,7 @@ impl Router {
         response: Response,
         max_body_bytes: usize,
     ) -> Response {
-        let (_, response_body) = response.into_parts();
+        let (response_parts, response_body) = response.into_parts();
         let body_bytes = match to_bytes(response_body, max_body_bytes).await {
             Ok(bytes) => bytes,
             Err(e) => {
@@ -1235,7 +1244,13 @@ impl Router {
         if !req.return_documents {
             rerank_response.drop_documents();
         }
-        Json(rerank_response).into_response()
+        let mut response = Json(rerank_response).into_response();
+        if let Some(worker_id) = response_parts.headers.get(&header_utils::HEADER_WORKER_ID) {
+            response
+                .headers_mut()
+                .insert(header_utils::HEADER_WORKER_ID.clone(), worker_id.clone());
+        }
+        response
     }
 }
 
@@ -1855,6 +1870,25 @@ mod tests {
         assert_eq!(rerank.model, "test-model");
         assert_eq!(rerank.results.len(), 1);
         assert_eq!(rerank.results[0].document, None);
+    }
+
+    #[tokio::test]
+    async fn build_rerank_response_preserves_worker_id() {
+        let req = rerank_request();
+        let body = rerank_worker_body();
+        let mut upstream = Response::new(Body::from(body.clone()));
+        upstream.headers_mut().insert(
+            header_utils::HEADER_WORKER_ID.clone(),
+            HeaderValue::from_static("0198b7c7-8f80-7000-8000-000000000001"),
+        );
+
+        let response = Router::build_rerank_response(&req, None, upstream, body.len()).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers()[&header_utils::HEADER_WORKER_ID],
+            "0198b7c7-8f80-7000-8000-000000000001"
+        );
     }
 
     #[tokio::test]

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -845,7 +845,8 @@ impl Router {
             // JSON body (success or 4xx error). Don't relabel non-SSE
             // responses as SSE; leave that judgment to whatever the worker
             // set.
-            let response_headers = header_utils::preserve_response_headers(res.headers());
+            let mut response_headers = header_utils::preserve_response_headers(res.headers());
+            header_utils::insert_routed_worker_id(&mut response_headers, worker.url());
             let stream = res.bytes_stream();
             // Bounded channel applies backpressure: if the downstream client
             // is slow, the upstream relay awaits on `send` rather than piling
@@ -948,7 +949,8 @@ impl Router {
             response = AttachedBody::wrap_response(response, load_guard);
             response
         } else {
-            let response_headers = header_utils::preserve_response_headers(res.headers());
+            let mut response_headers = header_utils::preserve_response_headers(res.headers());
+            header_utils::insert_routed_worker_id(&mut response_headers, worker.url());
             match res.bytes().await {
                 Ok(body) => {
                     let mut response = Response::new(Body::from(body));
@@ -1052,9 +1054,6 @@ impl Router {
     ) -> Response {
         let api_key = worker.api_key().cloned();
         let endpoint_url = worker.endpoint_url(route);
-        // Capture the ID before the request so a concurrent worker removal
-        // cannot make an already-routed response lose its attribution.
-        let worker_id = self.worker_registry.get_id_by_url(worker.url());
 
         let body = match serialize_request_body(typed_req, canonical_model, worker) {
             Ok(body) => body,
@@ -1104,9 +1103,7 @@ impl Router {
         if is_stream {
             // Preserve headers for streaming response
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
-            if let Some(worker_id) = worker_id.as_ref() {
-                header_utils::insert_worker_id(&mut response_headers, worker_id.as_str());
-            }
+            header_utils::insert_routed_worker_id(&mut response_headers, worker.url());
             // Ensure we set the correct content-type for SSE
             response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
 
@@ -1176,9 +1173,7 @@ impl Router {
                 }
                 Err(error_response) => error_response,
             };
-            if let Some(worker_id) = worker_id.as_ref() {
-                header_utils::insert_worker_id(response.headers_mut(), worker_id.as_str());
-            }
+            header_utils::insert_routed_worker_id(response.headers_mut(), worker.url());
 
             // load_guard dropped here automatically after response body is read
             response
@@ -1201,7 +1196,7 @@ impl Router {
         response: Response,
         max_body_bytes: usize,
     ) -> Response {
-        let (response_parts, response_body) = response.into_parts();
+        let (_, response_body) = response.into_parts();
         let body_bytes = match to_bytes(response_body, max_body_bytes).await {
             Ok(bytes) => bytes,
             Err(e) => {
@@ -1244,13 +1239,7 @@ impl Router {
         if !req.return_documents {
             rerank_response.drop_documents();
         }
-        let mut response = Json(rerank_response).into_response();
-        if let Some(worker_id) = response_parts.headers.get(&header_utils::HEADER_WORKER_ID) {
-            response
-                .headers_mut()
-                .insert(header_utils::HEADER_WORKER_ID.clone(), worker_id.clone());
-        }
-        response
+        Json(rerank_response).into_response()
     }
 }
 
@@ -1870,25 +1859,6 @@ mod tests {
         assert_eq!(rerank.model, "test-model");
         assert_eq!(rerank.results.len(), 1);
         assert_eq!(rerank.results[0].document, None);
-    }
-
-    #[tokio::test]
-    async fn build_rerank_response_preserves_worker_id() {
-        let req = rerank_request();
-        let body = rerank_worker_body();
-        let mut upstream = Response::new(Body::from(body.clone()));
-        upstream.headers_mut().insert(
-            header_utils::HEADER_WORKER_ID.clone(),
-            HeaderValue::from_static("0198b7c7-8f80-7000-8000-000000000001"),
-        );
-
-        let response = Router::build_rerank_response(&req, None, upstream, body.len()).await;
-
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(
-            response.headers()[&header_utils::HEADER_WORKER_ID],
-            "0198b7c7-8f80-7000-8000-000000000001"
-        );
     }
 
     #[tokio::test]

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -44,7 +44,8 @@ use crate::{
     routers::{
         common::{
             header_utils::{
-                extract_forwardable_request_headers, preserve_response_headers, ApiProvider,
+                extract_forwardable_request_headers, insert_routed_worker_id,
+                preserve_response_headers, ApiProvider,
             },
             mcp_utils::DEFAULT_MAX_ITERATIONS,
             persistence_utils::persist_conversation_items,
@@ -567,7 +568,8 @@ pub(super) async fn handle_simple_streaming_passthrough(
         return (status_code, error_body).into_response();
     }
 
-    let preserved_headers = preserve_response_headers(response.headers());
+    let mut preserved_headers = preserve_response_headers(response.headers());
+    insert_routed_worker_id(&mut preserved_headers, worker.url());
     let mut upstream_stream = response.bytes_stream();
 
     let (tx, rx) = sse_channel();

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -1568,7 +1568,10 @@ fn create_cors_layer(allowed_origins: Vec<String>) -> tower_http::cors::CorsLaye
                 http::Method::OPTIONS,
             ])
             .allow_headers([http::header::CONTENT_TYPE, http::header::AUTHORIZATION])
-            .expose_headers([http::header::HeaderName::from_static("x-request-id")])
+            .expose_headers([
+                http::header::HeaderName::from_static("x-request-id"),
+                http::header::HeaderName::from_static("x-smg-worker-id"),
+            ])
     };
 
     cors.max_age(Duration::from_secs(3600))

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -1568,10 +1568,7 @@ fn create_cors_layer(allowed_origins: Vec<String>) -> tower_http::cors::CorsLaye
                 http::Method::OPTIONS,
             ])
             .allow_headers([http::header::CONTENT_TYPE, http::header::AUTHORIZATION])
-            .expose_headers([
-                http::header::HeaderName::from_static("x-request-id"),
-                http::header::HeaderName::from_static("x-smg-worker-id"),
-            ])
+            .expose_headers([http::header::HeaderName::from_static("x-request-id")])
     };
 
     cors.max_age(Duration::from_secs(3600))

--- a/model_gateway/tests/routing/header_forwarding_test.rs
+++ b/model_gateway/tests/routing/header_forwarding_test.rs
@@ -3,7 +3,7 @@
 //! Tests for header propagation through the router to workers.
 
 use axum::{
-    body::Body,
+    body::{to_bytes, Body},
     extract::Request,
     http::{header::CONTENT_TYPE, StatusCode},
 };
@@ -302,6 +302,44 @@ mod header_forwarding_tests {
             "x-request-id should take priority"
         );
 
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_worker_id_is_stable_for_streaming_and_non_streaming_responses() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 19406,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+        let app = ctx.create_app();
+        let mut worker_ids = Vec::new();
+
+        for stream in [false, true] {
+            let payload = json!({
+                "model": "mock-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": stream
+            });
+            let req = Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_string(&payload).unwrap()))
+                .unwrap();
+
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            let worker_id = resp.headers()["x-smg-worker-id"].to_str().unwrap();
+            uuid::Uuid::parse_str(worker_id).expect("worker ID should be an opaque UUID");
+            worker_ids.push(worker_id.to_string());
+            to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        }
+
+        assert_eq!(worker_ids[0], worker_ids[1]);
         ctx.shutdown().await;
     }
 }

--- a/model_gateway/tests/routing/header_forwarding_test.rs
+++ b/model_gateway/tests/routing/header_forwarding_test.rs
@@ -306,7 +306,7 @@ mod header_forwarding_tests {
     }
 
     #[tokio::test]
-    async fn test_worker_id_is_stable_for_streaming_and_non_streaming_responses() {
+    async fn test_routed_worker_id_for_streaming_and_non_streaming_responses() {
         let ctx = AppTestContext::new(vec![MockWorkerConfig {
             port: 19406,
             worker_type: WorkerType::Regular,
@@ -316,7 +316,9 @@ mod header_forwarding_tests {
         }])
         .await;
         let app = ctx.create_app();
-        let mut worker_ids = Vec::new();
+        let worker_url = ctx.app_context.worker_registry.get_all()[0]
+            .url()
+            .to_string();
 
         for stream in [false, true] {
             let payload = json!({
@@ -333,13 +335,12 @@ mod header_forwarding_tests {
 
             let resp = app.clone().oneshot(req).await.unwrap();
             assert_eq!(resp.status(), StatusCode::OK);
-            let worker_id = resp.headers()["x-smg-worker-id"].to_str().unwrap();
-            uuid::Uuid::parse_str(worker_id).expect("worker ID should be an opaque UUID");
-            worker_ids.push(worker_id.to_string());
+            assert_eq!(
+                resp.headers()["x-smg-routed-worker-id"],
+                worker_url.as_str()
+            );
             to_bytes(resp.into_body(), usize::MAX).await.unwrap();
         }
-
-        assert_eq!(worker_ids[0], worker_ids[1]);
         ctx.shutdown().await;
     }
 }


### PR DESCRIPTION
## Description

### Problem

Clients cannot tell which backend worker served a response. That makes it harder to locate the relevant worker logs, diagnose routing behavior, or determine whether a retry landed on a different replica.

### Solution

Return the selected worker URL in `x-smg-routed-worker-id`. The value is the URL as known by the gateway, including the `@<rank>` suffix for data-parallel workers.

This ports the intent of https://github.com/sgl-project/sglang/pull/34976 to SMG while covering SMG's response paths.

## Changes

- Add `x-smg-routed-worker-id` to regular HTTP streaming and non-streaming responses.
- Add it to multipart/audio responses.
- Attribute PD responses to the decode worker that produced the client-visible response.
- Add it to simple OpenAI Responses streaming passthrough responses.
- Add integration coverage for streaming and non-streaming responses.

## Test Plan

- `cargo +nightly fmt --all -- --check`
- `cargo check -p smg --lib`
- `cargo test -p smg --test routing_tests test_routed_worker_id_for_streaming_and_non_streaming_responses`

`cargo clippy -p smg --lib --test routing_tests -- -D warnings` was previously checked and stops on the pre-existing `clippy::unneeded_wildcard_pattern` warning at `model_gateway/src/worker/monitor.rs:825`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (blocked by the pre-existing warning noted above)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
