### PR TITLE
fix(zmq): update mock-worker test to 5-arg connect_handshake

### DIFF
--- a/crates/mock_worker/src/zmq.rs
+++ b/crates/mock_worker/src/zmq.rs
@@ -367,16 +367,9 @@ mod tests {
             let _engine = tokio::spawn(serve(cfg.clone(), handshake.clone(), rank));
         }
 
-        let transport = connect_handshake(
-            &handshake,
-            2,
-            "127.0.0.1",
-            Some(&input),
-            Some(&output),
-            Duration::from_secs(10),
-        )
-        .await
-        .expect("frontend handshake");
+        let transport = connect_handshake(&handshake, 2, &input, &output, Duration::from_secs(10))
+            .await
+            .expect("frontend handshake");
         let client = EngineCoreClient::new(transport);
         assert_eq!(client.engines().len(), 2);
 


### PR DESCRIPTION
## Description

### Problem

`main` fails `cargo clippy --all-targets --all-features -- -D warnings` ([run](https://github.com/smg-project/smg/actions/runs/32087117879/job/95561874351)): #2170 changed `connect_handshake` from six arguments (`Option<&String>` addresses) to five (`&str` addresses), while #2166 merged independently with a mock-worker test still written against the old signature. Each PR was green on its own branch; combined they break compilation of the mock-worker test target with E0061.

### Solution

Update the one stale call site in `two_ranks_share_one_socket_set` to the current five-argument signature, matching the sibling test in the same file. All other `connect_handshake` call sites already use the new form.

## Changes

- `crates/mock_worker/src/zmq.rs`: call `connect_handshake(&handshake, 2, &input, &output, Duration::from_secs(10))` instead of the removed six-argument form.

## Test Plan

- `cargo clippy --all-targets -- -D warnings` — clean workspace-wide (previously failed compiling `mock-worker (lib test)`)
- `cargo test -p mock-worker` — 8 passed, including `zmq::tests::two_ranks_share_one_socket_set`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>