### PR TITLE
test(zmq): wait for the background handshake before routing

### DIFF
--- a/model_gateway/tests/zmq_backend_test.rs
+++ b/model_gateway/tests/zmq_backend_test.rs
@@ -2,10 +2,10 @@
 //! (`routers/grpc/zmq_client.rs`), driven against a real in-process mock
 //! EngineCore (`mock-worker`'s `zmq` mode) over `ipc://` data-plane sockets.
 //!
-//! Everything below the router is real: the worker's lazy ZMQ connect binds
-//! the frontend sockets, completes the vLLM handshake with the mock engine(s),
-//! and streams `EngineCoreOutputs` back through the shared gRPC request
-//! pipeline (`ConnectionMode::Zmq` rides `uses_grpc_pipeline`). Before this
+//! Everything below the router is real: the worker's background handshake
+//! driver binds the frontend sockets, completes the vLLM handshake with the
+//! mock engine(s), and streams `EngineCoreOutputs` back through the shared
+//! gRPC request pipeline (`ConnectionMode::Zmq` rides `uses_grpc_pipeline`). Before this
 //! suite, that whole path had CPU coverage only inside `engine-zmq-client`;
 //! the gateway half was exercised only on GPU e2e lanes.
 //!
@@ -29,7 +29,7 @@ use smg::{
     config::RouterConfig,
     middleware::{RouteRequestMeta, TenantKey},
     routers::{RouterFactory, RouterTrait},
-    worker::{BasicWorkerBuilder, ConnectionMode, RuntimeType, WorkerType},
+    worker::{BasicWorkerBuilder, ConnectionMode, RuntimeType, Worker, WorkerType},
 };
 
 const MODEL: &str = "zmq-backend-test-model";
@@ -148,14 +148,27 @@ async fn build_router(fixture: &ZmqFixture, engine_count: usize) -> Box<dyn Rout
     if engine_count > 1 {
         builder = builder.zmq_engine_group(engine_count);
     }
+    let worker = Arc::new(builder.build());
     app_context
         .worker_registry
-        .register(Arc::new(builder.build()))
+        .register(worker.clone())
         .unwrap();
 
-    RouterFactory::create_router(&app_context)
+    let router = RouterFactory::create_router(&app_context)
         .await
-        .expect("router should build over a ZMQ worker")
+        .expect("router should build over a ZMQ worker");
+
+    // Acquisition fails fast while the background driver completes the
+    // handshake; wait for it to land so requests hit a connected worker.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while !matches!(worker.get_backend_client().await, Ok(Some(_))) {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "ZMQ handshake never completed against the mock engine(s)"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    router
 }
 
 #[expect(
@@ -176,8 +189,8 @@ fn test_meta() -> RouteRequestMeta {
     RouteRequestMeta::new(TenantKey::from("zmq-backend-test"))
 }
 
-/// The full gateway path over ZMQ: router -> lazy handshake -> mock EngineCore
-/// -> streamed outputs -> assembled non-streaming response. A regression
+/// The full gateway path over ZMQ: router -> handshaked backend -> mock
+/// EngineCore -> streamed outputs -> assembled non-streaming response. A regression
 /// anywhere in the ipc:// bind, handshake, or output translation fails here on
 /// CPU, without an H100 e2e lane.
 #[tokio::test]


### PR DESCRIPTION
## Description

### Problem

`main` fails the `unit-tests` job ([run](https://github.com/smg-project/smg/actions/runs/32122966648/job/95721427829)): all four gateway tests in `zmq_backend_test.rs` get 500 instead of 200. Another semantic merge race — #2179 added these tests assuming the old contract where the first request drives the ZMQ handshake inline, while #2177 deliberately changed acquisition to fail fast (`ConnectionFailed`) while a background driver completes the handshake. Each PR was green on its own branch; combined, every request the tests send races the handshake and fails.

### Solution

Make `build_router` wait for the worker's backend client to land before returning, so tests only route once the worker is connected — matching production, where the manager promotes a ZMQ worker on the `WorkerConnected` signal before it takes traffic. The first `get_backend_client()` call kicks the background driver; the loop then polls until the handshake completes (10s deadline). Also updates the two doc comments that still described the inline-handshake contract.

## Changes

- `model_gateway/tests/zmq_backend_test.rs`: keep the worker handle, poll `get_backend_client()` until `Ok(Some(_))` after building the router; refresh stale doc comments.

## Test Plan

- `cargo test -p smg --test zmq_backend_test` — 13 passed (previously 4 failed with 500s)
- `cargo test -p smg` — full suite green, exit 0
- `cargo clippy --all-targets -- -D warnings` workspace-wide — clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>