### PR TITLE
feat(cli): add intent-revealing aliases for routing and health flags

### DIFF
--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -415,9 +415,13 @@ class RouterArgs:
         )
         routing_group.add_argument(
             f"--{prefix}cache-threshold",
+            f"--{prefix}cache-match-threshold",
             type=float,
             default=RouterArgs.cache_threshold,
-            help="Cache threshold (0.0-1.0) for cache-aware routing",
+            help=(
+                "Minimum matched-prefix share (0.0-1.0) before cache-aware routing"
+                " pins a request to a worker already holding that prefix"
+            ),
         )
         routing_group.add_argument(
             f"--{prefix}prefix-token-count",
@@ -479,19 +483,21 @@ class RouterArgs:
         )
         routing_group.add_argument(
             f"--{prefix}balance-abs-threshold",
+            f"--{prefix}spill-abs-threshold",
             type=int,
             default=RouterArgs.balance_abs_threshold,
             help=(
-                "Absolute threshold for load difference. Balancing is triggered if"
+                "Spill gate, absolute part. Balancing is triggered if"
                 " `(max_load - min_load) > abs_threshold` and the relative threshold is also met."
             ),
         )
         routing_group.add_argument(
             f"--{prefix}balance-rel-threshold",
+            f"--{prefix}spill-rel-threshold",
             type=float,
             default=RouterArgs.balance_rel_threshold,
             help=(
-                "Relative threshold for load difference. Balancing is triggered if"
+                "Spill gate, relative part. Balancing is triggered if"
                 " `max_load > min_load * rel_threshold` and the absolute threshold is also met."
             ),
         )
