### PR TITLE
feat(router): header routing hints for body-free selection

### DIFF
--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -1409,6 +1409,9 @@ impl CacheAwarePolicy {
             //   * matched worker gone/unhealthy: select nothing and DON'T insert
             //     (closure returns None), falling back to first-healthy below.
             let mut selected_idx: Option<usize> = None;
+            // Hinted token prefixes (x-smg-routing-tokens) insert as-is: the
+            // tree page-aligns internally, so a truncated prefix still trains
+            // affinity.
             let result = tree.match_and_insert_with(tokens, |result| {
                 let match_rate = if result.input_token_count == 0 {
                     0.0

--- a/model_gateway/src/policies/consistent_hashing.rs
+++ b/model_gateway/src/policies/consistent_hashing.rs
@@ -23,7 +23,7 @@ use rand::RngExt as _;
 use super::{LoadBalancingPolicy, SelectWorkerInfo};
 use crate::{
     observability::metrics::Metrics,
-    routers::common::header_utils::{extract_routing_key, extract_target_worker},
+    routers::common::header_utils::{extract_routing_key_hint, extract_target_worker},
     worker::Worker,
 };
 
@@ -123,7 +123,11 @@ impl ConsistentHashingPolicy {
         }
 
         let target_worker = extract_target_worker(info.headers);
-        let routing_key = extract_routing_key(info.headers);
+        // Both sides apply the hint caps: an over-cap or non-UTF-8 key must not
+        // influence placement on any path.
+        let routing_key = info
+            .routing_key
+            .or_else(|| extract_routing_key_hint(info.headers));
 
         // Priority 1: X-SMG-Target-Worker - direct routing by worker index
         // O(1) parse + O(1) bounds check + O(1) health check
@@ -274,6 +278,22 @@ mod tests {
         }
 
         assert!(distribution.len() > 1, "Should distribute across workers");
+    }
+
+    #[test]
+    fn test_over_cap_routing_key_is_ignored() {
+        let policy = ConsistentHashingPolicy::new();
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+
+        let headers = headers_with_routing_key(&"k".repeat(129));
+        let info = SelectWorkerInfo {
+            headers: Some(&headers),
+            ..Default::default()
+        };
+
+        let (result, branch) = policy.select_worker_impl(&workers, &info);
+        assert!(result.is_some());
+        assert_eq!(branch, Branch::RandomFallback);
     }
 
     #[test]
@@ -507,6 +527,85 @@ mod tests {
             Some(original_idx),
             "Should return to original worker after recovery"
         );
+    }
+
+    #[test]
+    fn test_routing_key_hint_field_routes_consistently() {
+        let policy = ConsistentHashingPolicy::new();
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+
+        let info = SelectWorkerInfo {
+            routing_key: Some("user-123"),
+            ..Default::default()
+        };
+
+        let (first_result, branch) = policy.select_worker_impl(&workers, &info);
+        let first_idx = first_result.unwrap();
+        assert_eq!(branch, Branch::RoutingKeyHit);
+
+        for _ in 0..10 {
+            let (result, branch) = policy.select_worker_impl(&workers, &info);
+            assert_eq!(result, Some(first_idx));
+            assert_eq!(branch, Branch::RoutingKeyHit);
+        }
+    }
+
+    #[test]
+    fn test_routing_key_hint_field_distributes() {
+        let policy = ConsistentHashingPolicy::new();
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+
+        let mut distribution = HashMap::new();
+        for i in 0..100 {
+            let key = format!("user-{i}");
+            let info = SelectWorkerInfo {
+                routing_key: Some(&key),
+                ..Default::default()
+            };
+            let (result, _) = policy.select_worker_impl(&workers, &info);
+            *distribution.entry(result.unwrap()).or_insert(0) += 1;
+        }
+
+        assert!(distribution.len() > 1, "Should distribute across workers");
+    }
+
+    #[test]
+    fn test_routing_key_hint_wins_over_raw_header() {
+        let policy = ConsistentHashingPolicy::new();
+        let workers = create_workers(&[
+            "http://w1:8000",
+            "http://w2:8000",
+            "http://w3:8000",
+            "http://w4:8000",
+        ]);
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
+
+        let select_by_key = |key: &str| {
+            let info = SelectWorkerInfo {
+                routing_key: Some(key),
+                hash_ring: Some(ring.clone()),
+                ..Default::default()
+            };
+            policy.select_worker_impl(&workers, &info).0.unwrap()
+        };
+
+        // Find two keys that land on different workers.
+        let base_idx = select_by_key("key-0");
+        let other_key = (1..64)
+            .map(|i| format!("key-{i}"))
+            .find(|key| select_by_key(key) != base_idx)
+            .expect("some key must land on a different worker");
+
+        let headers = headers_with_routing_key(&other_key);
+        let info = SelectWorkerInfo {
+            routing_key: Some("key-0"),
+            headers: Some(&headers),
+            hash_ring: Some(ring.clone()),
+            ..Default::default()
+        };
+        let (result, branch) = policy.select_worker_impl(&workers, &info);
+        assert_eq!(result, Some(base_idx), "the validated hint must win");
+        assert_eq!(branch, Branch::RoutingKeyHit);
     }
 
     #[test]

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -251,12 +251,18 @@ pub struct SelectWorkerInfo<'a> {
     pub request_text: Option<&'a str>,
     /// Tokenized request for prefix-hash routing
     /// Used by PrefixHashPolicy for token-based prefix hashing
+    /// The HTTP router substitutes a valid `x-smg-routing-tokens` hint here:
+    /// the hint wins over body-derived tokens/text for selection.
     pub tokens: Option<&'a [u32]>,
     /// HTTP headers for header-based routing policies
     /// Policies can extract routing information from headers like:
     /// - X-SMG-Target-Worker: Direct routing to a specific worker by index
     /// - X-SMG-Routing-Key: Consistent hash routing for session affinity
     pub headers: Option<&'a http::HeaderMap>,
+    /// Validated `x-smg-routing-key` hint (non-empty UTF-8, <= 128 bytes);
+    /// consistent_hashing and prefix_hash prefer it over their other keying
+    /// input.
+    pub routing_key: Option<&'a str>,
     /// Pre-computed hash ring for O(log n) consistent hashing
     /// Built and cached by WorkerRegistry, passed through to avoid per-request rebuilds
     pub hash_ring: Option<Arc<HashRing>>,

--- a/model_gateway/src/policies/prefix_hash.rs
+++ b/model_gateway/src/policies/prefix_hash.rs
@@ -257,13 +257,18 @@ impl PrefixHashPolicy {
             return (None, Branch::NoHealthyWorkers);
         }
 
-        // Pre-tokenized requests hash their token prefix, the rest hash the
-        // equivalent span of routing text.
-        let prefix_hash = match (info.tokens, info.request_text) {
-            (Some(tokens), _) if !tokens.is_empty() => self.compute_prefix_hash(tokens),
-            (_, Some(text)) if !text.is_empty() => self.compute_text_prefix_hash(text),
-            // Nothing to hash: stay serviceable by falling back to load.
-            _ => return (Self::least_loaded_healthy(workers), Branch::NoRoutingKey),
+        // A validated x-smg-routing-key hint overrides token/text keying.
+        // Otherwise pre-tokenized requests hash their token prefix, the rest
+        // hash the equivalent span of routing text.
+        let prefix_hash = if let Some(key) = info.routing_key {
+            xxhash_rust::xxh3::xxh3_64(key.as_bytes())
+        } else {
+            match (info.tokens, info.request_text) {
+                (Some(tokens), _) if !tokens.is_empty() => self.compute_prefix_hash(tokens),
+                (_, Some(text)) if !text.is_empty() => self.compute_text_prefix_hash(text),
+                // Nothing to hash: stay serviceable by falling back to load.
+                _ => return (Self::least_loaded_healthy(workers), Branch::NoRoutingKey),
+            }
         };
 
         // Find worker using ring with load balancing
@@ -487,6 +492,69 @@ mod tests {
         let (result2, _) = policy.select_worker_impl(&workers, &tokens_and_text);
 
         assert_eq!(result1, result2);
+    }
+
+    #[test]
+    fn test_routing_key_hint_overrides_token_and_text_keying() {
+        let policy = PrefixHashPolicy::with_defaults();
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
+
+        let key_only = SelectWorkerInfo {
+            routing_key: Some("session-42"),
+            hash_ring: Some(ring.clone()),
+            ..Default::default()
+        };
+        let (key_only_result, branch) = policy.select_worker_impl(&workers, &key_only);
+        assert!(key_only_result.is_some(), "a key alone must be routable");
+        assert_eq!(branch, Branch::RingHit);
+
+        // Same key with entirely different tokens and text keeps the worker.
+        for tokens in [vec![1u32, 2, 3], vec![900u32, 901, 902, 903]] {
+            let info = SelectWorkerInfo {
+                routing_key: Some("session-42"),
+                tokens: Some(&tokens),
+                request_text: Some("unrelated prompt text"),
+                hash_ring: Some(ring.clone()),
+                ..Default::default()
+            };
+            let (result, _) = policy.select_worker_impl(&workers, &info);
+            assert_eq!(result, key_only_result, "the routing key must win");
+        }
+    }
+
+    #[test]
+    fn test_routing_key_hint_consistent_and_distributes() {
+        let policy = PrefixHashPolicy::with_defaults();
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
+
+        let info = SelectWorkerInfo {
+            routing_key: Some("sticky-session"),
+            hash_ring: Some(ring.clone()),
+            ..Default::default()
+        };
+        let (first, _) = policy.select_worker_impl(&workers, &info);
+        for _ in 0..10 {
+            let (result, _) = policy.select_worker_impl(&workers, &info);
+            assert_eq!(result, first);
+        }
+
+        let mut distribution = std::collections::HashMap::new();
+        for i in 0..100 {
+            let key = format!("session-{i}");
+            let info = SelectWorkerInfo {
+                routing_key: Some(&key),
+                hash_ring: Some(ring.clone()),
+                ..Default::default()
+            };
+            let (result, _) = policy.select_worker_impl(&workers, &info);
+            *distribution.entry(result.unwrap()).or_insert(0) += 1;
+        }
+        assert!(
+            distribution.len() > 1,
+            "distinct keys must not pile onto one worker, got {distribution:?}"
+        );
     }
 
     #[test]

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -21,7 +21,7 @@ use crate::{
     config::types::{PolicyConfig, RoutingKeyOverrideConfig},
     mesh::adapters::TreeSyncAdapter,
     policies::cache_aware::LoadReceiver,
-    routers::common::header_utils::extract_routing_key,
+    routers::common::header_utils::extract_routing_key_hint,
     worker::{KvEventMonitor, Worker},
 };
 
@@ -124,7 +124,7 @@ impl PolicyRegistry {
     ) -> Option<usize> {
         if let Some(sticky) = self.routing_key_sticky.as_ref() {
             if Self::routing_key_override_applies(policy.name())
-                && extract_routing_key(info.headers).is_some()
+                && extract_routing_key_hint(info.headers).is_some()
             {
                 return sticky.select_worker(workers, info);
             }

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -9,8 +9,50 @@ use http::header::HeaderName;
 
 static HEADER_TARGET_WORKER: HeaderName = HeaderName::from_static("x-smg-target-worker");
 static HEADER_ROUTING_KEY: HeaderName = HeaderName::from_static("x-smg-routing-key");
+static HEADER_ROUTING_TOKENS: HeaderName = HeaderName::from_static("x-smg-routing-tokens");
 static HEADER_MCP: HeaderName = HeaderName::from_static("x-smg-mcp");
 static HEADER_ROUTED_WORKER_ID: HeaderName = HeaderName::from_static("x-smg-routed-worker-id");
+
+/// `x-smg-routing-tokens` hard caps: token id count and header-value bytes.
+pub const ROUTING_TOKENS_HINT_MAX_IDS: usize = 512;
+pub const ROUTING_TOKENS_HINT_MAX_BYTES: usize = 4096;
+/// `x-smg-routing-key` hard cap: bytes of opaque UTF-8.
+pub const ROUTING_KEY_HINT_MAX_BYTES: usize = 128;
+
+/// Parse the `x-smg-routing-tokens` hint: comma-separated decimal u32 ids.
+/// Hints affect placement only, never authorization; malformed or over-cap
+/// values are ignored entirely (`None`, falling back to body-derived
+/// routing), never an error.
+pub fn parse_routing_tokens_hint(headers: Option<&HeaderMap>) -> Option<Vec<u32>> {
+    let value = headers?.get(&HEADER_ROUTING_TOKENS)?.as_bytes();
+    if value.is_empty() || value.len() > ROUTING_TOKENS_HINT_MAX_BYTES {
+        return None;
+    }
+    let text = std::str::from_utf8(value).ok()?;
+    // Every id but the last costs at least two bytes (digit + comma), so this
+    // capacity always suffices and the loop never reallocates.
+    let mut ids = Vec::with_capacity(ROUTING_TOKENS_HINT_MAX_IDS.min(value.len() / 2 + 1));
+    for part in text.split(',') {
+        if ids.len() == ROUTING_TOKENS_HINT_MAX_IDS {
+            return None;
+        }
+        if part.is_empty() || !part.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        ids.push(part.parse::<u32>().ok()?);
+    }
+    Some(ids)
+}
+
+/// Extract the `x-smg-routing-key` hint: opaque non-empty UTF-8. Over-cap or
+/// non-UTF-8 values are ignored (`None`), never an error.
+pub fn extract_routing_key_hint(headers: Option<&HeaderMap>) -> Option<&str> {
+    let value = headers?.get(&HEADER_ROUTING_KEY)?.as_bytes();
+    if value.is_empty() || value.len() > ROUTING_KEY_HINT_MAX_BYTES {
+        return None;
+    }
+    std::str::from_utf8(value).ok()
+}
 
 fn extract_header_value<'a>(headers: Option<&'a HeaderMap>, name: &HeaderName) -> Option<&'a str> {
     headers
@@ -520,5 +562,149 @@ mod tests {
         let auth = ApiProvider::Anthropic.extract_auth_header(Some(&headers), None);
 
         assert_eq!(auth.unwrap(), "anthropic-key");
+    }
+
+    fn tokens_hint_headers(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-smg-routing-tokens", value.parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn test_parse_routing_tokens_hint_valid() {
+        let headers = tokens_hint_headers("1,2,3");
+        assert_eq!(
+            parse_routing_tokens_hint(Some(&headers)),
+            Some(vec![1, 2, 3])
+        );
+
+        let headers = tokens_hint_headers("42");
+        assert_eq!(parse_routing_tokens_hint(Some(&headers)), Some(vec![42]));
+
+        let headers = tokens_hint_headers(&format!("0,{}", u32::MAX));
+        assert_eq!(
+            parse_routing_tokens_hint(Some(&headers)),
+            Some(vec![0, u32::MAX])
+        );
+    }
+
+    #[test]
+    fn test_parse_routing_tokens_hint_exactly_max_ids() {
+        let value = vec!["7"; ROUTING_TOKENS_HINT_MAX_IDS].join(",");
+        let headers = tokens_hint_headers(&value);
+        let parsed = parse_routing_tokens_hint(Some(&headers)).unwrap();
+        assert_eq!(parsed.len(), ROUTING_TOKENS_HINT_MAX_IDS);
+    }
+
+    #[test]
+    fn test_parse_routing_tokens_hint_rejects_over_id_cap() {
+        let value = vec!["7"; ROUTING_TOKENS_HINT_MAX_IDS + 1].join(",");
+        let headers = tokens_hint_headers(&value);
+        assert_eq!(parse_routing_tokens_hint(Some(&headers)), None);
+    }
+
+    #[test]
+    fn test_parse_routing_tokens_hint_rejects_over_byte_cap() {
+        // 512 ids of 9 digits each stay under the id cap but exceed 4096 bytes.
+        let value = vec!["123456789"; ROUTING_TOKENS_HINT_MAX_IDS].join(",");
+        assert!(value.len() > ROUTING_TOKENS_HINT_MAX_BYTES);
+        let headers = tokens_hint_headers(&value);
+        assert_eq!(parse_routing_tokens_hint(Some(&headers)), None);
+    }
+
+    #[test]
+    fn test_parse_routing_tokens_hint_rejects_malformed() {
+        for value in [
+            "",
+            ",",
+            "1,,3",
+            "1,2,",
+            ",1",
+            "a",
+            "1,x,3",
+            "-1",
+            "+1",
+            "1, 2",
+            " 1",
+            "1.5",
+            "0x10",
+            "4294967296", // u32::MAX + 1
+            "999999999999999999999",
+        ] {
+            let headers = tokens_hint_headers(value);
+            assert_eq!(
+                parse_routing_tokens_hint(Some(&headers)),
+                None,
+                "value {value:?} must be ignored"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_routing_tokens_hint_rejects_non_utf8() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-smg-routing-tokens",
+            HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
+        );
+        assert_eq!(parse_routing_tokens_hint(Some(&headers)), None);
+    }
+
+    #[test]
+    fn test_parse_routing_tokens_hint_missing() {
+        assert_eq!(parse_routing_tokens_hint(None), None);
+        let headers = HeaderMap::new();
+        assert_eq!(parse_routing_tokens_hint(Some(&headers)), None);
+    }
+
+    #[test]
+    fn test_extract_routing_key_hint_valid() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-smg-routing-key", "session-abc".parse().unwrap());
+        assert_eq!(
+            extract_routing_key_hint(Some(&headers)),
+            Some("session-abc")
+        );
+
+        let max_key = "k".repeat(ROUTING_KEY_HINT_MAX_BYTES);
+        let mut headers = HeaderMap::new();
+        headers.insert("x-smg-routing-key", max_key.parse().unwrap());
+        assert_eq!(
+            extract_routing_key_hint(Some(&headers)),
+            Some(max_key.as_str())
+        );
+    }
+
+    #[test]
+    fn test_extract_routing_key_hint_accepts_non_ascii_utf8() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-smg-routing-key",
+            HeaderValue::from_bytes("clé-café".as_bytes()).unwrap(),
+        );
+        assert_eq!(extract_routing_key_hint(Some(&headers)), Some("clé-café"));
+    }
+
+    #[test]
+    fn test_extract_routing_key_hint_rejects_over_cap_empty_and_non_utf8() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-smg-routing-key",
+            "k".repeat(ROUTING_KEY_HINT_MAX_BYTES + 1).parse().unwrap(),
+        );
+        assert_eq!(extract_routing_key_hint(Some(&headers)), None);
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-smg-routing-key", "".parse().unwrap());
+        assert_eq!(extract_routing_key_hint(Some(&headers)), None);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-smg-routing-key",
+            HeaderValue::from_bytes(&[0xc3, 0x28]).unwrap(),
+        );
+        assert_eq!(extract_routing_key_hint(Some(&headers)), None);
+
+        assert_eq!(extract_routing_key_hint(None), None);
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -264,6 +264,7 @@ impl WorkerSelectionStage {
                 request_text: text,
                 tokens,
                 headers,
+                routing_key: None,
                 hash_ring,
                 leg: WorkerLeg::Single,
             },
