### PR TITLE
fix(protocols): emit structured mcp_call.error per current OpenAI schema

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1909,8 +1909,7 @@ pub enum ResponseInputOutputItem {
     /// Shape mirrors [`ResponseOutputItem::McpCall`] but `approval_request_id`,
     /// `error`, `output`, and `status` are optional on the input side so
     /// replay of an abridged or in-flight call (no output yet) stays
-    /// lossless. Matches OpenAI Python SDK 2.8.1
-    /// `types/responses/response_input_item.py::McpCall`.
+    /// lossless.
     #[serde(rename = "mcp_call")]
     McpCall {
         id: String,
@@ -1919,8 +1918,12 @@ pub enum ResponseInputOutputItem {
         server_label: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         approval_request_id: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        error: Option<String>,
+        #[serde(
+            default,
+            deserialize_with = "mcp_call_error_compat",
+            skip_serializing_if = "Option::is_none"
+        )]
+        error: Option<McpToolCallError>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         output: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2132,6 +2135,53 @@ pub struct McpToolInfo {
     pub annotations: Option<Value>,
 }
 
+/// Structured `mcp_call.error`: a `type`-tagged union of protocol,
+/// tool-execution, and HTTP failures. OpenAI removed the legacy plain-string
+/// shape from the wire; stored/replayed string errors still deserialize via
+/// [`mcp_call_error_compat`].
+#[expect(
+    clippy::enum_variant_names,
+    reason = "variant names mirror the spec's `*_error` tag set"
+)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+pub enum McpToolCallError {
+    #[serde(rename = "mcp_protocol_error")]
+    ProtocolError { code: i64, message: String },
+    #[serde(rename = "mcp_tool_execution_error")]
+    ToolExecutionError { content: Value },
+    #[serde(rename = "http_error")]
+    HttpError { code: i64, message: String },
+}
+
+impl McpToolCallError {
+    /// Wrap a bare failure message in the tool-execution variant.
+    pub fn execution(message: impl Into<String>) -> Self {
+        Self::ToolExecutionError {
+            content: Value::String(message.into()),
+        }
+    }
+}
+
+/// Accept both the structured union and the legacy plain-string error shape.
+fn mcp_call_error_compat<'de, D>(deserializer: D) -> Result<Option<McpToolCallError>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Compat {
+        Structured(McpToolCallError),
+        Legacy(String),
+    }
+    Ok(
+        Option::<Compat>::deserialize(deserializer)?.map(|error| match error {
+            Compat::Structured(error) => error,
+            Compat::Legacy(message) => McpToolCallError::execution(message),
+        }),
+    )
+}
+
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(tag = "type")]
@@ -2194,7 +2244,8 @@ pub enum ResponseOutputItem {
         status: String,
         approval_request_id: Option<String>,
         arguments: String,
-        error: Option<String>,
+        #[serde(default, deserialize_with = "mcp_call_error_compat")]
+        error: Option<McpToolCallError>,
         name: String,
         output: String,
         server_label: String,

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -4109,6 +4109,100 @@ fn test_mcp_call_input_item_full_round_trip() {
     );
 }
 
