### PR TITLE
fix(router): clippy cleanups in lineage-sticky selection paths

### DIFF
--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -160,10 +160,7 @@ impl PolicyRegistry {
     /// Resolve the effective sticky key: the rid-derived key wins, the header
     /// is the fallback when no rid is present. Header keys go through the
     /// same validated extraction the policies use.
-    fn effective_sticky_key<'a>(
-        &self,
-        info: &SelectWorkerInfo<'a>,
-    ) -> Option<(&'a str, &'static str)> {
+    fn effective_sticky_key<'a>(info: &SelectWorkerInfo<'a>) -> Option<(&'a str, &'static str)> {
         info.rid_key.map(|k| (k, "rid")).or_else(|| {
             info.routing_key
                 .or_else(|| extract_routing_key_hint(info.headers))
@@ -184,8 +181,8 @@ impl PolicyRegistry {
     ) -> Option<usize> {
         if let Some(sticky) = self.routing_key_sticky.as_ref() {
             if Self::routing_key_override_applies(policy.name()) {
-                if let Some((key, source)) = self.effective_sticky_key(info) {
-                    return self.select_sticky(sticky, policy, workers, info, key, source);
+                if let Some((key, source)) = Self::effective_sticky_key(info) {
+                    return Self::select_sticky(sticky, policy, workers, info, key, source);
                 }
             }
         }
@@ -196,7 +193,6 @@ impl PolicyRegistry {
     /// otherwise assign — via the underlying policy in `delegate` mode, via
     /// the sticky map's own assignment mode otherwise — and pin the result.
     fn select_sticky(
-        &self,
         sticky: &Arc<ManualPolicy>,
         policy: &Arc<dyn LoadBalancingPolicy>,
         workers: &[Arc<dyn Worker>],

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -14,6 +14,7 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo, WorkerLeg},
     routers::{
+        common::header_utils::extract_routing_key_hint,
         error,
         grpc::{
             context::{EncodeWorkerAssignment, RequestContext, WorkerSelection},
@@ -95,10 +96,9 @@ impl PipelineStage for WorkerSelectionStage {
             .policy_registry
             .derive_rid_key(ctx.input.request_type.rid())
             .map(str::to_string);
-        ctx.state.sticky_key = rid_key.clone().or_else(|| {
-            crate::routers::common::header_utils::extract_routing_key_hint(headers)
-                .map(str::to_string)
-        });
+        ctx.state.sticky_key = rid_key
+            .clone()
+            .or_else(|| extract_routing_key_hint(headers).map(str::to_string));
         let rid_key = rid_key.as_deref();
 
         let model_id = ctx.input.model_id.as_str();

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -634,7 +634,7 @@ impl PDRouter {
         let effective_key = context
             .rid_key
             .as_deref()
-            .or_else(|| crate::routers::common::header_utils::extract_routing_key_hint(headers));
+            .or_else(|| header_utils::extract_routing_key_hint(headers));
         let load_guards = vec![
             WorkerLoadGuard::with_key(prefill.clone(), effective_key),
             WorkerLoadGuard::with_key(decode.clone(), effective_key),


### PR DESCRIPTION
## Description
### Problem
Post-merge CI on main fails clippy with five errors introduced by #2206: two `absolute_paths`/`unnecessary_qualification` uses of `extract_routing_key_hint` (pd_router, gRPC worker selection) and two `unused_self` methods in the policy registry.
### Solution
Import the helper where it is used; make `effective_sticky_key` and `select_sticky` associated functions (neither reads `self`). No behavior change.
## Test Plan
- `cargo clippy -p smg --lib -- -D warnings` clean (previously 5 errors)
- Registry test module green post-change
- `cargo +nightly fmt --all --check` clean
<details><summary>Checklist</summary>

- [x] Format + clippy (lib) clean
- [x] No behavior change; existing tests green
- [x] DCO sign-off, conventional commit
</details>