### PR TITLE
feat(router): truncate routing tokens at configured media boundaries

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -516,6 +516,7 @@ struct Router {
     least_load_max_waiting_requests: u32,
     stream_request_bodies_over: u64,
     stream_body_stall_timeout_secs: u64,
+    routing_token_boundaries: Vec<u32>,
     routing_key_headers: Vec<String>,
 }
 
@@ -876,6 +877,7 @@ impl Router {
             .upstream_pool_idle_timeout_secs(self.upstream_pool_idle_timeout_secs)
             .stream_request_bodies_over(self.stream_request_bodies_over)
             .stream_body_stall_timeout_secs(self.stream_body_stall_timeout_secs)
+            .routing_token_boundaries(self.routing_token_boundaries.clone())
             .multimodal_tensor_transport(multimodal_tensor_transport)
             .multimodal_shm_min_bytes(self.multimodal_shm_min_bytes)
             .routing_key_override(config::RoutingKeyOverrideConfig {
@@ -1041,6 +1043,7 @@ impl Router {
         least_load_max_waiting_requests = 0,
         stream_request_bodies_over = 0,
         stream_body_stall_timeout_secs = 300,
+        routing_token_boundaries = vec![],
         routing_key_headers = vec![String::from("x-smg-routing-key")],
     ))]
     #[expect(clippy::too_many_arguments)]
@@ -1182,6 +1185,7 @@ impl Router {
         least_load_max_waiting_requests: u32,
         stream_request_bodies_over: u64,
         stream_body_stall_timeout_secs: u64,
+        routing_token_boundaries: Vec<u32>,
         routing_key_headers: Vec<String>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
@@ -1337,6 +1341,7 @@ impl Router {
             least_load_max_waiting_requests,
             stream_request_bodies_over,
             stream_body_stall_timeout_secs,
+            routing_token_boundaries,
             routing_key_headers,
         })
     }

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -217,6 +217,7 @@ class RouterArgs:
     least_load_max_waiting_requests: int = 0
     stream_request_bodies_over: int = 0
     stream_body_stall_timeout_secs: int = 300