+/// Structured `mcp_call.error` variants round-trip byte-for-byte on both the
+/// input and output item shapes.
+#[test]
+fn test_mcp_call_structured_error_round_trips() {
+    let errors = [
+        json!({"type": "mcp_protocol_error", "code": -32601, "message": "method not found"}),
+        json!({"type": "mcp_tool_execution_error", "content": "rate limited"}),
+        json!({"type": "mcp_tool_execution_error", "content": [{"type": "text", "text": "boom"}]}),
+        json!({"type": "http_error", "code": 502, "message": "bad gateway"}),
+    ];
+    for error in errors {
+        let input_payload = json!({
+            "type": "mcp_call",
+            "id": "mcp_call_3",
+            "arguments": "{}",
+            "name": "ask_question",
+            "server_label": "deepwiki",
+            "error": error,
+        });
+        let item: ResponseInputOutputItem = serde_json::from_value(input_payload.clone())
+            .unwrap_or_else(|e| panic!("structured error should deserialize: {e}"));
+        assert_eq!(
+            serde_json::to_value(&item).expect("serialize"),
+            input_payload
+        );
+
+        let output_payload = json!({
+            "type": "mcp_call",
+            "id": "mcp_call_3",
+            "status": "failed",
+            "arguments": "{}",
+            "name": "ask_question",
+            "output": "",
+            "server_label": "deepwiki",
+            "error": error,
+        });
+        let item: ResponseOutputItem = serde_json::from_value(output_payload.clone())
+            .unwrap_or_else(|e| panic!("structured error should deserialize: {e}"));
+        assert_eq!(
+            serde_json::to_value(&item).expect("serialize"),
+            output_payload
+        );
+    }
+}
+
+/// Legacy plain-string `mcp_call.error` (pre-union wire shape, still present in
+/// stored history) coerces to the tool-execution variant so replay serializes
+/// the object form OpenAI now requires.
+#[test]
+fn test_mcp_call_legacy_string_error_coerces_to_structured() {
+    let item: ResponseInputOutputItem = serde_json::from_value(json!({
+        "type": "mcp_call",
+        "id": "mcp_call_4",
+        "arguments": "{}",
+        "name": "brave_web_search",
+        "server_label": "brave",
+        "status": "failed",
+        "error": "Tool call failed: rate limited",
+    }))
+    .expect("legacy string error should still deserialize");
+
+    match &item {
+        ResponseInputOutputItem::McpCall { error, .. } => {
+            assert_eq!(
+                error,
+                &Some(McpToolCallError::execution(
+                    "Tool call failed: rate limited"
+                ))
+            );
+        }
+        other => panic!("expected McpCall, got {other:?}"),
+    }
+    assert_eq!(
+        serde_json::to_value(&item).expect("serialize")["error"],
+        json!({"type": "mcp_tool_execution_error", "content": "Tool call failed: rate limited"})
+    );
+
+    let item: ResponseOutputItem = serde_json::from_value(json!({
+        "type": "mcp_call",
+        "id": "mcp_call_4",
+        "status": "failed",
+        "arguments": "{}",
+        "name": "brave_web_search",
+        "output": "",
+        "server_label": "brave",
+        "error": "Tool call failed: rate limited",
+    }))
+    .expect("legacy string error should still deserialize");
+    assert_eq!(
+        serde_json::to_value(&item).expect("serialize")["error"],
+        json!({"type": "mcp_tool_execution_error", "content": "Tool call failed: rate limited"})
+    );
+}
+
 /// Input-item `mcp_list_tools` round-trips with a non-empty `tools` array; the
 /// optional `error` field is omitted on serialize when absent.
 #[test]

--- a/model_gateway/src/routers/common/openai_bridge/transformer.rs
+++ b/model_gateway/src/routers/common/openai_bridge/transformer.rs
@@ -2,8 +2,8 @@
 
 use openai_protocol::responses::{
     CodeInterpreterCallStatus, CodeInterpreterOutput, FileSearchCallStatus, FileSearchResult,
-    ImageGenerationCallStatus, ResponseOutputItem, WebSearchAction, WebSearchCallStatus,
-    WebSearchSource,
+    ImageGenerationCallStatus, McpToolCallError, ResponseOutputItem, WebSearchAction,
+    WebSearchCallStatus, WebSearchSource,
 };
 use tracing::warn;
 
@@ -61,7 +61,7 @@ fn failed_mcp_call(output: &smg_mcp::ToolExecutionOutput) -> ResponseOutputItem 
         status: "failed".to_string(),
         approval_request_id: None,
         arguments: output.arguments_str.clone(),
-        error: Some(err_msg),
+        error: Some(McpToolCallError::execution(err_msg)),
         name: output.tool_name.clone(),
         output: String::new(),
         server_label: output.server_label.clone(),
@@ -1613,7 +1613,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(status, "failed");
-                assert_eq!(error.as_deref(), Some("upstream broke"));
+                assert_eq!(error, Some(McpToolCallError::execution("upstream broke")));
                 assert_eq!(output, "");
                 assert_eq!(arguments, "{\"q\":\"v\"}");
                 assert_eq!(name, "brave_web_search");