@@ -388,6 +389,7 @@ impl WorkerSelectionStage {
             request_text: text,
             tokens,
             headers,
+            routing_key: None,
             hash_ring,
             leg: WorkerLeg::Prefill,
         };
@@ -565,6 +567,7 @@ impl WorkerSelectionStage {
             request_text: text,
             tokens,
             headers,
+            routing_key: None,
             hash_ring: hash_ring.clone(),
             leg: WorkerLeg::Prefill,
         };
@@ -642,6 +645,7 @@ fn assign_encode_workers(
                 request_text: None,
                 tokens: None,
                 headers: Some(&routing_headers),
+                routing_key: None,
                 hash_ring: hash_ring.clone(),
                 leg: WorkerLeg::Single,
             };

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -949,6 +949,7 @@ impl PDRouter {
                     request_text,
                     tokens,
                     headers,
+                    routing_key: None,
                     hash_ring,
                     leg,
                 },

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -240,6 +240,7 @@ impl Router {
                 request_text: text,
                 tokens,
                 headers,
+                routing_key: header_utils::extract_routing_key_hint(headers),
                 hash_ring,
                 leg: crate::policies::WorkerLeg::Single,
             },
@@ -329,10 +330,14 @@ impl Router {
         let start = Instant::now();
         let is_stream = typed_req.is_stream();
         // Pre-tokenized requests route on the token tree; the decimal-string
-        // rendering is only materialized when there are no tokens.
-        let routing_tokens: Option<Vec<u32>> = typed_req
-            .routing_tokens()
-            .map(|ids| ids.iter().map(|&id| id as u32).collect());
+        // rendering is only materialized when there are no tokens. A valid
+        // x-smg-routing-tokens hint wins over body-derived tokens/text.
+        let routing_tokens: Option<Vec<u32>> = header_utils::parse_routing_tokens_hint(headers)
+            .or_else(|| {
+                typed_req
+                    .routing_tokens()
+                    .map(|ids| ids.iter().map(|&id| id as u32).collect())
+            });
         let text = routing_tokens
             .is_none()
             .then(|| typed_req.extract_text_for_routing());
@@ -639,7 +644,11 @@ impl Router {
     ) -> Response {
         let start = Instant::now();
         let is_stream = body.is_stream();
-        let text = body.extract_text_for_routing();
+        // A valid x-smg-routing-tokens hint wins over body-derived text.
+        let hinted_tokens = header_utils::parse_routing_tokens_hint(headers);
+        let text = hinted_tokens
+            .is_none()
+            .then(|| body.extract_text_for_routing());
         // Resolve once, here, for the same reason as `route_typed_request`:
         // only `get_by_model` understands aliases, so the policy and hash ring
         // lookups below would silently fall back to router defaults on an
@@ -736,9 +745,10 @@ impl Router {
             &policy,
             &available,
             &SelectWorkerInfo {
-                request_text: Some(&text),
-                tokens: None,
+                request_text: text.as_deref(),
+                tokens: hinted_tokens.as_deref(),
                 headers,
+                routing_key: header_utils::extract_routing_key_hint(headers),
                 hash_ring,
                 leg: crate::policies::WorkerLeg::Single,
             },

--- a/model_gateway/tests/routing/header_routing_hints_test.rs
+++ b/model_gateway/tests/routing/header_routing_hints_test.rs
@@ -1,0 +1,305 @@
+//! Header routing-hint integration tests.
+//!
+//! `x-smg-routing-tokens` and `x-smg-routing-key` let text-needing policies
+//! route without the body content: a valid token hint wins over body-derived
+//! tokens/text, a valid key hint wins over token/text keying, and anything
+//! malformed or over-cap is ignored so the request routes exactly as it
+//! would without the header.
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{header::CONTENT_TYPE, StatusCode},
+};
+use serde_json::json;
+use smg::{
+    policies::{CacheAwareConfig, CacheAwarePolicy, LoadBalancingPolicy, SelectWorkerInfo},
+    routers::common::header_utils::parse_routing_tokens_hint,
+    worker::{BasicWorkerBuilder, Worker, WorkerType},
+};
+use tower::ServiceExt;
+
+use crate::common::{
+    mock_worker::{set_request_recorder, RequestRecorder},
+    AppTestContext, TestRouterConfig, TestWorkerConfig,
+};
+
+#[cfg(test)]
+mod header_routing_hints_tests {
+    use super::*;
+
+    const WORKER_COUNT: u16 = 3;
+
+    /// Start `WORKER_COUNT` recorded workers behind a router with `config`.
+    async fn setup(
+        config: smg::config::RouterConfig,
+        worker_port: u16,
+    ) -> (AppTestContext, Vec<Arc<RequestRecorder>>, String) {
+        let recorders: Vec<Arc<RequestRecorder>> = (0..WORKER_COUNT)
+            .map(|i| {
+                let recorder = RequestRecorder::new();
+                set_request_recorder(worker_port + i, Arc::clone(&recorder));
+                recorder
+            })
+            .collect();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            TestWorkerConfig::healthy_workers(worker_port, WORKER_COUNT),
+        )
+        .await;
+
+        let model_id = ctx
+            .app_context
+            .worker_registry
+            .get_all()
+            .first()
+            .expect("workers are registered")
+            .model_id()
+            .to_string();
+
+        (ctx, recorders, model_id)
+    }
+
+    fn chat_request(model: &str, prompt: &str, hints: &[(&str, &str)]) -> Request<Body> {
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json");
+        for (name, value) in hints {
+            builder = builder.header(*name, *value);
+        }
+        builder
+            .body(Body::from(
+                json!({
+                    "model": model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "stream": false
+                })
+                .to_string(),
+            ))
+            .unwrap()
+    }
+
+    /// 32 comma-separated ids: two full token-tree pages (PAGE_SIZE = 16).
+    fn token_hint() -> String {
+        (100u32..132)
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    #[tokio::test]
+    async fn test_token_hint_pins_cache_aware_worker_across_bodies() {
+        let (ctx, recorders, model_id) = setup(TestRouterConfig::cache_aware(3170), 19450).await;
+        let app = ctx.create_app();
+        let hint = token_hint();
+
+        for i in 0..6 {
+            let response = app
+                .clone()
+                .oneshot(chat_request(
+                    &model_id,
+                    &format!("entirely different prompt {i}"),
+                    &[("x-smg-routing-tokens", &hint)],
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        let served: Vec<usize> = recorders.iter().map(|r| r.bodies().len()).collect();
+        assert_eq!(
+            served.iter().filter(|count| **count > 0).count(),
+            1,
+            "one hinted prefix must pin to a single worker, got {served:?}"
+        );
+        assert_eq!(served.iter().sum::<usize>(), 6);
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_no_hint_distinct_bodies_spread_cache_aware_workers() {
+        let (ctx, recorders, model_id) = setup(TestRouterConfig::cache_aware(3171), 19453).await;
+        let app = ctx.create_app();
+
+        // Prompts share no prefix, so the string tree never produces a cache hit.
+        for prompt in [
+            "alpha wolves hunt at dusk",
+            "borrow a cup of sugar",
+            "cedar boxes hold old maps",
+            "delta flights leave early",
+            "every engine hums a note",
+            "frozen lakes crack loudly",
+        ] {
+            let response = app
+                .clone()
+                .oneshot(chat_request(&model_id, prompt, &[]))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        let served: Vec<usize> = recorders.iter().map(|r| r.bodies().len()).collect();
+        assert!(
+            served.iter().filter(|count| **count > 0).count() > 1,
+            "without a hint, distinct prompts must not pile onto one worker, got {served:?}"
+        );
+        assert_eq!(served.iter().sum::<usize>(), 6);
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_malformed_hints_are_ignored_and_requests_route() {
+        let (ctx, recorders, model_id) = setup(TestRouterConfig::cache_aware(3172), 19456).await;
+        let app = ctx.create_app();
+
+        let over_cap_tokens = vec!["7"; 513].join(",");
+        let over_cap_key = "k".repeat(129);
+        let malformed: Vec<(&str, &str)> = vec![
+            ("x-smg-routing-tokens", "1,not-a-number,3"),
+            ("x-smg-routing-tokens", "-5,3"),
+            ("x-smg-routing-tokens", over_cap_tokens.as_str()),
+            ("x-smg-routing-key", over_cap_key.as_str()),
+        ];
+
+        for (name, value) in &malformed {
+            let response = app
+                .clone()
+                .oneshot(chat_request(
+                    &model_id,
+                    "same prompt every time",
+                    &[(name, value)],
+                ))
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "a bad hint must never fail the request ({name}: {value:.32})"
+            );
+        }
+
+        let served: usize = recorders.iter().map(|r| r.bodies().len()).sum();
+        assert_eq!(served, malformed.len(), "every request must reach a worker");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_routing_key_hint_pins_prefix_hash_worker_across_prompts() {
+        let (ctx, recorders, model_id) =
+            setup(TestRouterConfig::prefix_hash(3173, 16), 19459).await;
+        let app = ctx.create_app();
+
+        for i in 0..6 {
+            let response = app
+                .clone()
+                .oneshot(chat_request(
+                    &model_id,
+                    &format!("entirely different prompt {i}"),
+                    &[("x-smg-routing-key", "session-abc")],
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        let pinned: Vec<usize> = recorders.iter().map(|r| r.bodies().len()).collect();
+        assert_eq!(
+            pinned.iter().filter(|count| **count > 0).count(),
+            1,
+            "one routing key must pin to a single worker, got {pinned:?}"
+        );
+
+        // Distinct keys with the same prompt must spread.
+        for i in 0..12 {
+            let response = app
+                .clone()
+                .oneshot(chat_request(
+                    &model_id,
+                    "same prompt every time",
+                    &[("x-smg-routing-key", &format!("session-{i}"))],
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        let served: Vec<usize> = recorders.iter().map(|r| r.bodies().len()).collect();
+        let spread: Vec<usize> = served
+            .iter()
+            .zip(&pinned)
+            .map(|(total, before)| total - before)
+            .collect();
+        assert!(
+            spread.iter().filter(|count| **count > 0).count() > 1,
+            "distinct keys must not pile onto one worker, got {spread:?}"
+        );
+        assert_eq!(served.iter().sum::<usize>(), 18);
+
+        ctx.shutdown().await;
+    }
+
+    /// Policy-layer check: hinted tokens flow through cache_aware's token-tree
+    /// selection with no request text at all, exactly as the router builds
+    /// `SelectWorkerInfo` from a parsed `x-smg-routing-tokens` header.
+    #[test]
+    fn test_cache_aware_selects_same_worker_for_same_hinted_prefix() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        });
+
+        let workers: Vec<Arc<dyn Worker>> = ["http://w1:8000", "http://w2:8000", "http://w3:8000"]
+            .iter()
+            .map(|url| {
+                let worker = BasicWorkerBuilder::new(*url)
+                    .worker_type(WorkerType::Regular)
+                    .health_config(openai_protocol::worker::HealthCheckConfig {
+                        disable_health_check: true,
+                        ..Default::default()
+                    })
+                    .build();
+                policy.add_worker(&worker);
+                Arc::new(worker) as Arc<dyn Worker>
+            })
+            .collect();
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-smg-routing-tokens", token_hint().parse().unwrap());
+        let hinted = parse_routing_tokens_hint(Some(&headers)).expect("hint is valid");
+        let info = SelectWorkerInfo {
+            tokens: Some(&hinted),
+            request_text: None,
+            ..Default::default()
+        };
+
+        let first = policy
+            .select_worker(&workers, &info)
+            .expect("hinted request must route");
+        for _ in 0..5 {
+            assert_eq!(
+                policy.select_worker(&workers, &info),
+                Some(first),
+                "the same hinted prefix must keep its worker"
+            );
+        }
+
+        // A different hinted prefix is free to learn its own worker.
+        let other: Vec<u32> = (500u32..532).collect();
+        let other_info = SelectWorkerInfo {
+            tokens: Some(&other),
+            request_text: None,
+            ..Default::default()
+        };
+        let other_first = policy
+            .select_worker(&workers, &other_info)
+            .expect("hinted request must route");
+        assert_ne!(other_first, first, "an unseen prefix goes to min-load");
+    }
+}

--- a/model_gateway/tests/routing/mod.rs
+++ b/model_gateway/tests/routing/mod.rs
@@ -3,6 +3,7 @@
 pub mod cache_aware_backward_compat_test;
 pub mod grpc_completion_batch_test;
 pub mod header_forwarding_test;
+pub mod header_routing_hints_test;
 pub mod load_balancing_test;
 pub mod manual_routing_test;
 pub mod model_alias_test;


### PR DESCRIPTION
## Description

### Problem

Cache-affinity policies (`cache_aware`, `prefix_hash`) need the prompt text or token ids to route, which forces buffering and parsing the request body even when the body is dominated by bytes the policy never looks at. There is no way for a client (or a fronting proxy that already tokenizes) to hand the router just the routing-relevant signal.

Closes #2196.

### Solution

Accept two optional routing-hint headers on the HTTP dispatch path, parsed from headers alone — before and independent of body parsing. Presence of a valid header activates the hint; there is no new flag.

**Header contract**

| Header | Encoding | Hard caps | Semantics |
|---|---|---|---|
| `x-smg-routing-tokens` | comma-separated decimal token ids (u32), the prompt's leading tokens | at most 512 ids AND at most 4096 bytes of header value | When present and valid, it wins over body-derived tokens/text for worker selection. Flows through the existing token-based selection paths (`cache_aware` token tree, `prefix_hash` token hashing). |
| `x-smg-routing-key` | opaque non-empty UTF-8 key | at most 128 bytes | Exposed as `SelectWorkerInfo::routing_key`; `consistent_hashing` and `prefix_hash` prefer it over their current keying input (raw header / tokens / text). |

Malformed or over-cap values are ignored entirely — the request falls back to today's body-derived routing. A bad hint is never an error and never a panic.

**Tree insertion for hinted requests:** `cache_aware` inserts the hinted token prefix into the token tree. The tree page-aligns internally, so a block-aligned truncated prefix is tolerated and affinity learning stays alive for hinted traffic.

**Security:** hints affect placement only, never authorization; over-cap/malformed input degrades silently to today's behavior. `x-smg-routing-tokens` is not forwarded to workers.

## Changes

- `model_gateway/src/routers/common/header_utils.rs`: `parse_routing_tokens_hint` / `extract_routing_key_hint` with the caps above. Allocation-conscious: the token parse allocates once, bounded by the 512-id cap, and never reallocates.
- `model_gateway/src/policies/mod.rs`: new `SelectWorkerInfo::routing_key` field (validated hint).
- `model_gateway/src/routers/http/router.rs`: `route_typed_request` prefers a valid token hint over `routing_tokens()`/`extract_text_for_routing()`; both `SelectWorkerInfo` sites (typed requests, multipart transcription) populate `routing_key` and hinted tokens from headers.
- `model_gateway/src/policies/consistent_hashing.rs`: the validated `routing_key` wins; the raw header remains the fallback (unchanged behavior when no hint field is populated, e.g. the gRPC path).
- `model_gateway/src/policies/prefix_hash.rs`: a validated routing key overrides token/text keying (hashed onto the same ring).
- `model_gateway/src/policies/cache_aware.rs`: invariant comment at the token-tree insertion site (hinted prefixes insert as-is).
- `pd_router` / gRPC worker-selection construction sites pass `routing_key: None` (byte-identical behavior).

## Test Plan

No headers ⇒ byte-identical behavior: the full existing suite passes unmodified (`cargo test -p smg`).

New tests:

- `header_utils` parser (fuzz-ish): valid ids incl. `0`/`u32::MAX`, exactly-512 ids, 513 ids, >4096-byte value, non-numeric/negative/`+`/spaces/empty segments/overflow, non-UTF-8 value; key hint at 128/129 bytes, empty, non-ASCII UTF-8, non-UTF-8 bytes.
- `consistent_hashing`: `routing_key` field routes consistently and distributes across keys; validated hint wins over a conflicting raw `x-smg-routing-key` header.
- `prefix_hash`: routing key overrides token/text keying; same key stable across calls; distinct keys distribute.
- `tests/routing/header_routing_hints_test.rs` (HTTP surface, mock workers):
  - same 32-token hint with six entirely different bodies pins `cache_aware` to one worker;
  - no hint + distinct bodies spread (control);
  - malformed/over-cap hints on both headers still route with 200;
  - same `x-smg-routing-key` pins `prefix_hash` across different prompts; distinct keys spread;
  - policy-layer: `SelectWorkerInfo` built exactly as the router builds it (parsed hint, no text) keeps the same `cache_aware` worker for the same hinted prefix.

```
cargo build -p smg
cargo +nightly fmt --check
cargo clippy -p smg --all-targets -- -D warnings
cargo test -p smg
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
