### PR TITLE
fix(grpc-client): bound gRPC connect attempts

### DIFF
--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -46,6 +46,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 # Mock-server harness for the abort-on-drop behavioral tests.
 tokio-stream = { version = "0.1", features = ["net"] }
+tower = { version = "0.5", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -42,6 +42,7 @@ tonic-prost-build = "0.14.6"
 prost-build = "0.14.4"
 
 [dev-dependencies]
+hyper-util = { version = "0.1", features = ["tokio"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 # Mock-server harness for the abort-on-drop behavioral tests.
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/crates/grpc_client/src/channel.rs
+++ b/crates/grpc_client/src/channel.rs
@@ -92,7 +92,8 @@ mod tests {
 
     use hyper_util::rt::TokioIo;
     use tokio::io::DuplexStream;
-    use tonic::codegen::{http::Uri, Service};
+    use tonic::codegen::http::Uri;
+    use tower::Service;
 
     use super::{configured_endpoint, normalize_grpc_endpoint, DEFAULT_CONNECT_TIMEOUT};
 
@@ -121,7 +122,8 @@ mod tests {
     }
 
     /// A connector that never completes must be bounded by the caller's
-    /// `connect_timeout`.
+    /// `connect_timeout`, preventing the kernel SYN retry ceiling described by
+    /// [`DEFAULT_CONNECT_TIMEOUT`] from governing a black-holed dial.
     ///
     /// The upper bound has to sit *below* [`DEFAULT_CONNECT_TIMEOUT`], otherwise
     /// an implementation that silently ignored the argument and fell back to the

--- a/crates/grpc_client/src/channel.rs
+++ b/crates/grpc_client/src/channel.rs
@@ -23,8 +23,19 @@ pub fn normalize_grpc_endpoint(endpoint: &str) -> String {
     }
 }
 
+/// Default ceiling on a single TCP/TLS connect attempt.
+///
+/// tonic applies no connect timeout of its own, so without this a dial to a
+/// black-holing peer (SYN dropped rather than refused — a pod IP whose
+/// container is not listening yet) sits in `SYN_SENT` until the kernel gives
+/// up: `net.ipv4.tcp_syn_retries` defaults to 6, i.e. ~127s. Bounding the
+/// attempt here keeps those sockets from accumulating faster than they drain.
+/// Matches the upstream HTTP client's connect timeout in `AppContext`.
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Connect a `tonic::Channel` to the given endpoint with the SMG-standard
-/// keep-alive and HTTP/2 window profile applied.
+/// keep-alive and HTTP/2 window profile applied, using
+/// [`DEFAULT_CONNECT_TIMEOUT`].
 ///
 /// The endpoint may use any of `http://`, `https://`, `grpc://`, or
 /// `grpcs://` — gRPC schemes are normalised to their HTTP(S) equivalents
@@ -32,8 +43,21 @@ pub fn normalize_grpc_endpoint(endpoint: &str) -> String {
 pub async fn connect_channel(
     endpoint: &str,
 ) -> Result<Channel, Box<dyn std::error::Error + Send + Sync>> {
+    connect_channel_with_timeout(endpoint, DEFAULT_CONNECT_TIMEOUT).await
+}
+
+/// Same as [`connect_channel`], but with an explicit connect timeout.
+///
+/// Callers that already bound the dial with their own deadline (health and
+/// reachability probes) should pass that deadline through so tonic reaps the
+/// socket itself, rather than relying on the outer future being dropped.
+pub async fn connect_channel_with_timeout(
+    endpoint: &str,
+    connect_timeout: Duration,
+) -> Result<Channel, Box<dyn std::error::Error + Send + Sync>> {
     let http_endpoint = normalize_grpc_endpoint(endpoint);
     let channel = Channel::from_shared(http_endpoint)?
+        .connect_timeout(connect_timeout)
         .http2_keep_alive_interval(Duration::from_secs(30))
         .keep_alive_timeout(Duration::from_secs(10))
         .keep_alive_while_idle(true)
@@ -52,7 +76,52 @@ pub async fn connect_channel(
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_grpc_endpoint;
+    use std::time::{Duration, Instant};
+
+    use super::{connect_channel_with_timeout, normalize_grpc_endpoint, DEFAULT_CONNECT_TIMEOUT};
+
+    #[test]
+    fn default_connect_timeout_is_below_the_kernel_syn_ceiling() {
+        // The point of the default is to beat the ~127s kernel SYN timeout
+        // (tcp_syn_retries=6); if it ever grows past that it stops doing its job.
+        assert!(DEFAULT_CONNECT_TIMEOUT < Duration::from_secs(127));
+    }
+
+    /// A dial to a black-holing peer must be bounded by the caller's
+    /// `connect_timeout` rather than by the kernel's SYN retry ceiling.
+    /// `192.0.2.1` is TEST-NET-1 (RFC 5737) and is not routable, so the connect
+    /// either fails fast with an unreachable error or is cut off by our
+    /// timeout — never hangs for the ~127s a retrying SYN would otherwise take.
+    ///
+    /// The upper bound has to sit *below* [`DEFAULT_CONNECT_TIMEOUT`], otherwise
+    /// an implementation that silently ignored the argument and fell back to the
+    /// default would still pass. `PROBE_TIMEOUT` is generous enough to absorb
+    /// scheduler variance on a loaded CI box.
+    #[tokio::test]
+    async fn connect_timeout_bounds_a_blackholed_dial() {
+        const PROBE_TIMEOUT: Duration = Duration::from_millis(300);
+        const UPPER_BOUND: Duration = Duration::from_secs(2);
+
+        // Guards the discriminating power of the assertion below: if the
+        // default ever drops to within the bound, this test silently stops
+        // distinguishing "argument honored" from "default used".
+        assert!(
+            UPPER_BOUND < DEFAULT_CONNECT_TIMEOUT,
+            "UPPER_BOUND ({UPPER_BOUND:?}) must stay below DEFAULT_CONNECT_TIMEOUT \
+             ({DEFAULT_CONNECT_TIMEOUT:?}) for this test to prove the argument is used"
+        );
+
+        let start = Instant::now();
+        let result = connect_channel_with_timeout("grpc://192.0.2.1:1", PROBE_TIMEOUT).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "unroutable dial should not succeed");
+        assert!(
+            elapsed < UPPER_BOUND,
+            "dial took {elapsed:?}, over the {UPPER_BOUND:?} bound; \
+             the {PROBE_TIMEOUT:?} connect_timeout argument was not applied"
+        );
+    }
 
     #[test]
     fn normalize_grpc_to_http() {

--- a/crates/grpc_client/src/channel.rs
+++ b/crates/grpc_client/src/channel.rs
@@ -9,7 +9,7 @@
 
 use std::time::Duration;
 
-use tonic::transport::Channel;
+use tonic::transport::{Channel, Endpoint};
 
 /// Convert a `grpc://` or `grpcs://` endpoint to a tonic-compatible
 /// `http://` or `https://` URI. Other schemes (or schemeless inputs) are
@@ -55,8 +55,18 @@ pub async fn connect_channel_with_timeout(
     endpoint: &str,
     connect_timeout: Duration,
 ) -> Result<Channel, Box<dyn std::error::Error + Send + Sync>> {
+    let channel = configured_endpoint(endpoint, connect_timeout)?
+        .connect()
+        .await?;
+    Ok(channel)
+}
+
+fn configured_endpoint(
+    endpoint: &str,
+    connect_timeout: Duration,
+) -> Result<Endpoint, tonic::transport::Error> {
     let http_endpoint = normalize_grpc_endpoint(endpoint);
-    let channel = Channel::from_shared(http_endpoint)?
+    Ok(Endpoint::from_shared(http_endpoint)?
         .connect_timeout(connect_timeout)
         .http2_keep_alive_interval(Duration::from_secs(30))
         .keep_alive_timeout(Duration::from_secs(10))
@@ -68,17 +78,40 @@ pub async fn connect_channel_with_timeout(
         // typical inference response (multi-MB tokenized payloads +
         // streaming chunks) without head-of-line blocking.
         .initial_stream_window_size(Some(16 * 1024 * 1024))
-        .initial_connection_window_size(Some(32 * 1024 * 1024))
-        .connect()
-        .await?;
-    Ok(channel)
+        .initial_connection_window_size(Some(32 * 1024 * 1024)))
 }
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
+    use std::{
+        future::{pending, Pending},
+        io,
+        task::{Context, Poll},
+        time::{Duration, Instant},
+    };
 
-    use super::{connect_channel_with_timeout, normalize_grpc_endpoint, DEFAULT_CONNECT_TIMEOUT};
+    use hyper_util::rt::TokioIo;
+    use tokio::io::DuplexStream;
+    use tonic::codegen::{http::Uri, Service};
+
+    use super::{configured_endpoint, normalize_grpc_endpoint, DEFAULT_CONNECT_TIMEOUT};
+
+    #[derive(Clone, Copy)]
+    struct PendingConnector;
+
+    impl Service<Uri> for PendingConnector {
+        type Response = TokioIo<DuplexStream>;
+        type Error = io::Error;
+        type Future = Pending<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _request: Uri) -> Self::Future {
+            pending()
+        }
+    }
 
     #[test]
     fn default_connect_timeout_is_below_the_kernel_syn_ceiling() {
@@ -87,19 +120,17 @@ mod tests {
         assert!(DEFAULT_CONNECT_TIMEOUT < Duration::from_secs(127));
     }
 
-    /// A dial to a black-holing peer must be bounded by the caller's
-    /// `connect_timeout` rather than by the kernel's SYN retry ceiling.
-    /// `192.0.2.1` is TEST-NET-1 (RFC 5737) and is not routable, so the connect
-    /// either fails fast with an unreachable error or is cut off by our
-    /// timeout — never hangs for the ~127s a retrying SYN would otherwise take.
+    /// A connector that never completes must be bounded by the caller's
+    /// `connect_timeout`.
     ///
     /// The upper bound has to sit *below* [`DEFAULT_CONNECT_TIMEOUT`], otherwise
     /// an implementation that silently ignored the argument and fell back to the
     /// default would still pass. `PROBE_TIMEOUT` is generous enough to absorb
     /// scheduler variance on a loaded CI box.
     #[tokio::test]
-    async fn connect_timeout_bounds_a_blackholed_dial() {
+    async fn connect_timeout_bounds_a_pending_connector() {
         const PROBE_TIMEOUT: Duration = Duration::from_millis(300);
+        const LOWER_BOUND: Duration = Duration::from_millis(200);
         const UPPER_BOUND: Duration = Duration::from_secs(2);
 
         // Guards the discriminating power of the assertion below: if the
@@ -112,10 +143,18 @@ mod tests {
         );
 
         let start = Instant::now();
-        let result = connect_channel_with_timeout("grpc://192.0.2.1:1", PROBE_TIMEOUT).await;
+        let result = configured_endpoint("grpc://unused.invalid", PROBE_TIMEOUT)
+            .expect("build test endpoint")
+            .connect_with_connector(PendingConnector)
+            .await;
         let elapsed = start.elapsed();
 
-        assert!(result.is_err(), "unroutable dial should not succeed");
+        assert!(result.is_err(), "pending connector should time out");
+        assert!(
+            elapsed >= LOWER_BOUND,
+            "dial failed in {elapsed:?}, before the {PROBE_TIMEOUT:?} timeout; \
+             the test did not exercise timeout handling"
+        );
         assert!(
             elapsed < UPPER_BOUND,
             "dial took {elapsed:?}, over the {UPPER_BOUND:?} bound; \

--- a/crates/grpc_client/src/lib.rs
+++ b/crates/grpc_client/src/lib.rs
@@ -28,8 +28,7 @@ use std::sync::Arc;
 
 pub use abort_on_drop::{AbortOnDropClient, AbortOnDropStream};
 pub use channel::{
-    connect_channel, connect_channel_with_timeout, normalize_grpc_endpoint,
-    DEFAULT_CONNECT_TIMEOUT,
+    connect_channel, connect_channel_with_timeout, normalize_grpc_endpoint, DEFAULT_CONNECT_TIMEOUT,
 };
 pub use mlx_engine::{proto as mlx_proto, MlxEngineClient};
 pub use sglang_scheduler::{

--- a/crates/grpc_client/src/lib.rs
+++ b/crates/grpc_client/src/lib.rs
@@ -27,7 +27,10 @@ pub mod vllm_engine;
 use std::sync::Arc;
 
 pub use abort_on_drop::{AbortOnDropClient, AbortOnDropStream};
-pub use channel::{connect_channel, normalize_grpc_endpoint};
+pub use channel::{
+    connect_channel, connect_channel_with_timeout, normalize_grpc_endpoint,
+    DEFAULT_CONNECT_TIMEOUT,
+};
 pub use mlx_engine::{proto as mlx_proto, MlxEngineClient};
 pub use sglang_scheduler::{
     proto as sglang_proto, SglangGenerateRequestOptions, SglangSchedulerClient,

--- a/model_gateway/src/workflow/steps/util.rs
+++ b/model_gateway/src/workflow/steps/util.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use reqwest::Client;
+use smg_grpc_client::connect_channel_with_timeout;
 
 use crate::routers::grpc::client::GrpcClient;
 
@@ -113,12 +114,34 @@ pub(crate) async fn do_grpc_health_check(
     Ok(())
 }
 
+/// Dial the endpoint once to decide whether it is worth probing per-runtime.
+///
+/// All five runtime clients dial the same authority, so an endpoint that
+/// cannot be reached at the transport level fails five identical connects.
+/// One dial answers that question, which matters during a mass worker
+/// registration: an unready pod that black-holes SYN would otherwise hold
+/// five in-flight sockets per attempt instead of one.
+async fn grpc_transport_reachable(grpc_url: &str, timeout_secs: u64) -> Result<(), String> {
+    let timeout = Duration::from_secs(timeout_secs);
+    let connect_future = connect_channel_with_timeout(grpc_url, timeout);
+    tokio::time::timeout(timeout, connect_future)
+        .await
+        .map_err(|_| "gRPC connection timeout".to_string())?
+        .map_err(|e| format!("gRPC connection failed: {e}"))?;
+    Ok(())
+}
+
 /// Check if gRPC is reachable by trying all known runtime types in parallel.
 ///
 /// We don't care which runtime it is here — that's `DetectBackendStep`'s job.
 /// We just need to know: does this endpoint speak gRPC at all?
+///
+/// The per-runtime fan-out is gated behind a single transport probe so an
+/// unreachable endpoint costs one connect rather than five.
 pub(crate) async fn try_grpc_reachable(url: &str, timeout_secs: u64) -> Result<(), String> {
     let grpc_url = grpc_reachable_url(url)?;
+
+    grpc_transport_reachable(&grpc_url, timeout_secs).await?;
 
     let (sglang, vllm, trtllm, mlx, tokenspeed) = tokio::join!(
         do_grpc_health_check(&grpc_url, timeout_secs, "sglang"),
@@ -186,5 +209,36 @@ mod tests {
     fn grpc_reachable_url_rejects_http_schemes() {
         assert!(grpc_reachable_url("http://localhost:30000").is_err());
         assert!(grpc_reachable_url("https://localhost:30000").is_err());
+    }
+
+    /// An endpoint that cannot be reached at the transport level must
+    /// short-circuit before the per-runtime fan-out, so one unreachable worker
+    /// costs one dial rather than five.
+    ///
+    /// The two failure paths are distinguishable by their error text, and only
+    /// the aggregate can be constructed *after* all five `do_grpc_health_check`
+    /// calls have run. So asserting the transport error — and the absence of any
+    /// runtime name — is what proves no per-runtime probe was started.
+    /// `192.0.2.1` is TEST-NET-1 (RFC 5737) and is not routable.
+    #[tokio::test]
+    async fn unreachable_transport_short_circuits_the_runtime_fanout() {
+        let err = try_grpc_reachable("grpc://192.0.2.1:1", 1)
+            .await
+            .expect_err("unroutable endpoint should not be reachable");
+
+        assert!(
+            err.starts_with("gRPC connection"),
+            "expected the transport-gate error, got: {err}"
+        );
+        assert!(
+            !err.contains("gRPC not reachable"),
+            "fan-out aggregate was produced, so the gate did not short-circuit: {err}"
+        );
+        for runtime in ["sglang", "vllm", "trtllm", "mlx", "tokenspeed"] {
+            assert!(
+                !err.contains(runtime),
+                "error names {runtime}, so a per-runtime probe ran: {err}"
+            );
+        }
     }
 }

--- a/model_gateway/src/workflow/steps/util.rs
+++ b/model_gateway/src/workflow/steps/util.rs
@@ -1,7 +1,8 @@
 //! Shared URL normalization and network probe utilities for worker steps.
 
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
+use futures::stream::{FuturesUnordered, StreamExt};
 use reqwest::Client;
 use smg_grpc_client::connect_channel_with_timeout;
 
@@ -134,6 +135,44 @@ async fn grpc_transport_reachable(grpc_url: &str, timeout_secs: u64) -> Result<(
     Ok(())
 }
 
+const GRPC_RUNTIME_TYPES: [&str; 5] = ["sglang", "vllm", "trtllm", "mlx", "tokenspeed"];
+
+async fn first_success_or_all_errors<F>(
+    mut checks: FuturesUnordered<F>,
+    runtimes: &[&str],
+) -> Result<(), String>
+where
+    F: Future<Output = (usize, Result<(), String>)>,
+{
+    let mut errors = vec![None; runtimes.len()];
+
+    while let Some((index, result)) = checks.next().await {
+        match result {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                if let Some(slot) = errors.get_mut(index) {
+                    *slot = Some(error);
+                }
+            }
+        }
+    }
+
+    let details = runtimes
+        .iter()
+        .enumerate()
+        .map(|(index, runtime)| match errors[index].as_deref() {
+            Some(error) => format!("{runtime}={error}"),
+            None => format!("{runtime}=health check did not complete"),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Err(format!(
+        "gRPC not reachable (tried {}): {details}",
+        runtimes.join(", ")
+    ))
+}
+
 /// Check if gRPC is reachable by trying all known runtime types in parallel.
 ///
 /// We don't care which runtime it is here — that's `DetectBackendStep`'s job.
@@ -141,6 +180,7 @@ async fn grpc_transport_reachable(grpc_url: &str, timeout_secs: u64) -> Result<(
 ///
 /// The per-runtime fan-out is gated behind a single transport probe so an
 /// unreachable endpoint costs one connect rather than five.
+/// The remaining runtime probes are cancelled after the first success.
 /// `timeout_secs` bounds the gate and fan-out together, not each phase.
 pub(crate) async fn try_grpc_reachable(url: &str, timeout_secs: u64) -> Result<(), String> {
     let grpc_url = grpc_reachable_url(url)?;
@@ -149,24 +189,18 @@ pub(crate) async fn try_grpc_reachable(url: &str, timeout_secs: u64) -> Result<(
     let reachability = Box::pin(async {
         grpc_transport_reachable(&grpc_url, timeout_secs).await?;
 
-        let (sglang, vllm, trtllm, mlx, tokenspeed) = tokio::join!(
-            do_grpc_health_check(&grpc_url, timeout_secs, "sglang"),
-            do_grpc_health_check(&grpc_url, timeout_secs, "vllm"),
-            do_grpc_health_check(&grpc_url, timeout_secs, "trtllm"),
-            do_grpc_health_check(&grpc_url, timeout_secs, "mlx"),
-            do_grpc_health_check(&grpc_url, timeout_secs, "tokenspeed"),
-        );
-
-        match (sglang, vllm, trtllm, mlx, tokenspeed) {
-            (Ok(()), _, _, _, _)
-            | (_, Ok(()), _, _, _)
-            | (_, _, Ok(()), _, _)
-            | (_, _, _, Ok(()), _)
-            | (_, _, _, _, Ok(())) => Ok(()),
-            (Err(e1), Err(e2), Err(e3), Err(e4), Err(e5)) => Err(format!(
-                "gRPC not reachable (tried sglang, vllm, trtllm, mlx, tokenspeed): sglang={e1}, vllm={e2}, trtllm={e3}, mlx={e4}, tokenspeed={e5}",
-            )),
+        let checks = FuturesUnordered::new();
+        for (index, runtime) in GRPC_RUNTIME_TYPES.iter().copied().enumerate() {
+            let grpc_url = &grpc_url;
+            checks.push(async move {
+                (
+                    index,
+                    do_grpc_health_check(grpc_url, timeout_secs, runtime).await,
+                )
+            });
         }
+
+        first_success_or_all_errors(checks, &GRPC_RUNTIME_TYPES).await
     });
 
     tokio::time::timeout(timeout, reachability)
@@ -176,7 +210,23 @@ pub(crate) async fn try_grpc_reachable(url: &str, timeout_secs: u64) -> Result<(
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        future::pending,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+    };
+
     use super::*;
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
 
     #[test]
     fn http_health_url_accepts_http_https_and_bare_urls() {
@@ -222,17 +272,51 @@ mod tests {
         assert!(grpc_reachable_url("https://localhost:30000").is_err());
     }
 
+    #[tokio::test]
+    async fn runtime_fanout_returns_on_first_success_and_cancels_stalled_checks() {
+        let stalled_started = Arc::new(AtomicBool::new(false));
+        let stalled_cancelled = Arc::new(AtomicBool::new(false));
+        let checks = FuturesUnordered::new();
+
+        for (index, succeeds) in [false, true].into_iter().enumerate() {
+            let stalled_started = Arc::clone(&stalled_started);
+            let stalled_cancelled = Arc::clone(&stalled_cancelled);
+            checks.push(async move {
+                let result = if succeeds {
+                    tokio::task::yield_now().await;
+                    Ok(())
+                } else {
+                    stalled_started.store(true, Ordering::SeqCst);
+                    let _drop_flag = DropFlag(stalled_cancelled);
+                    pending::<Result<(), String>>().await
+                };
+                (index, result)
+            });
+        }
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            first_success_or_all_errors(checks, &["stalled", "healthy"]),
+        )
+        .await;
+
+        assert!(matches!(result, Ok(Ok(()))));
+        assert!(stalled_started.load(Ordering::SeqCst));
+        assert!(stalled_cancelled.load(Ordering::SeqCst));
+    }
+
     /// An endpoint that cannot be reached at the transport level must
     /// short-circuit before the per-runtime fan-out, so one unreachable worker
     /// costs one dial rather than five.
     ///
-    /// Use the reserved local port 1 so the transport dial fails without a
-    /// bind-then-drop port-reuse race or dependence on TEST-NET routing.
+    /// TCP port 0 cannot be owned by a listener: binding it asks the OS for an
+    /// ephemeral nonzero port. This makes the local transport failure
+    /// deterministic without a bind-then-drop port-reuse race.
     /// The fan-out aggregate can only be constructed after all runtime probes
     /// run, so the transport error proves the gate returned first.
     #[tokio::test]
     async fn unreachable_transport_short_circuits_the_runtime_fanout() {
-        let err = try_grpc_reachable("grpc://127.0.0.1:1", 1)
+        let err = try_grpc_reachable("grpc://127.0.0.1:0", 1)
             .await
             .expect_err("closed local endpoint should not be reachable");
 

--- a/model_gateway/src/workflow/steps/util.rs
+++ b/model_gateway/src/workflow/steps/util.rs
@@ -123,8 +123,13 @@ pub(crate) async fn do_grpc_health_check(
 /// five in-flight sockets per attempt instead of one.
 async fn grpc_transport_reachable(grpc_url: &str, timeout_secs: u64) -> Result<(), String> {
     let timeout = Duration::from_secs(timeout_secs);
-    connect_channel_with_timeout(grpc_url, timeout)
+    let connect_future = connect_channel_with_timeout(grpc_url, timeout);
+
+    // tonic's connect timeout is applied to the connector. Keep an outer
+    // deadline as a safety net for the remaining Channel::connect setup.
+    tokio::time::timeout(timeout, connect_future)
         .await
+        .map_err(|_| "gRPC connection timeout".to_string())?
         .map_err(|e| format!("gRPC connection failed: {e}"))?;
     Ok(())
 }
@@ -213,19 +218,13 @@ mod tests {
     /// short-circuit before the per-runtime fan-out, so one unreachable worker
     /// costs one dial rather than five.
     ///
-    /// Use a freshly released local port so the transport dial fails
-    /// deterministically instead of depending on TEST-NET routing behavior.
+    /// Use the reserved local port 1 so the transport dial fails without a
+    /// bind-then-drop port-reuse race or dependence on TEST-NET routing.
     /// The fan-out aggregate can only be constructed after all runtime probes
     /// run, so the transport error proves the gate returned first.
     #[tokio::test]
     async fn unreachable_transport_short_circuits_the_runtime_fanout() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind test listener");
-        let address = listener.local_addr().expect("read listener address");
-        drop(listener);
-
-        let err = try_grpc_reachable(&format!("grpc://{address}"), 1)
+        let err = try_grpc_reachable("grpc://127.0.0.1:1", 1)
             .await
             .expect_err("closed local endpoint should not be reachable");
 

--- a/model_gateway/src/workflow/steps/util.rs
+++ b/model_gateway/src/workflow/steps/util.rs
@@ -123,10 +123,8 @@ pub(crate) async fn do_grpc_health_check(
 /// five in-flight sockets per attempt instead of one.
 async fn grpc_transport_reachable(grpc_url: &str, timeout_secs: u64) -> Result<(), String> {
     let timeout = Duration::from_secs(timeout_secs);
-    let connect_future = connect_channel_with_timeout(grpc_url, timeout);
-    tokio::time::timeout(timeout, connect_future)
+    connect_channel_with_timeout(grpc_url, timeout)
         .await
-        .map_err(|_| "gRPC connection timeout".to_string())?
         .map_err(|e| format!("gRPC connection failed: {e}"))?;
     Ok(())
 }
@@ -215,16 +213,21 @@ mod tests {
     /// short-circuit before the per-runtime fan-out, so one unreachable worker
     /// costs one dial rather than five.
     ///
-    /// The two failure paths are distinguishable by their error text, and only
-    /// the aggregate can be constructed *after* all five `do_grpc_health_check`
-    /// calls have run. So asserting the transport error — and the absence of any
-    /// runtime name — is what proves no per-runtime probe was started.
-    /// `192.0.2.1` is TEST-NET-1 (RFC 5737) and is not routable.
+    /// Use a freshly released local port so the transport dial fails
+    /// deterministically instead of depending on TEST-NET routing behavior.
+    /// The fan-out aggregate can only be constructed after all runtime probes
+    /// run, so the transport error proves the gate returned first.
     #[tokio::test]
     async fn unreachable_transport_short_circuits_the_runtime_fanout() {
-        let err = try_grpc_reachable("grpc://192.0.2.1:1", 1)
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
-            .expect_err("unroutable endpoint should not be reachable");
+            .expect("bind test listener");
+        let address = listener.local_addr().expect("read listener address");
+        drop(listener);
+
+        let err = try_grpc_reachable(&format!("grpc://{address}"), 1)
+            .await
+            .expect_err("closed local endpoint should not be reachable");
 
         assert!(
             err.starts_with("gRPC connection"),

--- a/model_gateway/src/workflow/steps/util.rs
+++ b/model_gateway/src/workflow/steps/util.rs
@@ -141,29 +141,37 @@ async fn grpc_transport_reachable(grpc_url: &str, timeout_secs: u64) -> Result<(
 ///
 /// The per-runtime fan-out is gated behind a single transport probe so an
 /// unreachable endpoint costs one connect rather than five.
+/// `timeout_secs` bounds the gate and fan-out together, not each phase.
 pub(crate) async fn try_grpc_reachable(url: &str, timeout_secs: u64) -> Result<(), String> {
     let grpc_url = grpc_reachable_url(url)?;
+    let timeout = Duration::from_secs(timeout_secs);
 
-    grpc_transport_reachable(&grpc_url, timeout_secs).await?;
+    let reachability = Box::pin(async {
+        grpc_transport_reachable(&grpc_url, timeout_secs).await?;
 
-    let (sglang, vllm, trtllm, mlx, tokenspeed) = tokio::join!(
-        do_grpc_health_check(&grpc_url, timeout_secs, "sglang"),
-        do_grpc_health_check(&grpc_url, timeout_secs, "vllm"),
-        do_grpc_health_check(&grpc_url, timeout_secs, "trtllm"),
-        do_grpc_health_check(&grpc_url, timeout_secs, "mlx"),
-        do_grpc_health_check(&grpc_url, timeout_secs, "tokenspeed"),
-    );
+        let (sglang, vllm, trtllm, mlx, tokenspeed) = tokio::join!(
+            do_grpc_health_check(&grpc_url, timeout_secs, "sglang"),
+            do_grpc_health_check(&grpc_url, timeout_secs, "vllm"),
+            do_grpc_health_check(&grpc_url, timeout_secs, "trtllm"),
+            do_grpc_health_check(&grpc_url, timeout_secs, "mlx"),
+            do_grpc_health_check(&grpc_url, timeout_secs, "tokenspeed"),
+        );
 
-    match (sglang, vllm, trtllm, mlx, tokenspeed) {
-        (Ok(()), _, _, _, _)
-        | (_, Ok(()), _, _, _)
-        | (_, _, Ok(()), _, _)
-        | (_, _, _, Ok(()), _)
-        | (_, _, _, _, Ok(())) => Ok(()),
-        (Err(e1), Err(e2), Err(e3), Err(e4), Err(e5)) => Err(format!(
-            "gRPC not reachable (tried sglang, vllm, trtllm, mlx, tokenspeed): sglang={e1}, vllm={e2}, trtllm={e3}, mlx={e4}, tokenspeed={e5}",
-        )),
-    }
+        match (sglang, vllm, trtllm, mlx, tokenspeed) {
+            (Ok(()), _, _, _, _)
+            | (_, Ok(()), _, _, _)
+            | (_, _, Ok(()), _, _)
+            | (_, _, _, Ok(()), _)
+            | (_, _, _, _, Ok(())) => Ok(()),
+            (Err(e1), Err(e2), Err(e3), Err(e4), Err(e5)) => Err(format!(
+                "gRPC not reachable (tried sglang, vllm, trtllm, mlx, tokenspeed): sglang={e1}, vllm={e2}, trtllm={e3}, mlx={e4}, tokenspeed={e5}",
+            )),
+        }
+    });
+
+    tokio::time::timeout(timeout, reachability)
+        .await
+        .map_err(|_| "gRPC reachability timeout".to_string())?
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`connect_channel` built its Endpoint with a keep-alive and window profile but never set `connect_timeout`. tonic applies no default, so a dial to a peer that drops SYN rather than refusing it — a pod IP whose engine container is not listening yet — stays in SYN_SENT until the kernel gives up, ~127s at the default `tcp_syn_retries=6`.

`try_grpc_reachable` then multiplied that by five: it fanned out `do_grpc_health_check` across sglang, vllm, trtllm, mlx and tokenspeed concurrently, and all five dial the same authority. An unreachable endpoint therefore failed five identical connects per attempt and held five sockets for the full kernel ceiling.

Together these let `detect_connection_mode` accumulate SYN_SENT sockets during worker registration faster than they drain, with each step taking 6-11s instead of failing fast.

- Add `DEFAULT_CONNECT_TIMEOUT` (10s, matching the upstream HTTP client in `AppContext`) and apply it in `connect_channel`.
- Add `connect_channel_with_timeout` so probes that already have a deadline can push it down to tonic, which reaps the socket itself instead of depending on the outer future being dropped.
- Gate the per-runtime fan-out in `try_grpc_reachable` behind a single transport probe, so an unreachable endpoint costs one connect rather than five.

## Description

### Problem

<!-- What problem is this PR trying to solve? -->

### Solution

<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