@@ -1635,7 +1635,7 @@ mod tests {
         let item = transform_tool_output(&output, ResponseFormat::Passthrough);
         match item {
             ResponseOutputItem::McpCall { error, .. } => {
-                assert_eq!(error.as_deref(), Some("rate limited"));
+                assert_eq!(error, Some(McpToolCallError::execution("rate limited")));
             }
             _ => panic!("Expected McpCall"),
         }

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -14,7 +14,7 @@ use axum::http::HeaderMap;
 use bytes::Bytes;
 use openai_protocol::{
     event_types::{is_function_call_type, ItemType, McpEvent, OutputItemEvent},
-    responses::{generate_id, ResponseInput, ResponseTool, ResponsesRequest},
+    responses::{generate_id, McpToolCallError, ResponseInput, ResponseTool, ResponsesRequest},
 };
 use serde_json::{json, to_value, Value};
 use smg_mcp::{McpServerBinding, McpToolSession, ToolExecutionInput, ToolExecutionResult};
@@ -1229,7 +1229,7 @@ fn build_mcp_call_item(
         "status": if success { "completed" } else { "failed" },
         "approval_request_id": Value::Null,
         "arguments": arguments,
-        "error": error,
+        "error": error.map(McpToolCallError::execution),
         "name": tool_name,
         "output": output,
         "server_label": server_label


### PR DESCRIPTION
## Description

### Problem

The `openai-responses` E2E lane fails intermittently on main ([run](https://github.com/smg-project/smg/actions/runs/32122966648/job/95721429093)): resuming a conversation via `previous_response_id` gets `400 Bad Request` from OpenAI — `"Invalid type for 'input[5].error': expected an object, but got a string instead."`

OpenAI changed `mcp_call.error` from `string | null` to a `type`-tagged union on 2026-08-14 and removed the string shape the same day ([openai-openapi@7348a53](https://github.com/openai/openai-openapi/commit/7348a53136), [openai-openapi@c094647](https://github.com/openai/openai-openapi/commit/c09464730a)):

- `{"type": "mcp_protocol_error", "code": <int>, "message": <string>}`
- `{"type": "mcp_tool_execution_error", "content": <any>}`
- `{"type": "http_error", "code": <int>, "message": <string>}`

SMG types the field as `Option<String>` and its MCP orchestrator writes plain strings when a tool call fails. When an MCP call flakes (the E2E lane uses the real Brave Search MCP service), the failed item is stored with a string `error`; every later turn of that conversation replays it upstream and 400s — which is why the failure recurs through all `--reruns 2` attempts, and why the same conversation breaks for real deployments, not just CI.

### Solution

Align the Responses API types with the current schema and keep old data working:

- New `McpToolCallError` union in `openai-protocol`, wire tags matching the spec exactly.
- Both `McpCall` item variants (`ResponseOutputItem`, `ResponseInputOutputItem`) type `error` as `Option<McpToolCallError>`.
- A field-level compat deserializer still accepts the legacy plain-string shape (stored history from before this change) and coerces it to `mcp_tool_execution_error`, so replaying pre-fix rows now serializes the object form OpenAI requires.
- SMG's two failure construction sites emit the tool-execution variant: the orchestrator's failed-call transform and the tool-loop's not-executed marker.

Known adjacent surfaces left as-is: `GET /v1/responses/{id}` and conversation-item listing serve stored `raw_response`/item JSON verbatim, so rows persisted before this fix still show the legacy string on retrieval (new rows store the structured form). The `response.mcp_call.failed` SSE event's `error` field is an SMG extension — OpenAI's event schema has no error property at all — and events are never replayed as input, so it is unchanged.

## Changes

- `crates/protocols/src/responses.rs`: add `McpToolCallError` + legacy-string compat deserializer; switch both `McpCall` variants' `error` to the union.
- `model_gateway/src/routers/common/openai_bridge/transformer.rs`: `failed_mcp_call` emits `mcp_tool_execution_error`.
- `model_gateway/src/routers/openai/mcp/tool_loop.rs`: `build_mcp_call_item` wraps its error message in the union.
- `crates/protocols/tests/responses.rs`: round-trip tests for all union shapes on both item variants; legacy-string coercion tests proving replay serializes the object form.

## Test Plan

- `cargo test -p openai-protocol` — 130 passed, including the new `test_mcp_call_structured_error_round_trips` and `test_mcp_call_legacy_string_error_coerces_to_structured`
- `cargo test -p smg` — full suite green, exit 0
- `cargo clippy --all-targets -- -D warnings` workspace-wide — clean
- Verified the union's wire tags and required fields against the current [openai-openapi](https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml) `MCPToolCall`/`MCPToolCallError` schemas

### Breaking change

> ⚠️ `mcp_call.error` in `/v1/responses` output items is now a structured object (`{"type": "mcp_tool_execution_error", "content": ...}` et al.) instead of a plain string, matching OpenAI's Responses API as of 2026-08-14. Clients that parsed the failure message out of a string `error` must read the union; plain-string errors are still accepted on input for backward compatibility.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>