+    routing_token_boundaries: list[int] = dataclasses.field(default_factory=list)
     # Ordered header names checked for the routing key; first valid wins
     routing_key_headers: list[str] = dataclasses.field(
         default_factory=lambda: ["x-smg-routing-key"]
@@ -628,6 +629,21 @@ class RouterArgs:
                 " pauses while the worker applies backpressure, so a slow"
                 " worker read never trips it. Applies only to bodies streamed"
                 " via --stream-request-bodies-over. 0 disables"
+            ),
+        )
+        routing_group.add_argument(
+            f"--{prefix}routing-token-boundaries",
+            type=int,
+            nargs="*",
+            action="extend",
+            # None (not []) so an unset prefixed variant falls back to the
+            # unprefixed backend value in from_cli_args.
+            default=None,
+            help=(
+                "Token ids that end the routing-relevant prefix. Routing"
+                " tokens are truncated at the first occurrence of any listed"
+                " id before worker selection (e.g. multimodal placeholder"
+                " ids). Empty disables truncation"
             ),
         )
         routing_group.add_argument(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -843,6 +843,44 @@ class TestParseRouterArgs:
 
         assert router_args.selector == {"component": "engine", "env": "prod"}
 
+    def test_routing_token_boundaries_fall_back_to_backend_value(self):
+        """An unset prefixed list must not shadow the backend's value."""
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser, use_router_prefix=True)
+        namespace = parser.parse_args([])
+        namespace.routing_token_boundaries = [200091, 200038]
+
+        router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
+
+        assert router_args.routing_token_boundaries == [200091, 200038]
+
+    def test_routing_token_boundaries_prefixed_value_wins(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser, use_router_prefix=True)
+        namespace = parser.parse_args(["--router-routing-token-boundaries", "200091", "200038"])
+        # A competing backend value must lose to the explicit prefixed list.
+        namespace.routing_token_boundaries = [111]
+
+        router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
+
+        assert router_args.routing_token_boundaries == [200091, 200038]
+
+    def test_routing_token_boundaries_explicit_empty_disables(self):
+        """A bare prefixed flag yields [] and beats the backend value.
+
+        Regression pin for the prefixed default: it must stay None (unset)
+        so only an explicitly supplied flag — even valueless — takes
+        precedence.
+        """
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser, use_router_prefix=True)
+        namespace = parser.parse_args(["--router-routing-token-boundaries"])
+        namespace.routing_token_boundaries = [200091]
+
+        router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
+
+        assert router_args.routing_token_boundaries == []
+
     def test_parse_repeated_model_alias_args(self):
         router_args = parse_router_args(
             [
@@ -1283,6 +1321,7 @@ class TestRouterArgsFieldOrder:
         "least_load_max_waiting_requests",
         "stream_request_bodies_over",
         "stream_body_stall_timeout_secs",
+        "routing_token_boundaries",
         "routing_key_headers",
     ]
 
@@ -1308,6 +1347,7 @@ class TestRouterArgsFieldOrder:
             "least_load_max_waiting_requests",
             "stream_request_bodies_over",
             "stream_body_stall_timeout_secs",
+            "routing_token_boundaries",
             "routing_key_headers",
         ):
             assert names.index(appended) > marker, (

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -215,6 +215,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn routing_token_boundaries(mut self, ids: Vec<u32>) -> Self {
+        self.config.routing_token_boundaries = ids;
+        self
+    }
+
     pub fn upstream_pool_idle_timeout_secs(mut self, secs: u64) -> Self {
         self.config.upstream_pool_idle_timeout_secs = secs;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -37,6 +37,13 @@ pub struct RouterConfig {
     /// Per-request sticky-session routing (rid-lineage keys, header fallback).
     #[serde(default, alias = "sticky_sessions")]
     pub routing_key_override: RoutingKeyOverrideConfig,
+    /// Token ids that end the routing-relevant prefix. Routing tokens are
+    /// truncated at the first occurrence of any listed id before worker
+    /// selection: content past a media placeholder is never shareable across
+    /// conversations, and match ratios over the full sequence shrink as
+    /// conversations grow. Empty disables truncation.
+    #[serde(default)]
+    pub routing_token_boundaries: Vec<u32>,
     pub host: String,
     pub port: u16,
     /// Dedicated port for the isolated Kubernetes liveness/readiness/health
@@ -955,6 +962,7 @@ impl Default for RouterConfig {
             },
             policy: PolicyConfig::Random,
             routing_key_override: RoutingKeyOverrideConfig::default(),
+            routing_token_boundaries: Vec::new(),
             host: "0.0.0.0".to_string(),
             port: 3001,
             health_check_port: None,
@@ -1372,6 +1380,26 @@ mod tests {
             RoutingKeyOverrideConfig::default().assignment_mode,
             ManualAssignmentMode::Delegate
         );
+    }
+
+    #[test]
+    fn test_routing_token_boundaries_serde_default_and_roundtrip() {
+        // Config files predating the field deserialize to no boundaries.
+        let mut json: serde_json::Value = serde_json::to_value(RouterConfig::default()).unwrap();
+        json.as_object_mut()
+            .unwrap()
+            .remove("routing_token_boundaries")
+            .unwrap();
+        let without: RouterConfig = serde_json::from_value(json).unwrap();
+        assert!(without.routing_token_boundaries.is_empty());
+
+        let config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .routing_token_boundaries(vec![200091, 200038])
+            .build_unchecked();
+        let json = serde_json::to_string(&config).unwrap();
+        let with: RouterConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(with.routing_token_boundaries, vec![200091, 200038]);
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -355,6 +355,12 @@ struct CliArgs {
     #[arg(long, num_args = 0.., default_value = "x-smg-routing-key", value_parser = parse_routing_key_header, help_heading = "Routing Policy")]
     routing_key_headers: Vec<String>,
 
+    /// Token ids that end the routing-relevant prefix (e.g. multimodal
+    /// placeholder ids); routing tokens are truncated at the first occurrence
+    /// before worker selection. Empty disables
+    #[arg(long, num_args = 0.., help_heading = "Routing Policy")]
+    routing_token_boundaries: Vec<u32>,
+
     /// Enable IGW (Inference Gateway) mode for multi-model support
     #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
     enable_igw: bool,
@@ -1737,6 +1743,7 @@ impl CliArgs {
                 ),
                 headers: self.routing_key_headers.clone(),
             })
+            .routing_token_boundaries(self.routing_token_boundaries.clone())
             .retries(!self.disable_retries)
             .upstream_http2(self.upstream_http2)
             .circuit_breaker(!self.disable_circuit_breaker)
@@ -2139,6 +2146,18 @@ mod tests {
         .to_router_config(vec![], vec![])
         .unwrap();
         assert_eq!(format!("{canonical:?}"), format!("{aliased:?}"));
+    }
+
+    /// Routing-token boundaries are a router-only setting and must flow into
+    /// `RouterConfig`.
+    #[test]
+    fn routing_token_boundaries_flag_flows_into_router_config() {
+        let cli = cli_args_from(&["--routing-token-boundaries", "200091", "200038"]);
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(router_config.routing_token_boundaries, vec![200091, 200038]);
+
+        let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
+        assert!(defaults.routing_token_boundaries.is_empty());
     }
 
     /// `--health-check-port` must flow into BOTH conversion paths

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -1289,6 +1289,15 @@ impl Metrics {
         .set(count as f64);
     }
 
+    /// Record a routing-token truncation at a configured boundary id
+    pub fn record_routing_tokens_truncated(router_type: &'static str) {
+        counter!(
+            "smg_routing_tokens_truncated_total",
+            "router_type" => router_type
+        )
+        .increment(1);
+    }
+
     /// Record health check result
     pub fn record_worker_health_check(worker_type: &'static str, result: &'static str) {
         counter!(

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -28,5 +28,6 @@ pub mod openai_bridge;
 pub mod persistence_utils;
 pub mod realtime;
 pub mod retry;
+pub(crate) mod routing_tokens;
 pub mod sse;
 pub mod worker_selection;

--- a/model_gateway/src/routers/common/routing_tokens.rs
+++ b/model_gateway/src/routers/common/routing_tokens.rs
@@ -1,0 +1,68 @@
+//! Routing-token boundary truncation shared by the HTTP, PD and gRPC
+//! selection paths.
+
+use crate::observability::metrics::Metrics;
+
+/// Slice `tokens` at the first configured boundary id. Content past a
+/// boundary is never shareable across conversations, and match ratios over
+/// the full sequence shrink as conversations grow.
+pub(crate) fn truncate_slice<'a>(
+    tokens: &'a [u32],
+    boundaries: &[u32],
+    router_type: &'static str,
+) -> &'a [u32] {
+    if boundaries.is_empty() {
+        return tokens;
+    }
+    match tokens.iter().position(|id| boundaries.contains(id)) {
+        Some(cut) => {
+            Metrics::record_routing_tokens_truncated(router_type);
+            &tokens[..cut]
+        }
+        None => tokens,
+    }
+}
+
+/// Owned variant: truncates in place, no reallocation.
+pub(crate) fn truncate_owned(
+    mut tokens: Vec<u32>,
+    boundaries: &[u32],
+    router_type: &'static str,
+) -> Vec<u32> {
+    let keep = truncate_slice(&tokens, boundaries, router_type).len();
+    tokens.truncate(keep);
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cuts_at_first_of_several_boundaries() {
+        assert_eq!(
+            truncate_slice(&[1, 2, 900, 3, 901], &[900, 901], "http"),
+            &[1, 2]
+        );
+        assert_eq!(
+            truncate_owned(vec![1, 2, 901, 3, 900], &[900, 901], "http"),
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn boundary_first_yields_empty() {
+        assert_eq!(truncate_slice(&[900, 1], &[900], "http"), &[] as &[u32]);
+        assert_eq!(
+            truncate_owned(vec![900, 1], &[900], "http"),
+            Vec::<u32>::new()
+        );
+    }
+
+    #[test]
+    fn no_boundaries_or_no_match_is_identity() {
+        assert_eq!(truncate_slice(&[1, 900, 2], &[], "http"), &[1, 900, 2]);
+        assert_eq!(truncate_slice(&[1, 2, 3], &[900], "http"), &[1, 2, 3]);
+        assert_eq!(truncate_owned(vec![1, 2], &[900], "http"), vec![1, 2]);
+    }
+}

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -14,6 +14,7 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo, WorkerLeg},
     routers::{
+        common::routing_tokens,
         error,
         grpc::{
             context::{EncodeWorkerAssignment, RequestContext, WorkerSelection},
@@ -42,6 +43,8 @@ pub(crate) struct WorkerSelectionStage {
     worker_registry: Arc<WorkerRegistry>,
     policy_registry: Arc<PolicyRegistry>,
     mode: WorkerSelectionMode,
+    /// Token ids that end the routing-relevant prefix; empty disables.
+    routing_token_boundaries: Vec<u32>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -59,12 +62,28 @@ impl WorkerSelectionStage {
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
         mode: WorkerSelectionMode,
+        routing_token_boundaries: Vec<u32>,
     ) -> Self {
         Self {
             worker_registry,
             policy_registry,
             mode,
+            routing_token_boundaries,
         }
+    }
+
+    /// Boundary-truncated routing tokens. No token ids at all falls back to
+    /// text; a boundary-emptied prefix stays `Some(&[])` (match rate 0,
+    /// min-load) so full text cannot defeat the truncation.
+    fn truncated_routing_tokens<'a>(&self, ids: &'a [u32]) -> Option<&'a [u32]> {
+        if ids.is_empty() {
+            return None;
+        }
+        Some(routing_tokens::truncate_slice(
+            ids,
+            &self.routing_token_boundaries,
+            metrics_labels::ROUTER_GRPC,
+        ))
     }
 }
 
@@ -87,8 +106,7 @@ impl PipelineStage for WorkerSelectionStage {
         let text = prep.routing_text();
 
         // Get tokens for PrefixHash policy support
-        let ids = prep.token_ids();
-        let tokens = if ids.is_empty() { None } else { Some(ids) };
+        let tokens = self.truncated_routing_tokens(prep.token_ids());
 
         let headers = ctx.input.headers.as_ref();
         let rid_key = self
@@ -830,6 +848,7 @@ mod tests {
             worker_registry,
             policy_registry,
             WorkerSelectionMode::PrefillDecode,
+            Vec::new(),
         );
         let (prefill_hits, decode_hits) = count_select_pd_pair_hits(&stage, model_id, 40);
         assert_even_pd_round_robin_coverage(
@@ -862,6 +881,7 @@ mod tests {
             worker_registry,
             policy_registry,
             WorkerSelectionMode::PrefillDecode,
+            Vec::new(),
         );
         let (prefill_hits, decode_hits) = count_select_pd_pair_hits(&stage, model_id, 40);
         assert_even_pd_round_robin_coverage(
@@ -900,6 +920,7 @@ mod tests {
             Arc::clone(&worker_registry),
             Arc::clone(&policy_registry),
             WorkerSelectionMode::PrefillDecode,
+            Vec::new(),
         );
 
         assert!(
@@ -951,6 +972,7 @@ mod tests {
             worker_registry,
             policy_registry.clone(),
             WorkerSelectionMode::Regular,
+            Vec::new(),
         );
 
         let rid_key = policy_registry.derive_rid_key(Some("conv7_t1"));
@@ -978,5 +1000,118 @@ mod tests {
                 .unwrap();
             assert_eq!(again.url(), first.url(), "follow-up must pin by rid key");
         }
+    }
+
+    fn register_regular_grpc_workers(registry: &WorkerRegistry, model_id: &str, n: usize) {
+        for i in 0..n {
+            registry
+                .register(Arc::new(
+                    BasicWorkerBuilder::new(format!("grpc://127.0.0.1:{}", 8200 + i))
+                        .model(ModelCard::new(model_id))
+                        .worker_type(WorkerType::Regular)
+                        .connection_mode(ConnectionMode::Grpc)
+                        .health_config(no_health_check())
+                        .build(),
+                ))
+                .unwrap();
+        }
+    }
+
+    fn cache_aware_stage(model_id: &str, boundaries: Vec<u32>) -> WorkerSelectionStage {
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        register_regular_grpc_workers(&worker_registry, model_id, 2);
+        let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 1_000,
+            balance_rel_threshold: 1_000.0,
+            eviction_interval_secs: 3_600,
+            max_tree_size: 1 << 24,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+            overlap_decay: 0.0,
+            selection_temperature: 0.0,
+        }));
+        policy_registry.on_worker_added(model_id, None);
+        policy_registry.init_cache_aware_policy(model_id, &worker_registry.get_all());
+        WorkerSelectionStage::new(
+            worker_registry,
+            policy_registry,
+            WorkerSelectionMode::Regular,
+            boundaries,
+        )
+    }
+
+    /// 64-token conversation prefix, boundary 900, per-request tail.
+    fn grpc_conversation(tail_seed: u32, tail_len: u32) -> Vec<u32> {
+        let mut t: Vec<u32> = (1..65).collect();
+        t.push(900);
+        t.extend(tail_seed..tail_seed + 32.min(tail_len));
+        if tail_len > 32 {
+            t.extend(10_000 + tail_seed..10_000 + tail_seed + (tail_len - 32));
+        }
+        t
+    }
+
+    #[tokio::test]
+    async fn grpc_follow_up_pins_with_boundaries() {
+        let model_id = "test-model-boundaries";
+        let stage = cache_aware_stage(model_id, vec![900]);
+
+        let turn1_full = grpc_conversation(5_000, 32);
+        let turn1 = stage.truncated_routing_tokens(&turn1_full);
+        assert_eq!(turn1, Some(&turn1_full[..64]));
+        let first = stage
+            .select_single_worker(model_id, None, turn1, None, None)
+            .unwrap();
+
+        let turn2_full = grpc_conversation(7_000, 200);
+        for _ in 0..4 {
+            let follow_up = stage
+                .select_single_worker(
+                    model_id,
+                    None,
+                    stage.truncated_routing_tokens(&turn2_full),
+                    None,
+                    None,
+                )
+                .unwrap();
+            assert_eq!(first.url(), follow_up.url());
+        }
+
+        // Boundary-emptied prefix stays Some(&[]): min-load, never the text
+        // fallback. Only a genuinely token-free request yields None.
+        assert_eq!(
+            stage.truncated_routing_tokens(&[900, 1]),
+            Some(&[] as &[u32])
+        );
+        assert_eq!(stage.truncated_routing_tokens(&[]), None);
+    }
+
+    #[tokio::test]
+    async fn grpc_follow_up_misses_without_boundaries() {
+        let model_id = "test-model-no-boundaries";
+        let stage = cache_aware_stage(model_id, Vec::new());
+
+        let turn1_full = grpc_conversation(5_000, 32);
+        let tokens1 = stage.truncated_routing_tokens(&turn1_full);
+        assert_eq!(tokens1, Some(turn1_full.as_slice()));
+        let first = stage
+            .select_single_worker(model_id, None, tokens1, None, None)
+            .unwrap();
+
+        let mut turn2_full = turn1_full.clone();
+        turn2_full.extend(7_000..7_200);
+        let second = stage
+            .select_single_worker(
+                model_id,
+                None,
+                stage.truncated_routing_tokens(&turn2_full),
+                None,
+                None,
+            )
+            .unwrap();
+
+        assert_ne!(first.url(), second.url());
     }
 }

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -87,11 +87,17 @@ pub(crate) struct PipelineDeps {
     /// `None` when tenant rate limiting is disabled; read only by the
     /// endpoints that insert `RateLimitReserveStage` (chat/messages/completion/harmony).
     rate_limit_manager: Option<Arc<RateLimitManager>>,
+    /// Token ids that end the routing-relevant prefix; empty disables.
+    routing_token_boundaries: Vec<u32>,
 }
 
 impl PipelineDeps {
     /// Full deps for the chat/messages/harmony endpoints, which consume the
     /// configured parser factories/overrides.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "constructor mirrors the deps struct; a builder would only move the arity"
+    )]
     pub(crate) fn new(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
@@ -100,6 +106,7 @@ impl PipelineDeps {
         configured_tool_parser: Option<String>,
         configured_reasoning_parser: Option<String>,
         rate_limit_manager: Option<Arc<RateLimitManager>>,
+        routing_token_boundaries: Vec<u32>,
     ) -> Self {
         Self {
             worker_registry,
@@ -109,6 +116,7 @@ impl PipelineDeps {
             configured_tool_parser,
             configured_reasoning_parser,
             rate_limit_manager,
+            routing_token_boundaries,
         }
     }
 
@@ -118,6 +126,7 @@ impl PipelineDeps {
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
         rate_limit_manager: Option<Arc<RateLimitManager>>,
+        routing_token_boundaries: Vec<u32>,
     ) -> Self {
         Self {
             worker_registry,
@@ -127,6 +136,7 @@ impl PipelineDeps {
             configured_tool_parser: None,
             configured_reasoning_parser: None,
             rate_limit_manager,
+            routing_token_boundaries,
         }
     }
 
@@ -191,6 +201,7 @@ impl PipelineDeps {
             configured_tool_parser: None,
             configured_reasoning_parser: None,
             rate_limit_manager: None,
+            routing_token_boundaries: Vec::new(),
         }
     }
 }
@@ -296,6 +307,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.routing_token_boundaries.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                 ];
@@ -325,6 +337,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.routing_token_boundaries.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                 ];
@@ -355,6 +368,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.routing_token_boundaries.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                 ];
@@ -387,6 +401,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.routing_token_boundaries.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                     Box::new(harmony::stages::HarmonyRequestBuildingStage::new(
@@ -409,6 +424,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.routing_token_boundaries.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                     Box::new(EmbeddingRequestBuildingStage::new()),
@@ -428,6 +444,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.routing_token_boundaries.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                     Box::new(EmbeddingRequestBuildingStage::new()),
@@ -1565,7 +1582,7 @@ mod alias_pipeline_tests {
             .unwrap();
 
         let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin));
-        let deps = PipelineDeps::pair(worker_registry.clone(), policy_registry, None);
+        let deps = PipelineDeps::pair(worker_registry.clone(), policy_registry, None, Vec::new());
         let pipeline = RequestPipeline::build(Endpoint::Chat, Mode::PrefillDecode, &deps).unwrap();
         let components = Arc::new(SharedComponents {
             tokenizer_registry,

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -372,6 +372,7 @@ impl GrpcRouter {
             ctx.configured_tool_parser.clone(),
             ctx.configured_reasoning_parser.clone(),
             ctx.rate_limit_manager.clone(),
+            ctx.router_config.routing_token_boundaries.clone(),
         );
         // Deps for the parser-free endpoints (completion/embeddings/classify).
         // Only completion's stage list actually reads `rate_limit_manager`;
@@ -380,6 +381,7 @@ impl GrpcRouter {
             worker_registry.clone(),
             policy_registry.clone(),
             ctx.rate_limit_manager.clone(),
+            ctx.router_config.routing_token_boundaries.clone(),
         );
 
         // Present in every mode: chat/generate, messages, completion.

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -37,6 +37,7 @@ use crate::{
         common::{
             header_utils,
             retry::{is_retryable_status, RetryExecutor},
+            routing_tokens,
             sse::{SseEncoder, SSE_CHANNEL_BUFFER},
         },
         error,
@@ -54,6 +55,8 @@ pub struct PDRouter {
     pub client: Client,
     pub retry_config: RetryConfig,
     pub api_key: Option<String>,
+    /// Token ids that end the routing-relevant prefix; empty disables.
+    pub routing_token_boundaries: Vec<u32>,
 }
 
 #[derive(Clone)]
@@ -172,6 +175,7 @@ impl PDRouter {
             client: ctx.client.clone(),
             retry_config: ctx.router_config.effective_retry_config(),
             api_key: ctx.router_config.api_key.clone(),
+            routing_token_boundaries: ctx.router_config.routing_token_boundaries.clone(),
         })
     }
 
@@ -820,6 +824,31 @@ impl PDRouter {
         prefill_policy.needs_request_text() || decode_policy.needs_request_text()
     }
 
+    /// Routing inputs for `/generate`: token ids win over text, truncated at
+    /// the configured boundaries.
+    fn generate_routing_inputs(
+        &self,
+        body: &GenerateRequest,
+    ) -> (Option<String>, Option<Vec<u32>>) {
+        if !self.policies_need_request_text() {
+            return (None, None);
+        }
+        match body.routing_tokens() {
+            Some(ids) => {
+                let tokens = ids.iter().map(|&id| id as u32).collect();
+                (
+                    None,
+                    Some(routing_tokens::truncate_owned(
+                        tokens,
+                        &self.routing_token_boundaries,
+                        metrics_labels::ROUTER_HTTP,
+                    )),
+                )
+            }
+            None => (body.text.as_deref().map(|s| s.to_string()), None),
+        }
+    }
+
     #[expect(
         clippy::unused_async,
         reason = "async for API consistency; callers await uniformly"
@@ -1451,14 +1480,7 @@ impl RouterTrait for PDRouter {
         let is_stream = body.stream;
         let return_logprob = body.return_logprob.unwrap_or(false);
 
-        let (request_text, routing_tokens) = if self.policies_need_request_text() {
-            match body.routing_tokens() {
-                Some(ids) => (None, Some(ids.iter().map(|&id| id as u32).collect())),
-                None => (body.text.as_deref().map(|s| s.to_string()), None),
-            }
-        } else {
-            (None, None)
-        };
+        let (request_text, routing_tokens) = self.generate_routing_inputs(body);
 
         let batch_size = Self::get_generate_batch_size(body);
 
@@ -1614,7 +1636,59 @@ mod tests {
             client: Client::new(),
             retry_config: RetryConfig::default(),
             api_key: Some("test_api_key".to_string()),
+            routing_token_boundaries: Vec::new(),
         }
+    }
+
+    fn cache_aware_pd_router(boundaries: Vec<u32>) -> PDRouter {
+        let mut router = create_test_pd_router();
+        router.policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 1_000,
+            balance_rel_threshold: 1_000.0,
+            eviction_interval_secs: 3_600,
+            max_tree_size: 1 << 24,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+            overlap_decay: 0.0,
+            selection_temperature: 0.0,
+        }));
+        router.routing_token_boundaries = boundaries;
+        router
+    }
+
+    #[tokio::test]
+    async fn pd_generate_routing_inputs_truncate_at_boundary() {
+        let router = cache_aware_pd_router(vec![900]);
+        let body: GenerateRequest =
+            serde_json::from_value(serde_json::json!({"input_ids": [1, 2, 3, 900, 4, 5]})).unwrap();
+        let (text, tokens) = router.generate_routing_inputs(&body);
+        assert_eq!(text, None);
+        assert_eq!(tokens, Some(vec![1, 2, 3]));
+
+        let media_first: GenerateRequest =
+            serde_json::from_value(serde_json::json!({"input_ids": [900, 4, 5]})).unwrap();
+        let (text, tokens) = router.generate_routing_inputs(&media_first);
+        assert_eq!(text, None);
+        assert_eq!(tokens, Some(Vec::new()));
+    }
+
+    #[tokio::test]
+    async fn pd_generate_routing_inputs_identity_without_boundaries() {
+        let router = cache_aware_pd_router(Vec::new());
+        let body: GenerateRequest =
+            serde_json::from_value(serde_json::json!({"input_ids": [1, 2, 900, 3]})).unwrap();
+        let (_, tokens) = router.generate_routing_inputs(&body);
+        assert_eq!(tokens, Some(vec![1, 2, 900, 3]));
+    }
+
+    #[test]
+    fn pd_generate_routing_inputs_skips_text_free_policies() {
+        let router = create_test_pd_router();
+        let body: GenerateRequest =
+            serde_json::from_value(serde_json::json!({"input_ids": [1, 2, 3]})).unwrap();
+        assert_eq!(router.generate_routing_inputs(&body), (None, None));
     }
 
     fn create_test_worker(url: String, worker_type: WorkerType, healthy: bool) -> Box<dyn Worker> {

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -59,6 +59,7 @@ use crate::{
                 ws::handle_realtime_ws, RealtimeLabels, RealtimeRegistry,
             },
             retry::{is_retryable_status, RetryExecutor},
+            routing_tokens,
             sse::SSE_CHANNEL_BUFFER,
             worker_selection::{SelectWorkerRequest, WorkerSelector},
         },
