### PR TITLE
test(middleware): pin the queued-request no-buffer invariant and expose admission metrics

### DIFF
--- a/model_gateway/src/middleware/concurrency.rs
+++ b/model_gateway/src/middleware/concurrency.rs
@@ -45,6 +45,7 @@ struct TokenPermit {
 impl TokenPermit {
     fn try_acquire(token_bucket: Arc<TokenBucket>, tokens: f64) -> Result<Self, ()> {
         token_bucket.try_acquire(tokens)?;
+        Metrics::record_admission_inflight_acquired();
         Ok(Self {
             token_bucket,
             tokens,
@@ -57,6 +58,7 @@ impl TokenPermit {
         timeout: Duration,
     ) -> Result<Self, Elapsed> {
         token_bucket.acquire_timeout(tokens, timeout).await?;
+        Metrics::record_admission_inflight_acquired();
         Ok(Self {
             token_bucket,
             tokens,
@@ -72,6 +74,24 @@ impl Drop for TokenPermit {
         );
         // Use lock-free sync return - no runtime needed, guaranteed token return
         self.token_bucket.return_tokens_sync(self.tokens);
+        Metrics::record_admission_inflight_released();
+    }
+}
+
+/// Holds one slot of the queue-depth gauge; drop covers admit, reject, and
+/// request cancellation.
+struct QueueDepthGuard;
+
+impl QueueDepthGuard {
+    fn enter() -> Self {
+        Metrics::record_admission_queue_entered();
+        Self
+    }
+}
+
+impl Drop for QueueDepthGuard {
+    fn drop(&mut self) {
+        Metrics::record_admission_queue_exited();
     }
 }
 
@@ -265,7 +285,11 @@ pub async fn concurrency_limit_middleware(
             match queue_tx.try_send(queued) {
                 Ok(()) => {
                     // Wait for token from queue processor
-                    match permit_rx.await {
+                    let permit_result = {
+                        let _queued = QueueDepthGuard::enter();
+                        permit_rx.await
+                    };
+                    match permit_result {
                         Ok(Ok(permit)) => {
                             debug!("Acquired token from queue");
                             Metrics::record_http_rate_limit(metrics_labels::RATE_LIMIT_ALLOWED);
@@ -274,6 +298,9 @@ pub async fn concurrency_limit_middleware(
                         Ok(Err(status)) => {
                             warn!("Queue returned error status: {}", status);
                             Metrics::record_http_rate_limit(metrics_labels::RATE_LIMIT_REJECTED);
+                            Metrics::record_admission_rejected(
+                                metrics_labels::ADMISSION_REJECTED_TIMEOUT,
+                            );
                             status.into_response()
                         }
                         Err(_) => {
@@ -286,6 +313,7 @@ pub async fn concurrency_limit_middleware(
                 Err(_) => {
                     warn!("Request queue is full, returning 429");
                     Metrics::record_http_rate_limit(metrics_labels::RATE_LIMIT_REJECTED);
+                    Metrics::record_admission_rejected(metrics_labels::ADMISSION_REJECTED_FULL);
                     StatusCode::TOO_MANY_REQUESTS.into_response()
                 }
             }
@@ -299,7 +327,110 @@ pub async fn concurrency_limit_middleware(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        OnceLock,
+    };
+
+    use axum::{routing::post, Router};
+    use llm_tokenizer::registry::TokenizerRegistry;
+    use metrics_exporter_prometheus::PrometheusBuilder;
+    use smg_data_connector::{
+        MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
+    };
+    use tokio::sync::Notify;
+    use tower::ServiceExt;
+
     use super::*;
+    use crate::{
+        app_context::AppContext, config::RouterConfig, health::ProbeState,
+        policies::PolicyRegistry, routers::router_manager::RouterManager, worker::WorkerRegistry,
+    };
+
+    fn test_app_state(
+        bucket: Arc<TokenBucket>,
+        queue_tx: Option<mpsc::Sender<QueuedRequest>>,
+    ) -> Arc<AppState> {
+        let router_config = RouterConfig::default();
+        let context = Arc::new(
+            AppContext::builder()
+                .client(reqwest::Client::new())
+                .rate_limiter(Some(bucket))
+                .tokenizer_registry(Arc::new(TokenizerRegistry::new()))
+                .reasoning_parser_factory(None)
+                .tool_parser_factory(None)
+                .worker_registry(Arc::new(WorkerRegistry::new()))
+                .policy_registry(Arc::new(PolicyRegistry::new(router_config.policy.clone())))
+                .router_config(router_config)
+                .response_storage(Arc::new(MemoryResponseStorage::new()))
+                .conversation_storage(Arc::new(MemoryConversationStorage::new()))
+                .conversation_item_storage(Arc::new(MemoryConversationItemStorage::new()))
+                .worker_monitor(None)
+                .worker_job_queue(Arc::new(OnceLock::new()))
+                .workflow_engines(Arc::new(OnceLock::new()))
+                .mcp_orchestrator(Arc::new(OnceLock::new()))
+                .build()
+                .unwrap(),
+        );
+        Arc::new(AppState {
+            router: Arc::new(RouterManager::new(
+                context.worker_registry.clone(),
+                context.client.clone(),
+            )),
+            probe_state: ProbeState::new(context.inflight_tracker.clone()),
+            context,
+            concurrency_queue_tx: queue_tx,
+            router_manager: None,
+            mesh_handler: None,
+            mesh_adapters: None,
+        })
+    }
+
+    fn echo_app(app_state: Arc<AppState>) -> Router {
+        Router::new()
+            .route("/echo", post(|body: Bytes| async move { body }))
+            .layer(axum::middleware::from_fn_with_state(
+                app_state,
+                concurrency_limit_middleware,
+            ))
+    }
+
+    fn echo_request(body: Body) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/echo")
+            .body(body)
+            .unwrap()
+    }
+
+    fn assert_metric_line(rendered: &str, series: &str, value: &str) {
+        let expected = format!("{series} {value}");
+        assert!(
+            rendered.lines().any(|line| line == expected),
+            "expected `{expected}`; rendered:\n{rendered}"
+        );
+    }
+
+    /// Sets `polled` on the first poll, so a test can detect any body
+    /// collection that happens while the request is parked at admission.
+    struct PollRecordingBody {
+        polled: Arc<AtomicBool>,
+        payload: Option<Bytes>,
+    }
+
+    impl http_body::Body for PollRecordingBody {
+        type Data = Bytes;
+        type Error = std::convert::Infallible;
+
+        fn poll_frame(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            let this = self.get_mut();
+            this.polled.store(true, Ordering::SeqCst);
+            Poll::Ready(this.payload.take().map(|bytes| Ok(Frame::data(bytes))))
+        }
+    }
 
     #[test]
     fn response_body_holds_token_until_dropped() {
@@ -354,5 +485,176 @@ mod tests {
             .run()
             .await;
         assert_eq!(bucket.available_tokens(), 1.0);
+    }
+
+    /// A request parked in the admission queue must keep its body unpolled;
+    /// collection may only happen at handler extraction after admission.
+    #[tokio::test]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test drives two concurrent requests through the real middleware stack"
+    )]
+    async fn queued_request_body_stays_unpolled_until_admitted() {
+        let bucket = Arc::new(TokenBucket::new(1, 0));
+        let (limiter, processor) =
+            ConcurrencyLimiter::new(Some(bucket.clone()), 4, Duration::from_secs(5));
+        tokio::spawn(processor.unwrap().run());
+
+        let hold_gate = Arc::new(Notify::new());
+        let entered = Arc::new(Notify::new());
+        let hold = {
+            let hold_gate = hold_gate.clone();
+            let entered = entered.clone();
+            move || {
+                let hold_gate = hold_gate.clone();
+                let entered = entered.clone();
+                async move {
+                    entered.notify_one();
+                    hold_gate.notified().await;
+                    "held"
+                }
+            }
+        };
+        let app = Router::new()
+            .route("/hold", post(hold))
+            .route("/echo", post(|body: Bytes| async move { body }))
+            .layer(axum::middleware::from_fn_with_state(
+                test_app_state(bucket, limiter.queue_tx),
+                concurrency_limit_middleware,
+            ));
+
+        let first = tokio::spawn(
+            app.clone().oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/hold")
+                    .body(Body::empty())
+                    .unwrap(),
+            ),
+        );
+        entered.notified().await;
+
+        let polled = Arc::new(AtomicBool::new(false));
+        let second = tokio::spawn(app.clone().oneshot(echo_request(Body::new(
+            PollRecordingBody {
+                polled: polled.clone(),
+                payload: Some(Bytes::from_static(b"parked-payload")),
+            },
+        ))));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !second.is_finished(),
+            "second request must be parked in the queue"
+        );
+        assert!(
+            !polled.load(Ordering::SeqCst),
+            "parked request body must not be polled"
+        );
+
+        hold_gate.notify_one();
+        let first_response = first.await.unwrap().unwrap();
+        assert_eq!(first_response.status(), StatusCode::OK);
+        drop(first_response);
+
+        let second_response = second.await.unwrap().unwrap();
+        assert_eq!(second_response.status(), StatusCode::OK);
+        let echoed = axum::body::to_bytes(second_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&echoed[..], b"parked-payload");
+        assert!(polled.load(Ordering::SeqCst));
+    }
+
+    /// Queue depth and inflight gauges move as requests park, and a full
+    /// queue rejects with reason="full".
+    #[test]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test parks a request in the background while asserting gauge movement"
+    )]
+    fn admission_metrics_track_depth_inflight_and_full_queue() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let bucket = Arc::new(TokenBucket::new(1, 0));
+                let (limiter, processor) =
+                    ConcurrencyLimiter::new(Some(bucket.clone()), 1, Duration::from_secs(5));
+                // Keep the queue channel open but undrained: the first
+                // request parks and the second finds the queue full.
+                let _processor = processor.unwrap();
+                let app = echo_app(test_app_state(bucket.clone(), limiter.queue_tx));
+
+                let held = TokenPermit::try_acquire(bucket, 1.0).unwrap();
+                let parked = tokio::spawn(app.clone().oneshot(echo_request(Body::from("parked"))));
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                assert!(!parked.is_finished());
+
+                let rejected = app
+                    .oneshot(echo_request(Body::from("rejected")))
+                    .await
+                    .unwrap();
+                assert_eq!(rejected.status(), StatusCode::TOO_MANY_REQUESTS);
+
+                let rendered = handle.render();
+                assert_metric_line(&rendered, "smg_admission_queue_depth", "1");
+                assert_metric_line(&rendered, "smg_admission_inflight", "1");
+                assert_metric_line(
+                    &rendered,
+                    "smg_admission_queue_rejected_total{reason=\"full\"}",
+                    "1",
+                );
+
+                parked.abort();
+                let _ = parked.await;
+                drop(held);
+            });
+        });
+    }
+
+    /// A request that outlives the queue timeout is rejected with
+    /// reason="timeout" and releases its queue-depth slot.
+    #[test]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "queue processor runs as a background task"
+    )]
+    fn admission_metrics_record_timeout_rejections() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let bucket = Arc::new(TokenBucket::new(1, 0));
+                let (limiter, processor) =
+                    ConcurrencyLimiter::new(Some(bucket.clone()), 4, Duration::from_millis(100));
+                tokio::spawn(processor.unwrap().run());
+                let app = echo_app(test_app_state(bucket.clone(), limiter.queue_tx));
+
+                let held = TokenPermit::try_acquire(bucket, 1.0).unwrap();
+                let response = app.oneshot(echo_request(Body::from("late"))).await.unwrap();
+                assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+                drop(held);
+            });
+        });
+
+        let rendered = handle.render();
+        assert_metric_line(
+            &rendered,
+            "smg_admission_queue_rejected_total{reason=\"timeout\"}",
+            "1",
+        );
+        assert_metric_line(&rendered, "smg_admission_queue_depth", "0");
+        assert_metric_line(&rendered, "smg_admission_inflight", "0");
     }
 }

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -231,6 +231,18 @@ pub(crate) fn init_metrics() {
         "smg_http_rate_limit_total",
         "Rate limiting decisions by result (allowed/rejected)"
     );
