### PR TITLE
fix(router): time streamed-body stalls on client waits, not worker backpressure

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -515,6 +515,7 @@ struct Router {
     upstream_pool_idle_timeout_secs: u64,
     least_load_max_waiting_requests: u32,
     stream_request_bodies_over: u64,
+    stream_body_stall_timeout_secs: u64,
 }
 
 impl Router {
@@ -865,6 +866,7 @@ impl Router {
             .upstream_http2(self.upstream_http2)
             .upstream_pool_idle_timeout_secs(self.upstream_pool_idle_timeout_secs)
             .stream_request_bodies_over(self.stream_request_bodies_over)
+            .stream_body_stall_timeout_secs(self.stream_body_stall_timeout_secs)
             .multimodal_tensor_transport(multimodal_tensor_transport)
             .multimodal_shm_min_bytes(self.multimodal_shm_min_bytes)
             .routing_key_override(config::RoutingKeyOverrideConfig {
@@ -1027,6 +1029,7 @@ impl Router {
         upstream_pool_idle_timeout_secs = 3,
         least_load_max_waiting_requests = 0,
         stream_request_bodies_over = 0,
+        stream_body_stall_timeout_secs = 300,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1166,6 +1169,7 @@ impl Router {
         upstream_pool_idle_timeout_secs: u64,
         least_load_max_waiting_requests: u32,
         stream_request_bodies_over: u64,
+        stream_body_stall_timeout_secs: u64,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1319,6 +1323,7 @@ impl Router {
             upstream_pool_idle_timeout_secs,
             least_load_max_waiting_requests,
             stream_request_bodies_over,
+            stream_body_stall_timeout_secs,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -215,6 +215,7 @@ class RouterArgs:
     upstream_pool_idle_timeout_secs: int = 3
     least_load_max_waiting_requests: int = 0
     stream_request_bodies_over: int = 0
+    stream_body_stall_timeout_secs: int = 300
 
     @staticmethod
     def add_cli_args(
@@ -598,6 +599,18 @@ class RouterArgs:
                 " no body mutation. Streamed bodies cannot be replayed, so"
                 " those requests bypass router-level retries; bodies without"
                 " a Content-Length header always buffer. 0 disables"
+            ),
+        )
+        routing_group.add_argument(
+            f"--{prefix}stream-body-stall-timeout-secs",
+            type=int,
+            default=RouterArgs.stream_body_stall_timeout_secs,
+            help=(
+                "Abort a streamed request body once the upstream sender has"
+                " waited on the client for this many seconds (408). The clock"
+                " pauses while the worker applies backpressure, so a slow"
+                " worker read never trips it. Applies only to bodies streamed"
+                " via --stream-request-bodies-over. 0 disables"
             ),
         )
         routing_group.add_argument(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1224,6 +1224,7 @@ class TestRouterArgsFieldOrder:
         "upstream_pool_idle_timeout_secs",
         "least_load_max_waiting_requests",
         "stream_request_bodies_over",
+        "stream_body_stall_timeout_secs",
     ]
 
     def test_complete_field_sequence_is_frozen(self):
@@ -1247,6 +1248,7 @@ class TestRouterArgsFieldOrder:
             "upstream_pool_idle_timeout_secs",
             "least_load_max_waiting_requests",
             "stream_request_bodies_over",
+            "stream_body_stall_timeout_secs",
         ):
             assert names.index(appended) > marker, (
                 f"{appended} must be appended after worker_startup_delay to "

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -210,6 +210,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn stream_body_stall_timeout_secs(mut self, secs: u64) -> Self {
+        self.config.stream_body_stall_timeout_secs = secs;
+        self
+    }
+
     pub fn upstream_pool_idle_timeout_secs(mut self, secs: u64) -> Self {
         self.config.upstream_pool_idle_timeout_secs = secs;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -57,6 +57,12 @@ pub struct RouterConfig {
     /// bodies without a Content-Length header always buffer. `0` disables.
     #[serde(default)]
     pub stream_request_bodies_over: u64,
+    /// Abort a streamed request body once the upstream sender has waited on
+    /// the client for this many seconds (408). The clock pauses while the
+    /// worker applies backpressure, so a slow worker read never trips it.
+    /// `0` disables the watchdog.
+    #[serde(default = "default_stream_body_stall_timeout_secs")]
+    pub stream_body_stall_timeout_secs: u64,
     pub request_timeout_secs: u64,
     /// Idle timeout for pooled upstream connections. Must stay below the
     /// backend HTTP server's keep-alive timeout (vLLM and SGLang default to
@@ -657,6 +663,10 @@ fn default_upstream_pool_idle_timeout_secs() -> u64 {
     3
 }
 
+fn default_stream_body_stall_timeout_secs() -> u64 {
+    300
+}
+
 fn default_prefix_hash_balance_abs_threshold() -> usize {
     10
 }
@@ -908,6 +918,7 @@ impl Default for RouterConfig {
             runtime_worker_threads: None,
             max_payload_size: 536_870_912, // 512MB
             stream_request_bodies_over: 0,
+            stream_body_stall_timeout_secs: default_stream_body_stall_timeout_secs(),
             request_timeout_secs: 1800, // 30 minutes
             upstream_pool_idle_timeout_secs: default_upstream_pool_idle_timeout_secs(),
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading
@@ -1172,6 +1183,27 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let with: RouterConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(with.stream_request_bodies_over, 4 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_stream_body_stall_timeout_serde_default_and_roundtrip() {
+        // Config files predating the field deserialize to the 300s default.
+        let mut json: serde_json::Value = serde_json::to_value(RouterConfig::default()).unwrap();
+        json.as_object_mut()
+            .unwrap()
+            .remove("stream_body_stall_timeout_secs")
+            .unwrap();
+        let without: RouterConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(without.stream_body_stall_timeout_secs, 300);
+
+        // The disabling zero round-trips instead of reverting to the default.
+        let config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .stream_body_stall_timeout_secs(0)
+            .build_unchecked();
+        let json = serde_json::to_string(&config).unwrap();
+        let with: RouterConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(with.stream_body_stall_timeout_secs, 0);
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -536,6 +536,14 @@ struct CliArgs {
     #[arg(long, default_value_t = 0, help_heading = "Request Handling")]
     stream_request_bodies_over: u64,
 
+    /// Abort a streamed request body once the upstream sender has waited on
+    /// the client for this many seconds (408, request_body_stalled). The
+    /// clock pauses while the worker applies backpressure, so a slow worker
+    /// read never trips it. Applies only to bodies streamed via
+    /// --stream-request-bodies-over. 0 disables
+    #[arg(long, default_value_t = 300, help_heading = "Request Handling")]
+    stream_body_stall_timeout_secs: u64,
+
     /// CORS allowed origins
     #[arg(long, num_args = 0.., help_heading = "Request Handling")]
     cors_allowed_origins: Vec<String>,
@@ -1568,6 +1576,7 @@ impl CliArgs {
             .runtime_worker_threads(self.runtime_worker_threads)
             .max_payload_size(self.max_payload_size)
             .stream_request_bodies_over(self.stream_request_bodies_over)
+            .stream_body_stall_timeout_secs(self.stream_body_stall_timeout_secs)
             .request_timeout_secs(self.request_timeout_secs)
             .upstream_pool_idle_timeout_secs(self.upstream_pool_idle_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
@@ -1937,6 +1946,18 @@ mod tests {
         let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
         assert_eq!(defaults.kv_indexer_ttl_secs, None);
         assert_eq!(defaults.kv_indexer_max_entries, None);
+    }
+
+    /// The streamed-body stall timeout is a router-only setting and must
+    /// flow into `RouterConfig`.
+    #[test]
+    fn stream_stall_timeout_flag_flows_into_router_config() {
+        let cli = cli_args_from(&["--stream-body-stall-timeout-secs", "120"]);
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(router_config.stream_body_stall_timeout_secs, 120);
+
+        let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(defaults.stream_body_stall_timeout_secs, 300);
     }
 
     /// `--health-check-port` must flow into BOTH conversion paths

--- a/model_gateway/src/routers/http/request_stream.rs
+++ b/model_gateway/src/routers/http/request_stream.rs
@@ -1,5 +1,5 @@
 //! Streamed request-body pass-through: byte accounting for the ingress
-//! payload cap and forwarding-progress tracking for the stall watchdog.
+//! payload cap and client-wait tracking for the stall watchdog.
 
 use std::{
     io,
@@ -14,17 +14,24 @@ use std::{
 
 use bytes::Bytes;
 use futures_util::Stream;
-use tokio::time::Instant;
+use tokio::{sync::Notify, time::Instant};
 
-/// Abort a streamed dispatch when no request-body bytes move for this long:
-/// a stalled uploader must not hold a worker slot indefinitely.
-pub(crate) const STREAM_PROGRESS_TIMEOUT: Duration = Duration::from_secs(60);
+/// Sentinel for `waiting_since_ms`: no client wait is in progress.
+const NOT_WAITING: u64 = u64::MAX;
 
-/// Shared view of a streamed request body: forwarding progress for the stall
+/// Shared view of a streamed request body: client-wait state for the stall
 /// watchdog, plus the terminal payload-limit flag the dispatcher maps to 413.
+///
+/// The stall clock runs only while the upstream sender is actively waiting on
+/// the client — an inbound poll returned `Pending`. While the worker applies
+/// backpressure the body is not polled, no wait is recorded, and the watchdog
+/// stays disarmed: a slow worker read must never be blamed on the client.
 pub(crate) struct StreamProgress {
     started: Instant,
-    last_progress_ms: AtomicU64,
+    /// Milliseconds after `started` at which the current client wait began,
+    /// or [`NOT_WAITING`].
+    waiting_since_ms: AtomicU64,
+    wait_started: Notify,
     body_complete: AtomicBool,
     limit_exceeded: AtomicBool,
     inbound_error: AtomicBool,
@@ -34,16 +41,30 @@ impl StreamProgress {
     pub(crate) fn new() -> Self {
         Self {
             started: Instant::now(),
-            last_progress_ms: AtomicU64::new(0),
+            waiting_since_ms: AtomicU64::new(NOT_WAITING),
+            wait_started: Notify::new(),
             body_complete: AtomicBool::new(false),
             limit_exceeded: AtomicBool::new(false),
             inbound_error: AtomicBool::new(false),
         }
     }
 
-    fn touch(&self) {
-        let elapsed = u64::try_from(self.started.elapsed().as_millis()).unwrap_or(u64::MAX);
-        self.last_progress_ms.store(elapsed, Ordering::Relaxed);
+    /// An inbound poll returned `Pending`: the sender wants bytes the client
+    /// has not produced. Starts the wait clock unless one is already running.
+    fn client_pending(&self) {
+        if self.waiting_since_ms.load(Ordering::Relaxed) != NOT_WAITING {
+            return;
+        }
+        let elapsed = u64::try_from(self.started.elapsed().as_millis())
+            .unwrap_or(NOT_WAITING - 1)
+            .min(NOT_WAITING - 1);
+        self.waiting_since_ms.store(elapsed, Ordering::Relaxed);
+        self.wait_started.notify_one();
+    }
+
+    /// The inbound stream yielded (bytes, error, or end): stop the wait clock.
+    fn client_progress(&self) {
+        self.waiting_since_ms.store(NOT_WAITING, Ordering::Relaxed);
     }
 
     pub(crate) fn limit_exceeded(&self) -> bool {
@@ -56,20 +77,37 @@ impl StreamProgress {
         self.inbound_error.load(Ordering::Relaxed)
     }
 
-    /// Resolves once no body bytes have moved for `idle`. Never resolves
-    /// after the body is fully forwarded: waiting on the worker's response is
-    /// not an upload stall.
-    pub(crate) async fn stalled(&self, idle: Duration) {
+    /// Resolves once a single client wait has lasted `idle`. Never resolves
+    /// while no wait is in progress (worker backpressure), after the body is
+    /// fully forwarded, or when `idle` is `None` (watchdog disabled).
+    pub(crate) async fn stalled(&self, idle: Option<Duration>) {
+        let Some(idle) = idle else {
+            return std::future::pending().await;
+        };
         loop {
             if self.body_complete.load(Ordering::Relaxed) {
                 std::future::pending::<()>().await;
             }
-            let seen = self.last_progress_ms.load(Ordering::Relaxed);
-            tokio::time::sleep_until(self.started + Duration::from_millis(seen) + idle).await;
+            let seen = self.waiting_since_ms.load(Ordering::Relaxed);
+            if seen == NOT_WAITING {
+                // notify_one stores a permit, so a wait that starts between
+                // the load above and this await is not missed.
+                self.wait_started.notified().await;
+                continue;
+            }
+            match Duration::from_millis(seen)
+                .checked_add(idle)
+                .and_then(|window| self.started.checked_add(window))
+            {
+                // An unrepresentable deadline can never pass: park like a
+                // disabled watchdog.
+                None => std::future::pending::<()>().await,
+                Some(deadline) => tokio::time::sleep_until(deadline).await,
+            }
             if self.body_complete.load(Ordering::Relaxed) {
                 continue;
             }
-            if self.last_progress_ms.load(Ordering::Relaxed) == seen {
+            if self.waiting_since_ms.load(Ordering::Relaxed) == seen {
                 return;
             }
         }
@@ -77,10 +115,10 @@ impl StreamProgress {
 }
 
 /// Counts request-body bytes against `limit` as they stream to the worker,
-/// reporting progress to [`StreamProgress`]. An over-limit body — caught by
-/// this counter or surfaced as an ingress `LengthLimitError` from the inner
-/// stream — flags the shared limit marker and terminates with an error, which
-/// aborts the upstream send.
+/// reporting client-wait transitions to [`StreamProgress`]. An over-limit
+/// body — caught by this counter or surfaced as an ingress `LengthLimitError`
+/// from the inner stream — flags the shared limit marker and terminates with
+/// an error, which aborts the upstream send.
 pub(crate) struct CappedBodyStream<S> {
     inner: S,
     progress: Arc<StreamProgress>,
@@ -115,6 +153,7 @@ where
         }
         match Pin::new(&mut this.inner).poll_next(cx) {
             Poll::Ready(Some(Ok(chunk))) => {
+                this.progress.client_progress();
                 this.forwarded = this.forwarded.saturating_add(chunk.len());
                 if this.forwarded > this.limit {
                     this.done = true;
@@ -123,11 +162,11 @@ where
                         "request body exceeded the payload limit",
                     ))));
                 }
-                this.progress.touch();
                 Poll::Ready(Some(Ok(chunk)))
             }
             Poll::Ready(Some(Err(e))) => {
                 this.done = true;
+                this.progress.client_progress();
                 if is_length_limit_error(&e) {
                     this.progress.limit_exceeded.store(true, Ordering::Relaxed);
                 } else {
@@ -137,10 +176,14 @@ where
             }
             Poll::Ready(None) => {
                 this.done = true;
+                this.progress.client_progress();
                 this.progress.body_complete.store(true, Ordering::Relaxed);
                 Poll::Ready(None)
             }
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                this.progress.client_pending();
+                Poll::Pending
+            }
         }
     }
 }
@@ -159,14 +202,53 @@ fn is_length_limit_error(err: &(dyn std::error::Error + 'static)) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
     use axum::body::Body;
-    use futures_util::{stream, StreamExt};
+    use futures_util::{stream, task::noop_waker_ref, StreamExt};
     use http_body_util::Limited;
+    use tokio::time::{advance, timeout};
 
     use super::*;
 
+    const IDLE: Option<Duration> = Some(Duration::from_secs(60));
+
     fn chunks(parts: &[&'static [u8]]) -> Vec<Result<Bytes, io::Error>> {
         parts.iter().map(|c| Ok(Bytes::from_static(c))).collect()
+    }
+
+    /// Inner stream that replays a fixed script of poll results, so tests
+    /// control exactly when the body is pending versus delivering.
+    struct Scripted {
+        steps: VecDeque<Poll<Option<Result<Bytes, io::Error>>>>,
+    }
+
+    fn scripted(
+        steps: impl IntoIterator<Item = Poll<Option<Result<Bytes, io::Error>>>>,
+    ) -> Scripted {
+        Scripted {
+            steps: steps.into_iter().collect(),
+        }
+    }
+
+    fn chunk_step(data: &'static [u8]) -> Poll<Option<Result<Bytes, io::Error>>> {
+        Poll::Ready(Some(Ok(Bytes::from_static(data))))
+    }
+
+    impl Stream for Scripted {
+        type Item = Result<Bytes, io::Error>;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            self.get_mut()
+                .steps
+                .pop_front()
+                .unwrap_or(Poll::Ready(None))
+        }
+    }
+
+    fn poll_once<S: Stream + Unpin>(s: &mut S) -> Poll<Option<S::Item>> {
+        let mut cx = Context::from_waker(noop_waker_ref());
+        Pin::new(s).poll_next(&mut cx)
     }
 
     #[tokio::test]
@@ -244,28 +326,121 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn stalled_fires_after_idle_window() {
+    async fn pending_poll_arms_watchdog() {
         let progress = Arc::new(StreamProgress::new());
-        tokio::time::timeout(
-            Duration::from_secs(120),
-            progress.stalled(Duration::from_secs(60)),
-        )
-        .await
-        .expect("watchdog must fire once the idle window passes");
+        let mut stream =
+            CappedBodyStream::new(scripted([Poll::Pending]), usize::MAX, Arc::clone(&progress));
+
+        assert!(poll_once(&mut stream).is_pending());
+
+        timeout(Duration::from_secs(120), progress.stalled(IDLE))
+            .await
+            .expect("a client wait past the idle window must fire the watchdog");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unpolled_body_never_stalls() {
+        let progress = Arc::new(StreamProgress::new());
+        let mut stream = CappedBodyStream::new(
+            scripted([chunk_step(b"abc")]),
+            usize::MAX,
+            Arc::clone(&progress),
+        );
+
+        // One delivery, then the sender stops polling (worker backpressure).
+        assert!(matches!(poll_once(&mut stream), Poll::Ready(Some(Ok(_)))));
+
+        timeout(Duration::from_secs(600), progress.stalled(IDLE))
+            .await
+            .expect_err("no outstanding client wait: backpressure must not stall");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn delivery_disarms_watchdog_after_pending() {
+        let progress = Arc::new(StreamProgress::new());
+        let mut stream = CappedBodyStream::new(
+            scripted([Poll::Pending, chunk_step(b"abc")]),
+            usize::MAX,
+            Arc::clone(&progress),
+        );
+
+        assert!(poll_once(&mut stream).is_pending());
+        advance(Duration::from_secs(30)).await;
+        assert!(matches!(poll_once(&mut stream), Poll::Ready(Some(Ok(_)))));
+
+        timeout(Duration::from_secs(600), progress.stalled(IDLE))
+            .await
+            .expect_err("a delivered chunk must stop the wait clock");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn re_pending_restarts_the_wait_window() {
+        let progress = Arc::new(StreamProgress::new());
+        let mut stream = CappedBodyStream::new(
+            scripted([Poll::Pending, chunk_step(b"abc"), Poll::Pending]),
+            usize::MAX,
+            Arc::clone(&progress),
+        );
+
+        assert!(poll_once(&mut stream).is_pending());
+        advance(Duration::from_secs(50)).await;
+        assert!(matches!(poll_once(&mut stream), Poll::Ready(Some(Ok(_)))));
+        assert!(poll_once(&mut stream).is_pending());
+
+        // The second wait began at t=50s: not stalled at t=109s, stalled by
+        // t=110s.
+        timeout(Duration::from_secs(59), progress.stalled(IDLE))
+            .await
+            .expect_err("the wait window must restart at the second pending");
+        timeout(Duration::from_secs(2), progress.stalled(IDLE))
+            .await
+            .expect("the restarted wait must fire once it lasts the window");
     }
 
     #[tokio::test(start_paused = true)]
     async fn stalled_never_fires_after_body_completes() {
         let progress = Arc::new(StreamProgress::new());
-        let stream =
-            CappedBodyStream::new(stream::iter(chunks(&[b"abc"])), 8, Arc::clone(&progress));
-        let _drained: Vec<_> = stream.collect().await;
+        let mut stream = CappedBodyStream::new(
+            scripted([Poll::Pending, chunk_step(b"abc"), Poll::Ready(None)]),
+            usize::MAX,
+            Arc::clone(&progress),
+        );
 
-        tokio::time::timeout(
+        assert!(poll_once(&mut stream).is_pending());
+        assert!(matches!(poll_once(&mut stream), Poll::Ready(Some(Ok(_)))));
+        assert!(matches!(poll_once(&mut stream), Poll::Ready(None)));
+
+        timeout(Duration::from_secs(600), progress.stalled(IDLE))
+            .await
+            .expect_err("a fully forwarded body must disarm the watchdog");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unrepresentable_deadline_parks_instead_of_panicking() {
+        let progress = Arc::new(StreamProgress::new());
+        let mut stream =
+            CappedBodyStream::new(scripted([Poll::Pending]), usize::MAX, Arc::clone(&progress));
+
+        assert!(poll_once(&mut stream).is_pending());
+
+        timeout(
             Duration::from_secs(600),
-            progress.stalled(Duration::from_secs(60)),
+            progress.stalled(Some(Duration::from_secs(u64::MAX))),
         )
         .await
-        .expect_err("a fully forwarded body must disarm the watchdog");
+        .expect_err("an unrepresentable deadline must park, not panic or fire");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_none_disables_watchdog() {
+        let progress = Arc::new(StreamProgress::new());
+        let mut stream =
+            CappedBodyStream::new(scripted([Poll::Pending]), usize::MAX, Arc::clone(&progress));
+
+        assert!(poll_once(&mut stream).is_pending());
+
+        timeout(Duration::from_secs(600), progress.stalled(None))
+            .await
+            .expect_err("a disabled watchdog must never fire");
     }
 }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -1,4 +1,8 @@
-use std::{error::Error as _, sync::Arc, time::Instant};
+use std::{
+    error::Error as _,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use axum::{
     body::{to_bytes, Body},
@@ -62,7 +66,7 @@ use crate::{
         grpc::utils::{error_type_from_status, route_to_endpoint},
         http::{
             request_body::{serialize_request_body, RequestBodyError},
-            request_stream::{CappedBodyStream, StreamProgress, STREAM_PROGRESS_TIMEOUT},
+            request_stream::{CappedBodyStream, StreamProgress},
         },
         router_manager::RouterManager,
         RouterTrait,
@@ -88,6 +92,9 @@ pub struct Router {
     retry_config: RetryConfig,
     /// Cap on buffered worker response bodies, mirroring the ingress limit.
     max_payload_size: usize,
+    /// Streamed-body stall watchdog: abort a dispatch once a single client
+    /// wait lasts this long. `None` disables.
+    stream_stall_timeout: Option<Duration>,
     realtime_registry: Arc<RealtimeRegistry>,
     webrtc_bind_addr: Option<std::net::IpAddr>,
     webrtc_stun_server: Option<String>,
@@ -152,6 +159,10 @@ impl Router {
             client: ctx.client.clone(),
             retry_config: ctx.router_config.effective_retry_config(),
             max_payload_size: ctx.router_config.max_payload_size,
+            stream_stall_timeout: match ctx.router_config.stream_body_stall_timeout_secs {
+                0 => None,
+                secs => Some(Duration::from_secs(secs)),
+            },
             realtime_registry: ctx.realtime_registry.clone(),
             webrtc_bind_addr: ctx.webrtc_bind_addr,
             webrtc_stun_server: ctx.webrtc_stun_server.clone(),
@@ -1223,10 +1234,11 @@ impl Router {
     ///
     /// The body is never buffered: a counting wrapper caps it at the ingress
     /// payload limit (over-limit → 413, upstream send aborted) and a watchdog
-    /// aborts the dispatch when no bytes move for [`STREAM_PROGRESS_TIMEOUT`]
-    /// (→ 408). The response relay is the buffered path's, with SSE detected
-    /// from the worker's Content-Type because the request's `stream` flag is
-    /// unread.
+    /// aborts the dispatch once the sender waits on the client for
+    /// `stream_stall_timeout` (→ 408; the clock pauses under worker
+    /// backpressure). The response relay is the buffered path's, with SSE
+    /// detected from the worker's Content-Type because the request's `stream`
+    /// flag is unread.
     async fn send_streamed_request(
         &self,
         headers: &HeaderMap,
@@ -1260,17 +1272,17 @@ impl Router {
         tokio::pin!(send);
         let sent = tokio::select! {
             sent = &mut send => sent,
-            () = progress.stalled(STREAM_PROGRESS_TIMEOUT) => {
+            () = progress.stalled(self.stream_stall_timeout) => {
+                let timeout_secs = self.stream_stall_timeout.map_or(0, |d| d.as_secs());
                 warn!(
-                    timeout_secs = STREAM_PROGRESS_TIMEOUT.as_secs(),
-                    "Streamed request body made no progress; aborting dispatch"
+                    timeout_secs,
+                    "Streamed request body stalled waiting on the client; aborting dispatch"
                 );
                 return error::create_error(
                     StatusCode::REQUEST_TIMEOUT,
                     STREAMED_BODY_STALLED,
                     format!(
-                        "No request body bytes were forwarded for {} seconds",
-                        STREAM_PROGRESS_TIMEOUT.as_secs()
+                        "No request body bytes arrived from the client for {timeout_secs} seconds"
                     ),
                 );
             }
@@ -2095,6 +2107,7 @@ mod tests {
             client: Client::new(),
             retry_config: RetryConfig::default(),
             max_payload_size: 536_870_912,
+            stream_stall_timeout: Some(Duration::from_secs(60)),
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,
@@ -2291,6 +2304,7 @@ mod tests {
             client: Client::new(),
             retry_config: RetryConfig::default(),
             max_payload_size,
+            stream_stall_timeout: Some(Duration::from_secs(60)),
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,


### PR DESCRIPTION
## Description
### Problem
The streamed-body stall watchdog (60s, hardcoded) timed any window in which no body bytes moved. A prefill-saturated worker draining a streamed body slowly applies backpressure, the sender stops polling the body, no bytes move — and the watchdog blamed the client, aborting the dispatch with 408 `request_body_stalled`. On the first streaming routers in a production video lane this killed ~62% of /generate requests (3,401×408 vs 2,107×200 in 35 min) and forced a rollout revert.
### Solution
The stall clock runs only while the upstream sender is actively waiting on the client — an inbound poll returned `Pending` — and pauses whenever the worker applies backpressure (no outstanding poll). It fires only when a single continuous client wait exceeds the window. The window is configurable via `--stream-body-stall-timeout-secs` (default 300; 0 disables; unrepresentable deadlines park instead of panicking). This unblocks re-rolling `--stream-request-bodies-over`.

Semantic note: 408 now means "one continuous client wait exceeded N", not "no bytes moved for N"; with the clock pausing under backpressure, a slow-trickling client holds a worker slot longer — bounded by `request_timeout_secs`.

## Changes
- `request_stream.rs`: client-wait state machine (`waiting_since_ms` + `Notify`) replaces the moved-bytes clock; `stalled()` takes `Option<Duration>`; overflow-safe deadline via `checked_add` with park-forever fallback
- `router.rs`: config-driven timeout on `Router`; 408 message/log now name the client wait
- Config: `stream_body_stall_timeout_secs` (types/builder/CLI, serde default 300) + flow test
- Python bindings: field appended at the positional tail (lib.rs, `router_args.py`, frozen-sequence tests)

## Test Plan
- Unit: scripted poll-sequence tests prove clock-start on `Pending` only, no fire without polls (backpressure — the prod-defect regression), disarm on delivery/EOF, epoch restart, disable via 0, overflow-park — each fails under the old semantics; all deterministic under paused time
- Router: 408/400/413 circuit-breaker-exclusion tests green; `--test routing_tests` stream-body e2e suite 16/16
- `cargo +nightly fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test -p smg` (26 binaries, 2258 passed, 0 failed), `cargo build -p smg-python`

<details><summary>Checklist</summary>

- [x] Format + clippy clean
- [x] Tests added and passing
- [x] Bindings updated (Python); Go unaffected
- [x] DCO sign-off, conventional commit
</details>