@@ -569,9 +575,13 @@ class RouterArgs:
         )
         routing_group.add_argument(
             f"--{prefix}max-idle-secs",
+            f"--{prefix}sticky-key-idle-secs",
             type=int,
             default=RouterArgs.max_idle_secs,
-            help="Maximum idle time in seconds before eviction (for manual policy)",
+            help=(
+                "How long an unused sticky routing key stays pinned: keys idle"
+                " beyond this many seconds are evicted from the sticky map"
+            ),
         )
         routing_group.add_argument(
             f"--{prefix}assignment-mode",
@@ -623,8 +633,13 @@ class RouterArgs:
         )
         routing_group.add_argument(
             f"--{prefix}routing-key-override",
+            f"--{prefix}sticky-sessions",
             action="store_true",
-            help="Honor X-SMG-Routing-Key for sticky routing on any policy",
+            help=(
+                "Sticky sessions: route every request of a conversation to the"
+                " same worker, on any policy (keys derived from the request-id"
+                " lineage, falling back to X-SMG-Routing-Key)"
+            ),
         )
         routing_group.add_argument(
             f"--{prefix}dp-minimum-tokens-scheduler",
@@ -1044,9 +1059,14 @@ class RouterArgs:
         )
         health_group.add_argument(
             f"--{prefix}remove-unhealthy-workers",
+            f"--{prefix}worker-auto-recovery",
             action="store_true",
             default=RouterArgs.remove_unhealthy_workers,
-            help="Remove workers from the registry when they are marked unhealthy",
+            help=(
+                "Let workers recover after prolonged failure: unhealthy workers"
+                " are removed so service discovery re-registers and re-probes"
+                " them once their engine returns"
+            ),
         )
         # Tokenizer configuration
         tokenizer_group.add_argument(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1072,6 +1072,54 @@ class TestPrefixHashArgs:
         assert router_args.prefix_hash_load_factor == 2.0
 
 
+class TestFlagAliases:
+    """Intent-revealing alias flags land on the same dests as the canonical names."""
+
+    def test_alias_flags_land_on_canonical_dests(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser)
+        namespace = parser.parse_args(
+            [
+                "--sticky-sessions",
+                "--worker-auto-recovery",
+                "--cache-match-threshold",
+                "0.6",
+                "--spill-abs-threshold",
+                "8",
+                "--spill-rel-threshold",
+                "1.2",
+                "--sticky-key-idle-secs",
+                "300",
+            ]
+        )
+        router_args = RouterArgs.from_cli_args(namespace)
+        assert router_args.routing_key_override is True
+        assert router_args.remove_unhealthy_workers is True
+        assert router_args.cache_threshold == 0.6
+        assert router_args.balance_abs_threshold == 8
+        assert router_args.balance_rel_threshold == 1.2
+        assert router_args.max_idle_secs == 300
+
+    def test_alias_flags_match_canonical_parse(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser)
+        canonical = RouterArgs.from_cli_args(
+            parser.parse_args(["--routing-key-override", "--cache-threshold", "0.6"])
+        )
+        aliased = RouterArgs.from_cli_args(
+            parser.parse_args(["--sticky-sessions", "--cache-match-threshold", "0.6"])
+        )
+        assert canonical == aliased
+
+    def test_alias_flags_honor_router_prefix(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser, use_router_prefix=True)
+        namespace = parser.parse_args(["--router-sticky-sessions", "--router-worker-auto-recovery"])
+        router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
+        assert router_args.routing_key_override is True
+        assert router_args.remove_unhealthy_workers is True
+
+
 class TestRouterArgsFieldOrder:
     """RouterArgs generates a positional __init__, so field order is a public
     contract: a mid-list insertion silently rebinds every later positional

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -34,8 +34,8 @@ pub struct RouterConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub zmq_engine_count: Option<usize>,
     pub policy: PolicyConfig,
-    /// Per-request sticky-routing override (honors `X-SMG-Routing-Key`).
-    #[serde(default)]
+    /// Per-request sticky-session routing (rid-lineage keys, header fallback).
+    #[serde(default, alias = "sticky_sessions")]
     pub routing_key_override: RoutingKeyOverrideConfig,
     pub host: String,
     pub port: u16,
@@ -475,7 +475,10 @@ pub struct RoutingKeyOverrideConfig {
     pub enabled: bool,
     #[serde(default = "default_manual_eviction_interval_secs")]
     pub eviction_interval_secs: u64,
-    #[serde(default = "default_manual_max_idle_secs")]
+    #[serde(
+        default = "default_manual_max_idle_secs",
+        alias = "sticky_key_idle_secs"
+    )]
     pub max_idle_secs: u64,
     /// Defaults to `delegate`: first-seen keys route via the underlying
     /// policy, then pin.
@@ -516,15 +519,17 @@ pub enum PolicyConfig {
 
     #[serde(rename = "cache_aware")]
     CacheAware {
+        /// Minimum matched-prefix share before a request pins to a holder.
+        #[serde(alias = "cache_match_threshold")]
         cache_threshold: f32,
-        /// Absolute load margin for the per-request candidate gate: the
-        /// selected worker spills to least-loaded when its load exceeds the
-        /// healthy-fleet mean by this many requests AND by
-        /// `balance_rel_threshold`.
+        /// Spill gate, absolute part: the selected worker spills to
+        /// least-loaded when its load exceeds the healthy-fleet mean by this
+        /// many requests AND by `balance_rel_threshold`.
+        #[serde(alias = "spill_abs_threshold")]
         balance_abs_threshold: usize,
-        /// Relative load margin (multiple of the healthy-fleet mean) for the
-        /// per-request candidate gate; fires only together with
-        /// `balance_abs_threshold`.
+        /// Spill gate, relative part (multiple of the healthy-fleet mean);
+        /// fires only together with `balance_abs_threshold`.
+        #[serde(alias = "spill_rel_threshold")]
         balance_rel_threshold: f32,
         eviction_interval_secs: u64,
         max_tree_size: usize,
@@ -598,8 +603,10 @@ pub enum PolicyConfig {
     #[serde(rename = "bucket")]
     Bucket {
         /// Absolute load difference threshold for load balancing
+        #[serde(alias = "spill_abs_threshold")]
         balance_abs_threshold: usize,
         /// Relative load ratio threshold for load balancing
+        #[serde(alias = "spill_rel_threshold")]
         balance_rel_threshold: f32,
         /// Interval between bucket boundary adjustment cycles (seconds)
         bucket_adjust_interval_secs: usize,
@@ -615,8 +622,12 @@ pub enum PolicyConfig {
         /// Interval between TTL eviction cycles (seconds, default: 60)
         #[serde(default = "default_manual_eviction_interval_secs")]
         eviction_interval_secs: u64,
-        /// Maximum idle time before eviction (seconds, default: 14400 = 4 hours)
-        #[serde(default = "default_manual_max_idle_secs")]
+        /// Maximum idle time before a key is evicted (seconds, default:
+        /// 14400 = 4 hours)
+        #[serde(
+            default = "default_manual_max_idle_secs",
+            alias = "sticky_key_idle_secs"
+        )]
         max_idle_secs: u64,
         /// Assignment mode for new routing keys (default: random)
         #[serde(default)]
@@ -828,7 +839,9 @@ pub struct HealthCheckConfig {
     pub check_interval_secs: u64,
     pub endpoint: String,
     pub disable_health_check: bool,
-    #[serde(default)]
+    /// Let workers recover after prolonged failure: removal re-enters them
+    /// through service discovery once their engine returns.
+    #[serde(default, alias = "worker_auto_recovery")]
     pub remove_unhealthy_workers: bool,
     /// Seconds to keep a Ready worker in `Draining` after `RemoveWorker`
     /// is submitted before the registry entry is removed. Lets in-flight
@@ -1222,6 +1235,76 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let with: RouterConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(with.stream_body_stall_timeout_secs, 0);
+    }
+
+    #[test]
+    fn alias_field_spellings_deserialize_and_serialize_canonically() {
+        // Config files may use the intent-revealing spellings; alias in,
+        // canonical out.
+        let mut json = serde_json::to_value(RouterConfig::default()).unwrap();
+        let obj = json.as_object_mut().unwrap();
+        let v = obj.remove("routing_key_override").unwrap();
+        obj.insert("sticky_sessions".to_string(), v);
+        let hc = obj
+            .get_mut("health_check")
+            .unwrap()
+            .as_object_mut()
+            .unwrap();
+        hc.remove("remove_unhealthy_workers").unwrap();
+        hc.insert(
+            "worker_auto_recovery".to_string(),
+            serde_json::Value::Bool(true),
+        );
+        let cfg: RouterConfig = serde_json::from_value(json).unwrap();
+        assert!(cfg.health_check.remove_unhealthy_workers);
+        let out = serde_json::to_string(&cfg).unwrap();
+        assert!(out.contains("routing_key_override"));
+        assert!(out.contains("remove_unhealthy_workers"));
+        assert!(!out.contains("sticky_sessions"));
+        assert!(!out.contains("worker_auto_recovery"));
+    }
+
+    #[test]
+    fn policy_alias_field_spellings_deserialize_identically() {
+        let canonical: PolicyConfig = serde_json::from_value(serde_json::json!({
+            "type": "cache_aware",
+            "cache_threshold": 0.6,
+            "balance_abs_threshold": 8,
+            "balance_rel_threshold": 1.2,
+            "eviction_interval_secs": 60,
+            "max_tree_size": 1024,
+        }))
+        .unwrap();
+        let aliased: PolicyConfig = serde_json::from_value(serde_json::json!({
+            "type": "cache_aware",
+            "cache_match_threshold": 0.6,
+            "spill_abs_threshold": 8,
+            "spill_rel_threshold": 1.2,
+            "eviction_interval_secs": 60,
+            "max_tree_size": 1024,
+        }))
+        .unwrap();
+        assert_eq!(format!("{canonical:?}"), format!("{aliased:?}"));
+        let out = serde_json::to_string(&aliased).unwrap();
+        assert!(!out.contains("cache_match_threshold"));
+        assert!(!out.contains("spill_abs_threshold"));
+
+        let manual: PolicyConfig = serde_json::from_value(serde_json::json!({
+            "type": "manual",
+            "sticky_key_idle_secs": 123,
+        }))
+        .unwrap();
+        match manual {
+            PolicyConfig::Manual { max_idle_secs, .. } => assert_eq!(max_idle_secs, 123),
+            other => panic!("expected manual policy, got {other:?}"),
+        }
+
+        let override_cfg: RoutingKeyOverrideConfig = serde_json::from_value(serde_json::json!({
+            "enabled": true,
+            "sticky_key_idle_secs": 321,
+        }))
+        .unwrap();
+        assert_eq!(override_cfg.max_idle_secs, 321);
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -205,49 +205,65 @@ struct CliArgs {
     #[arg(long, default_value = "cache_aware", value_parser = ["random", "round_robin", "passthrough", "cache_aware", "power_of_two", "least_load", "prefix_hash", "consistent_hashing", "manual", "bucket"], help_heading = "Routing Policy")]
     policy: String,
 
-    /// Cache threshold (0.0-1.0) for cache-aware routing
-    #[arg(long, default_value_t = 0.3, help_heading = "Routing Policy")]
+    /// Minimum matched-prefix share (0.0-1.0) before cache-aware routing
+    /// pins a request to a worker already holding that prefix; below it the
+    /// request is load-balanced instead
+    #[arg(
+        long,
+        visible_alias = "cache-match-threshold",
+        default_value_t = 0.3,
+        help_heading = "Routing Policy"
+    )]
     cache_threshold: f32,
 
-    /// Absolute load margin for the balancing check. For cache-aware routing
-    /// the selected worker spills to least-loaded when its load exceeds the
-    /// healthy-fleet mean by this many requests AND by balance_rel_threshold.
-    #[arg(long, default_value_t = 64, help_heading = "Routing Policy")]
+    /// Spill gate, absolute part: a matched worker is skipped for the
+    /// least-loaded one when its load exceeds the healthy-fleet mean by this
+    /// many requests AND by --balance-rel-threshold
+    #[arg(
+        long,
+        visible_alias = "spill-abs-threshold",
+        default_value_t = 64,
+        help_heading = "Routing Policy"
+    )]
     balance_abs_threshold: usize,
 
-    /// Relative load margin for the balancing check (multiple of the
-    /// healthy-fleet mean); fires only together with balance_abs_threshold.
-    #[arg(long, default_value_t = 1.5, help_heading = "Routing Policy")]
+    /// Spill gate, relative part (multiple of the healthy-fleet mean); fires
+    /// only together with --balance-abs-threshold
+    #[arg(
+        long,
+        visible_alias = "spill-rel-threshold",
+        default_value_t = 1.5,
+        help_heading = "Routing Policy"
+    )]
     balance_rel_threshold: f32,
 
-    /// Cache-aware KV-usage spread (hottest minus coldest backend, 0.0-1.0)
-    /// above which cache affinity is abandoned for shortest-queue, even if
-    /// request counts look balanced (catches long-context KV imbalance). Backend
-    /// must report token_usage. >= 1.0 disables it.
+    /// Abandon cache affinity for shortest-queue when the KV-usage spread
+    /// (hottest minus coldest backend, 0.0-1.0) exceeds this — catches
+    /// long-context KV imbalance that request counts miss. Backend must
+    /// report token_usage. >= 1.0 disables it.
     #[arg(long, default_value_t = 1.0, help_heading = "Routing Policy")]
     balance_token_usage_threshold: f32,
 
-    /// Cache-aware KV-utilization ceiling (0.0-1.0): when the hottest backend
-    /// exceeds it, shed load off that engine regardless of spread. A safety
-    /// valve for critically-saturated engines, best set high (e.g. 0.9).
-    /// >= 1.0 disables it.
+    /// Safety valve for critically-saturated engines: when the hottest
+    /// backend's KV utilization (0.0-1.0) exceeds this, shed load off it
+    /// regardless of spread. Best set high (e.g. 0.9). >= 1.0 disables it.
     #[arg(long, default_value_t = 1.0, help_heading = "Routing Policy")]
     overload_token_usage_threshold: f32,
 
-    /// Cache-aware anti-hotspot decay: divide each candidate's overlap score
-    /// by 1 + overlap_decay * x, where x is the worker's waiting-prefill
-    /// backlog (blocks above the candidate minimum) per request block.
-    /// Requires backend load reporting. 0.0 disables.
+    /// Anti-hotspot decay: de-rank cache-affine candidates by their
+    /// waiting-prefill backlog (overlap score divided by 1 + overlap_decay
+    /// * backlog blocks per request block). Requires backend load
+    /// reporting. 0.0 disables.
     #[arg(long, default_value_t = 0.0, help_heading = "Routing Policy")]
     overlap_decay: f32,
 
-    /// Cache-aware softmax temperature over min-max normalized scores for
-    /// event-driven selection. 0.0 is exact argmax; larger values spread
-    /// picks across candidates.
+    /// Spread event-driven cache-aware picks across near-equal candidates:
+    /// softmax temperature over min-max normalized scores. 0.0 is exact
+    /// argmax.
     #[arg(long, default_value_t = 0.0, help_heading = "Routing Policy")]
     selection_temperature: f32,
 
-    /// Interval in seconds between cache eviction operations
+    /// Interval in seconds between cache-tree eviction cycles
     #[arg(long, default_value_t = 120, help_heading = "Routing Policy")]
     eviction_interval: u64,
 
@@ -257,16 +273,26 @@ struct CliArgs {
     #[arg(long, default_value_t = 67108864, help_heading = "Routing Policy")]
     max_tree_size: usize,
 
-    /// KV cache block size for event-driven cache-aware routing
+    /// Match granularity for cache-aware token routing: the token-tree page
+    /// size, and the KV block size assumed for event-driven selection
     #[arg(long, default_value_t = 16, help_heading = "Routing Policy")]
     block_size: usize,
 
-    /// Maximum idle time in seconds before eviction (for manual policy)
-    #[arg(long, default_value_t = 14400, help_heading = "Routing Policy")]
+    /// How long an unused sticky routing key stays pinned: keys idle beyond
+    /// this many seconds are evicted from the manual-policy / sticky-session
+    /// map
+    #[arg(
+        long,
+        visible_alias = "sticky-key-idle-secs",
+        default_value_t = 14400,
+        help_heading = "Routing Policy"
+    )]
     max_idle_secs: u64,
 
-    /// Assignment mode for a new routing key. Defaults to random for the
-    /// manual policy and delegate for the routing-key override sticky map
+    /// How a first-seen routing key picks its worker: random, min_load
+    /// (fewest requests), min_group (fewest keys), or delegate (route via
+    /// the underlying policy, then pin). Defaults to random for the manual
+    /// policy and delegate for the sticky-session map
     #[arg(long, value_parser = ["random", "min_load", "min_group", "delegate"], help_heading = "Routing Policy")]
     assignment_mode: Option<String>,
 
@@ -308,12 +334,18 @@ struct CliArgs {
     #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
     dp_aware: bool,
 
-    /// Honor a sticky routing key on any policy (reuses the manual
-    /// eviction/idle/assignment knobs for the sticky map). The key is derived
-    /// from the request body's rid with per-turn/per-retry suffixes stripped,
-    /// falling back to X-SMG-Routing-Key when no rid is present; raw-streamed
-    /// requests carry no readable rid and use the header only
-    #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
+    /// Sticky sessions: route every request of a conversation to the same
+    /// worker, on any policy. The key is derived from the request body's rid
+    /// with per-turn/per-retry suffixes stripped (conv_t2_r1 -> conv),
+    /// falling back to X-SMG-Routing-Key when no rid is present;
+    /// raw-streamed requests carry no readable rid and use the header only.
+    /// Reuses the manual eviction/idle/assignment knobs for the sticky map
+    #[arg(
+        long,
+        visible_alias = "sticky-sessions",
+        default_value_t = false,
+        help_heading = "Routing Policy"
+    )]
     routing_key_override: bool,
 
     /// Enable IGW (Inference Gateway) mode for multi-model support
@@ -648,32 +680,41 @@ struct CliArgs {
     disable_circuit_breaker: bool,
 
     // ==================== Health Checks ====================
-    /// Failures before marking worker unhealthy
+    /// Consecutive probe failures before a worker is taken out of rotation
     #[arg(long, default_value_t = 3, help_heading = "Health Checks")]
     health_failure_threshold: u32,
 
-    /// Successes before marking worker healthy
+    /// Consecutive probe successes before a worker returns to rotation
     #[arg(long, default_value_t = 2, help_heading = "Health Checks")]
     health_success_threshold: u32,
 
-    /// Timeout in seconds for health check requests
+    /// Timeout in seconds for a single health probe
     #[arg(long, default_value_t = 5, help_heading = "Health Checks")]
     health_check_timeout_secs: u64,
 
-    /// Interval in seconds between health checks
+    /// Interval in seconds between health probes of each worker
     #[arg(long, default_value_t = 60, help_heading = "Health Checks")]
     health_check_interval_secs: u64,
 
-    /// Health check endpoint path
+    /// HTTP path probed on each worker
     #[arg(long, default_value = "/health", help_heading = "Health Checks")]
     health_check_endpoint: String,
 
-    /// Disable all worker health checks at startup
+    /// Disable all worker health probing
     #[arg(long, default_value_t = false, help_heading = "Health Checks")]
     disable_health_check: bool,
 
-    /// Remove workers from the registry when they are marked unhealthy
-    #[arg(long, default_value_t = false, help_heading = "Health Checks")]
+    /// Let workers recover after prolonged failure: a worker that stays
+    /// unhealthy long enough is removed from the registry so service
+    /// discovery re-registers and re-probes it once its engine returns
+    /// (without this, a worker unreachable for ~12 minutes reaches a
+    /// terminal Failed state and is never probed again)
+    #[arg(
+        long,
+        visible_alias = "worker-auto-recovery",
+        default_value_t = false,
+        help_heading = "Health Checks"
+    )]
     remove_unhealthy_workers: bool,
 
     /// Seconds to keep a Ready worker in `Draining` before removing it from
@@ -2017,6 +2058,43 @@ mod tests {
             config.routing_key_override.assignment_mode,
             ManualAssignmentMode::Delegate
         );
+    }
+
+    #[test]
+    fn alias_flags_parse_identically_to_canonical() {
+        let canonical = cli_args_from(&[
+            "--policy",
+            "cache_aware",
+            "--cache-threshold",
+            "0.6",
+            "--balance-abs-threshold",
+            "8",
+            "--balance-rel-threshold",
+            "1.2",
+            "--max-idle-secs",
+            "300",
+            "--routing-key-override",
+            "--remove-unhealthy-workers",
+        ])
+        .to_router_config(vec![], vec![])
+        .unwrap();
+        let aliased = cli_args_from(&[
+            "--policy",
+            "cache_aware",
+            "--cache-match-threshold",
+            "0.6",
+            "--spill-abs-threshold",
+            "8",
+            "--spill-rel-threshold",
+            "1.2",
+            "--sticky-key-idle-secs",
+            "300",
+            "--sticky-sessions",
+            "--worker-auto-recovery",
+        ])
+        .to_router_config(vec![], vec![])
+        .unwrap();
+        assert_eq!(format!("{canonical:?}"), format!("{aliased:?}"));
     }
 
     /// `--health-check-port` must flow into BOTH conversion paths


### PR DESCRIPTION
## Description
### Problem
Routing and health flags are named after internal mechanisms, not operator intent. In production this misleads at the worst times: a recent outage persisted because `--remove-unhealthy-workers` — actually the worker-*recovery* mechanism — reads as destructive and was left off, and `--routing-key-override` now carries conversation-sticky routing under a name from two semantic generations ago.
### Solution
Visible CLI aliases (clap `visible_alias`) and config-file field aliases (serde `alias`) with intent-revealing names; canonical names, serialization, dests, and all behavior unchanged. Help text for the Routing Policy and Health Checks groups rewritten to lead with what each flag buys the operator. New spellings: `--sticky-sessions`, `--worker-auto-recovery`, `--cache-match-threshold`, `--spill-abs-threshold`, `--spill-rel-threshold`, `--sticky-key-idle-secs`.

## Changes
- `main.rs`: six `visible_alias` entries; operator-language help for both flag groups
- `config/types.rs`: matching `#[serde(alias)]` on the CacheAware/Bucket/Manual variants, `RoutingKeyOverrideConfig`, `HealthCheckConfig`, and the RouterConfig sticky field; serialization stays canonical
- Python bindings: alias option strings on the same argparse dests (prefixed and unprefixed); dataclass fields unchanged

## Test Plan
- Rust: alias CLI invocation produces a Debug-identical `RouterConfig` to the canonical invocation; serde alias-in/canonical-out asserted at config and policy levels
- Python: alias flags land on canonical dests (both prefix modes); canonical == aliased dataclass equality; frozen field-order test unaffected
- `cargo +nightly fmt --all --check`; config lib module 128 passed / bin CLI 17 passed; full clippy + suite in CI

<details><summary>Checklist</summary>

- [x] Format clean; lint self-audited (`#[expect]` with reason, no `unwrap` in prod paths)
- [x] Tests added and passing
- [x] No binding surface change (aliases only); Go unaffected
- [x] DCO sign-off, conventional commit
</details>