+    describe_gauge!(
+        "smg_admission_queue_depth",
+        "Requests currently parked in the admission queue"
+    );
+    describe_counter!(
+        "smg_admission_queue_rejected_total",
+        "Requests rejected at admission by reason (full/timeout)"
+    );
+    describe_gauge!(
+        "smg_admission_inflight",
+        "Requests currently holding an admission token"
+    );
 
     // Layer 2: Router metrics
     describe_counter!(
@@ -730,6 +742,10 @@ pub mod metrics_labels {
     pub const RATE_LIMIT_ALLOWED: &str = "allowed";
     pub const RATE_LIMIT_REJECTED: &str = "rejected";
 
+    // Admission rejection reasons
+    pub const ADMISSION_REJECTED_FULL: &str = "full";
+    pub const ADMISSION_REJECTED_TIMEOUT: &str = "timeout";
+
     // Circuit breaker states
     pub const CB_CLOSED: &str = "closed";
     pub const CB_OPEN: &str = "open";
@@ -826,6 +842,35 @@ impl Metrics {
             "result" => result
         )
         .increment(1);
+    }
+
+    /// Track a request entering the admission queue.
+    pub fn record_admission_queue_entered() {
+        gauge!("smg_admission_queue_depth").increment(1.0);
+    }
+
+    /// Track a request leaving the admission queue (admitted, rejected, or cancelled).
+    pub fn record_admission_queue_exited() {
+        gauge!("smg_admission_queue_depth").decrement(1.0);
+    }
+
+    /// Record a request rejected at admission.
+    pub fn record_admission_rejected(reason: &'static str) {
+        counter!(
+            "smg_admission_queue_rejected_total",
+            "reason" => reason
+        )
+        .increment(1);
+    }
+
+    /// Track acquisition of an admission token.
+    pub fn record_admission_inflight_acquired() {
+        gauge!("smg_admission_inflight").increment(1.0);
+    }
+
+    /// Track release of an admission token.
+    pub fn record_admission_inflight_released() {
+        gauge!("smg_admission_inflight").decrement(1.0);
     }
 
     /// Record one multimodal tensor sent over `path` ("inline"|"shm"|"remote") for `runtime`.

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -731,6 +731,9 @@ pub struct ServerConfig {
 /// the original `concurrency_limit_middleware`. Either runs innermost of the
 /// protective layers (closest to the handler), after tenant resolution has
 /// populated `RouteRequestMeta`.
+///
+/// Invariant: a request parked at admission keeps its body unread — bodies
+/// are collected only at handler extraction, after a permit is granted.
 fn with_admission_layer(
     router: Router<Arc<AppState>>,
     admission_mode: &middleware::scheduler::AdmissionMode,


### PR DESCRIPTION
## Description

### Problem

The admission/concurrency queue relies on an unwritten invariant: a request parked in the queue must not have its body collected — bodies are only read at handler extraction after a permit is granted. Nothing pinned this, so a refactor that pre-reads bodies in the middleware would silently start buffering every queued request. The queue also had zero observability: no way to see current depth, in-flight admissions, or why requests are rejected.

### Solution

- Add a regression test that drives two concurrent requests through the real `concurrency_limit_middleware` stack: the first occupies the single token, the second parks in the queue with an instrumented body that records any poll. The test asserts the parked body is never polled, then releases the first request and asserts the second completes with its body intact.
- Document the invariant at the layer-ordering site (`with_admission_layer`).
- Add admission-queue metrics through the existing `Metrics` facade and wire them in the middleware:
  - `smg_admission_queue_depth` (gauge): requests currently parked in the queue, maintained by a drop guard so cancellation is covered.
  - `smg_admission_queue_rejected_total{reason="full"|"timeout"}` (counter): queue-full and queue-timeout rejections.
  - `smg_admission_inflight` (gauge): requests currently holding an admission token, tracked at `TokenPermit` acquire/drop so streaming responses stay counted until fully delivered.

Admission behavior is unchanged; the middleware only gains metric recording.

## Changes

- `model_gateway/src/middleware/concurrency.rs`: record inflight gauge in `TokenPermit` acquire/drop; `QueueDepthGuard` around the queue wait; rejection counters on the queue-full and queue-timeout paths; new tests (`queued_request_body_stays_unpolled_until_admitted`, `admission_metrics_track_depth_inflight_and_full_queue`, `admission_metrics_record_timeout_rejections`) plus a minimal in-crate `AppState` harness.
- `model_gateway/src/observability/metrics.rs`: describe the three new metrics, add `Metrics::record_admission_*` helpers and `ADMISSION_REJECTED_FULL`/`ADMISSION_REJECTED_TIMEOUT` label constants.
- `model_gateway/src/server.rs`: invariant comment on `with_admission_layer`.

## Test Plan

- `cargo test -p smg --lib middleware::concurrency` — all 6 tests pass.
- Falsified the invariant test: temporarily made the middleware collect the body (`axum::body::to_bytes` + rebuild request) before admission; `queued_request_body_stays_unpolled_until_admitted` fails with `parked request body must not be polled`. Reverted the break; the test passes again.
- Metrics assertions run against a thread-local Prometheus recorder (same idiom as the PD metrics tests): parked request → `smg_admission_queue_depth 1`, held token → `smg_admission_inflight 1`, full queue → `smg_admission_queue_rejected_total{reason="full"} 1`, queue timeout → `smg_admission_queue_rejected_total{reason="timeout"} 1` with depth and inflight back to 0.
- `cargo build -p smg`, `cargo +nightly fmt --check`, `cargo clippy -p smg --all-targets -- -D warnings`, full `cargo test -p smg` all pass.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
