### PR TITLE
feat(router): stream large request bodies past a size threshold

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -514,6 +514,7 @@ struct Router {
     selection_temperature: f32,
     upstream_pool_idle_timeout_secs: u64,
     least_load_max_waiting_requests: u32,
+    stream_request_bodies_over: u64,
 }
 
 impl Router {
@@ -863,6 +864,7 @@ impl Router {
             .dp_aware(self.dp_aware)
             .upstream_http2(self.upstream_http2)
             .upstream_pool_idle_timeout_secs(self.upstream_pool_idle_timeout_secs)
+            .stream_request_bodies_over(self.stream_request_bodies_over)
             .multimodal_tensor_transport(multimodal_tensor_transport)
             .multimodal_shm_min_bytes(self.multimodal_shm_min_bytes)
             .routing_key_override(config::RoutingKeyOverrideConfig {
@@ -1024,6 +1026,7 @@ impl Router {
         selection_temperature = 0.0,
         upstream_pool_idle_timeout_secs = 3,
         least_load_max_waiting_requests = 0,
+        stream_request_bodies_over = 0,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1162,6 +1165,7 @@ impl Router {
         selection_temperature: f32,
         upstream_pool_idle_timeout_secs: u64,
         least_load_max_waiting_requests: u32,
+        stream_request_bodies_over: u64,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1314,6 +1318,7 @@ impl Router {
             selection_temperature,
             upstream_pool_idle_timeout_secs,
             least_load_max_waiting_requests,
+            stream_request_bodies_over,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -214,6 +214,7 @@ class RouterArgs:
     selection_temperature: float = 0.0
     upstream_pool_idle_timeout_secs: int = 3
     least_load_max_waiting_requests: int = 0
+    stream_request_bodies_over: int = 0
 
     @staticmethod
     def add_cli_args(
@@ -585,6 +586,19 @@ class RouterArgs:
             type=int,
             default=RouterArgs.max_payload_size,
             help="Maximum payload size in bytes",
+        )
+        routing_group.add_argument(
+            f"--{prefix}stream-request-bodies-over",
+            type=int,
+            default=RouterArgs.stream_request_bodies_over,
+            help=(
+                "Forward request bodies larger than this many bytes to the"
+                " worker as a raw stream instead of buffering, when the"
+                " route's policy needs no request text and the worker applies"
+                " no body mutation. Streamed bodies cannot be replayed, so"
+                " those requests bypass router-level retries; bodies without"
+                " a Content-Length header always buffer. 0 disables"
+            ),
         )
         routing_group.add_argument(
             f"--{prefix}dp-aware",

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1223,6 +1223,7 @@ class TestRouterArgsFieldOrder:
         "selection_temperature",
         "upstream_pool_idle_timeout_secs",
         "least_load_max_waiting_requests",
+        "stream_request_bodies_over",
     ]
 
     def test_complete_field_sequence_is_frozen(self):
@@ -1245,6 +1246,7 @@ class TestRouterArgsFieldOrder:
             "selection_temperature",
             "upstream_pool_idle_timeout_secs",
             "least_load_max_waiting_requests",
+            "stream_request_bodies_over",
         ):
             assert names.index(appended) > marker, (
                 f"{appended} must be appended after worker_startup_delay to "

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -205,6 +205,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn stream_request_bodies_over(mut self, bytes: u64) -> Self {
+        self.config.stream_request_bodies_over = bytes;
+        self
+    }
+
     pub fn upstream_pool_idle_timeout_secs(mut self, secs: u64) -> Self {
         self.config.upstream_pool_idle_timeout_secs = secs;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -50,6 +50,13 @@ pub struct RouterConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_worker_threads: Option<usize>,
     pub max_payload_size: usize,
+    /// Forward request bodies larger than this many bytes to the worker as a
+    /// raw stream instead of buffering, when the route's policy needs no
+    /// request text and the worker applies no body mutation. Streamed bodies
+    /// cannot be replayed, so those requests bypass router-level retries;
+    /// bodies without a Content-Length header always buffer. `0` disables.
+    #[serde(default)]
+    pub stream_request_bodies_over: u64,
     pub request_timeout_secs: u64,
     /// Idle timeout for pooled upstream connections. Must stay below the
     /// backend HTTP server's keep-alive timeout (vLLM and SGLang default to
@@ -900,7 +907,8 @@ impl Default for RouterConfig {
             health_check_port: None,
             runtime_worker_threads: None,
             max_payload_size: 536_870_912, // 512MB
-            request_timeout_secs: 1800,    // 30 minutes
+            stream_request_bodies_over: 0,
+            request_timeout_secs: 1800, // 30 minutes
             upstream_pool_idle_timeout_secs: default_upstream_pool_idle_timeout_secs(),
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading
             worker_startup_delay_secs: 0,
@@ -1052,6 +1060,7 @@ mod tests {
         assert_eq!(config.host, "0.0.0.0");
         assert_eq!(config.port, 3001);
         assert_eq!(config.max_payload_size, 536_870_912);
+        assert_eq!(config.stream_request_bodies_over, 0);
         assert_eq!(config.request_timeout_secs, 1800);
         assert_eq!(config.upstream_pool_idle_timeout_secs, 3);
         assert_eq!(config.worker_startup_timeout_secs, 1800);
@@ -1142,6 +1151,27 @@ mod tests {
         assert!(json.contains("health_check_port"));
         let with: RouterConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(with.health_check_port, Some(8081));
+    }
+
+    #[test]
+    fn test_stream_request_bodies_over_serde_roundtrip_and_backward_compat() {
+        // Config files predating the field deserialize to the disabled default.
+        let mut json: serde_json::Value = serde_json::to_value(RouterConfig::default()).unwrap();
+        json.as_object_mut()
+            .unwrap()
+            .remove("stream_request_bodies_over")
+            .unwrap();
+        let without: RouterConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(without.stream_request_bodies_over, 0);
+
+        // When set, the value round-trips.
+        let config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .stream_request_bodies_over(4 * 1024 * 1024)
+            .build_unchecked();
+        let json = serde_json::to_string(&config).unwrap();
+        let with: RouterConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(with.stream_request_bodies_over, 4 * 1024 * 1024);
     }
 
     #[test]

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -677,6 +677,19 @@ impl ConfigValidator {
             });
         }
 
+        // The body-limit layer rejects payloads above max_payload_size before
+        // the streaming threshold is consulted, so a threshold at or above it
+        // could never activate.
+        if config.stream_request_bodies_over != 0
+            && config.stream_request_bodies_over >= config.max_payload_size as u64
+        {
+            return Err(ConfigError::InvalidValue {
+                field: "stream_request_bodies_over".to_string(),
+                value: config.stream_request_bodies_over.to_string(),
+                reason: format!("Must be < max_payload_size ({})", config.max_payload_size),
+            });
+        }
+
         if config.request_timeout_secs == 0 {
             return Err(ConfigError::InvalidValue {
                 field: "request_timeout_secs".to_string(),
@@ -1077,6 +1090,25 @@ impl ConfigValidator {
 mod tests {
     use super::*;
     use crate::worker::ConnectionMode;
+
+    #[test]
+    fn stream_threshold_at_or_above_payload_cap_is_rejected() {
+        let below = RouterConfig {
+            stream_request_bodies_over: 1024,
+            ..Default::default()
+        };
+        assert!(ConfigValidator::validate(&below).is_ok());
+
+        let at_cap = RouterConfig {
+            stream_request_bodies_over: RouterConfig::default().max_payload_size as u64,
+            ..Default::default()
+        };
+        assert!(matches!(
+            ConfigValidator::validate(&at_cap),
+            Err(ConfigError::InvalidValue { ref field, .. })
+                if field == "stream_request_bodies_over"
+        ));
+    }
 
     #[test]
     fn mesh_server_name_with_colon_is_rejected() {

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -524,6 +524,18 @@ struct CliArgs {
     #[arg(long, default_value_t = 536870912, help_heading = "Request Handling")]
     max_payload_size: usize,
 
+    /// Forward request bodies larger than this many bytes to the worker as a
+    /// raw stream instead of buffering, when the route's policy needs no
+    /// request text and the worker applies no body mutation. Streamed bodies
+    /// are forwarded verbatim, so JSON validation and normalization defer to
+    /// the worker, and they cannot be replayed, so those requests bypass
+    /// router-level retries; bodies without a Content-Length header always
+    /// buffer. WASM OnRequest modules inspect buffered bodies, so deployments
+    /// running them keep buffering (and their own body-size cap) ahead of
+    /// this. Must be below max-payload-size. 0 disables
+    #[arg(long, default_value_t = 0, help_heading = "Request Handling")]
+    stream_request_bodies_over: u64,
+
     /// CORS allowed origins
     #[arg(long, num_args = 0.., help_heading = "Request Handling")]
     cors_allowed_origins: Vec<String>,
@@ -1555,6 +1567,7 @@ impl CliArgs {
             .health_check_port(self.health_check_port)
             .runtime_worker_threads(self.runtime_worker_threads)
             .max_payload_size(self.max_payload_size)
+            .stream_request_bodies_over(self.stream_request_bodies_over)
             .request_timeout_secs(self.request_timeout_secs)
             .upstream_pool_idle_timeout_secs(self.upstream_pool_idle_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -516,6 +516,17 @@ impl PolicyRegistry {
     /// [`LoadBalancingPolicy::needs_backend_loads`]: `power_of_two` and
     /// `least_load` always consume load reports; `cache_aware` does when its
     /// pressure knobs are configured.
+    /// Whether any registered policy (default or per-model) routes on
+    /// request text. Content-blind dispatch must stay buffered when one
+    /// does: the model inside the unread body could select that policy.
+    pub fn any_policy_needs_request_text(&self) -> bool {
+        self.default_policy.needs_request_text()
+            || self
+                .model_policies
+                .iter()
+                .any(|entry| entry.value().needs_request_text())
+    }
+
     pub fn get_all_load_aware_policies(&self) -> Vec<Arc<dyn LoadBalancingPolicy>> {
         let mut policies = Vec::new();
 

--- a/model_gateway/src/routers/http/mod.rs
+++ b/model_gateway/src/routers/http/mod.rs
@@ -3,6 +3,7 @@
 pub mod pd_router;
 pub mod pd_types;
 pub(crate) mod request_body;
+pub(crate) mod request_stream;
 pub mod router;
 
 use serde_json::Value;

--- a/model_gateway/src/routers/http/request_stream.rs
+++ b/model_gateway/src/routers/http/request_stream.rs
@@ -1,0 +1,271 @@
+//! Streamed request-body pass-through: byte accounting for the ingress
+//! payload cap and forwarding-progress tracking for the stall watchdog.
+
+use std::{
+    io,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use bytes::Bytes;
+use futures_util::Stream;
+use tokio::time::Instant;
+
+/// Abort a streamed dispatch when no request-body bytes move for this long:
+/// a stalled uploader must not hold a worker slot indefinitely.
+pub(crate) const STREAM_PROGRESS_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Shared view of a streamed request body: forwarding progress for the stall
+/// watchdog, plus the terminal payload-limit flag the dispatcher maps to 413.
+pub(crate) struct StreamProgress {
+    started: Instant,
+    last_progress_ms: AtomicU64,
+    body_complete: AtomicBool,
+    limit_exceeded: AtomicBool,
+    inbound_error: AtomicBool,
+}
+
+impl StreamProgress {
+    pub(crate) fn new() -> Self {
+        Self {
+            started: Instant::now(),
+            last_progress_ms: AtomicU64::new(0),
+            body_complete: AtomicBool::new(false),
+            limit_exceeded: AtomicBool::new(false),
+            inbound_error: AtomicBool::new(false),
+        }
+    }
+
+    fn touch(&self) {
+        let elapsed = u64::try_from(self.started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.last_progress_ms.store(elapsed, Ordering::Relaxed);
+    }
+
+    pub(crate) fn limit_exceeded(&self) -> bool {
+        self.limit_exceeded.load(Ordering::Relaxed)
+    }
+
+    /// True when the inbound body stream itself failed (client disconnect or
+    /// reset mid-upload) — a client-caused abort, never worker-attributed.
+    pub(crate) fn inbound_error(&self) -> bool {
+        self.inbound_error.load(Ordering::Relaxed)
+    }
+
+    /// Resolves once no body bytes have moved for `idle`. Never resolves
+    /// after the body is fully forwarded: waiting on the worker's response is
+    /// not an upload stall.
+    pub(crate) async fn stalled(&self, idle: Duration) {
+        loop {
+            if self.body_complete.load(Ordering::Relaxed) {
+                std::future::pending::<()>().await;
+            }
+            let seen = self.last_progress_ms.load(Ordering::Relaxed);
+            tokio::time::sleep_until(self.started + Duration::from_millis(seen) + idle).await;
+            if self.body_complete.load(Ordering::Relaxed) {
+                continue;
+            }
+            if self.last_progress_ms.load(Ordering::Relaxed) == seen {
+                return;
+            }
+        }
+    }
+}
+
+/// Counts request-body bytes against `limit` as they stream to the worker,
+/// reporting progress to [`StreamProgress`]. An over-limit body — caught by
+/// this counter or surfaced as an ingress `LengthLimitError` from the inner
+/// stream — flags the shared limit marker and terminates with an error, which
+/// aborts the upstream send.
+pub(crate) struct CappedBodyStream<S> {
+    inner: S,
+    progress: Arc<StreamProgress>,
+    limit: usize,
+    forwarded: usize,
+    done: bool,
+}
+
+impl<S> CappedBodyStream<S> {
+    pub(crate) fn new(inner: S, limit: usize, progress: Arc<StreamProgress>) -> Self {
+        Self {
+            inner,
+            progress,
+            limit,
+            forwarded: 0,
+            done: false,
+        }
+    }
+}
+
+impl<S, E> Stream for CappedBodyStream<S>
+where
+    S: Stream<Item = Result<Bytes, E>> + Unpin,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    type Item = Result<Bytes, io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.done {
+            return Poll::Ready(None);
+        }
+        match Pin::new(&mut this.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(chunk))) => {
+                this.forwarded = this.forwarded.saturating_add(chunk.len());
+                if this.forwarded > this.limit {
+                    this.done = true;
+                    this.progress.limit_exceeded.store(true, Ordering::Relaxed);
+                    return Poll::Ready(Some(Err(io::Error::other(
+                        "request body exceeded the payload limit",
+                    ))));
+                }
+                this.progress.touch();
+                Poll::Ready(Some(Ok(chunk)))
+            }
+            Poll::Ready(Some(Err(e))) => {
+                this.done = true;
+                if is_length_limit_error(&e) {
+                    this.progress.limit_exceeded.store(true, Ordering::Relaxed);
+                } else {
+                    this.progress.inbound_error.store(true, Ordering::Relaxed);
+                }
+                Poll::Ready(Some(Err(io::Error::other(e))))
+            }
+            Poll::Ready(None) => {
+                this.done = true;
+                this.progress.body_complete.store(true, Ordering::Relaxed);
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// True when `err`'s source chain contains the ingress body-limit error.
+fn is_length_limit_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(err) = current {
+        if err.is::<http_body_util::LengthLimitError>() {
+            return true;
+        }
+        current = err.source();
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use futures_util::{stream, StreamExt};
+    use http_body_util::Limited;
+
+    use super::*;
+
+    fn chunks(parts: &[&'static [u8]]) -> Vec<Result<Bytes, io::Error>> {
+        parts.iter().map(|c| Ok(Bytes::from_static(c))).collect()
+    }
+
+    #[tokio::test]
+    async fn body_at_limit_passes_through_and_completes() {
+        let progress = Arc::new(StreamProgress::new());
+        let stream = CappedBodyStream::new(
+            stream::iter(chunks(&[b"abc", b"defgh"])),
+            8,
+            Arc::clone(&progress),
+        );
+
+        let collected: Vec<_> = stream.collect().await;
+
+        let bytes: Vec<u8> = collected
+            .into_iter()
+            .flat_map(|c| c.unwrap().to_vec())
+            .collect();
+        assert_eq!(bytes, b"abcdefgh");
+        assert!(!progress.limit_exceeded());
+        assert!(progress.body_complete.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn over_limit_body_errors_and_flags() {
+        let progress = Arc::new(StreamProgress::new());
+        let mut stream = CappedBodyStream::new(
+            stream::iter(chunks(&[b"abc", b"defgh"])),
+            7,
+            Arc::clone(&progress),
+        );
+
+        assert_eq!(stream.next().await.unwrap().unwrap().as_ref(), b"abc");
+        stream.next().await.unwrap().unwrap_err();
+        assert!(progress.limit_exceeded());
+        // Terminal after the error: nothing further is forwarded.
+        assert!(stream.next().await.is_none());
+        assert!(!progress.body_complete.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn inner_non_limit_error_flags_inbound_error() {
+        let progress = Arc::new(StreamProgress::new());
+        let failing = stream::iter([
+            Ok(Bytes::from_static(b"abc")),
+            Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "client reset",
+            )),
+        ]);
+        let mut stream = CappedBodyStream::new(failing, usize::MAX, Arc::clone(&progress));
+
+        assert_eq!(stream.next().await.unwrap().unwrap().as_ref(), b"abc");
+        stream.next().await.unwrap().unwrap_err();
+        assert!(progress.inbound_error());
+        assert!(!progress.limit_exceeded());
+    }
+
+    #[tokio::test]
+    async fn inner_length_limit_error_flags_exceeded() {
+        let progress = Arc::new(StreamProgress::new());
+        let limited = Body::new(Limited::new(Body::from(vec![0u8; 64]), 8));
+        let mut stream = CappedBodyStream::new(
+            limited.into_data_stream(),
+            usize::MAX,
+            Arc::clone(&progress),
+        );
+
+        while let Some(item) = stream.next().await {
+            if item.is_err() {
+                break;
+            }
+        }
+
+        assert!(progress.limit_exceeded());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_fires_after_idle_window() {
+        let progress = Arc::new(StreamProgress::new());
+        tokio::time::timeout(
+            Duration::from_secs(120),
+            progress.stalled(Duration::from_secs(60)),
+        )
+        .await
+        .expect("watchdog must fire once the idle window passes");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_never_fires_after_body_completes() {
+        let progress = Arc::new(StreamProgress::new());
+        let stream =
+            CappedBodyStream::new(stream::iter(chunks(&[b"abc"])), 8, Arc::clone(&progress));
+        let _drained: Vec<_> = stream.collect().await;
+
+        tokio::time::timeout(
+            Duration::from_secs(600),
+            progress.stalled(Duration::from_secs(60)),
+        )
+        .await
+        .expect_err("a fully forwarded body must disarm the watchdog");
+    }
+}

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -2,8 +2,12 @@ use std::{error::Error as _, sync::Arc, time::Instant};
 
 use axum::{
     body::{to_bytes, Body},
-    extract::Request,
-    http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, Method, StatusCode},
+    extract::{Request, State},
+    http::{
+        header::{CONTENT_LENGTH, CONTENT_TYPE},
+        HeaderMap, HeaderValue, Method, StatusCode,
+    },
+    middleware::Next,
     response::{IntoResponse, Response},
     Json,
 };
@@ -35,8 +39,8 @@ use tracing::{error, warn};
 
 use crate::{
     app_context::AppContext,
-    config::types::RetryConfig,
-    middleware::TenantRequestMeta,
+    config::types::{RetryConfig, RouterConfig},
+    middleware::{scheduler::PreemptionGuard, TenantRequestMeta},
     observability::{
         events::{self, Event},
         metrics::{bool_to_static_str, metrics_labels, Metrics},
@@ -56,7 +60,11 @@ use crate::{
         },
         error::{self, extract_error_code_from_response},
         grpc::utils::{error_type_from_status, route_to_endpoint},
-        http::request_body::{serialize_request_body, RequestBodyError},
+        http::{
+            request_body::{serialize_request_body, RequestBodyError},
+            request_stream::{CappedBodyStream, StreamProgress, STREAM_PROGRESS_TIMEOUT},
+        },
+        router_manager::RouterManager,
         RouterTrait,
     },
     worker::{AttachedBody, ConnectionMode, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType},
@@ -64,6 +72,13 @@ use crate::{
 
 /// Max body size for a WebRTC `/v1/realtime/calls` SDP offer (10 MiB).
 const WEBRTC_REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
+
+/// Error codes for streamed-body aborts the client caused. They carry no
+/// worker verdict: recording a circuit-breaker sample for them would let slow
+/// or oversized uploaders open a healthy worker's breaker.
+const STREAMED_BODY_STALLED: &str = "request_body_stalled";
+const STREAMED_BODY_TOO_LARGE: &str = "request_body_too_large";
+const STREAMED_BODY_ABORTED: &str = "request_body_aborted";
 
 /// Regular router that uses injected load balancing policies
 pub struct Router {
@@ -1107,13 +1122,27 @@ impl Router {
             }
         };
 
+        self.forward_worker_response(res, is_stream, worker.url(), load_guard)
+            .await
+    }
+
+    /// Relay a worker response to the client. A streaming response flows
+    /// through a bounded channel with the load guard attached to the body; a
+    /// buffered response is read capped at the ingress payload limit.
+    async fn forward_worker_response(
+        &self,
+        res: reqwest::Response,
+        is_stream: bool,
+        worker_url: &str,
+        load_guard: WorkerLoadGuard,
+    ) -> Response {
         let status = StatusCode::from_u16(res.status().as_u16())
             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
         if is_stream {
             // Preserve headers for streaming response
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
-            header_utils::insert_routed_worker_id(&mut response_headers, worker.url());
+            header_utils::insert_routed_worker_id(&mut response_headers, worker_url);
             // Ensure we set the correct content-type for SSE
             response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
 
@@ -1183,11 +1212,108 @@ impl Router {
                 }
                 Err(error_response) => error_response,
             };
-            header_utils::insert_routed_worker_id(response.headers_mut(), worker.url());
+            header_utils::insert_routed_worker_id(response.headers_mut(), worker_url);
 
             // load_guard dropped here automatically after response body is read
             response
         }
+    }
+
+    /// Forward a raw request body to `worker` as a chunked stream.
+    ///
+    /// The body is never buffered: a counting wrapper caps it at the ingress
+    /// payload limit (over-limit → 413, upstream send aborted) and a watchdog
+    /// aborts the dispatch when no bytes move for [`STREAM_PROGRESS_TIMEOUT`]
+    /// (→ 408). The response relay is the buffered path's, with SSE detected
+    /// from the worker's Content-Type because the request's `stream` flag is
+    /// unread.
+    async fn send_streamed_request(
+        &self,
+        headers: &HeaderMap,
+        body: Body,
+        route: &'static str,
+        worker: &dyn Worker,
+        load_guard: WorkerLoadGuard,
+    ) -> Response {
+        let api_key = worker.api_key().cloned();
+        let endpoint_url = worker.endpoint_url(route);
+
+        let progress = Arc::new(StreamProgress::new());
+        let capped = CappedBodyStream::new(
+            body.into_data_stream(),
+            self.max_payload_size,
+            Arc::clone(&progress),
+        );
+
+        let mut request_builder = self
+            .client
+            .post(&endpoint_url)
+            .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .body(reqwest::Body::wrap_stream(capped));
+        request_builder = header_utils::apply_forwarded_request_headers(
+            request_builder,
+            Some(headers),
+            api_key.as_ref(),
+        );
+
+        let send = send_with_stale_conn_retry(request_builder);
+        tokio::pin!(send);
+        let sent = tokio::select! {
+            sent = &mut send => sent,
+            () = progress.stalled(STREAM_PROGRESS_TIMEOUT) => {
+                warn!(
+                    timeout_secs = STREAM_PROGRESS_TIMEOUT.as_secs(),
+                    "Streamed request body made no progress; aborting dispatch"
+                );
+                return error::create_error(
+                    StatusCode::REQUEST_TIMEOUT,
+                    STREAMED_BODY_STALLED,
+                    format!(
+                        "No request body bytes were forwarded for {} seconds",
+                        STREAM_PROGRESS_TIMEOUT.as_secs()
+                    ),
+                );
+            }
+        };
+
+        let res = match sent {
+            Ok(res) => res,
+            Err(_) if progress.limit_exceeded() => {
+                warn!(
+                    limit = self.max_payload_size,
+                    "Streamed request body exceeded the payload limit"
+                );
+                return error::create_error(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    STREAMED_BODY_TOO_LARGE,
+                    format!("Request body exceeded {} bytes", self.max_payload_size),
+                );
+            }
+            Err(_) if progress.inbound_error() => {
+                return error::create_error(
+                    StatusCode::BAD_REQUEST,
+                    STREAMED_BODY_ABORTED,
+                    "The request body stream failed before it was fully forwarded",
+                );
+            }
+            Err(e) => {
+                error!(
+                    "Failed to send streamed request worker_url={} route={} error={}",
+                    worker.url(),
+                    route,
+                    e
+                );
+                return convert_reqwest_error(e);
+            }
+        };
+
+        let is_stream = res
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|ct| ct.to_str().ok())
+            .is_some_and(|ct| ct.starts_with("text/event-stream"));
+        self.forward_worker_response(res, is_stream, worker.url(), load_guard)
+            .await
     }
 
     /// Build the public rerank response.
@@ -1394,6 +1520,198 @@ fn convert_reqwest_error(e: reqwest::Error) -> Response {
 }
 
 use async_trait::async_trait;
+
+impl Router {
+    /// Streamed pass-through: select a worker from headers alone and
+    /// forward the raw body verbatim (JSON validation and normalization
+    /// defer to the worker). `Err` hands the request back untouched —
+    /// body unconsumed — for the buffered typed path. Callers gate on
+    /// the size threshold via [`stream_large_request_bodies`].
+    pub(crate) async fn route_streaming_request(
+        &self,
+        req: Request<Body>,
+        route: &'static str,
+    ) -> Result<Response, Request<Body>> {
+        // Content-blind eligibility: the model and stream flag sit inside the
+        // unread body, so any registered policy that routes on request text
+        // (the body's model could select it) forces the buffered path, and
+        // every fallback hands the request back with its body unconsumed.
+        let model_id = crate::worker::UNKNOWN_MODEL_ID;
+        if self.policy_registry.any_policy_needs_request_text() {
+            return Err(req);
+        }
+        // A body-mutating worker (`prepare_request`) anywhere in the fleet
+        // forces the buffered path: the mutation needs the parsed body.
+        let candidates = self.worker_registry.get_workers_filtered(
+            None,
+            Some(WorkerType::Regular),
+            Some(ConnectionMode::Http),
+            None,
+            false,
+        );
+        if candidates.iter().any(|w| w.mutates_request()) {
+            return Err(req);
+        }
+        let Some(worker) = self.select_worker_for_model(model_id, None, None, Some(req.headers()))
+        else {
+            return Err(req);
+        };
+        // Guards a registration race: a mutating worker that joined after the
+        // fleet check above must still not receive an unmutated stream.
+        if worker.mutates_request() {
+            return Err(req);
+        }
+
+        let start = Instant::now();
+        let endpoint = route_to_endpoint(route);
+        Metrics::record_router_request(
+            metrics_labels::ROUTER_HTTP,
+            metrics_labels::BACKEND_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            model_id,
+            endpoint,
+            "false",
+        );
+
+        let load_guard = WorkerLoadGuard::new(worker.clone(), Some(req.headers()));
+        events::RequestSentEvent { url: worker.url() }.emit();
+
+        let (parts, body) = req.into_parts();
+        let mut headers_with_trace = parts.headers;
+        inject_trace_context_http(&mut headers_with_trace);
+
+        let response = self
+            .send_streamed_request(
+                &headers_with_trace,
+                body,
+                route,
+                worker.as_ref(),
+                load_guard,
+            )
+            .await;
+
+        events::RequestReceivedEvent {}.emit();
+        let status = response.status();
+        let error_code = extract_error_code_from_response(&response);
+        if error_code != STREAMED_BODY_STALLED
+            && error_code != STREAMED_BODY_TOO_LARGE
+            && error_code != STREAMED_BODY_ABORTED
+        {
+            worker.record_outcome(status.as_u16());
+            if status.is_server_error() {
+                Metrics::record_worker_error(
+                    metrics_labels::WORKER_REGULAR,
+                    metrics_labels::CONNECTION_HTTP,
+                    error_type_from_status(status),
+                );
+            }
+        }
+        Metrics::record_router_upstream_response(
+            metrics_labels::ROUTER_HTTP,
+            status.as_u16(),
+            error_code,
+        );
+        if status.is_success() {
+            Metrics::record_router_duration(
+                metrics_labels::ROUTER_HTTP,
+                metrics_labels::BACKEND_REGULAR,
+                metrics_labels::CONNECTION_HTTP,
+                model_id,
+                endpoint,
+                start.elapsed(),
+            );
+        } else if !is_retryable_status(status) {
+            Metrics::record_router_error(
+                metrics_labels::ROUTER_HTTP,
+                metrics_labels::BACKEND_REGULAR,
+                metrics_labels::CONNECTION_HTTP,
+                model_id,
+                endpoint,
+                error_type_from_status(status),
+            );
+        }
+        Ok(response)
+    }
+}
+
+/// Whether the request qualifies for the streamed body pass-through:
+/// `--stream-request-bodies-over` is on and the declared Content-Length
+/// exceeds it. Chunked uploads carry no Content-Length and always buffer.
+fn exceeds_stream_threshold(threshold: u64, req: &Request<Body>) -> bool {
+    threshold > 0
+        && req
+            .headers()
+            .get(CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok())
+            .is_some_and(|len| len > threshold)
+}
+
+/// State for [`stream_large_request_bodies`]: the app-level router handle
+/// (the manager in production, a concrete router in tests) and the streaming
+/// threshold.
+#[derive(Clone)]
+pub struct StreamBodyState {
+    router: Arc<dyn RouterTrait>,
+    threshold: u64,
+}
+
+impl StreamBodyState {
+    pub fn new(router: Arc<dyn RouterTrait>, config: &RouterConfig) -> Self {
+        Self {
+            router,
+            threshold: config.stream_request_bodies_over,
+        }
+    }
+}
+
+/// Route-layer middleware: a typed-JSON request whose declared Content-Length
+/// exceeds the threshold is offered to the HTTP regular router's streamed
+/// pass-through before the handler's `Json`/`ValidatedJson` extractor can
+/// buffer it. Any decline — other route, below threshold, no HTTP regular
+/// router, router-side ineligibility — falls through to the untouched
+/// handler with the body unconsumed. Sits inside the admission layer, so
+/// streamed requests hold an admission permit and race the preemption token.
+pub async fn stream_large_request_bodies(
+    State(state): State<StreamBodyState>,
+    cancel: PreemptionGuard,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let route: &'static str = match req.uri().path() {
+        "/generate" => "/generate",
+        "/v1/chat/completions" => "/v1/chat/completions",
+        "/v1/completions" => "/v1/completions",
+        "/v1/messages" => "/v1/messages",
+        "/v1/embeddings" => "/v1/embeddings",
+        "/v1/classify" => "/v1/classify",
+        _ => return next.run(req).await,
+    };
+    if !exceeds_stream_threshold(state.threshold, &req) {
+        return next.run(req).await;
+    }
+    let resolved = match state.router.as_any().downcast_ref::<RouterManager>() {
+        // Multi-router deployments route by the model inside the body; a
+        // content-blind dispatch could pick a router that does not serve it.
+        Some(manager) if manager.router_count() > 1 => return next.run(req).await,
+        Some(manager) => match manager.select_router_for_request(None) {
+            Some(selected) => selected,
+            None => return next.run(req).await,
+        },
+        None => Arc::clone(&state.router),
+    };
+    let Some(http) = resolved.as_any().downcast_ref::<Router>() else {
+        return next.run(req).await;
+    };
+    cancel
+        .guard(async move {
+            match http.route_streaming_request(req, route).await {
+                Ok(response) => response,
+                Err(req) => next.run(req).await,
+            }
+        })
+        .await
+}
 
 #[async_trait]
 impl RouterTrait for Router {
@@ -1930,5 +2248,338 @@ mod tests {
             extract_error_code_from_response(&response),
             "read_response_body_failed"
         );
+    }
+
+    fn least_load_policy() -> PolicyConfig {
+        PolicyConfig::LeastLoad {
+            load_check_interval_secs: 10,
+            kv_pressure_weight: 0.15,
+            mean_prefill_tokens: 1024,
+            default_throughput: 2000.0,
+            max_waiting_requests: 0,
+        }
+    }
+
+    fn cache_aware_policy() -> PolicyConfig {
+        PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 32,
+            balance_rel_threshold: 1.1,
+            eviction_interval_secs: 0,
+            max_tree_size: 4096,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+            overlap_decay: 0.0,
+            selection_temperature: 0.0,
+        }
+    }
+
+    fn streaming_router(
+        policy: PolicyConfig,
+        max_payload_size: usize,
+        workers: Vec<crate::worker::BasicWorker>,
+    ) -> Router {
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let policy_registry = Arc::new(PolicyRegistry::new(policy));
+        for worker in workers {
+            worker_registry.register_or_replace(Arc::new(worker));
+        }
+        Router {
+            worker_registry,
+            policy_registry,
+            client: Client::new(),
+            retry_config: RetryConfig::default(),
+            max_payload_size,
+            realtime_registry: Arc::new(RealtimeRegistry::new()),
+            webrtc_bind_addr: None,
+            webrtc_stun_server: None,
+        }
+    }
+
+    fn plain_worker(url: &str) -> crate::worker::BasicWorker {
+        BasicWorkerBuilder::new(url)
+            .worker_type(WorkerType::Regular)
+            .health_config(no_health_check())
+            .build()
+    }
+
+    type CapturedUpstreamRequest = Arc<tokio::sync::Mutex<Option<(HeaderMap, Bytes)>>>;
+
+    /// Loopback engine stub: captures the forwarded `/generate` request and
+    /// answers with the given content type and body.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test stub server lives for the duration of the test process"
+    )]
+    async fn spawn_capture_stub(
+        content_type: &'static str,
+        response_body: &'static str,
+    ) -> (String, CapturedUpstreamRequest) {
+        let captured: CapturedUpstreamRequest = Arc::new(tokio::sync::Mutex::new(None));
+        let sink = Arc::clone(&captured);
+        let app = axum::Router::new().route(
+            "/generate",
+            axum::routing::post(move |headers: HeaderMap, body: Bytes| {
+                let sink = Arc::clone(&sink);
+                async move {
+                    *sink.lock().await = Some((headers, body));
+                    ([(CONTENT_TYPE, content_type)], response_body)
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}"), captured)
+    }
+
+    fn streamed_request(chunks: &[&'static [u8]]) -> Request<Body> {
+        let chunks: Vec<Result<Bytes, std::io::Error>> =
+            chunks.iter().map(|c| Ok(Bytes::from_static(c))).collect();
+        Request::builder()
+            .method(Method::POST)
+            .uri("/generate")
+            .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .body(Body::from_stream(stream::iter(chunks)))
+            .unwrap()
+    }
+
+    fn request_with_content_length(len: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder().method(Method::POST).uri("/generate");
+        if let Some(len) = len {
+            builder = builder.header(CONTENT_LENGTH, len);
+        }
+        builder.body(Body::empty()).unwrap()
+    }
+
+    #[test]
+    fn stream_threshold_requires_flag_and_larger_content_length() {
+        assert_eq!(RouterConfig::default().stream_request_bodies_over, 0);
+        assert!(!exceeds_stream_threshold(
+            0,
+            &request_with_content_length(Some("10000"))
+        ));
+
+        assert!(!exceeds_stream_threshold(
+            1024,
+            &request_with_content_length(None)
+        ));
+        assert!(!exceeds_stream_threshold(
+            1024,
+            &request_with_content_length(Some("1024"))
+        ));
+        assert!(!exceeds_stream_threshold(
+            1024,
+            &request_with_content_length(Some("not-a-number"))
+        ));
+        assert!(exceeds_stream_threshold(
+            1024,
+            &request_with_content_length(Some("1025"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn streamed_request_forwards_chunked_and_relays_response() {
+        let (url, captured) = spawn_capture_stub("application/json", r#"{"text":"ok"}"#).await;
+        let router = streaming_router(least_load_policy(), 1024 * 1024, vec![plain_worker(&url)]);
+
+        let response = router
+            .route_streaming_request(
+                streamed_request(&[b"{\"text\":\"", b"hello\"}"]),
+                "/generate",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get("x-smg-routed-worker-id").is_some());
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(body.as_ref(), br#"{"text":"ok"}"#);
+
+        let (headers, body) = captured.lock().await.take().unwrap();
+        assert_eq!(body.as_ref(), b"{\"text\":\"hello\"}");
+        assert!(
+            headers.get(CONTENT_LENGTH).is_none(),
+            "streamed forward must not carry a Content-Length"
+        );
+        assert_eq!(
+            headers
+                .get(http::header::TRANSFER_ENCODING)
+                .and_then(|v| v.to_str().ok()),
+            Some("chunked")
+        );
+        assert_eq!(
+            headers.get(CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+    }
+
+    #[tokio::test]
+    async fn streamed_sse_response_relays_as_event_stream() {
+        let (url, _captured) = spawn_capture_stub("text/event-stream", "data: hi\n\n").await;
+        let router = streaming_router(least_load_policy(), 1024 * 1024, vec![plain_worker(&url)]);
+
+        let response = router
+            .route_streaming_request(streamed_request(&[b"{\"stream\":true}"]), "/generate")
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream")
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(body.as_ref(), b"data: hi\n\n");
+    }
+
+    #[tokio::test]
+    async fn oversized_streamed_body_yields_413() {
+        let (url, _captured) = spawn_capture_stub("application/json", "{}").await;
+        let router = streaming_router(least_load_policy(), 8, vec![plain_worker(&url)]);
+
+        let response = router
+            .route_streaming_request(streamed_request(&[b"12345678", b"9"]), "/generate")
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "request_body_too_large"
+        );
+    }
+
+    /// A stalled uploader must abort with 408 and leave the worker's circuit
+    /// breaker untouched: 408 is a retryable status, so recording it as a
+    /// worker outcome would trip a threshold-1 breaker here.
+    #[tokio::test(start_paused = true)]
+    async fn stalled_streamed_body_yields_408_without_breaker_sample() {
+        let (url, _captured) = spawn_capture_stub("application/json", "{}").await;
+        let worker = BasicWorkerBuilder::new(&url)
+            .worker_type(WorkerType::Regular)
+            .health_config(no_health_check())
+            .circuit_breaker_config(crate::worker::CircuitBreakerConfig {
+                failure_threshold: 1,
+                ..Default::default()
+            })
+            .build();
+        let router = streaming_router(least_load_policy(), 1024 * 1024, vec![worker]);
+
+        let stalled_body = Body::from_stream(
+            stream::iter([Ok::<_, std::io::Error>(Bytes::from_static(b"{\"text\":\""))])
+                .chain(stream::pending()),
+        );
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/generate")
+            .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .body(stalled_body)
+            .unwrap();
+
+        let response = router
+            .route_streaming_request(req, "/generate")
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "request_body_stalled"
+        );
+        let worker = &router.worker_registry.get_all()[0];
+        assert!(
+            worker.circuit_breaker_can_execute(),
+            "a client-caused stall must not record a breaker failure"
+        );
+    }
+
+    /// A client abort mid-upload must map to the excluded 400 code and leave
+    /// the worker's threshold-1 circuit breaker untouched.
+    #[tokio::test]
+    async fn aborted_streamed_body_yields_400_without_breaker_sample() {
+        let (url, _captured) = spawn_capture_stub("application/json", "{}").await;
+        let worker = BasicWorkerBuilder::new(&url)
+            .worker_type(WorkerType::Regular)
+            .health_config(no_health_check())
+            .circuit_breaker_config(crate::worker::CircuitBreakerConfig {
+                failure_threshold: 1,
+                ..Default::default()
+            })
+            .build();
+        let router = streaming_router(least_load_policy(), 1024 * 1024, vec![worker]);
+
+        let aborted_body = Body::from_stream(stream::iter([
+            Ok(Bytes::from_static(b"{\"text\":\"")),
+            Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "client reset",
+            )),
+        ]));
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/generate")
+            .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .body(aborted_body)
+            .unwrap();
+
+        let response = router
+            .route_streaming_request(req, "/generate")
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "request_body_aborted"
+        );
+        let worker = &router.worker_registry.get_all()[0];
+        assert!(
+            worker.circuit_breaker_can_execute(),
+            "a client abort must not record a breaker failure"
+        );
+    }
+
+    async fn assert_falls_back_with_body_intact(router: &Router) {
+        let req = router
+            .route_streaming_request(streamed_request(&[b"{\"text\":\"hello\"}"]), "/generate")
+            .await
+            .unwrap_err();
+
+        let body = to_bytes(req.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(body.as_ref(), b"{\"text\":\"hello\"}");
+    }
+
+    #[tokio::test]
+    async fn text_needing_policy_falls_back_to_buffered() {
+        let router = streaming_router(
+            cache_aware_policy(),
+            1024 * 1024,
+            vec![plain_worker("http://worker1:8080")],
+        );
+        assert_falls_back_with_body_intact(&router).await;
+    }
+
+    #[tokio::test]
+    async fn mutating_worker_falls_back_to_buffered() {
+        let worker = BasicWorkerBuilder::new("http://worker1:8080")
+            .worker_type(WorkerType::Regular)
+            .health_config(no_health_check())
+            .dp_config(3, 8)
+            .build();
+        let router = streaming_router(least_load_policy(), 1024 * 1024, vec![worker]);
+        assert_falls_back_with_body_intact(&router).await;
+    }
+
+    #[tokio::test]
+    async fn missing_worker_falls_back_to_buffered() {
+        let router = streaming_router(least_load_policy(), 1024 * 1024, vec![]);
+        assert_falls_back_with_body_intact(&router).await;
     }
 }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -55,8 +55,12 @@ use crate::{
         metrics_server, otel_trace, runtime_metrics,
     },
     routers::{
-        common::realtime::ws::RealtimeQueryParams, conversations, parse,
-        responses as response_handlers, router_manager::RouterManager, tokenize, RouterTrait,
+        common::realtime::ws::RealtimeQueryParams,
+        conversations,
+        http::router::{stream_large_request_bodies, StreamBodyState},
+        parse, responses as response_handlers,
+        router_manager::RouterManager,
+        tokenize, RouterTrait,
     },
     service_discovery::{start_service_discovery, ServiceDiscoveryConfig},
     wasm::route::{add_wasm_module, list_wasm_modules, remove_wasm_module},
@@ -828,6 +832,12 @@ pub fn build_app(
             .route("/v1/messages", post(v1_messages))
             .route("/v1/interactions", post(v1_interactions))
             .route("/v1/classify", post(v1_classify))
+            // Streamed pass-through for large typed-JSON bodies; everything
+            // else passes to the handlers untouched.
+            .route_layer(axum::middleware::from_fn_with_state(
+                StreamBodyState::new(app_state.router.clone(), &app_state.context.router_config),
+                stream_large_request_bodies,
+            ))
             // Tokenize / Detokenize endpoints
             .route("/v1/tokenize", post(v1_tokenize))
             .route("/v1/detokenize", post(v1_detokenize))

--- a/model_gateway/tests/routing/mod.rs
+++ b/model_gateway/tests/routing/mod.rs
@@ -14,6 +14,7 @@ pub mod power_of_two_test;
 pub mod prefix_hash_test;
 pub mod service_discovery_test;
 pub mod stream_relay_disconnect_test;
+pub mod stream_request_body_test;
 pub mod test_openai_routing;
 pub mod test_pd_routing;
 pub mod worker_management_test;

--- a/model_gateway/tests/routing/stream_request_body_test.rs
+++ b/model_gateway/tests/routing/stream_request_body_test.rs
@@ -1,0 +1,291 @@
+//! Streamed request-body pass-through (`--stream-request-bodies-over`).
+//!
+//! Above the threshold, with a policy that needs no request text, the raw
+//! body must flow to the worker as a chunked stream, byte-for-byte. Below the
+//! threshold, without a Content-Length, or under a text-needing policy, the
+//! buffered typed path (which re-serializes and sends a Content-Length) must
+//! be used instead.
+
+use std::sync::Arc;
+
+use axum::{
+    body::{Body, Bytes},
+    extract::{Request, State},
+    http::{
+        header::{CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING},
+        HeaderMap, StatusCode,
+    },
+    Json,
+};
+use futures_util::stream;
+use serde_json::{json, Value};
+use smg::{
+    config::{PolicyConfig, RouterConfig},
+    worker::{BasicWorkerBuilder, ModelCard, Worker, WorkerType},
+};
+use tokio::sync::Mutex;
+use tower::ServiceExt;
+
+use crate::common::AppTestContext;
+
+type Captured = Arc<Mutex<Vec<(HeaderMap, Bytes)>>>;
+
+/// Loopback engine stub: captures every forwarded generate/chat request and
+/// answers with canned JSON.
+#[expect(
+    clippy::disallowed_methods,
+    clippy::unwrap_used,
+    reason = "test infrastructure - panicking on failure is intentional"
+)]
+async fn spawn_capture_worker() -> (String, Captured) {
+    let captured: Captured = Arc::new(Mutex::new(Vec::new()));
+
+    async fn capture(State(sink): State<Captured>, headers: HeaderMap, body: Bytes) -> Json<Value> {
+        sink.lock().await.push((headers, body));
+        Json(json!({"text": "ok"}))
+    }
+
+    let app = axum::Router::new()
+        .route("/generate", axum::routing::post(capture))
+        .route("/v1/chat/completions", axum::routing::post(capture))
+        .with_state(Arc::clone(&captured));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    (format!("http://{addr}"), captured)
+}
+
+fn least_load_policy() -> PolicyConfig {
+    PolicyConfig::LeastLoad {
+        load_check_interval_secs: 10,
+        kv_pressure_weight: 0.15,
+        mean_prefill_tokens: 1024,
+        default_throughput: 2000.0,
+        max_waiting_requests: 0,
+    }
+}
+
+fn cache_aware_policy() -> PolicyConfig {
+    PolicyConfig::CacheAware {
+        cache_threshold: 0.5,
+        balance_abs_threshold: 32,
+        balance_rel_threshold: 1.1,
+        eviction_interval_secs: 0,
+        max_tree_size: 4096,
+        block_size: 16,
+        balance_token_usage_threshold: 1.0,
+        overload_token_usage_threshold: 1.0,
+        overlap_decay: 0.0,
+        selection_temperature: 0.0,
+    }
+}
+
+/// App wired through the real `build_app` stack with the capture stub as the
+/// only worker.
+async fn streaming_app(
+    policy: PolicyConfig,
+    threshold: u64,
+    max_payload_size: usize,
+) -> (axum::Router, Captured, AppTestContext) {
+    let (worker_url, captured) = spawn_capture_worker().await;
+
+    let mut config = RouterConfig::builder()
+        .regular_mode(vec![])
+        .host("127.0.0.1")
+        .port(3002)
+        .max_payload_size(max_payload_size)
+        .stream_request_bodies_over(threshold)
+        .request_timeout_secs(600)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .max_concurrent_requests(64)
+        .queue_timeout_secs(60)
+        .build_unchecked();
+    config.policy = policy;
+    config.health_check.disable_health_check = true;
+
+    let ctx = AppTestContext::new_with_config(config, vec![]).await;
+
+    let worker: Arc<dyn Worker> = Arc::new(
+        BasicWorkerBuilder::new(&worker_url)
+            .worker_type(WorkerType::Regular)
+            .models(vec![ModelCard::new("mock-model")])
+            .health_config(openai_protocol::worker::HealthCheckConfig {
+                disable_health_check: true,
+                ..Default::default()
+            })
+            .build(),
+    );
+    ctx.app_context.worker_registry.register(worker);
+
+    let app = ctx.create_app();
+    (app, captured, ctx)
+}
+
+#[expect(
+    clippy::unwrap_used,
+    reason = "test infrastructure - panicking on failure is intentional"
+)]
+fn generate_payload(text_len: usize) -> Vec<u8> {
+    serde_json::to_vec(&json!({"text": "x".repeat(text_len), "stream": false})).unwrap()
+}
+
+#[expect(
+    clippy::unwrap_used,
+    reason = "test infrastructure - panicking on failure is intentional"
+)]
+fn chunked_json_request(uri: &str, payload: Vec<u8>, content_length: Option<u64>) -> Request<Body> {
+    let chunks: Vec<Result<Bytes, std::io::Error>> = payload
+        .chunks(1024)
+        .map(|c| Ok(Bytes::copy_from_slice(c)))
+        .collect();
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header(CONTENT_TYPE, "application/json");
+    if let Some(len) = content_length {
+        builder = builder.header(CONTENT_LENGTH, len);
+    }
+    builder
+        .body(Body::from_stream(stream::iter(chunks)))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn large_generate_body_streams_to_worker_chunked() {
+    let (app, captured, ctx) = streaming_app(least_load_policy(), 1024, 64 * 1024 * 1024).await;
+    let payload = generate_payload(16 * 1024);
+
+    let req = chunked_json_request("/generate", payload.clone(), Some(payload.len() as u64));
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let parsed: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(parsed["text"], "ok");
+
+    let captured = captured.lock().await;
+    let (headers, body) = captured.first().unwrap();
+    assert_eq!(
+        body.as_ref(),
+        payload.as_slice(),
+        "streamed body must reach the worker byte-for-byte"
+    );
+    assert!(
+        headers.get(CONTENT_LENGTH).is_none(),
+        "streamed forward must not carry a Content-Length"
+    );
+    assert_eq!(
+        headers.get(TRANSFER_ENCODING).and_then(|v| v.to_str().ok()),
+        Some("chunked")
+    );
+    drop(captured);
+    ctx.shutdown().await;
+}
+
+#[tokio::test]
+async fn large_chat_body_streams_to_worker_chunked() {
+    let (app, captured, ctx) = streaming_app(least_load_policy(), 1024, 64 * 1024 * 1024).await;
+    let payload = serde_json::to_vec(&json!({
+        "model": "mock-model",
+        "messages": [{"role": "user", "content": "y".repeat(16 * 1024)}]
+    }))
+    .unwrap();
+
+    let req = chunked_json_request(
+        "/v1/chat/completions",
+        payload.clone(),
+        Some(payload.len() as u64),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let captured = captured.lock().await;
+    let (headers, body) = captured.first().unwrap();
+    assert_eq!(body.as_ref(), payload.as_slice());
+    assert!(headers.get(CONTENT_LENGTH).is_none());
+    drop(captured);
+    ctx.shutdown().await;
+}
+
+#[tokio::test]
+async fn below_threshold_body_stays_buffered() {
+    let (app, captured, ctx) =
+        streaming_app(least_load_policy(), 64 * 1024, 64 * 1024 * 1024).await;
+    let payload = generate_payload(64);
+
+    let req = chunked_json_request("/generate", payload.clone(), Some(payload.len() as u64));
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let captured = captured.lock().await;
+    let (headers, _) = captured.first().unwrap();
+    assert!(
+        headers.get(CONTENT_LENGTH).is_some(),
+        "the buffered path sends a fixed-length body"
+    );
+    drop(captured);
+    ctx.shutdown().await;
+}
+
+#[tokio::test]
+async fn missing_content_length_stays_buffered() {
+    let (app, captured, ctx) = streaming_app(least_load_policy(), 1024, 64 * 1024 * 1024).await;
+    let payload = generate_payload(16 * 1024);
+
+    let req = chunked_json_request("/generate", payload, None);
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let captured = captured.lock().await;
+    let (headers, _) = captured.first().unwrap();
+    assert!(headers.get(CONTENT_LENGTH).is_some());
+    drop(captured);
+    ctx.shutdown().await;
+}
+
+#[tokio::test]
+async fn text_needing_policy_stays_buffered_above_threshold() {
+    let (app, captured, ctx) = streaming_app(cache_aware_policy(), 1024, 64 * 1024 * 1024).await;
+    let payload = generate_payload(16 * 1024);
+
+    let req = chunked_json_request("/generate", payload.clone(), Some(payload.len() as u64));
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let captured = captured.lock().await;
+    let (headers, _) = captured.first().unwrap();
+    assert!(
+        headers.get(CONTENT_LENGTH).is_some(),
+        "a text-needing policy must keep the buffered path"
+    );
+    drop(captured);
+    ctx.shutdown().await;
+}
+
+#[tokio::test]
+async fn oversized_streamed_body_is_rejected_with_413() {
+    let (app, captured, ctx) = streaming_app(least_load_policy(), 1024, 4096).await;
+    // The declared length passes the ingress check; the actual stream is far
+    // larger, so the cap must trip while forwarding.
+    let payload = generate_payload(64 * 1024);
+
+    let req = chunked_json_request("/generate", payload, Some(2048));
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(
+        resp.headers()
+            .get("X-SMG-Error-Code")
+            .and_then(|v| v.to_str().ok()),
+        Some("request_body_too_large")
+    );
+    assert!(captured.lock().await.is_empty());
+    ctx.shutdown().await;
+}


### PR DESCRIPTION
## Description

### Problem

The HTTP router fully buffers every request body: the typed handlers extract `Json<T>` (collecting and parsing the entire payload), and dispatch re-serializes it into a fresh buffer that is held until the worker has consumed the body. For multimodal requests carrying inline media, a single request can occupy tens to hundreds of MB of router memory for its whole dispatch lifetime, roughly twice over (parsed struct + serialized bytes). Router memory scales as `in_flight x payload_size`, large payloads add a full store-and-forward hop to TTFT, and parsing/re-encoding large JSON bodies costs significant CPU — even though the router never needs the media bytes for routing.

### Solution

Opt-in streaming pass-through for large request bodies, gated by a new `--stream-request-bodies-over <bytes>` flag (0 = disabled, the default). When the flag is on and a request's declared Content-Length exceeds the threshold, a route-layer middleware (`stream_large_request_bodies`, living in the HTTP router module) intercepts the request before the handler's `Json`/`ValidatedJson` extractor can buffer it and offers it to the HTTP regular router's streamed pass-through. The handlers themselves are untouched — identical signatures and bodies to today — and the server's entire change is one `route_layer` line. The middleware owns the route whitelist and threshold check, resolves the concrete HTTP regular router (unwrapping the manager when present), and passes the request through untouched for every decline. The router accepts a request only when the active policy reports `needs_request_text() == false` and no worker in the fleet mutates request bodies (`prepare_request`); it then selects a worker from headers via the existing policy machinery and forwards the body with `reqwest::Body::wrap_stream` — only flow-control windows stay in memory, and backpressure propagates end to end. Every decline hands the request back with its body unconsumed, so the buffered typed path runs exactly as today.

Scope and tradeoffs:

- HTTP regular router only, with no shared surface: the gRPC routers, the HTTP PD router, and the OpenAI-compat routers are untouched — a deployment whose router is any other type falls through to the buffered path inside `offer_streaming_request`.
- Streamed bodies cannot be replayed: streamed requests bypass the router-level `RetryExecutor` and the one-shot stale-connection resend (`try_clone() == None` already falls through). Documented on the flag.
- Requests without a Content-Length (chunked uploads) always buffer; the streaming decision is made before any body byte is read.
- Text-needing policies (`cache_aware`, `bucket`) keep the buffered path so routing quality is unchanged — the check scans the default and every per-model policy. Multi-router (IGW) deployments and deployments running WASM `OnRequest` modules also keep the buffered path: the former must route by the model inside the body, the latter buffer for inspection ahead of this layer.
- Streamed bodies are forwarded verbatim: JSON validation and normalization defer to the worker, which parses the same OpenAI-surface payload and rejects invalid requests itself. Config rejects `stream_request_bodies_over >= max_payload_size` at startup (the body-limit layer would otherwise make streaming unreachable).
- `max_payload_size` is enforced on the streamed path by a counting stream wrapper that aborts the upstream send and returns 413 once the limit is exceeded (it also recognizes the ingress `LengthLimitError` from the request-body-limit layer).
- A progress watchdog aborts the dispatch with 408 when no body bytes move for 60 seconds (`STREAM_PROGRESS_TIMEOUT`), so a stalled uploader cannot hold a worker slot; it disarms once the body is fully forwarded, since waiting on a long prefill is not an upload stall. Client-caused aborts — stall (408), over-cap (413), and mid-upload disconnect (400 `request_body_aborted`) — record no circuit-breaker sample against the worker.
- `WorkerLoadGuard`, circuit-breaker outcome recording for worker-attributed results, and the response relay are identical to the buffered path — the relay tail of `send_typed_request` is factored into a shared `forward_worker_response`, with SSE detected from the worker's response Content-Type because the request's `stream` flag is unread.

## Changes

- `model_gateway/src/config/types.rs`, `config/builder.rs`: new `RouterConfig::stream_request_bodies_over` (serde-defaulted; old config files unaffected) plus builder method.
- `model_gateway/src/main.rs`: `--stream-request-bodies-over` CLI flag wired through the `RouterConfig` builder.
- `model_gateway/src/routers/http/request_stream.rs` (new): `CappedBodyStream` byte-cap wrapper and `StreamProgress` stall watchdog.
- `model_gateway/src/routers/http/router.rs`: the entire feature — `stream_large_request_bodies` route-layer middleware (route whitelist, threshold gate, concrete-router resolution, preemption race), inherent `route_streaming_request` (eligibility + dispatch), `send_streamed_request`; response relay factored into `forward_worker_response`, shared verbatim with the buffered path. No trait or manager changes.
- `model_gateway/src/server.rs`: one `route_layer` insertion on the protected route group (inside the admission layer, so streamed requests hold an admission permit and the preemption token). Handlers are unchanged; every non-qualifying request reaches them byte-identically to today. `/v1/rerank` keeps the buffered path (the router composes its response from the worker body); `/v1/responses` and `/v1/interactions` are unchanged.
- `bindings/python/src/lib.rs`, `bindings/python/src/smg/router_args.py`, `bindings/python/tests/test_arg_parser.py`: `stream_request_bodies_over` appended at the tail of the constructor signature, dataclass, and frozen-order test lists (positional-caller compatible).

## Test Plan

Flag off (default) is byte-for-byte today's behavior: the entire existing suite passes unmodified, and the converted handlers extract through the same axum types.

New coverage:

- `model_gateway/tests/routing/stream_request_body_test.rs` (full `build_app` stack against a loopback capture worker):
  - `large_generate_body_streams_to_worker_chunked` / `large_chat_body_streams_to_worker_chunked` — least_load, body over threshold: worker receives the exact client bytes, chunked, with no Content-Length; response relays intact.
  - `below_threshold_body_stays_buffered`, `missing_content_length_stays_buffered`, `text_needing_policy_stays_buffered_above_threshold` (cache_aware) — buffered path retained, fixed-length upstream body.
  - `oversized_streamed_body_is_rejected_with_413` — declared length lies, actual stream exceeds `max_payload_size`: 413 `request_body_too_large`, upstream send aborted.
- `model_gateway/src/routers/http/router.rs` unit tests: chunked end-to-end forward + relay, SSE response relay, 413 cap, 408 stall without a circuit-breaker sample (paused clock), and body-intact fallbacks for text-needing policy / mutating (dp) worker / no worker.
- `model_gateway/src/routers/http/request_stream.rs` unit tests: cap accounting, inner `LengthLimitError` recognition, watchdog firing and disarming.
- `model_gateway/src/routers/router_manager.rs`: delegation to the default router; body returned intact when no router exists.
- Config serde backward-compat test and CLI/dataclass default tests; Python `test_arg_parser.py` (45 passed, 1 skipped) against the compiled bindings.

Gates: `cargo build -p smg`, `cargo +nightly fmt --check`, `cargo clippy -p smg --all-targets -- -D warnings`, full `cargo test -p smg`, `cargo build -p smg-python`, `cargo build -p smg-golang` — all green.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>




