### PR TITLE
feat(router): stream hinted large bodies under text-routing policies

### DIFF
--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -52,9 +52,11 @@ pub struct RouterConfig {
     pub max_payload_size: usize,
     /// Forward request bodies larger than this many bytes to the worker as a
     /// raw stream instead of buffering, when the route's policy needs no
-    /// request text and the worker applies no body mutation. Streamed bodies
-    /// cannot be replayed, so those requests bypass router-level retries;
-    /// bodies without a Content-Length header always buffer. `0` disables.
+    /// request text — or the request carries a valid routing hint header
+    /// that stands in for it — and the worker applies no body mutation.
+    /// Streamed bodies cannot be replayed, so those requests bypass
+    /// router-level retries; bodies without a Content-Length header always
+    /// buffer. `0` disables.
     #[serde(default)]
     pub stream_request_bodies_over: u64,
     /// Abort a streamed request body once the upstream sender has waited on

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -526,13 +526,15 @@ struct CliArgs {
 
     /// Forward request bodies larger than this many bytes to the worker as a
     /// raw stream instead of buffering, when the route's policy needs no
-    /// request text and the worker applies no body mutation. Streamed bodies
-    /// are forwarded verbatim, so JSON validation and normalization defer to
-    /// the worker, and they cannot be replayed, so those requests bypass
-    /// router-level retries; bodies without a Content-Length header always
-    /// buffer. WASM OnRequest modules inspect buffered bodies, so deployments
-    /// running them keep buffering (and their own body-size cap) ahead of
-    /// this. Must be below max-payload-size. 0 disables
+    /// request text — or the request carries a valid x-smg-routing-tokens
+    /// hint, or a valid x-smg-routing-key under --routing-key-override — and
+    /// the worker applies no body mutation. Streamed bodies are forwarded
+    /// verbatim, so JSON validation and normalization defer to the worker,
+    /// and they cannot be replayed, so those requests bypass router-level
+    /// retries; bodies without a Content-Length header always buffer. WASM
+    /// OnRequest modules inspect buffered bodies, so deployments running
+    /// them keep buffering (and their own body-size cap) ahead of this.
+    /// Must be below max-payload-size. 0 disables
     #[arg(long, default_value_t = 0, help_heading = "Request Handling")]
     stream_request_bodies_over: u64,
 

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -21,7 +21,7 @@ use crate::{
     config::types::{PolicyConfig, RoutingKeyOverrideConfig},
     mesh::adapters::TreeSyncAdapter,
     policies::cache_aware::LoadReceiver,
-    routers::common::header_utils::extract_routing_key_hint,
+    routers::common::header_utils::{extract_routing_key_hint, parse_routing_tokens_hint},
     worker::{KvEventMonitor, Worker},
 };
 
@@ -510,23 +510,38 @@ impl PolicyRegistry {
             .unwrap_or_else(|| PolicyFactory::create_from_config(&PolicyConfig::ConsistentHashing))
     }
 
+    /// Whether any registered policy (default or per-model) routes on
+    /// request text this request cannot supply. Content-blind dispatch must
+    /// stay buffered when one does: the model inside the unread body could
+    /// select that policy. A routing hint lifts the requirement — with a
+    /// valid `x-smg-routing-tokens` the buffered path never extracts text
+    /// either (the hint wins over body-derived routing), and a valid
+    /// `x-smg-routing-key` under the sticky override supersedes the policy
+    /// before it reads text. Hints are validated by the same extractors
+    /// selection uses, so malformed or over-cap values lift nothing.
+    pub fn any_policy_needs_request_text(&self, headers: Option<&http::HeaderMap>) -> bool {
+        if parse_routing_tokens_hint(headers).is_some() {
+            return false;
+        }
+        let keyed_override =
+            self.routing_key_sticky.is_some() && extract_routing_key_hint(headers).is_some();
+        let needs_text = |policy: &Arc<dyn LoadBalancingPolicy>| {
+            policy.needs_request_text()
+                && !(keyed_override && Self::routing_key_override_applies(policy.name()))
+        };
+        needs_text(&self.default_policy)
+            || self
+                .model_policies
+                .iter()
+                .any(|entry| needs_text(entry.value()))
+    }
+
     /// Get all load-aware policies that need periodic load updates (lock-free).
     ///
     /// Membership is policy-reported via
     /// [`LoadBalancingPolicy::needs_backend_loads`]: `power_of_two` and
     /// `least_load` always consume load reports; `cache_aware` does when its
     /// pressure knobs are configured.
-    /// Whether any registered policy (default or per-model) routes on
-    /// request text. Content-blind dispatch must stay buffered when one
-    /// does: the model inside the unread body could select that policy.
-    pub fn any_policy_needs_request_text(&self) -> bool {
-        self.default_policy.needs_request_text()
-            || self
-                .model_policies
-                .iter()
-                .any(|entry| entry.value().needs_request_text())
-    }
-
     pub fn get_all_load_aware_policies(&self) -> Vec<Arc<dyn LoadBalancingPolicy>> {
         let mut policies = Vec::new();
 
@@ -812,6 +827,74 @@ mod tests {
         let a = reg.select_worker(&policy, &workers, &info).unwrap();
         let b = reg.select_worker(&policy, &workers, &info).unwrap();
         assert_ne!(a, b);
+    }
+
+    fn cache_aware_config() -> PolicyConfig {
+        PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 32,
+            balance_rel_threshold: 1.1,
+            eviction_interval_secs: 0,
+            max_tree_size: 4096,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+            overlap_decay: 0.0,
+            selection_temperature: 0.0,
+        }
+    }
+
+    fn headers_with_tokens(value: &str) -> http::HeaderMap {
+        let mut h = http::HeaderMap::new();
+        h.insert("x-smg-routing-tokens", value.parse().unwrap());
+        h
+    }
+
+    fn enabled_override() -> RoutingKeyOverrideConfig {
+        RoutingKeyOverrideConfig {
+            enabled: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn request_text_scan_is_false_for_text_free_policies() {
+        let reg = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        assert!(!reg.any_policy_needs_request_text(None));
+        assert!(!reg.any_policy_needs_request_text(Some(&headers_with_key("k"))));
+    }
+
+    #[test]
+    fn tokens_hint_lifts_text_requirement_only_when_valid() {
+        let reg = PolicyRegistry::new(cache_aware_config());
+        assert!(reg.any_policy_needs_request_text(None));
+        assert!(!reg.any_policy_needs_request_text(Some(&headers_with_tokens("1,2,3"))));
+        // Malformed and over-cap hints are ignored, exactly like selection.
+        assert!(reg.any_policy_needs_request_text(Some(&headers_with_tokens("1,,3"))));
+        let over_cap = vec!["7"; 513].join(",");
+        assert!(reg.any_policy_needs_request_text(Some(&headers_with_tokens(&over_cap))));
+    }
+
+    #[test]
+    fn key_hint_lifts_text_requirement_only_under_enabled_override() {
+        let without = PolicyRegistry::new(cache_aware_config());
+        assert!(without.any_policy_needs_request_text(Some(&headers_with_key("session-A"))));
+
+        let with = PolicyRegistry::with_override(cache_aware_config(), enabled_override());
+        assert!(with.any_policy_needs_request_text(None));
+        assert!(!with.any_policy_needs_request_text(Some(&headers_with_key("session-A"))));
+        let over_cap = "k".repeat(129);
+        assert!(with.any_policy_needs_request_text(Some(&headers_with_key(&over_cap))));
+    }
+
+    #[test]
+    fn per_model_text_policy_scanned_with_the_same_hint_rules() {
+        let reg = PolicyRegistry::with_override(PolicyConfig::RoundRobin, enabled_override());
+        assert!(!reg.any_policy_needs_request_text(None));
+        reg.on_worker_added("llama-3", Some("cache_aware"));
+        assert!(reg.any_policy_needs_request_text(None));
+        assert!(!reg.any_policy_needs_request_text(Some(&headers_with_tokens("1,2,3"))));
+        assert!(!reg.any_policy_needs_request_text(Some(&headers_with_key("session-A"))));
     }
 
     #[test]

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -1546,10 +1546,14 @@ impl Router {
     ) -> Result<Response, Request<Body>> {
         // Content-blind eligibility: the model and stream flag sit inside the
         // unread body, so any registered policy that routes on request text
-        // (the body's model could select it) forces the buffered path, and
-        // every fallback hands the request back with its body unconsumed.
+        // (the body's model could select it) forces the buffered path unless
+        // a valid routing hint header stands in for the text. Every fallback
+        // hands the request back with its body unconsumed.
         let model_id = crate::worker::UNKNOWN_MODEL_ID;
-        if self.policy_registry.any_policy_needs_request_text() {
+        if self
+            .policy_registry
+            .any_policy_needs_request_text(Some(req.headers()))
+        {
             return Err(req);
         }
         // A body-mutating worker (`prepare_request`) anywhere in the fleet
@@ -1564,8 +1568,15 @@ impl Router {
         if candidates.iter().any(|w| w.mutates_request()) {
             return Err(req);
         }
-        let Some(worker) = self.select_worker_for_model(model_id, None, None, Some(req.headers()))
-        else {
+        // Buffered-path parity: a valid tokens hint is exactly what selection
+        // would have received there (text is never extracted alongside it).
+        let hinted_tokens = header_utils::parse_routing_tokens_hint(Some(req.headers()));
+        let Some(worker) = self.select_worker_for_model(
+            model_id,
+            None,
+            hinted_tokens.as_deref(),
+            Some(req.headers()),
+        ) else {
             return Err(req);
         };
         // Guards a registration race: a mutating worker that joined after the
@@ -2004,7 +2015,11 @@ mod tests {
     use openai_protocol::worker::HealthCheckConfig;
 
     use super::*;
-    use crate::{config::types::PolicyConfig, worker::BasicWorkerBuilder};
+    use crate::{
+        config::types::{PolicyConfig, RoutingKeyOverrideConfig},
+        policies::CacheAwarePolicy,
+        worker::BasicWorkerBuilder,
+    };
 
     /// Accepts `kill_first` connections and closes them before any response
     /// bytes, then serves a minimal 200 on every later connection. Returns
@@ -2293,8 +2308,37 @@ mod tests {
         max_payload_size: usize,
         workers: Vec<crate::worker::BasicWorker>,
     ) -> Router {
+        streaming_router_with_registry(
+            Arc::new(PolicyRegistry::new(policy)),
+            max_payload_size,
+            workers,
+        )
+    }
+
+    fn streaming_router_with_key_override(
+        policy: PolicyConfig,
+        max_payload_size: usize,
+        workers: Vec<crate::worker::BasicWorker>,
+    ) -> Router {
+        streaming_router_with_registry(
+            Arc::new(PolicyRegistry::with_override(
+                policy,
+                RoutingKeyOverrideConfig {
+                    enabled: true,
+                    ..Default::default()
+                },
+            )),
+            max_payload_size,
+            workers,
+        )
+    }
+
+    fn streaming_router_with_registry(
+        policy_registry: Arc<PolicyRegistry>,
+        max_payload_size: usize,
+        workers: Vec<crate::worker::BasicWorker>,
+    ) -> Router {
         let worker_registry = Arc::new(WorkerRegistry::new());
-        let policy_registry = Arc::new(PolicyRegistry::new(policy));
         for worker in workers {
             worker_registry.register_or_replace(Arc::new(worker));
         }
@@ -2578,6 +2622,150 @@ mod tests {
             vec![plain_worker("http://worker1:8080")],
         );
         assert_falls_back_with_body_intact(&router).await;
+    }
+
+    fn with_header(mut req: Request<Body>, name: &'static str, value: &str) -> Request<Body> {
+        req.headers_mut().insert(name, value.parse().unwrap());
+        req
+    }
+
+    async fn routed_worker_id(router: &Router, req: Request<Body>) -> String {
+        let response = router
+            .route_streaming_request(req, "/generate")
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        response
+            .headers()
+            .get("x-smg-routed-worker-id")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn tokens_hint_streams_under_cache_aware_with_tree_affinity() {
+        let (url_a, _cap_a) = spawn_capture_stub("application/json", "{}").await;
+        let (url_b, _cap_b) = spawn_capture_stub("application/json", "{}").await;
+        let router = streaming_router(
+            cache_aware_policy(),
+            1024 * 1024,
+            vec![plain_worker(&url_a), plain_worker(&url_b)],
+        );
+        let workers = router.worker_registry.get_all();
+        router
+            .policy_registry
+            .get_default_policy()
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .unwrap()
+            .init_workers(&workers);
+
+        // The token tree pages by 16, so shorter hints train no affinity.
+        let hint: String = (1..=32u32)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        let first = routed_worker_id(
+            &router,
+            with_header(
+                streamed_request(&[b"{\"text\":\"hello\"}"]),
+                "x-smg-routing-tokens",
+                &hint,
+            ),
+        )
+        .await;
+        let second = routed_worker_id(
+            &router,
+            with_header(
+                streamed_request(&[b"{\"text\":\"other\"}"]),
+                "x-smg-routing-tokens",
+                &hint,
+            ),
+        )
+        .await;
+        assert_eq!(first, second, "same hint must stick to the tree tenant");
+    }
+
+    #[tokio::test]
+    async fn invalid_tokens_hint_keeps_text_needing_policy_buffered() {
+        let router = streaming_router(
+            cache_aware_policy(),
+            1024 * 1024,
+            vec![plain_worker("http://worker1:8080")],
+        );
+        let over_cap = vec!["7"; 513].join(",");
+        for hint in ["1,,3", over_cap.as_str()] {
+            let req = with_header(
+                streamed_request(&[b"{\"text\":\"hello\"}"]),
+                "x-smg-routing-tokens",
+                hint,
+            );
+            let req = router
+                .route_streaming_request(req, "/generate")
+                .await
+                .unwrap_err();
+            let body = to_bytes(req.into_body(), usize::MAX).await.unwrap();
+            assert_eq!(body.as_ref(), b"{\"text\":\"hello\"}");
+        }
+    }
+
+    #[tokio::test]
+    async fn key_hint_streams_under_cache_aware_only_with_override() {
+        // Without the sticky override nothing consumes the key content-blind.
+        let router = streaming_router(
+            cache_aware_policy(),
+            1024 * 1024,
+            vec![plain_worker("http://worker1:8080")],
+        );
+        let req = with_header(
+            streamed_request(&[b"{\"text\":\"hello\"}"]),
+            "x-smg-routing-key",
+            "media-1",
+        );
+        assert!(router
+            .route_streaming_request(req, "/generate")
+            .await
+            .is_err());
+
+        let (url_a, _cap_a) = spawn_capture_stub("application/json", "{}").await;
+        let (url_b, _cap_b) = spawn_capture_stub("application/json", "{}").await;
+        let router = streaming_router_with_key_override(
+            cache_aware_policy(),
+            1024 * 1024,
+            vec![plain_worker(&url_a), plain_worker(&url_b)],
+        );
+        let first = routed_worker_id(
+            &router,
+            with_header(
+                streamed_request(&[b"{\"text\":\"hello\"}"]),
+                "x-smg-routing-key",
+                "media-1",
+            ),
+        )
+        .await;
+        let second = routed_worker_id(
+            &router,
+            with_header(
+                streamed_request(&[b"{\"text\":\"other\"}"]),
+                "x-smg-routing-key",
+                "media-1",
+            ),
+        )
+        .await;
+        assert_eq!(first, second, "keyed requests must stick to one worker");
+
+        // Over-cap keys are ignored by the same extractor selection uses.
+        let req = with_header(
+            streamed_request(&[b"{\"text\":\"hello\"}"]),
+            "x-smg-routing-key",
+            &"k".repeat(129),
+        );
+        assert!(router
+            .route_streaming_request(req, "/generate")
+            .await
+            .is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description
### Problem
`--stream-request-bodies-over` declines whenever any registered policy routes on request text, so `cache_aware` fleets buffer every multi-MB body even when the request carries a routing hint that makes the body unnecessary for placement.
### Solution
Make streaming eligibility per-request. A valid `x-smg-routing-tokens` hint streams: the buffered path never extracts text alongside a hint, and the streamed path now feeds the same hint tokens to selection, so `cache_aware` keeps full token-tree affinity. A valid `x-smg-routing-key` streams when `--routing-key-override` is enabled, since the sticky override supersedes the policy before it would read text. Malformed or over-cap hints are ignored by the same validated extractors selection uses and keep buffering.

## Changes
- `PolicyRegistry::any_policy_needs_request_text` takes the request headers and treats hint-satisfied policies as text-free (same default + per-model scan)
- `route_streaming_request` passes parsed hint tokens into worker selection
- CLI/config doc updates for the flag

## Test Plan
- New registry unit tests: hint validity/override matrix incl. malformed, over-cap, and per-model policies
- New router tests: tokens-hint streaming with tree affinity (>=16-token page), invalid-hint fallback with body intact, key-hint streaming only under override with sticky repeat placement
- `cargo +nightly fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test -p smg`: all binaries, 0 failures

<details><summary>Checklist</summary>

- [x] Format + clippy clean
- [x] Tests added and passing
- [x] No bindings changes needed (doc-only config text)
- [x] DCO sign-off, conventional commit
</details>