@@ -95,6 +96,8 @@ pub struct Router {
     /// Streamed-body stall watchdog: abort a dispatch once a single client
     /// wait lasts this long. `None` disables.
     stream_stall_timeout: Option<Duration>,
+    /// Token ids that end the routing-relevant prefix; empty disables.
+    routing_token_boundaries: Vec<u32>,
     realtime_registry: Arc<RealtimeRegistry>,
     webrtc_bind_addr: Option<std::net::IpAddr>,
     webrtc_stun_server: Option<String>,
@@ -163,6 +166,7 @@ impl Router {
                 0 => None,
                 secs => Some(Duration::from_secs(secs)),
             },
+            routing_token_boundaries: ctx.router_config.routing_token_boundaries.clone(),
             realtime_registry: ctx.realtime_registry.clone(),
             webrtc_bind_addr: ctx.webrtc_bind_addr,
             webrtc_stun_server: ctx.webrtc_stun_server.clone(),
@@ -218,6 +222,18 @@ impl Router {
             }
             Err(e) => error::service_unavailable("no_workers", e),
         }
+    }
+
+    /// A boundary in first position yields an empty prefix: match rate 0,
+    /// min-load, and no full-text fallback into the string tree.
+    fn truncate_routing_tokens(&self, tokens: Option<Vec<u32>>) -> Option<Vec<u32>> {
+        tokens.map(|t| {
+            routing_tokens::truncate_owned(
+                t,
+                &self.routing_token_boundaries,
+                metrics_labels::ROUTER_HTTP,
+            )
+        })
     }
 
     /// Select worker considering circuit breaker state.
