### PR TITLE
feat(router): derive sticky routing keys from request-id lineage

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -402,7 +402,7 @@ struct Router {
     least_load_default_throughput: f64,
     least_load_mean_prefill_tokens: u32,
     max_idle_secs: u64,
-    assignment_mode: String,
+    assignment_mode: Option<String>,
     max_payload_size: usize,
     dp_aware: bool,
     dp_minimum_tokens_scheduler: bool,
@@ -545,15 +545,22 @@ impl Router {
         })
     }
 
-    fn parse_assignment_mode(&self) -> Result<config::ManualAssignmentMode, config::ConfigError> {
-        match self.assignment_mode.as_str() {
+    fn parse_assignment_mode(
+        &self,
+        default: config::ManualAssignmentMode,
+    ) -> Result<config::ManualAssignmentMode, config::ConfigError> {
+        let Some(mode) = self.assignment_mode.as_deref() else {
+            return Ok(default);
+        };
+        match mode {
             "random" => Ok(config::ManualAssignmentMode::Random),
             "min_load" => Ok(config::ManualAssignmentMode::MinLoad),
             "min_group" => Ok(config::ManualAssignmentMode::MinGroup),
+            "delegate" => Ok(config::ManualAssignmentMode::Delegate),
             other => Err(config::ConfigError::InvalidValue {
                 field: "assignment_mode".to_string(),
                 value: other.to_string(),
-                reason: "expected 'random', 'min_load', or 'min_group'".to_string(),
+                reason: "expected 'random', 'min_load', 'min_group', or 'delegate'".to_string(),
             }),
         }
     }
@@ -615,7 +622,8 @@ impl Router {
                 PolicyType::Manual => ConfigPolicyConfig::Manual {
                     eviction_interval_secs: self.eviction_interval_secs,
                     max_idle_secs: self.max_idle_secs,
-                    assignment_mode: self.parse_assignment_mode()?,
+                    assignment_mode: self
+                        .parse_assignment_mode(config::ManualAssignmentMode::Random)?,
                 },
                 PolicyType::ConsistentHashing => ConfigPolicyConfig::ConsistentHashing,
                 PolicyType::PrefixHash => ConfigPolicyConfig::PrefixHash {
@@ -873,7 +881,8 @@ impl Router {
                 enabled: self.routing_key_override,
                 eviction_interval_secs: self.eviction_interval_secs,
                 max_idle_secs: self.max_idle_secs,
-                assignment_mode: self.parse_assignment_mode()?,
+                assignment_mode: self
+                    .parse_assignment_mode(config::ManualAssignmentMode::Delegate)?,
             })
             .retries(!self.disable_retries)
             .circuit_breaker(!self.disable_circuit_breaker)
@@ -915,7 +924,7 @@ impl Router {
         least_load_default_throughput = 2000.0,
         least_load_mean_prefill_tokens = 1024,
         max_idle_secs = 14400,
-        assignment_mode = String::from("random"),
+        assignment_mode = None,
         max_payload_size = 512 * 1024 * 1024,
         dp_aware = false,
         dp_minimum_tokens_scheduler = false,
@@ -1056,7 +1065,7 @@ impl Router {
         least_load_default_throughput: f64,
         least_load_mean_prefill_tokens: u32,
         max_idle_secs: u64,
-        assignment_mode: String,
+        assignment_mode: Option<String>,
         max_payload_size: usize,
         dp_aware: bool,
         dp_minimum_tokens_scheduler: bool,

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -68,7 +68,8 @@ class RouterArgs:
     least_load_default_throughput: float = 2000.0
     least_load_mean_prefill_tokens: int = 1024
     max_idle_secs: int = 4 * 3600
-    assignment_mode: str = "random"  # Mode for manual policy new routing key assignment
+    # Routing-key assignment; defaults: random (manual policy), delegate (override)
+    assignment_mode: str | None = None
     max_payload_size: int = 512 * 1024 * 1024  # 512MB default for large batches
     bucket_adjust_interval_secs: int = 5
     dp_aware: bool = False
@@ -576,10 +577,12 @@ class RouterArgs:
             f"--{prefix}assignment-mode",
             type=str,
             default=RouterArgs.assignment_mode,
-            choices=["random", "min_load", "min_group"],
+            choices=["random", "min_load", "min_group", "delegate"],
             help=(
-                "Mode for assigning new routing keys in manual policy: random (default),"
-                " min_load (worker with fewest requests), min_group (worker with fewest routing keys)"
+                "Mode for assigning new routing keys: random, min_load (fewest"
+                " requests), min_group (fewest routing keys), delegate (route via"
+                " the underlying policy, then pin). Defaults to random for the"
+                " manual policy and delegate for the routing-key override"
             ),
         )
         routing_group.add_argument(

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -631,6 +631,10 @@ impl Normalizable for ChatCompletionRequest {
 // ============================================================================
 
 impl GenerationRequest for ChatCompletionRequest {
+    fn rid(&self) -> Option<&str> {
+        self.rid.as_deref()
+    }
+
     fn is_stream(&self) -> bool {
         self.stream
     }

--- a/crates/protocols/src/classify.rs
+++ b/crates/protocols/src/classify.rs
@@ -39,6 +39,10 @@ pub struct ClassifyRequest {
 }
 
 impl GenerationRequest for ClassifyRequest {
+    fn rid(&self) -> Option<&str> {
+        self.rid.as_deref()
+    }
+
     fn is_stream(&self) -> bool {
         false // Classification is always non-streaming
     }

--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -53,6 +53,12 @@ pub trait GenerationRequest: Send + Sync {
     fn routing_tokens(&self) -> Option<&[i32]> {
         None
     }
+
+    /// Client-provided request id, when the protocol carries one. Routing may
+    /// derive a session-affinity key from it; a batch reports its first id.
+    fn rid(&self) -> Option<&str> {
+        None
+    }
 }
 
 // ============================================================================

--- a/crates/protocols/src/completion.rs
+++ b/crates/protocols/src/completion.rs
@@ -212,6 +212,10 @@ fn validate_completion_cross_parameters(
 }
 
 impl GenerationRequest for CompletionRequest {
+    fn rid(&self) -> Option<&str> {
+        self.rid.as_deref()
+    }
+
     fn is_stream(&self) -> bool {
         self.stream
     }

--- a/crates/protocols/src/embedding.rs
+++ b/crates/protocols/src/embedding.rs
@@ -30,6 +30,10 @@ pub struct EmbeddingRequest {
 }
 
 impl GenerationRequest for EmbeddingRequest {
+    fn rid(&self) -> Option<&str> {
+        self.rid.as_deref()
+    }
+
     fn is_stream(&self) -> bool {
         // Embeddings are non-streaming
         false

--- a/crates/protocols/src/generate.rs
+++ b/crates/protocols/src/generate.rs
@@ -203,6 +203,10 @@ fn validate_generate_request(req: &GenerateRequest) -> Result<(), validator::Val
 }
 
 impl GenerationRequest for GenerateRequest {
+    fn rid(&self) -> Option<&str> {
+        self.rid.as_deref()
+    }
+
     fn is_stream(&self) -> bool {
         self.stream
     }

--- a/crates/protocols/src/messages.rs
+++ b/crates/protocols/src/messages.rs
@@ -114,6 +114,10 @@ impl CreateMessageRequest {
 }
 
 impl GenerationRequest for CreateMessageRequest {
+    fn rid(&self) -> Option<&str> {
+        self.rid.as_deref()
+    }
+
     fn is_stream(&self) -> bool {
         self.stream.unwrap_or(false)
     }

--- a/crates/protocols/src/rerank.rs
+++ b/crates/protocols/src/rerank.rs
@@ -53,6 +53,10 @@ pub struct RerankRequest {
 }
 
 impl GenerationRequest for RerankRequest {
+    fn rid(&self) -> Option<&str> {
+        self.rid.as_ref().and_then(StringOrArray::first)
+    }
+
     fn get_model(&self) -> Option<&str> {
         Some(&self.model)
     }

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -452,12 +452,22 @@ pub enum ManualAssignmentMode {
     MinLoad,
     /// Select worker with minimum active routing keys
     MinGroup,
+    /// Delegate the first assignment for a key to the underlying routing
+    /// policy, then pin. With `--policy manual` (no underlying policy to
+    /// delegate to) this falls back to min-load.
+    Delegate,
 }
 
-/// Per-request sticky-routing override: when `X-SMG-Routing-Key` is present, any
+/// Per-request sticky-routing override: when a sticky key is present, any
 /// eligible policy routes via manual sticky-map semantics. Reuses the manual
 /// policy knobs for the sticky map; eviction defaults match the manual policy so
 /// config-file users with only `enabled: true` still get TTL eviction (no leak).
+///
+/// Key priority is fixed: a key derived from the typed body's `rid` (per-turn
+/// `_t<n>` and per-retry `_r<n>` suffixes stripped, so every turn of a
+/// conversation shares one key) wins over `X-SMG-Routing-Key`; the header is
+/// the fallback when no rid is present. Raw-streamed requests have no readable
+/// body and therefore derive keys from the header only.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoutingKeyOverrideConfig {
     /// When false, policies are used unchanged.
@@ -467,8 +477,14 @@ pub struct RoutingKeyOverrideConfig {
     pub eviction_interval_secs: u64,
     #[serde(default = "default_manual_max_idle_secs")]
     pub max_idle_secs: u64,
-    #[serde(default)]
+    /// Defaults to `delegate`: first-seen keys route via the underlying
+    /// policy, then pin.
+    #[serde(default = "default_override_assignment_mode")]
     pub assignment_mode: ManualAssignmentMode,
+}
+
+fn default_override_assignment_mode() -> ManualAssignmentMode {
+    ManualAssignmentMode::Delegate
 }
 
 impl Default for RoutingKeyOverrideConfig {
@@ -477,7 +493,7 @@ impl Default for RoutingKeyOverrideConfig {
             enabled: false,
             eviction_interval_secs: default_manual_eviction_interval_secs(),
             max_idle_secs: default_manual_max_idle_secs(),
-            assignment_mode: ManualAssignmentMode::default(),
+            assignment_mode: default_override_assignment_mode(),
         }
     }
 }
@@ -1206,6 +1222,55 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let with: RouterConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(with.stream_body_stall_timeout_secs, 0);
+    }
+
+    #[test]
+    fn test_routing_key_override_serde_default_and_roundtrip() {
+        // Config files with only `enabled` deserialize to the defaults.
+        let json: serde_json::Value = serde_json::json!({ "enabled": true });
+        let cfg: RoutingKeyOverrideConfig = serde_json::from_value(json).unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.assignment_mode, ManualAssignmentMode::Delegate);
+
+        let cfg = RoutingKeyOverrideConfig {
+            enabled: true,
+            assignment_mode: ManualAssignmentMode::MinLoad,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let roundtripped: RoutingKeyOverrideConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtripped.assignment_mode, ManualAssignmentMode::MinLoad);
+    }
+
+    #[test]
+    fn delegate_assignment_mode_survives_serde_roundtrip() {
+        let json = serde_json::to_string(&ManualAssignmentMode::Delegate).unwrap();
+        assert_eq!(json, "\"delegate\"");
+        let back: ManualAssignmentMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ManualAssignmentMode::Delegate);
+
+        let cfg = RoutingKeyOverrideConfig {
+            enabled: true,
+            assignment_mode: ManualAssignmentMode::Delegate,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let roundtripped: RoutingKeyOverrideConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtripped.assignment_mode, ManualAssignmentMode::Delegate);
+    }
+
+    #[test]
+    fn assignment_mode_defaults_split_by_context() {
+        // Manual policy standalone keeps random; the override sticky map
+        // defaults to delegate. Both are operator-visible defaults.
+        assert_eq!(
+            ManualAssignmentMode::default(),
+            ManualAssignmentMode::Random
+        );
+        assert_eq!(
+            RoutingKeyOverrideConfig::default().assignment_mode,
+            ManualAssignmentMode::Delegate
+        );
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -265,9 +265,10 @@ struct CliArgs {
     #[arg(long, default_value_t = 14400, help_heading = "Routing Policy")]
     max_idle_secs: u64,
 
-    /// Assignment mode for manual policy when encountering a new routing key
-    #[arg(long, default_value = "random", value_parser = ["random", "min_load", "min_group"], help_heading = "Routing Policy")]
-    assignment_mode: String,
+    /// Assignment mode for a new routing key. Defaults to random for the
+    /// manual policy and delegate for the routing-key override sticky map
+    #[arg(long, value_parser = ["random", "min_load", "min_group", "delegate"], help_heading = "Routing Policy")]
+    assignment_mode: Option<String>,
 
     /// Number of prefix tokens to use for prefix_hash policy, or four times
     /// as many characters of the prompt when the request is untokenized
@@ -307,8 +308,11 @@ struct CliArgs {
     #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
     dp_aware: bool,
 
-    /// Honor X-SMG-Routing-Key for sticky routing on any policy (reuses the
-    /// manual eviction/idle/assignment knobs for the sticky map)
+    /// Honor a sticky routing key on any policy (reuses the manual
+    /// eviction/idle/assignment knobs for the sticky map). The key is derived
+    /// from the request body's rid with per-turn/per-retry suffixes stripped,
+    /// falling back to X-SMG-Routing-Key when no rid is present; raw-streamed
+    /// requests carry no readable rid and use the header only
     #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
     routing_key_override: bool,
 
@@ -1231,7 +1235,10 @@ impl CliArgs {
             "manual" => PolicyConfig::Manual {
                 eviction_interval_secs: self.eviction_interval,
                 max_idle_secs: self.max_idle_secs,
-                assignment_mode: Self::parse_assignment_mode(&self.assignment_mode),
+                assignment_mode: Self::parse_assignment_mode(
+                    self.assignment_mode.as_deref(),
+                    ManualAssignmentMode::Random,
+                ),
             },
             _ => PolicyConfig::RoundRobin,
         }
@@ -1241,11 +1248,16 @@ impl CliArgs {
         clippy::panic,
         reason = "unreachable: clap value_parser restricts valid assignment modes"
     )]
-    fn parse_assignment_mode(mode: &str) -> ManualAssignmentMode {
+    fn parse_assignment_mode(
+        mode: Option<&str>,
+        default: ManualAssignmentMode,
+    ) -> ManualAssignmentMode {
+        let Some(mode) = mode else { return default };
         match mode {
             "random" => ManualAssignmentMode::Random,
             "min_load" => ManualAssignmentMode::MinLoad,
             "min_group" => ManualAssignmentMode::MinGroup,
+            "delegate" => ManualAssignmentMode::Delegate,
             other => panic!("Unknown assignment mode: {other}"),
         }
     }
@@ -1663,7 +1675,10 @@ impl CliArgs {
                 enabled: self.routing_key_override,
                 eviction_interval_secs: self.eviction_interval,
                 max_idle_secs: self.max_idle_secs,
-                assignment_mode: Self::parse_assignment_mode(&self.assignment_mode),
+                assignment_mode: Self::parse_assignment_mode(
+                    self.assignment_mode.as_deref(),
+                    ManualAssignmentMode::Delegate,
+                ),
             })
             .retries(!self.disable_retries)
             .upstream_http2(self.upstream_http2)
@@ -1960,6 +1975,48 @@ mod tests {
 
         let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
         assert_eq!(defaults.stream_body_stall_timeout_secs, 300);
+    }
+
+    #[test]
+    fn routing_key_flags_flow_into_router_config() {
+        // The override enables with no other configuration; the sticky map
+        // defaults to delegate while the manual policy default stays random.
+        let cli = cli_args_from(&["--routing-key-override"]);
+        let config = cli.to_router_config(vec![], vec![]).unwrap();
+        let override_cfg = &config.routing_key_override;
+        assert!(override_cfg.enabled);
+        assert_eq!(override_cfg.assignment_mode, ManualAssignmentMode::Delegate);
+
+        // An explicit --assignment-mode overrides the sticky-map default.
+        let explicit = cli_args_from(&["--routing-key-override", "--assignment-mode", "min_load"])
+            .to_router_config(vec![], vec![])
+            .unwrap();
+        assert_eq!(
+            explicit.routing_key_override.assignment_mode,
+            ManualAssignmentMode::MinLoad
+        );
+
+        let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
+        assert!(!defaults.routing_key_override.enabled);
+    }
+
+    #[test]
+    fn manual_policy_assignment_default_stays_random() {
+        // One invocation, both contexts: the manual policy keeps its random
+        // default while the override sticky map defaults to delegate.
+        let config = cli_args_from(&["--policy", "manual", "--routing-key-override"])
+            .to_router_config(vec![], vec![])
+            .unwrap();
+        match &config.policy {
+            PolicyConfig::Manual {
+                assignment_mode, ..
+            } => assert_eq!(*assignment_mode, ManualAssignmentMode::Random),
+            other => panic!("expected manual policy, got {other:?}"),
+        }
+        assert_eq!(
+            config.routing_key_override.assignment_mode,
+            ManualAssignmentMode::Delegate
+        );
     }
 
     /// `--health-check-port` must flow into BOTH conversion paths

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -1346,6 +1346,15 @@ impl Metrics {
         gauge!("smg_manual_policy_cache_entries").set(count as f64);
     }
 
+    /// Record which source supplied the sticky routing key for a keyed request
+    pub fn record_routing_key_source(source: &'static str) {
+        counter!(
+            "smg_routing_key_source_total",
+            "source" => source
+        )
+        .increment(1);
+    }
+
     /// Set cache-aware string-tree cached characters for a model
     pub fn set_cache_tree_chars(model_id: &str, chars: usize) {
         let model = intern_model_label(model_id);

--- a/model_gateway/src/policies/manual.rs
+++ b/model_gateway/src/policies/manual.rs
@@ -29,24 +29,37 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ExecutionBranch {
+pub(crate) enum ExecutionBranch {
     NoHealthyWorkers,
     OccupiedHit,
     OccupiedMiss,
     Vacant,
     NoRoutingId,
+    CapRespill,
 }
 
 impl ExecutionBranch {
-    const fn as_str(self) -> &'static str {
+    pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::NoHealthyWorkers => "no_healthy_workers",
             Self::OccupiedHit => "occupied_hit",
             Self::OccupiedMiss => "occupied_miss",
             Self::Vacant => "vacant",
             Self::NoRoutingId => "no_routing_id",
+            Self::CapRespill => "cap_respill",
         }
     }
+}
+
+/// Result of a non-mutating pin probe for a sticky key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PinState {
+    /// A healthy pinned worker exists at this index.
+    Pinned(usize),
+    /// An entry exists but none of its candidates are healthy.
+    Stale,
+    /// No entry for this key.
+    Vacant,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -154,9 +167,80 @@ impl ManualPolicy {
     fn select_new_worker(&self, workers: &[Arc<dyn Worker>], healthy_indices: &[usize]) -> usize {
         match self.assignment_mode {
             ManualAssignmentMode::Random => random_select(healthy_indices),
-            ManualAssignmentMode::MinLoad => min_load_select(workers, healthy_indices),
+            ManualAssignmentMode::MinLoad | ManualAssignmentMode::Delegate => {
+                min_load_select(workers, healthy_indices)
+            }
             ManualAssignmentMode::MinGroup => min_group_select(workers, healthy_indices),
         }
+    }
+
+    pub(crate) fn assignment_mode(&self) -> ManualAssignmentMode {
+        self.assignment_mode
+    }
+
+    pub(crate) fn map_len(&self) -> usize {
+        self.routing_map.len()
+    }
+
+    /// Probe the pin for `key` without reassigning. Refreshes `last_access`
+    /// when an entry exists so probing counts as use.
+    pub(crate) fn peek_pin(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        key: &str,
+        healthy_indices: &[usize],
+    ) -> PinState {
+        match self.routing_map.get_mut(&RoutingId::new(key)) {
+            Some(mut entry) => {
+                entry.last_access = Instant::now();
+                match find_healthy_worker(&entry.candi_worker_urls, workers, healthy_indices) {
+                    Some(idx) => PinState::Pinned(idx),
+                    None => PinState::Stale,
+                }
+            }
+            None => PinState::Vacant,
+        }
+    }
+
+    /// Pin `key` to `url` as the primary candidate, keeping the previous
+    /// primary as bounded failover. Used by delegated assignment and
+    /// cap-respill, where the pin must follow the latest dispatch.
+    pub(crate) fn pin_front(&self, key: &str, url: &str) {
+        match self.routing_map.entry(RoutingId::new(key)) {
+            Entry::Occupied(mut entry) => {
+                let node = entry.get_mut();
+                node.candi_worker_urls.retain(|u| u != url);
+                node.candi_worker_urls.insert(0, url.to_string());
+                node.candi_worker_urls.truncate(MAX_CANDIDATE_WORKERS);
+                node.last_access = Instant::now();
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(Node {
+                    candi_worker_urls: vec![url.to_string()],
+                    last_access: Instant::now(),
+                });
+            }
+        }
+    }
+
+    /// Assign a worker for `key` via this policy's assignment mode, recording
+    /// the pin exactly like keyed selection does.
+    pub(crate) fn assign_pin(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        key: &str,
+        healthy_indices: &[usize],
+    ) -> (usize, ExecutionBranch) {
+        self.select_by_routing_id(workers, key, healthy_indices)
+    }
+
+    /// Raw assignment via this policy's mode, without touching the pin map.
+    pub(crate) fn assign_index(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        healthy_indices: &[usize],
+    ) -> usize {
+        self.select_new_worker(workers, healthy_indices)
     }
 
     fn select_by_routing_id(
@@ -938,6 +1022,62 @@ mod tests {
             );
             assert_eq!(branch, ExecutionBranch::OccupiedHit);
         }
+    }
+
+    #[test]
+    fn test_pin_front_promotes_and_bounds_candidates() {
+        let policy = ManualPolicy::new();
+        policy.pin_front("k", "http://w1:8000");
+        policy.pin_front("k", "http://w2:8000");
+        let node = policy.routing_map.get(&RoutingId::new("k")).unwrap();
+        assert_eq!(node.candi_worker_urls, ["http://w2:8000", "http://w1:8000"]);
+        drop(node);
+
+        // Re-pinning an existing candidate moves it to the front, deduped.
+        policy.pin_front("k", "http://w1:8000");
+        let node = policy.routing_map.get(&RoutingId::new("k")).unwrap();
+        assert_eq!(node.candi_worker_urls, ["http://w1:8000", "http://w2:8000"]);
+        drop(node);
+
+        policy.pin_front("k", "http://w3:8000");
+        let node = policy.routing_map.get(&RoutingId::new("k")).unwrap();
+        assert_eq!(node.candi_worker_urls.len(), MAX_CANDIDATE_WORKERS);
+        assert_eq!(node.candi_worker_urls[0], "http://w3:8000");
+    }
+
+    #[test]
+    fn test_peek_pin_states() {
+        let policy = ManualPolicy::new();
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000"]);
+        let healthy = vec![0, 1];
+
+        assert_eq!(policy.peek_pin(&workers, "k", &healthy), PinState::Vacant);
+
+        policy.pin_front("k", "http://w2:8000");
+        assert_eq!(
+            policy.peek_pin(&workers, "k", &healthy),
+            PinState::Pinned(1)
+        );
+
+        workers[1].set_status(WorkerStatus::NotReady);
+        assert_eq!(policy.peek_pin(&workers, "k", &[0]), PinState::Stale);
+    }
+
+    #[test]
+    fn test_delegate_mode_standalone_assigns_min_load() {
+        // With no underlying policy to delegate to, delegate degrades to
+        // min-load assignment.
+        let policy = ManualPolicy::with_config(ManualConfig {
+            assignment_mode: ManualAssignmentMode::Delegate,
+            ..Default::default()
+        });
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000"]);
+        workers[0].increment_load();
+
+        let info = SelectWorkerInfo::default();
+        let (result, branch) = policy.select_worker_impl(&workers, &info);
+        assert_eq!(result, Some(1));
+        assert_eq!(branch, ExecutionBranch::NoRoutingId);
     }
 
     #[test]

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -263,6 +263,10 @@ pub struct SelectWorkerInfo<'a> {
     /// consistent_hashing and prefix_hash prefer it over their other keying
     /// input.
     pub routing_key: Option<&'a str>,
+    /// Session key derived from the request body's `rid` (routers with typed
+    /// body access populate it); consumed by the routing-key override when
+    /// its key source includes rid.
+    pub rid_key: Option<&'a str>,
     /// Pre-computed hash ring for O(log n) consistent hashing
     /// Built and cached by WorkerRegistry, passed through to avoid per-request rebuilds
     pub hash_ring: Option<Arc<HashRing>>,

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -14,14 +14,19 @@ use tracing::{debug, info, warn};
 /// All subsequent workers of the same model use the established policy.
 /// When the last worker of a model is removed, the policy mapping is cleaned up.
 use super::{
+    get_healthy_worker_indices,
+    manual::{ExecutionBranch, PinState},
     BucketPolicy, CacheAwarePolicy, DPRankLoadPolicy, LoadBalancingPolicy, ManualConfig,
-    ManualPolicy, PolicyFactory, SelectWorkerInfo,
+    ManualPolicy, PolicyFactory, SelectWorkerInfo, WorkerLeg,
 };
 use crate::{
-    config::types::{PolicyConfig, RoutingKeyOverrideConfig},
+    config::types::{ManualAssignmentMode, PolicyConfig, RoutingKeyOverrideConfig},
     mesh::adapters::TreeSyncAdapter,
+    observability::metrics::Metrics,
     policies::cache_aware::LoadReceiver,
-    routers::common::header_utils::{extract_routing_key_hint, parse_routing_tokens_hint},
+    routers::common::header_utils::{
+        extract_routing_key_hint, parse_routing_tokens_hint, ROUTING_KEY_HINT_MAX_BYTES,
+    },
     worker::{KvEventMonitor, Worker},
 };
 
@@ -69,10 +74,38 @@ pub struct PolicyRegistry {
     // DP-rank policy: Supports the selection of dp-rank outside the engine.
     dp_rank_policy: Arc<OnceLock<Arc<dyn DPRankLoadPolicy>>>,
 
-    /// Shared sticky selector for the `X-SMG-Routing-Key` override. `Some` when the
+    /// Shared sticky selector for the routing-key override. `Some` when the
     /// override is enabled; consulted (instead of the configured policy) for keyed
     /// requests via [`PolicyRegistry::select_worker`].
     routing_key_sticky: Option<Arc<ManualPolicy>>,
+}
+
+/// A pinned worker at or over this many router-local in-flight requests (all
+/// traffic on that worker, not just this key; counted per router replica, so
+/// the effective fleet threshold multiplies with replica count) is bypassed
+/// and the request reassigned.
+const STICKY_INFLIGHT_CAP: usize = 2;
+
+/// `conv_t2_r1` -> `conv`: strip one trailing `_r<n>` retry suffix, then one
+/// trailing `_t<n>` turn suffix. A bare retry suffix is stripped too: a retry
+/// shares identity with its original regardless of turn structure.
+fn strip_lineage_suffixes(rid: &str) -> &str {
+    strip_suffix_tag(strip_suffix_tag(rid, 'r'), 't')
+}
+
+fn strip_suffix_tag(s: &str, tag: char) -> &str {
+    let Some((head, tail)) = s.rsplit_once('_') else {
+        return s;
+    };
+    let digits = match tail.strip_prefix(tag) {
+        Some(d) => d,
+        None => return s,
+    };
+    if !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()) {
+        head
+    } else {
+        s
+    }
 }
 
 impl PolicyRegistry {
@@ -95,7 +128,6 @@ impl PolicyRegistry {
                 assignment_mode: routing_key_override.assignment_mode,
             }))
         });
-
         Self {
             model_policies: Arc::new(DashMap::new()),
             model_worker_counts: Arc::new(DashMap::new()),
@@ -112,10 +144,38 @@ impl PolicyRegistry {
         }
     }
 
-    /// Select a worker, applying the `X-SMG-Routing-Key` sticky override when it is
-    /// enabled, the request carries the header, and the configured policy does not
-    /// already honor the key (`manual` / `consistent_hashing`). Otherwise delegates
-    /// to `policy`. `policy.name()` stays the real policy (for metrics).
+    /// Derive the session key from a request id: trailing `_r<n>` retry and
+    /// `_t<n>` turn suffixes are stripped so every turn of a conversation
+    /// shares one key. `None` when the override is disabled, there is no rid,
+    /// or the key exceeds the routing-key byte cap; a rid that is nothing but
+    /// suffix keys as itself.
+    pub fn derive_rid_key<'a>(&self, rid: Option<&'a str>) -> Option<&'a str> {
+        self.routing_key_sticky.as_ref()?;
+        let rid = rid?;
+        let stripped = strip_lineage_suffixes(rid);
+        let key = if stripped.is_empty() { rid } else { stripped };
+        (!key.is_empty() && key.len() <= ROUTING_KEY_HINT_MAX_BYTES).then_some(key)
+    }
+
+    /// Resolve the effective sticky key: the rid-derived key wins, the header
+    /// is the fallback when no rid is present. Header keys go through the
+    /// same validated extraction the policies use.
+    fn effective_sticky_key<'a>(
+        &self,
+        info: &SelectWorkerInfo<'a>,
+    ) -> Option<(&'a str, &'static str)> {
+        info.rid_key.map(|k| (k, "rid")).or_else(|| {
+            info.routing_key
+                .or_else(|| extract_routing_key_hint(info.headers))
+                .map(|k| (k, "header"))
+        })
+    }
+
+    /// Select a worker, applying the sticky routing-key override when it is
+    /// enabled, the request carries a key from the configured source, and the
+    /// configured policy does not already honor the key (`manual` /
+    /// `consistent_hashing`). Otherwise delegates to `policy`. `policy.name()`
+    /// stays the real policy (for metrics).
     pub fn select_worker(
         &self,
         policy: &Arc<dyn LoadBalancingPolicy>,
@@ -123,13 +183,89 @@ impl PolicyRegistry {
         info: &SelectWorkerInfo,
     ) -> Option<usize> {
         if let Some(sticky) = self.routing_key_sticky.as_ref() {
-            if Self::routing_key_override_applies(policy.name())
-                && extract_routing_key_hint(info.headers).is_some()
-            {
-                return sticky.select_worker(workers, info);
+            if Self::routing_key_override_applies(policy.name()) {
+                if let Some((key, source)) = self.effective_sticky_key(info) {
+                    return self.select_sticky(sticky, policy, workers, info, key, source);
+                }
             }
         }
         policy.select_worker(workers, info)
+    }
+
+    /// Keyed selection: honor an existing pin under the in-flight cap;
+    /// otherwise assign — via the underlying policy in `delegate` mode, via
+    /// the sticky map's own assignment mode otherwise — and pin the result.
+    fn select_sticky(
+        &self,
+        sticky: &Arc<ManualPolicy>,
+        policy: &Arc<dyn LoadBalancingPolicy>,
+        workers: &[Arc<dyn Worker>],
+        info: &SelectWorkerInfo,
+        key: &str,
+        source: &'static str,
+    ) -> Option<usize> {
+        Metrics::record_routing_key_source(source);
+
+        // PD legs namespace so prefill and decode stick independently.
+        let namespaced;
+        let key = if info.leg == WorkerLeg::Single {
+            key
+        } else {
+            namespaced = format!("{}{}", info.leg.routing_id_prefix(), key);
+            &namespaced
+        };
+
+        let over_cap = |idx: usize| workers[idx].load() >= STICKY_INFLIGHT_CAP;
+        let finish = |result: Option<usize>, branch: ExecutionBranch| {
+            Metrics::record_worker_manual_policy_branch(branch.as_str());
+            Metrics::set_manual_policy_cache_entries(sticky.map_len());
+            result
+        };
+
+        let healthy = get_healthy_worker_indices(workers);
+        if healthy.is_empty() {
+            return finish(None, ExecutionBranch::NoHealthyWorkers);
+        }
+        let delegate = sticky.assignment_mode() == ManualAssignmentMode::Delegate;
+
+        let pin = sticky.peek_pin(workers, key, &healthy);
+        if let PinState::Pinned(idx) = pin {
+            if !over_cap(idx) {
+                return finish(Some(idx), ExecutionBranch::OccupiedHit);
+            }
+            // Over the cap: reassign, but re-pin only on a strict improvement.
+            // Re-picking the pinned worker (a prefix-affine policy often will)
+            // or another saturated worker keeps the pin, so fleet-wide
+            // pressure cannot random-walk it off the prefix owner.
+            let new_idx = if delegate {
+                match policy.select_worker(workers, info) {
+                    Some(idx) => idx,
+                    None => return finish(None, ExecutionBranch::CapRespill),
+                }
+            } else {
+                sticky.assign_index(workers, &healthy)
+            };
+            if new_idx != idx && !over_cap(new_idx) {
+                sticky.pin_front(key, workers[new_idx].url());
+            }
+            return finish(Some(new_idx), ExecutionBranch::CapRespill);
+        }
+
+        if delegate {
+            let branch = match pin {
+                PinState::Stale => ExecutionBranch::OccupiedMiss,
+                _ => ExecutionBranch::Vacant,
+            };
+            let idx = match policy.select_worker(workers, info) {
+                Some(idx) => idx,
+                None => return finish(None, branch),
+            };
+            sticky.pin_front(key, workers[idx].url());
+            return finish(Some(idx), branch);
+        }
+
+        let (idx, branch) = sticky.assign_pin(workers, key, &healthy);
+        finish(Some(idx), branch)
     }
 
     /// Policies that already honor `X-SMG-Routing-Key` keep their own handling; all
@@ -914,6 +1050,258 @@ mod tests {
         let a = reg.select_worker(&policy, &workers, &info).unwrap();
         let b = reg.select_worker(&policy, &workers, &info).unwrap();
         assert_ne!(a, b);
+    }
+
+    fn rid_override(assignment_mode: ManualAssignmentMode) -> RoutingKeyOverrideConfig {
+        RoutingKeyOverrideConfig {
+            enabled: true,
+            assignment_mode,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn derive_rid_key_strips_turn_and_retry_suffixes() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        assert_eq!(reg.derive_rid_key(Some("conv123_t1")), Some("conv123"));
+        assert_eq!(reg.derive_rid_key(Some("conv123_t12")), Some("conv123"));
+        assert_eq!(reg.derive_rid_key(Some("conv123_t2_r1")), Some("conv123"));
+        assert_eq!(reg.derive_rid_key(Some("conv123_r1")), Some("conv123"));
+        assert_eq!(reg.derive_rid_key(Some("conv_t1_t2")), Some("conv_t1"));
+        assert_eq!(
+            reg.derive_rid_key(Some("under_scored_id")),
+            Some("under_scored_id")
+        );
+        assert_eq!(reg.derive_rid_key(Some("no-suffix")), Some("no-suffix"));
+        assert_eq!(reg.derive_rid_key(Some("conv_tx1")), Some("conv_tx1"));
+        assert_eq!(reg.derive_rid_key(Some("conv_t")), Some("conv_t"));
+        // A rid that is nothing but suffix keys as itself.
+        assert_eq!(reg.derive_rid_key(Some("_t1")), Some("_t1"));
+        assert_eq!(reg.derive_rid_key(None), None);
+        let over_cap = format!("{}_t1", "k".repeat(200));
+        assert_eq!(reg.derive_rid_key(Some(&over_cap)), None);
+
+        // Override disabled: rid never yields a key.
+        let disabled = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        assert_eq!(disabled.derive_rid_key(Some("conv123_t1")), None);
+    }
+
+    #[test]
+    fn rid_key_wins_over_header_and_header_is_fallback() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+
+        // Unique per-request header keys must not fragment the rid pin.
+        let poison_a = headers_with_key("req-aaa");
+        let poison_b = headers_with_key("req-bbb");
+        let first = reg
+            .select_worker(
+                &policy,
+                &workers,
+                &SelectWorkerInfo {
+                    headers: Some(&poison_a),
+                    rid_key: Some("conv42"),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        for headers in [&poison_b, &poison_a] {
+            assert_eq!(
+                reg.select_worker(
+                    &policy,
+                    &workers,
+                    &SelectWorkerInfo {
+                        headers: Some(headers),
+                        rid_key: Some("conv42"),
+                        ..Default::default()
+                    },
+                ),
+                Some(first)
+            );
+        }
+
+        // No rid: the header key gets its own stable pin (fallback works).
+        let session = headers_with_key("session-H");
+        let header_info = SelectWorkerInfo {
+            headers: Some(&session),
+            ..Default::default()
+        };
+        let pinned = reg.select_worker(&policy, &workers, &header_info).unwrap();
+        assert_eq!(
+            reg.select_worker(&policy, &workers, &header_info),
+            Some(pinned)
+        );
+    }
+
+    #[test]
+    fn delegate_assignment_routes_via_underlying_policy_then_pins() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::CacheAware {
+                cache_threshold: 0.5,
+                balance_abs_threshold: 32,
+                balance_rel_threshold: 1.1,
+                eviction_interval_secs: 0,
+                max_tree_size: 10000,
+                block_size: 16,
+                balance_token_usage_threshold: 1.0,
+                overload_token_usage_threshold: 1.0,
+                overlap_decay: 0.0,
+                selection_temperature: 0.0,
+            },
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+        policy
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .unwrap()
+            .init_workers(&workers);
+
+        let turn1_text = "conversation opening with a long shared instruction block";
+        let seeded = reg
+            .select_worker(
+                &policy,
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some(turn1_text),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // First keyed request delegates to the policy: the tree match must
+        // send it to the seeded worker, not a random pick.
+        let key = reg.derive_rid_key(Some("conv42_t1")).unwrap();
+        let keyed_turn1 = SelectWorkerInfo {
+            request_text: Some(turn1_text),
+            rid_key: Some(key),
+            ..Default::default()
+        };
+        assert_eq!(
+            reg.select_worker(&policy, &workers, &keyed_turn1),
+            Some(seeded)
+        );
+
+        // The follow-up shares no routable text; only the pin can send it
+        // back. The policy alone would pick the other worker (its tie-break
+        // counts prior selections), so equality proves the pin decided.
+        let keyed_turn2 = SelectWorkerInfo {
+            request_text: Some("unrelated follow-up tail"),
+            rid_key: reg.derive_rid_key(Some("conv42_t2")),
+            ..Default::default()
+        };
+        assert_eq!(
+            reg.select_worker(&policy, &workers, &keyed_turn2),
+            Some(seeded)
+        );
+    }
+
+    #[test]
+    fn cap_respill_reassigns_and_pin_follows_strict_improvement() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+        let info = SelectWorkerInfo {
+            rid_key: Some("convA"),
+            ..Default::default()
+        };
+
+        let pinned = reg.select_worker(&policy, &workers, &info).unwrap();
+        assert_eq!(reg.select_worker(&policy, &workers, &info), Some(pinned));
+
+        // At the cap (2 in-flight) the key reassigns to the idle worker and
+        // the pin follows it, even after the original drains.
+        workers[pinned].increment_load();
+        workers[pinned].increment_load();
+        let respilled = reg.select_worker(&policy, &workers, &info).unwrap();
+        assert_ne!(respilled, pinned);
+        workers[pinned].decrement_load();
+        workers[pinned].decrement_load();
+        assert_eq!(reg.select_worker(&policy, &workers, &info), Some(respilled));
+    }
+
+    #[test]
+    fn cap_respill_keeps_pin_when_no_strictly_better_pick() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+        let info = SelectWorkerInfo {
+            rid_key: Some("convB"),
+            ..Default::default()
+        };
+
+        let pinned = reg.select_worker(&policy, &workers, &info).unwrap();
+        // Saturate BOTH workers: the reassignment cannot strictly improve
+        // (every pick is at the cap), so the request dispatches wherever the
+        // policy says but the pin must survive.
+        for w in &workers {
+            w.increment_load();
+            w.increment_load();
+        }
+        for _ in 0..4 {
+            reg.select_worker(&policy, &workers, &info).unwrap();
+        }
+        for w in &workers {
+            w.decrement_load();
+            w.decrement_load();
+        }
+        assert_eq!(
+            reg.select_worker(&policy, &workers, &info),
+            Some(pinned),
+            "pin must not move to an equally saturated worker"
+        );
+    }
+
+    #[test]
+    fn cap_respill_under_legacy_assignment() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::MinLoad),
+        );
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+        let info = SelectWorkerInfo {
+            rid_key: Some("convC"),
+            ..Default::default()
+        };
+
+        let pinned = reg.select_worker(&policy, &workers, &info).unwrap();
+        workers[pinned].increment_load();
+        workers[pinned].increment_load();
+        let respilled = reg.select_worker(&policy, &workers, &info).unwrap();
+        assert_ne!(respilled, pinned);
+        workers[pinned].decrement_load();
+        workers[pinned].decrement_load();
+        assert_eq!(reg.select_worker(&policy, &workers, &info), Some(respilled));
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -191,7 +191,7 @@ impl PipelineStage for RequestExecutionStage {
         };
         ctx.state.load_guards = Some(LoadGuards::scaled(
             workers,
-            ctx.input.headers.as_ref(),
+            ctx.state.sticky_key.as_deref(),
             sub_requests,
         ));
 

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -91,11 +91,20 @@ impl PipelineStage for WorkerSelectionStage {
         let tokens = if ids.is_empty() { None } else { Some(ids) };
 
         let headers = ctx.input.headers.as_ref();
+        let rid_key = self
+            .policy_registry
+            .derive_rid_key(ctx.input.request_type.rid())
+            .map(str::to_string);
+        ctx.state.sticky_key = rid_key.clone().or_else(|| {
+            crate::routers::common::header_utils::extract_routing_key_hint(headers)
+                .map(str::to_string)
+        });
+        let rid_key = rid_key.as_deref();
 
         let model_id = ctx.input.model_id.as_str();
         let workers = match self.mode {
             WorkerSelectionMode::Regular => {
-                match self.select_single_worker(model_id, text, tokens, headers) {
+                match self.select_single_worker(model_id, text, tokens, headers, rid_key) {
                     Some(w) => WorkerSelection::Single { worker: w },
                     None => {
                         error!(
@@ -109,7 +118,7 @@ impl PipelineStage for WorkerSelectionStage {
                 }
             }
             WorkerSelectionMode::PrefillDecode => {
-                match self.select_pd_pair(model_id, text, tokens, headers) {
+                match self.select_pd_pair(model_id, text, tokens, headers, rid_key) {
                     Some((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
                         encode_assignments: None,
                         prefill,
@@ -147,6 +156,7 @@ impl PipelineStage for WorkerSelectionStage {
                     text,
                     tokens,
                     headers,
+                    rid_key,
                     &encode_item_hashes,
                 ) {
                     Some((encode_assignments, prefill, decode, runtime_type)) => {
@@ -221,6 +231,7 @@ impl WorkerSelectionStage {
         text: Option<&str>,
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
+        rid_key: Option<&str>,
     ) -> Option<Arc<dyn Worker>> {
         // Treat "unknown" model as wildcard (match any worker)
         let model_filter = if model_id == UNKNOWN_MODEL_ID {
@@ -265,6 +276,7 @@ impl WorkerSelectionStage {
                 tokens,
                 headers,
                 routing_key: None,
+                rid_key,
                 hash_ring,
                 leg: WorkerLeg::Single,
             },
@@ -288,6 +300,7 @@ impl WorkerSelectionStage {
         text: Option<&str>,
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
+        rid_key: Option<&str>,
     ) -> Option<PdWorkerPair> {
         // Treat "unknown" model as wildcard (match any worker)
         let model_filter = if model_id == UNKNOWN_MODEL_ID {
@@ -390,6 +403,7 @@ impl WorkerSelectionStage {
             tokens,
             headers,
             routing_key: None,
+            rid_key,
             hash_ring,
             leg: WorkerLeg::Prefill,
         };
@@ -440,6 +454,7 @@ impl WorkerSelectionStage {
         text: Option<&str>,
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
+        rid_key: Option<&str>,
         encode_item_hashes: &[Vec<u8>],
     ) -> Option<EncodePrefillDecodeWorkerSelection> {
         // Treat "unknown" model as wildcard (match any worker)
@@ -568,6 +583,7 @@ impl WorkerSelectionStage {
             tokens,
             headers,
             routing_key: None,
+            rid_key,
             hash_ring: hash_ring.clone(),
             leg: WorkerLeg::Prefill,
         };
@@ -646,6 +662,9 @@ fn assign_encode_workers(
                 tokens: None,
                 headers: Some(&routing_headers),
                 routing_key: None,
+                // Encode items key by media-content hash; a conversation key
+                // here would defeat per-item encode reuse.
+                rid_key: None,
                 hash_ring: hash_ring.clone(),
                 leg: WorkerLeg::Single,
             };
@@ -779,7 +798,7 @@ mod tests {
         let mut decode_hits = HashMap::new();
         for _ in 0..iterations {
             let (prefill, decode, _) = stage
-                .select_pd_pair(model_id, None, None, None)
+                .select_pd_pair(model_id, None, None, None, None)
                 .expect("select_pd_pair should return a pair");
             *prefill_hits.entry(prefill.url().to_string()).or_default() += 1;
             *decode_hits.entry(decode.url().to_string()).or_default() += 1;
@@ -883,16 +902,80 @@ mod tests {
         );
 
         assert!(
-            stage.select_pd_pair(model_id, None, None, None).is_none(),
+            stage
+                .select_pd_pair(model_id, None, None, None, None)
+                .is_none(),
             "ZMQ-only PD pools must not yield a pair"
         );
 
         // Adding gRPC legs makes selection succeed, and it never picks the ZMQ ones.
         let (prefill_urls, decode_urls) = register_pd_workers(&worker_registry, model_id, 4);
         let (prefill, decode, _) = stage
-            .select_pd_pair(model_id, None, None, None)
+            .select_pd_pair(model_id, None, None, None, None)
             .expect("gRPC PD pair should be selected");
         assert!(prefill_urls.contains(&prefill.url().to_string()));
         assert!(decode_urls.contains(&decode.url().to_string()));
+    }
+
+    /// gRPC selection pins by the rid-derived key under the override: repeats
+    /// of one conversation land on one worker even as a poisoned per-request
+    /// header key rotates; the header only keys requests without a rid.
+    #[test]
+    fn grpc_selection_pins_by_rid_key_under_override() {
+        use crate::config::types::{ManualAssignmentMode, RoutingKeyOverrideConfig};
+
+        let model_id = "test-model-rid-sticky";
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        for i in 0..2 {
+            worker_registry
+                .register(Arc::new(
+                    BasicWorkerBuilder::new(format!("grpc://127.0.0.1:{}", 8300 + i))
+                        .model(ModelCard::new(model_id))
+                        .worker_type(WorkerType::Regular)
+                        .connection_mode(ConnectionMode::Grpc)
+                        .health_config(no_health_check())
+                        .build(),
+                ))
+                .unwrap();
+        }
+        let policy_registry = Arc::new(PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            RoutingKeyOverrideConfig {
+                enabled: true,
+                assignment_mode: ManualAssignmentMode::Delegate,
+                ..Default::default()
+            },
+        ));
+        let stage = WorkerSelectionStage::new(
+            worker_registry,
+            policy_registry.clone(),
+            WorkerSelectionMode::Regular,
+        );
+
+        let rid_key = policy_registry.derive_rid_key(Some("conv7_t1"));
+        assert_eq!(rid_key, Some("conv7"));
+
+        let mut poison = HeaderMap::new();
+        poison.insert("x-smg-routing-key", "req-unique-1".parse().unwrap());
+        let first = stage
+            .select_single_worker(model_id, None, None, Some(&poison), rid_key)
+            .unwrap();
+        for (i, rid) in ["conv7_t2", "conv7_t2_r1", "conv7_t3"].iter().enumerate() {
+            let mut rotated = HeaderMap::new();
+            rotated.insert(
+                "x-smg-routing-key",
+                format!("req-unique-{}", i + 2).parse().unwrap(),
+            );
+            let again = stage
+                .select_single_worker(
+                    model_id,
+                    None,
+                    None,
+                    Some(&rotated),
+                    policy_registry.derive_rid_key(Some(rid)),
+                )
+                .unwrap();
+            assert_eq!(again.url(), first.url(), "follow-up must pin by rid key");
+        }
     }
 }

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -175,6 +175,10 @@ pub(crate) struct ProcessingState {
     // Stage 2: Worker selection outputs
     pub workers: Option<WorkerSelection>,
 
+    /// Effective sticky key (rid-derived wins, header falls back), recorded by
+    /// worker selection so load guards account keyed load identically.
+    pub sticky_key: Option<String>,
+
     // Stage 3: Client acquisition outputs
     pub clients: Option<ClientSelection>,
 
@@ -441,27 +445,29 @@ pub(crate) enum LoadGuards {
 }
 
 impl LoadGuards {
-    pub fn new(selection: &WorkerSelection, headers: Option<&HeaderMap>) -> Self {
+    pub fn new(selection: &WorkerSelection, routing_key: Option<&str>) -> Self {
         match selection {
             WorkerSelection::Single { worker } => LoadGuards::Single {
-                _guard: WorkerLoadGuard::new(worker.clone(), headers),
+                _guard: WorkerLoadGuard::with_key(worker.clone(), routing_key),
             },
             WorkerSelection::Disaggregated {
                 prefill, decode, ..
             } => LoadGuards::Disaggregated {
-                _prefill: WorkerLoadGuard::new(prefill.clone(), headers),
-                _decode: WorkerLoadGuard::new(decode.clone(), headers),
+                _prefill: WorkerLoadGuard::with_key(prefill.clone(), routing_key),
+                _decode: WorkerLoadGuard::with_key(decode.clone(), routing_key),
             },
         }
     }
 
     /// One guard set per concurrent sub-request.
-    pub fn scaled(selection: &WorkerSelection, headers: Option<&HeaderMap>, count: usize) -> Self {
+    pub fn scaled(selection: &WorkerSelection, routing_key: Option<&str>, count: usize) -> Self {
         if count <= 1 {
-            Self::new(selection, headers)
+            Self::new(selection, routing_key)
         } else {
             Self::Batch {
-                _guards: (0..count).map(|_| Self::new(selection, headers)).collect(),
+                _guards: (0..count)
+                    .map(|_| Self::new(selection, routing_key))
+                    .collect(),
             }
         }
     }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -64,6 +64,7 @@ struct PDRequestContext<'a> {
     return_logprob: bool,
     request_text: Option<String>,
     routing_tokens: Option<Vec<u32>>,
+    rid_key: Option<String>,
     model_id: &'a str,
     headers: Option<HeaderMap>,
 }
@@ -332,6 +333,7 @@ impl PDRouter {
                             .select_pd_pair(
                                 context.request_text.as_deref(),
                                 context.routing_tokens.as_deref(),
+                                context.rid_key.as_deref(),
                                 context.model_id,
                                 context.headers.as_ref(),
                             )
@@ -629,9 +631,13 @@ impl PDRouter {
         prefill: Arc<dyn Worker>,
         decode: Arc<dyn Worker>,
     ) -> Response {
+        let effective_key = context
+            .rid_key
+            .as_deref()
+            .or_else(|| crate::routers::common::header_utils::extract_routing_key_hint(headers));
         let load_guards = vec![
-            WorkerLoadGuard::new(prefill.clone(), headers),
-            WorkerLoadGuard::new(decode.clone(), headers),
+            WorkerLoadGuard::with_key(prefill.clone(), effective_key),
+            WorkerLoadGuard::with_key(decode.clone(), effective_key),
         ];
 
         let mut headers_with_trace = headers.cloned().unwrap_or_default();
@@ -822,6 +828,7 @@ impl PDRouter {
         &self,
         request_text: Option<&str>,
         tokens: Option<&[u32]>,
+        rid_key: Option<&str>,
         model_id: &str,
         headers: Option<&HeaderMap>,
     ) -> Result<(Arc<dyn Worker>, Arc<dyn Worker>), String> {
@@ -872,6 +879,7 @@ impl PDRouter {
             &prefill_policy,
             request_text,
             tokens,
+            rid_key,
             headers,
             hash_ring.clone(),
             "prefill",
@@ -883,6 +891,7 @@ impl PDRouter {
             &decode_policy,
             request_text,
             tokens,
+            rid_key,
             headers,
             hash_ring,
             "decode",
@@ -917,6 +926,7 @@ impl PDRouter {
         policy: &Arc<dyn LoadBalancingPolicy>,
         request_text: Option<&str>,
         tokens: Option<&[u32]>,
+        rid_key: Option<&str>,
         headers: Option<&HeaderMap>,
         hash_ring: Option<Arc<HashRing>>,
         worker_type: &str,
@@ -950,6 +960,7 @@ impl PDRouter {
                     tokens,
                     headers,
                     routing_key: None,
+                    rid_key,
                     hash_ring,
                     leg,
                 },
@@ -1340,7 +1351,7 @@ impl RouterTrait for PDRouter {
 
         // Select a random worker pair using the policy
         let (prefill, decode) = match self
-            .select_pd_pair(None, None, UNKNOWN_MODEL_ID, None)
+            .select_pd_pair(None, None, None, UNKNOWN_MODEL_ID, None)
             .await
         {
             Ok(pair) => pair,
@@ -1458,6 +1469,10 @@ impl RouterTrait for PDRouter {
             return_logprob,
             request_text,
             routing_tokens,
+            rid_key: self
+                .policy_registry
+                .derive_rid_key(body.rid())
+                .map(str::to_string),
             model_id,
             headers: headers.cloned(),
         };
@@ -1491,6 +1506,10 @@ impl RouterTrait for PDRouter {
             return_logprob,
             request_text,
             routing_tokens: None,
+            rid_key: self
+                .policy_registry
+                .derive_rid_key(body.rid())
+                .map(str::to_string),
             model_id,
             headers: headers.cloned(),
         };
@@ -1527,6 +1546,10 @@ impl RouterTrait for PDRouter {
             return_logprob,
             request_text,
             routing_tokens: None,
+            rid_key: self
+                .policy_registry
+                .derive_rid_key(body.rid())
+                .map(str::to_string),
             model_id,
             headers: headers.cloned(),
         };
@@ -1555,6 +1578,10 @@ impl RouterTrait for PDRouter {
             return_logprob: false,
             request_text: req_text,
             routing_tokens: None,
+            rid_key: self
+                .policy_registry
+                .derive_rid_key(body.rid())
+                .map(str::to_string),
             model_id,
             headers: headers.cloned(),
         };
@@ -1727,7 +1754,7 @@ mod tests {
             .register_or_replace(Arc::from(decode_worker));
 
         let result = router
-            .select_pd_pair(None, None, UNKNOWN_MODEL_ID, None)
+            .select_pd_pair(None, None, None, UNKNOWN_MODEL_ID, None)
             .await;
 
         assert!(result.is_ok());
@@ -1753,14 +1780,14 @@ mod tests {
         }
 
         let (prefill, decode) = router
-            .select_pd_pair(None, None, "GLM-5.2-Coding", None)
+            .select_pd_pair(None, None, None, "GLM-5.2-Coding", None)
             .await
             .expect("alias should select a PD pair");
         assert_eq!(prefill.url(), "http://prefill");
         assert_eq!(decode.url(), "http://decode");
 
         assert!(router
-            .select_pd_pair(None, None, "GLM-5.2-Unknown", None)
+            .select_pd_pair(None, None, None, "GLM-5.2-Unknown", None)
             .await
             .is_err());
     }
@@ -1770,7 +1797,7 @@ mod tests {
         let router = create_test_pd_router();
 
         let result = router
-            .select_pd_pair(None, None, UNKNOWN_MODEL_ID, None)
+            .select_pd_pair(None, None, None, UNKNOWN_MODEL_ID, None)
             .await;
 
         assert!(result.is_err());
@@ -1831,6 +1858,7 @@ mod tests {
             return_logprob: false,
             request_text: None,
             routing_tokens: None,
+            rid_key: None,
             model_id: UNKNOWN_MODEL_ID,
             headers: None,
         };

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -229,6 +229,7 @@ impl Router {
         text: Option<&str>,
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
+        rid_key: Option<&str>,
     ) -> Option<Arc<dyn Worker>> {
         // UNKNOWN_MODEL_ID means caller didn't specify a model — find any available worker
         let model_filter = if model_id == crate::worker::UNKNOWN_MODEL_ID {
@@ -267,6 +268,7 @@ impl Router {
                 tokens,
                 headers,
                 routing_key: header_utils::extract_routing_key_hint(headers),
+                rid_key,
                 hash_ring,
                 leg: crate::policies::WorkerLeg::Single,
             },
@@ -367,6 +369,7 @@ impl Router {
         let text = routing_tokens
             .is_none()
             .then(|| typed_req.extract_text_for_routing());
+        let rid_key = self.policy_registry.derive_rid_key(typed_req.rid());
         // Resolve once, here, so every registry, policy and metrics lookup
         // below is keyed by the canonical model ID. Only `get_by_model`
         // understands aliases; retry configs, hash rings and policies do not,
@@ -406,6 +409,7 @@ impl Router {
                         is_stream,
                         text.as_deref(),
                         routing_tokens.as_deref(),
+                        rid_key,
                     )
                     .await;
 
@@ -471,8 +475,9 @@ impl Router {
         is_stream: bool,
         text: Option<&str>,
         tokens: Option<&[u32]>,
+        rid_key: Option<&str>,
     ) -> Response {
-        let worker = match self.select_worker_for_model(model_id, text, tokens, headers) {
+        let worker = match self.select_worker_for_model(model_id, text, tokens, headers, rid_key) {
             Some(w) => w,
             None => {
                 // Distinguish "no workers for this model" from "workers exist but unavailable"
@@ -499,7 +504,12 @@ impl Router {
             }
         };
 
-        let load_guard = WorkerLoadGuard::new(worker.clone(), headers);
+        // Keyed-load accounting uses the same effective key as selection:
+        // rid-derived first, header fallback.
+        let load_guard = WorkerLoadGuard::with_key(
+            worker.clone(),
+            rid_key.or_else(|| header_utils::extract_routing_key_hint(headers)),
+        );
 
         // Note: Using borrowed reference avoids heap allocation
         events::RequestSentEvent { url: worker.url() }.emit();
@@ -775,6 +785,7 @@ impl Router {
                 tokens: hinted_tokens.as_deref(),
                 headers,
                 routing_key: header_utils::extract_routing_key_hint(headers),
+                rid_key: None,
                 hash_ring,
                 leg: crate::policies::WorkerLeg::Single,
             },
@@ -1570,12 +1581,15 @@ impl Router {
         }
         // Buffered-path parity: a valid tokens hint is exactly what selection
         // would have received there (text is never extracted alongside it).
+        // Streamed requests have no readable body, hence no rid key; the
+        // sticky override keys them by the header alone.
         let hinted_tokens = header_utils::parse_routing_tokens_hint(Some(req.headers()));
         let Some(worker) = self.select_worker_for_model(
             model_id,
             None,
             hinted_tokens.as_deref(),
             Some(req.headers()),
+            None,
         ) else {
             return Err(req);
         };

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -1663,10 +1663,16 @@ pub struct WorkerLoadGuard {
 
 impl WorkerLoadGuard {
     pub fn new(worker: Arc<dyn Worker>, headers: Option<&http::HeaderMap>) -> Self {
+        let key = extract_routing_key(headers).map(String::from);
+        Self::with_key(worker, key.as_deref())
+    }
+
+    /// Guard keyed by the caller-resolved effective sticky key (rid-derived
+    /// wins over the header), so keyed-load accounting matches selection.
+    pub fn with_key(worker: Arc<dyn Worker>, routing_key: Option<&str>) -> Self {
         worker.increment_load();
 
-        let routing_key = extract_routing_key(headers).map(String::from);
-
+        let routing_key = routing_key.map(String::from);
         if let Some(ref key) = routing_key {
             worker.increment_routing_key_load(key);
         }


### PR DESCRIPTION
## Description
### Problem
On multimodal conversation lanes, engine prefix cache for a conversation lives on the worker that served its previous turn, but content-similarity routing cannot recognize follow-ups: a follow-up body contains the whole previous exchange, so its matched/raw ratio shrinks with conversation length (~0.17 at turn 2) and no fixed threshold pins it. The sticky override's `X-SMG-Routing-Key` header is unusable on lanes whose gateway stamps a unique value per request — while request bodies already carry conversation lineage in their `rid` (`conv_t1`, `conv_t2_r1`).
### Behavior
This changes what the existing opt-in `--routing-key-override` flag does — **no new configuration surface; enabling = the existing flag**:
- The sticky key is derived from the body `rid` with per-turn (`_t<n>`) and per-retry (`_r<n>`) suffixes stripped, and **wins over the header**; the header is the fallback when no rid is present. Raw-streamed requests carry no readable body and use the header only.
- First-seen keys route via the **underlying policy** (delegate assignment, now the override's default — `--assignment-mode` still overrides), then pin.
- A fixed per-pin in-flight cap (2; the pinned worker's total router-local in-flight, per replica) reassigns saturated pins; the pin follows only a strictly better placement, so fleet-wide pressure cannot walk a pin off its prefix owner.
- Keyed-load accounting (`min_group`, per-worker key gauges) uses the same effective key on the HTTP, PD, and gRPC paths.

## Changes
- `crates/protocols`: `rid()` on `GenerationRequest` (all request types; batches report their first id)
- `policies/registry.rs`: fixed lineage stripping (plain string parsing), rid-first key resolution, keyed selection with delegate assignment and improvement-gated cap respill; `smg_routing_key_source_total` and a `cap_respill` branch label; every selection exit records metrics
- `policies/manual.rs`: `delegate` mode plus pin probe/promote primitives with bounded failover candidates
- HTTP, PD, and gRPC pipelines populate the rid key at selection; `WorkerLoadGuard::with_key` keys load accounting by the effective key everywhere (gRPC encode-item assignment intentionally keeps media-hash keying)
- Python bindings: `assignment_mode` becomes optional with context defaults; no new fields

## Composition
Open PR #2202 lifts streaming buffering when a valid `x-smg-routing-key` header is present. Under rid-wins semantics, buffered requests ignore that header while streamed ones fall back to it; whichever lands second must keep #2202's gate consistent (streamed + rid-less = header key), and lanes with junk headers should not combine streaming with the override until routing can peek bodies.

## Test Plan
- Registry: lineage-strip matrix (turn/retry/bare-retry/multi-underscore/all-suffix/over-cap/disabled); rid pins stable under rotating unique header keys with header fallback intact; delegate-vacant honors a seeded prefix-tree match and turn-2 returns to the pin; cap respill re-pins on strict improvement and holds the pin under uniform saturation, in delegate and legacy modes
- gRPC: follow-ups pin by rid through the worker-selection stage while a poisoned header rotates
- Config/CLI: override defaults to delegate with zero flags; explicit `--assignment-mode` overrides; serde roundtrip
- `cargo +nightly fmt --all --check`; targeted modules green (162 + 7); full clippy + suite in CI; `cargo build -p smg-python`

<details><summary>Checklist</summary>

- [x] Format clean; lint self-audited (`#[expect]` with reason, no `unwrap` in prod paths)
- [x] Tests added and passing
- [x] Bindings updated (Python); Go unaffected
- [x] DCO sign-off, conventional commit
</details>

**Deploy pairing (multimodal video lane):** add `--routing-key-override` (nothing else), keep cache_aware underlying with a sane threshold. **Dependency caveat:** pinning makes surviving engine cache reachable but cannot extend its lifetime — follow-ups within the engine's retention window convert immediately; longer-gap follow-ups additionally need engine-side retention extension.