@@ -360,12 +376,13 @@ impl Router {
         // Pre-tokenized requests route on the token tree; the decimal-string
         // rendering is only materialized when there are no tokens. A valid
         // x-smg-routing-tokens hint wins over body-derived tokens/text.
-        let routing_tokens: Option<Vec<u32>> = header_utils::parse_routing_tokens_hint(headers)
-            .or_else(|| {
+        let routing_tokens: Option<Vec<u32>> = self.truncate_routing_tokens(
+            header_utils::parse_routing_tokens_hint(headers).or_else(|| {
                 typed_req
                     .routing_tokens()
                     .map(|ids| ids.iter().map(|&id| id as u32).collect())
-            });
+            }),
+        );
         let text = routing_tokens
             .is_none()
             .then(|| typed_req.extract_text_for_routing());
@@ -681,7 +698,8 @@ impl Router {
         let start = Instant::now();
         let is_stream = body.is_stream();
         // A valid x-smg-routing-tokens hint wins over body-derived text.
-        let hinted_tokens = header_utils::parse_routing_tokens_hint(headers);
+        let hinted_tokens =
+            self.truncate_routing_tokens(header_utils::parse_routing_tokens_hint(headers));
         let text = hinted_tokens
             .is_none()
             .then(|| body.extract_text_for_routing());
@@ -1587,7 +1605,14 @@ impl Router {
         // would have received there (text is never extracted alongside it).
         // Streamed requests have no readable body, hence no rid key; the
         // sticky override keys them by the header alone.
-        let hinted_tokens = header_utils::parse_routing_tokens_hint(Some(req.headers()));
+        let hinted_tokens = self
+            .truncate_routing_tokens(header_utils::parse_routing_tokens_hint(Some(req.headers())));
+        // The stream was admitted on the hint's strength; a boundary-emptied
+        // hint leaves no shareable prefix, so route it buffered instead of
+        // content-blind.
+        if hinted_tokens.as_deref() == Some(&[]) {
+            return Err(req);
+        }
         let Some(worker) = self.select_worker_for_model(
             model_id,
             None,
@@ -2144,6 +2169,7 @@ mod tests {
             retry_config: RetryConfig::default(),
             max_payload_size: 536_870_912,
             stream_stall_timeout: Some(Duration::from_secs(60)),
+            routing_token_boundaries: Vec::new(),
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,
@@ -2155,6 +2181,192 @@ mod tests {
         let workers = router.worker_registry.get_all();
         workers[0].set_status(openai_protocol::worker::WorkerStatus::NotReady);
         router
+    }
+
+    fn cache_aware_router(boundaries: Vec<u32>) -> Router {
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 1_000,
+            balance_rel_threshold: 1_000.0,
+            eviction_interval_secs: 3_600,
+            max_tree_size: 1 << 24,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+            overlap_decay: 0.0,
+            selection_temperature: 0.0,
+        }));
+        for url in ["http://worker1:8080", "http://worker2:8080"] {
+            let worker = BasicWorkerBuilder::new(url)
+                .worker_type(WorkerType::Regular)
+                .health_config(no_health_check())
+                .build();
+            worker_registry.register_or_replace(Arc::new(worker));
+        }
+        policy_registry.on_worker_added(crate::worker::UNKNOWN_MODEL_ID, None);
+        policy_registry
+            .init_cache_aware_policy(crate::worker::UNKNOWN_MODEL_ID, &worker_registry.get_all());
+        Router {
+            worker_registry,
+            policy_registry,
+            client: Client::new(),
+            retry_config: RetryConfig::default(),
+            max_payload_size: 536_870_912,
+            stream_stall_timeout: None,
+            routing_token_boundaries: boundaries,
+            realtime_registry: Arc::new(RealtimeRegistry::new()),
+            webrtc_bind_addr: None,
+            webrtc_stun_server: None,
+        }
+    }
+
+    const BOUNDARY: u32 = 900;
+
+    /// 64-token conversation prefix (four full 16-token pages), then the
+    /// boundary, then per-request media/generation tail.
+    fn conversation_body(prefix_seed: u32, tail_seed: u32, tail_len: u32) -> Vec<u32> {
+        let mut t: Vec<u32> = (prefix_seed..prefix_seed + 64).collect();
+        t.push(BOUNDARY);
+        t.extend(tail_seed..tail_seed + tail_len);
+        t
+    }
+
+    #[test]
+    fn truncate_cuts_at_first_boundary_only() {
+        let mut router = create_test_regular_router();
+        router.routing_token_boundaries = vec![BOUNDARY, 901];
+
+        let cut = router
+            .truncate_routing_tokens(Some(vec![1, 2, 3, BOUNDARY, 4, 901, 5]))
+            .unwrap();
+        assert_eq!(cut, vec![1, 2, 3]);
+
+        let untouched = router.truncate_routing_tokens(Some(vec![1, 2, 3])).unwrap();
+        assert_eq!(untouched, vec![1, 2, 3]);
+
+        assert_eq!(
+            router.truncate_routing_tokens(Some(vec![BOUNDARY, 1])),
+            Some(Vec::new())
+        );
+        assert_eq!(router.truncate_routing_tokens(None), None);
+    }
+
+    #[test]
+    fn no_boundary_config_is_identity() {
+        let router = create_test_regular_router();
+        let tokens = vec![1, BOUNDARY, 2];
+        assert_eq!(
+            router
+                .truncate_routing_tokens(Some(tokens.clone()))
+                .unwrap(),
+            tokens
+        );
+    }
+
+    /// A follow-up replaying its conversation prefix plus a long tail pins to
+    /// the engine that served the first turn: truncation makes the match
+    /// ratio length-invariant (~1.0 instead of prefix/full ≈ 0.3).
+    #[tokio::test]
+    async fn follow_up_pins_to_first_turn_worker_with_boundaries() {
+        let router = cache_aware_router(vec![BOUNDARY]);
+
+        let turn1 = router
+            .truncate_routing_tokens(Some(conversation_body(1, 5_000, 32)))
+            .unwrap();
+        let first = router
+            .select_worker_for_model(
+                crate::worker::UNKNOWN_MODEL_ID,
+                None,
+                Some(&turn1),
+                None,
+                None,
+            )
+            .unwrap();
+
+        let turn2 = router
+            .truncate_routing_tokens(Some(conversation_body(1, 7_000, 200)))
+            .unwrap();
+        assert_eq!(turn2, turn1);
+        for _ in 0..4 {
+            let follow_up = router
+                .select_worker_for_model(
+                    crate::worker::UNKNOWN_MODEL_ID,
+                    None,
+                    Some(&turn2),
+                    None,
+                    None,
+                )
+                .unwrap();
+            assert_eq!(first.url(), follow_up.url());
+        }
+    }
+
+    /// Without truncation the same follow-up scores prefix/full below the
+    /// threshold and lands on the least-loaded (other) worker.
+    #[tokio::test]
+    async fn follow_up_misses_first_turn_worker_without_boundaries() {
+        let router = cache_aware_router(Vec::new());
+
+        let turn1 = conversation_body(1, 5_000, 32);
+        let first = router
+            .select_worker_for_model(
+                crate::worker::UNKNOWN_MODEL_ID,
+                None,
+                Some(&turn1),
+                None,
+                None,
+            )
+            .unwrap();
+
+        let mut turn2 = turn1.clone();
+        turn2.extend(7_000..7_200);
+        let second = router
+            .select_worker_for_model(
+                crate::worker::UNKNOWN_MODEL_ID,
+                None,
+                Some(&turn2),
+                None,
+                None,
+            )
+            .unwrap();
+
+        assert_ne!(first.url(), second.url());
+    }
+
+    /// Distinct conversations share no pre-boundary prefix and must not pin
+    /// to each other.
+    #[tokio::test]
+    async fn different_conversations_do_not_pin_with_boundaries() {
+        let router = cache_aware_router(vec![BOUNDARY]);
+
+        let conv_a = router
+            .truncate_routing_tokens(Some(conversation_body(1, 5_000, 32)))
+            .unwrap();
+        let first = router
+            .select_worker_for_model(
+                crate::worker::UNKNOWN_MODEL_ID,
+                None,
+                Some(&conv_a),
+                None,
+                None,
+            )
+            .unwrap();
+
+        let conv_b = router
+            .truncate_routing_tokens(Some(conversation_body(3_000, 5_000, 32)))
+            .unwrap();
+        let second = router
+            .select_worker_for_model(
+                crate::worker::UNKNOWN_MODEL_ID,
+                None,
+                Some(&conv_b),
+                None,
+                None,
+            )
+            .unwrap();
+
+        assert_ne!(first.url(), second.url());
     }
 
     #[test]
@@ -2370,6 +2582,7 @@ mod tests {
             retry_config: RetryConfig::default(),
             max_payload_size,
             stream_stall_timeout: Some(Duration::from_secs(60)),
+            routing_token_boundaries: Vec::new(),
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,
@@ -2707,6 +2920,79 @@ mod tests {
         )
         .await;
         assert_eq!(first, second, "same hint must stick to the tree tenant");
+    }
+
+    #[tokio::test]
+    async fn boundary_emptied_hint_falls_back_to_buffered() {
+        let mut router = streaming_router(
+            cache_aware_policy(),
+            1024 * 1024,
+            vec![plain_worker("http://worker1:8080")],
+        );
+        router.routing_token_boundaries = vec![BOUNDARY];
+
+        let req = with_header(
+            streamed_request(&[b"{\"text\":\"hello\"}"]),
+            "x-smg-routing-tokens",
+            "900,1,2",
+        );
+        let req = router
+            .route_streaming_request(req, "/generate")
+            .await
+            .unwrap_err();
+        let body = to_bytes(req.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(body.as_ref(), b"{\"text\":\"hello\"}");
+    }
+
+    #[tokio::test]
+    async fn boundary_truncated_hint_streams_with_prefix_affinity() {
+        let (url_a, _cap_a) = spawn_capture_stub("application/json", "{}").await;
+        let (url_b, _cap_b) = spawn_capture_stub("application/json", "{}").await;
+        let mut router = streaming_router(
+            cache_aware_policy(),
+            1024 * 1024,
+            vec![plain_worker(&url_a), plain_worker(&url_b)],
+        );
+        router.routing_token_boundaries = vec![BOUNDARY];
+        let workers = router.worker_registry.get_all();
+        router
+            .policy_registry
+            .get_default_policy()
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .unwrap()
+            .init_workers(&workers);
+
+        // Same 32-token prefix, boundary, then divergent tails: only the
+        // truncated prefix can pin the second request (untruncated ratio is
+        // 32/65 < threshold).
+        let hint = |tail_seed: u32| -> String {
+            (1..=32u32)
+                .chain(std::iter::once(BOUNDARY))
+                .chain(tail_seed..tail_seed + 32)
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+        let first = routed_worker_id(
+            &router,
+            with_header(
+                streamed_request(&[b"{\"text\":\"hello\"}"]),
+                "x-smg-routing-tokens",
+                &hint(5_000),
+            ),
+        )
+        .await;
+        let second = routed_worker_id(
+            &router,
+            with_header(
+                streamed_request(&[b"{\"text\":\"other\"}"]),
+                "x-smg-routing-tokens",
+                &hint(7_000),
+            ),
+        )
+        .await;
+        assert_eq!(first, second, "truncated prefixes must share a tenant");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description
### Problem
cache_aware matches the full wire `input_ids`, but on multimodal lanes an engine can only share prefix cache across conversations up to the first media placeholder (engine cache keys incorporate media content). Match ratios computed over the full sequence therefore shrink as conversations grow: on a production multimodal video lane, a conversation follow-up (~17k wire tokens containing its ~3k first-turn text) scores matched/raw ~= 0.17 and never returns to the engine holding its conversation state — measured at under 0.1% deep-prefix conversion for the ~37% of traffic that is follow-ups, while an automated fan-out cohort with near-identical prefixes (matched/raw >= 0.92) converts at 78%. No fixed threshold fixes this: third turns score lower still.
### Solution
`--routing-token-boundaries <ids>`: truncate extracted routing tokens at the first occurrence of any configured boundary id (e.g. media placeholder ids) before worker selection, on all three selection paths (HTTP regular, HTTP PD, gRPC pipeline). Matching then covers exactly the engine-shareable, conversation-invariant prefix: a follow-up scores ~1.0 against its own conversation at any length, unrelated requests score near zero. Empty config is byte-identical to today. A boundary in first position yields an empty prefix (match rate 0 → least-loaded), avoiding full-text fallback into the string tree. Truncations are observable via `smg_routing_tokens_truncated_total{router_type}`.

## Changes
- `routers/common/routing_tokens.rs`: shared truncation (borrowed-slice and in-place-owned variants) + metric
- `routers/http/router.rs`: truncation at both token-extraction sites before `SelectWorkerInfo`
- `routers/http/pd_router.rs`: `/generate` routing-input extraction factored into `generate_routing_inputs` with truncation
- gRPC: truncation at the `WorkerSelectionStage` choke point; boundaries plumbed through `PipelineDeps`
- Config: `routing_token_boundaries: Vec<u32>` (types/builder/CLI space-separated list, serde default) + flow test
- Python bindings: field appended at the positional tail (lib.rs x5, `router_args.py`, frozen-sequence tests)

## Composition
The obligation from #2202 is discharged in this PR: `route_streaming_request` truncates hinted tokens at the configured boundaries, and a boundary-emptied hint falls back to buffered routing (body unconsumed). No coordination needed with open PR #2206 (rid-based sticky): rid keys are not token sequences and are unaffected by token truncation.

## Test Plan
- Router (all three paths): follow-up pins to first-turn worker at threshold 0.5 with boundaries (repeat-selection hardened); the same follow-up provably lands elsewhere without boundaries; distinct conversations don't pin; boundary-first and no-boundary edge cases; empty-config identity
- Config: serde default/roundtrip; CLI list flow into `RouterConfig`
- `cargo +nightly fmt --all --check`; targeted module tests green (router 25, PD 12, gRPC selection 5, shared helper 3, config 38, CLI flow 1, pipeline 7); full clippy + suite in CI

<details><summary>Checklist</summary>

- [x] Format clean; lint self-audited (`#[expect]` with reason, no `unwrap` in prod paths)
- [x] Tests added and passing
- [x] Bindings updated (Python); Go unaffected
- [x] DCO sign-off, conventional commit
</details>
