### PR TITLE
feat(router): configurable routing-key header names

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -516,6 +516,7 @@ struct Router {
     least_load_max_waiting_requests: u32,
     stream_request_bodies_over: u64,
     stream_body_stall_timeout_secs: u64,
+    routing_key_headers: Vec<String>,
 }
 
 impl Router {
@@ -883,6 +884,7 @@ impl Router {
                 max_idle_secs: self.max_idle_secs,
                 assignment_mode: self
                     .parse_assignment_mode(config::ManualAssignmentMode::Delegate)?,
+                headers: self.routing_key_headers.clone(),
             })
             .retries(!self.disable_retries)
             .circuit_breaker(!self.disable_circuit_breaker)
@@ -1039,6 +1041,7 @@ impl Router {
         least_load_max_waiting_requests = 0,
         stream_request_bodies_over = 0,
         stream_body_stall_timeout_secs = 300,
+        routing_key_headers = vec![String::from("x-smg-routing-key")],
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1179,6 +1182,7 @@ impl Router {
         least_load_max_waiting_requests: u32,
         stream_request_bodies_over: u64,
         stream_body_stall_timeout_secs: u64,
+        routing_key_headers: Vec<String>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1333,6 +1337,7 @@ impl Router {
             least_load_max_waiting_requests,
             stream_request_bodies_over,
             stream_body_stall_timeout_secs,
+            routing_key_headers,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -217,6 +217,10 @@ class RouterArgs:
     least_load_max_waiting_requests: int = 0
     stream_request_bodies_over: int = 0
     stream_body_stall_timeout_secs: int = 300
+    # Ordered header names checked for the routing key; first valid wins
+    routing_key_headers: list[str] = dataclasses.field(
+        default_factory=lambda: ["x-smg-routing-key"]
+    )
 
     @staticmethod
     def add_cli_args(
@@ -638,7 +642,17 @@ class RouterArgs:
             help=(
                 "Sticky sessions: route every request of a conversation to the"
                 " same worker, on any policy (keys derived from the request-id"
-                " lineage, falling back to X-SMG-Routing-Key)"
+                " lineage, falling back to the routing-key headers)"
+            ),
+        )
+        routing_group.add_argument(
+            f"--{prefix}routing-key-headers",
+            type=str,
+            nargs="*",
+            action="extend",
+            help=(
+                "Ordered header names checked for the routing key; the first"
+                " header present with a valid value wins"
             ),
         )
         routing_group.add_argument(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -539,6 +539,16 @@ class TestParseRouterArgs:
         assert router_args.worker_urls == ["http://worker1:8000", "http://worker2:8000"]
         assert router_args.policy == "round_robin"
 
+    def test_parse_routing_key_headers(self):
+        """Ordered list flag; unset keeps the x-smg-routing-key default."""
+        router_args = parse_router_args(
+            ["--routing-key-headers", "x-routing-key", "x-smg-routing-key"]
+        )
+        assert router_args.routing_key_headers == ["x-routing-key", "x-smg-routing-key"]
+
+        defaults = parse_router_args([])
+        assert defaults.routing_key_headers == ["x-smg-routing-key"]
+
     def test_parse_pd_args(self):
         """Test parsing PD disaggregated mode arguments."""
         args = [
@@ -1273,6 +1283,7 @@ class TestRouterArgsFieldOrder:
         "least_load_max_waiting_requests",
         "stream_request_bodies_over",
         "stream_body_stall_timeout_secs",
+        "routing_key_headers",
     ]
 
     def test_complete_field_sequence_is_frozen(self):
@@ -1297,6 +1308,7 @@ class TestRouterArgsFieldOrder:
             "least_load_max_waiting_requests",
             "stream_request_bodies_over",
             "stream_body_stall_timeout_secs",
+            "routing_key_headers",
         ):
             assert names.index(appended) > marker, (
                 f"{appended} must be appended after worker_startup_delay to "

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -465,9 +465,10 @@ pub enum ManualAssignmentMode {
 ///
 /// Key priority is fixed: a key derived from the typed body's `rid` (per-turn
 /// `_t<n>` and per-retry `_r<n>` suffixes stripped, so every turn of a
-/// conversation shares one key) wins over `X-SMG-Routing-Key`; the header is
-/// the fallback when no rid is present. Raw-streamed requests have no readable
-/// body and therefore derive keys from the header only.
+/// conversation shares one key) wins over the routing-key headers; the first
+/// configured header carrying a valid value is the fallback when no rid is
+/// present. Raw-streamed requests have no readable body and therefore derive
+/// keys from the headers only.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoutingKeyOverrideConfig {
     /// When false, policies are used unchanged.
@@ -484,10 +485,20 @@ pub struct RoutingKeyOverrideConfig {
     /// policy, then pin.
     #[serde(default = "default_override_assignment_mode")]
     pub assignment_mode: ManualAssignmentMode,
+    /// Ordered header names consulted for the routing key; the first header
+    /// present with a valid value (non-empty UTF-8 within the byte cap) wins.
+    /// When the override is enabled, header keys get the same per-turn /
+    /// per-retry suffix stripping as rid-derived keys.
+    #[serde(default = "default_routing_key_headers")]
+    pub headers: Vec<String>,
 }
 
 fn default_override_assignment_mode() -> ManualAssignmentMode {
     ManualAssignmentMode::Delegate
+}
+
+fn default_routing_key_headers() -> Vec<String> {
+    vec!["x-smg-routing-key".to_string()]
 }
 
 impl Default for RoutingKeyOverrideConfig {
@@ -497,6 +508,7 @@ impl Default for RoutingKeyOverrideConfig {
             eviction_interval_secs: default_manual_eviction_interval_secs(),
             max_idle_secs: default_manual_max_idle_secs(),
             assignment_mode: default_override_assignment_mode(),
+            headers: default_routing_key_headers(),
         }
     }
 }
@@ -1314,15 +1326,21 @@ mod tests {
         let cfg: RoutingKeyOverrideConfig = serde_json::from_value(json).unwrap();
         assert!(cfg.enabled);
         assert_eq!(cfg.assignment_mode, ManualAssignmentMode::Delegate);
+        assert_eq!(cfg.headers, vec!["x-smg-routing-key".to_string()]);
 
         let cfg = RoutingKeyOverrideConfig {
             enabled: true,
             assignment_mode: ManualAssignmentMode::MinLoad,
+            headers: vec!["x-routing-key".into(), "x-smg-routing-key".into()],
             ..Default::default()
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let roundtripped: RoutingKeyOverrideConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(roundtripped.assignment_mode, ManualAssignmentMode::MinLoad);
+        assert_eq!(
+            roundtripped.headers,
+            vec!["x-routing-key".to_string(), "x-smg-routing-key".to_string()]
+        );
     }
 
     #[test]

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -94,6 +94,7 @@ impl ConfigValidator {
         Self::validate_policy(&config.policy)?;
         Self::validate_server_settings(config)?;
         Self::validate_storage_context_headers(config)?;
+        Self::validate_routing_key_headers(config)?;
         Self::validate_tenant_resolution(config)?;
         Self::validate_tenant_api_keys(config)?;
         Self::validate_model_aliases(config)?;
@@ -183,6 +184,17 @@ impl ConfigValidator {
             }
         }
 
+        Ok(())
+    }
+
+    fn validate_routing_key_headers(config: &RouterConfig) -> ConfigResult<()> {
+        for name in &config.routing_key_override.headers {
+            HeaderName::try_from(name.as_str()).map_err(|e| ConfigError::ValidationFailed {
+                reason: format!(
+                    "routing_key_override.headers contains an invalid HTTP header name '{name}': {e}"
+                ),
+            })?;
+        }
         Ok(())
     }
 
@@ -1223,6 +1235,23 @@ mod tests {
             },
             PolicyConfig::Random,
         )
+    }
+
+    #[test]
+    fn routing_key_headers_validated_as_header_names() {
+        let mut config = regular_mode_config();
+        config.routing_key_override.headers =
+            vec!["x-routing-key".to_string(), "x-smg-routing-key".to_string()];
+        assert!(ConfigValidator::validate(&config).is_ok());
+
+        for bad in ["", "has space", "bad\nname"] {
+            config.routing_key_override.headers = vec![bad.to_string()];
+            assert!(matches!(
+                ConfigValidator::validate(&config),
+                Err(ConfigError::ValidationFailed { ref reason })
+                    if reason.contains("routing_key_override.headers")
+            ));
+        }
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -337,8 +337,8 @@ struct CliArgs {
     /// Sticky sessions: route every request of a conversation to the same
     /// worker, on any policy. The key is derived from the request body's rid
     /// with per-turn/per-retry suffixes stripped (conv_t2_r1 -> conv),
-    /// falling back to X-SMG-Routing-Key when no rid is present;
-    /// raw-streamed requests carry no readable rid and use the header only.
+    /// falling back to the routing-key headers when no rid is present;
+    /// raw-streamed requests carry no readable rid and use the headers only.
     /// Reuses the manual eviction/idle/assignment knobs for the sticky map
     #[arg(
         long,
@@ -347,6 +347,13 @@ struct CliArgs {
         help_heading = "Routing Policy"
     )]
     routing_key_override: bool,
+
+    /// Ordered header names checked for the routing key; the first header
+    /// present with a valid value wins. Header keys get the same
+    /// per-turn/per-retry suffix stripping as rid-derived keys when the
+    /// override is enabled
+    #[arg(long, num_args = 0.., default_value = "x-smg-routing-key", value_parser = parse_routing_key_header, help_heading = "Routing Policy")]
+    routing_key_headers: Vec<String>,
 
     /// Enable IGW (Inference Gateway) mode for multi-model support
     #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
@@ -994,6 +1001,14 @@ enum OracleConnectSource {
 fn parse_model_id_from(s: &str) -> Result<String, String> {
     ModelIdSource::parse(s)?;
     Ok(s.to_string())
+}
+
+/// Validate `--routing-key-headers` values at CLI parse time; names are
+/// normalized to lowercase.
+fn parse_routing_key_header(s: &str) -> Result<String, String> {
+    http::header::HeaderName::try_from(s)
+        .map(|name| name.as_str().to_string())
+        .map_err(|e| format!("Invalid header name '{s}': {e}"))
 }
 
 /// Validate `--model-alias` value at CLI parse time (format: alias=canonical).
@@ -1720,6 +1735,7 @@ impl CliArgs {
                     self.assignment_mode.as_deref(),
                     ManualAssignmentMode::Delegate,
                 ),
+                headers: self.routing_key_headers.clone(),
             })
             .retries(!self.disable_retries)
             .upstream_http2(self.upstream_http2)
@@ -2039,6 +2055,34 @@ mod tests {
 
         let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
         assert!(!defaults.routing_key_override.enabled);
+        assert_eq!(
+            defaults.routing_key_override.headers,
+            vec!["x-smg-routing-key".to_string()]
+        );
+    }
+
+    #[test]
+    fn routing_key_headers_flow_into_router_config() {
+        // Space-separated list, order preserved; names normalize to lowercase.
+        let config = cli_args_from(&[
+            "--routing-key-headers",
+            "X-Routing-Key",
+            "x-smg-routing-key",
+        ])
+        .to_router_config(vec![], vec![])
+        .unwrap();
+        assert_eq!(
+            config.routing_key_override.headers,
+            vec!["x-routing-key".to_string(), "x-smg-routing-key".to_string()]
+        );
+
+        for bad in ["has space", "bad\u{7f}name", ""] {
+            let argv = ["smg", "--routing-key-headers", bad];
+            assert!(
+                Cli::try_parse_from(argv).is_err(),
+                "--routing-key-headers {bad:?} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use dashmap::DashMap;
+use http::{header::HeaderName, HeaderMap};
 use parking_lot::RwLock;
 use tracing::{debug, info, warn};
 
@@ -25,7 +26,7 @@ use crate::{
     observability::metrics::Metrics,
     policies::cache_aware::LoadReceiver,
     routers::common::header_utils::{
-        extract_routing_key_hint, parse_routing_tokens_hint, ROUTING_KEY_HINT_MAX_BYTES,
+        extract_routing_key_hint_named, parse_routing_tokens_hint, ROUTING_KEY_HINT_MAX_BYTES,
     },
     worker::{KvEventMonitor, Worker},
 };
@@ -78,6 +79,11 @@ pub struct PolicyRegistry {
     /// override is enabled; consulted (instead of the configured policy) for keyed
     /// requests via [`PolicyRegistry::select_worker`].
     routing_key_sticky: Option<Arc<ManualPolicy>>,
+
+    /// Ordered routing-key header names, parsed once from
+    /// `routing_key_override.headers`; the first header present with a valid
+    /// value wins.
+    routing_key_headers: Arc<Vec<HeaderName>>,
 }
 
 /// A pinned worker at or over this many router-local in-flight requests (all
@@ -128,6 +134,19 @@ impl PolicyRegistry {
                 assignment_mode: routing_key_override.assignment_mode,
             }))
         });
+        // ConfigValidator rejects invalid names at startup; skipping here
+        // covers direct construction.
+        let routing_key_headers = routing_key_override
+            .headers
+            .iter()
+            .filter_map(|name| match HeaderName::try_from(name.as_str()) {
+                Ok(parsed) => Some(parsed),
+                Err(_) => {
+                    warn!("Ignoring invalid routing-key header name: {name:?}");
+                    None
+                }
+            })
+            .collect();
         Self {
             model_policies: Arc::new(DashMap::new()),
             model_worker_counts: Arc::new(DashMap::new()),
@@ -141,6 +160,7 @@ impl PolicyRegistry {
             mesh_tree_sync: Arc::new(RwLock::new(None)),
             dp_rank_policy: Arc::new(OnceLock::new()),
             routing_key_sticky,
+            routing_key_headers: Arc::new(routing_key_headers),
         }
     }
 
@@ -157,15 +177,52 @@ impl PolicyRegistry {
         (!key.is_empty() && key.len() <= ROUTING_KEY_HINT_MAX_BYTES).then_some(key)
     }
 
-    /// Resolve the effective sticky key: the rid-derived key wins, the header
-    /// is the fallback when no rid is present. Header keys go through the
-    /// same validated extraction the policies use.
-    fn effective_sticky_key<'a>(info: &SelectWorkerInfo<'a>) -> Option<(&'a str, &'static str)> {
-        info.rid_key.map(|k| (k, "rid")).or_else(|| {
-            info.routing_key
-                .or_else(|| extract_routing_key_hint(info.headers))
-                .map(|k| (k, "header"))
+    /// Resolve the routing key from the configured header names: the first
+    /// header present with a valid value (non-empty UTF-8 within the byte
+    /// cap) wins.
+    pub fn resolve_routing_key<'a>(&self, headers: Option<&'a HeaderMap>) -> Option<&'a str> {
+        self.routing_key_headers
+            .iter()
+            .find_map(|name| extract_routing_key_hint_named(headers, name))
+    }
+
+    /// A key that is nothing but suffix keys as itself, like the rid path.
+    fn strip_header_key(raw: &str) -> &str {
+        let stripped = strip_lineage_suffixes(raw);
+        if stripped.is_empty() {
+            raw
+        } else {
+            stripped
+        }
+    }
+
+    /// The header-derived sticky key: the resolved routing key,
+    /// lineage-stripped when the override is enabled (matching selection),
+    /// raw otherwise.
+    pub fn sticky_header_key<'a>(&self, headers: Option<&'a HeaderMap>) -> Option<&'a str> {
+        let raw = self.resolve_routing_key(headers)?;
+        Some(if self.routing_key_sticky.is_some() {
+            Self::strip_header_key(raw)
+        } else {
+            raw
         })
+    }
+
+    /// Resolve the effective sticky key: the rid-derived key wins, the
+    /// configured routing-key headers are the fallback when no rid is
+    /// present. Header keys get the same lineage stripping as rid keys, so a
+    /// proxy forwarding `conv_t2` as a header pins the entry `conv`.
+    fn effective_sticky_key<'a>(
+        &self,
+        info: &SelectWorkerInfo<'a>,
+    ) -> Option<(&'a str, &'static str)> {
+        if let Some(key) = info.rid_key {
+            return Some((key, "rid"));
+        }
+        let raw = info
+            .routing_key
+            .or_else(|| self.resolve_routing_key(info.headers))?;
+        Some((Self::strip_header_key(raw), "header"))
     }
 
     /// Select a worker, applying the sticky routing-key override when it is
@@ -181,7 +238,7 @@ impl PolicyRegistry {
     ) -> Option<usize> {
         if let Some(sticky) = self.routing_key_sticky.as_ref() {
             if Self::routing_key_override_applies(policy.name()) {
-                if let Some((key, source)) = Self::effective_sticky_key(info) {
+                if let Some((key, source)) = self.effective_sticky_key(info) {
                     return Self::select_sticky(sticky, policy, workers, info, key, source);
                 }
             }
@@ -264,7 +321,7 @@ impl PolicyRegistry {
         finish(Some(idx), branch)
     }
 
-    /// Policies that already honor `X-SMG-Routing-Key` keep their own handling; all
+    /// Policies that already honor the routing key keep their own handling; all
     /// others (cache_aware, least_load, prefix_hash, ...) get the sticky override.
     fn routing_key_override_applies(name: &str) -> bool {
         !matches!(name, "manual" | "consistent_hashing")
@@ -648,15 +705,15 @@ impl PolicyRegistry {
     /// select that policy. A routing hint lifts the requirement — with a
     /// valid `x-smg-routing-tokens` the buffered path never extracts text
     /// either (the hint wins over body-derived routing), and a valid
-    /// `x-smg-routing-key` under the sticky override supersedes the policy
+    /// routing-key header under the sticky override supersedes the policy
     /// before it reads text. Hints are validated by the same extractors
     /// selection uses, so malformed or over-cap values lift nothing.
-    pub fn any_policy_needs_request_text(&self, headers: Option<&http::HeaderMap>) -> bool {
+    pub fn any_policy_needs_request_text(&self, headers: Option<&HeaderMap>) -> bool {
         if parse_routing_tokens_hint(headers).is_some() {
             return false;
         }
         let keyed_override =
-            self.routing_key_sticky.is_some() && extract_routing_key_hint(headers).is_some();
+            self.routing_key_sticky.is_some() && self.resolve_routing_key(headers).is_some();
         let needs_text = |policy: &Arc<dyn LoadBalancingPolicy>| {
             policy.needs_request_text()
                 && !(keyed_override && Self::routing_key_override_applies(policy.name()))
@@ -895,8 +952,8 @@ mod tests {
         }))
     }
 
-    fn headers_with_key(key: &str) -> http::HeaderMap {
-        let mut h = http::HeaderMap::new();
+    fn headers_with_key(key: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
         h.insert("x-smg-routing-key", key.parse().unwrap());
         h
     }
@@ -976,8 +1033,8 @@ mod tests {
         }
     }
 
-    fn headers_with_tokens(value: &str) -> http::HeaderMap {
-        let mut h = http::HeaderMap::new();
+    fn headers_with_tokens(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
         h.insert("x-smg-routing-tokens", value.parse().unwrap());
         h
     }
@@ -1046,6 +1103,156 @@ mod tests {
         let a = reg.select_worker(&policy, &workers, &info).unwrap();
         let b = reg.select_worker(&policy, &workers, &info).unwrap();
         assert_ne!(a, b);
+    }
+
+    fn override_with_headers(names: &[&str]) -> RoutingKeyOverrideConfig {
+        RoutingKeyOverrideConfig {
+            enabled: true,
+            headers: names.iter().map(|n| n.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    fn headers_with(name: &str, key: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(HeaderName::try_from(name).unwrap(), key.parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn resolve_routing_key_first_present_and_valid_wins() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            override_with_headers(&["x-routing-key", "x-smg-routing-key"]),
+        );
+
+        let mut both = headers_with("x-routing-key", "primary");
+        both.insert("x-smg-routing-key", "legacy".parse().unwrap());
+        assert_eq!(reg.resolve_routing_key(Some(&both)), Some("primary"));
+
+        let legacy_only = headers_with_key("legacy");
+        assert_eq!(reg.resolve_routing_key(Some(&legacy_only)), Some("legacy"));
+
+        // An invalid value under the first name falls through to the next.
+        let mut over_cap_first = headers_with("x-routing-key", &"k".repeat(129));
+        over_cap_first.insert("x-smg-routing-key", "legacy".parse().unwrap());
+        assert_eq!(
+            reg.resolve_routing_key(Some(&over_cap_first)),
+            Some("legacy")
+        );
+
+        assert_eq!(reg.resolve_routing_key(None), None);
+    }
+
+    #[test]
+    fn default_headers_ignore_unconfigured_names() {
+        let reg = PolicyRegistry::with_override(PolicyConfig::RoundRobin, enabled_override());
+        assert_eq!(
+            reg.resolve_routing_key(Some(&headers_with("x-routing-key", "primary"))),
+            None
+        );
+        assert_eq!(
+            reg.resolve_routing_key(Some(&headers_with_key("legacy"))),
+            Some("legacy")
+        );
+    }
+
+    #[test]
+    fn invalid_configured_header_names_are_skipped() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            override_with_headers(&["not a header", "x-routing-key"]),
+        );
+        assert_eq!(
+            reg.resolve_routing_key(Some(&headers_with("x-routing-key", "primary"))),
+            Some("primary")
+        );
+    }
+
+    #[test]
+    fn header_keys_share_rid_lineage_stripping() {
+        let reg = PolicyRegistry::with_override(PolicyConfig::RoundRobin, enabled_override());
+        assert_eq!(
+            reg.sticky_header_key(Some(&headers_with_key("conv_t2"))),
+            Some("conv")
+        );
+        assert_eq!(
+            reg.sticky_header_key(Some(&headers_with_key("conv_t2_r1"))),
+            Some("conv")
+        );
+        // A key that is nothing but suffix keys as itself.
+        assert_eq!(
+            reg.sticky_header_key(Some(&headers_with_key("_t1"))),
+            Some("_t1")
+        );
+
+        // Override disabled: raw key, no stripping.
+        let disabled = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        assert_eq!(
+            disabled.sticky_header_key(Some(&headers_with_key("conv_t2"))),
+            Some("conv_t2")
+        );
+    }
+
+    #[test]
+    fn header_turns_pin_the_same_sticky_entry() {
+        let reg = PolicyRegistry::with_override(PolicyConfig::RoundRobin, enabled_override());
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+            worker("http://w3", WorkerType::Regular),
+        ];
+        let t1 = headers_with_key("conv_t1");
+        let info_t1 = SelectWorkerInfo {
+            headers: Some(&t1),
+            ..Default::default()
+        };
+        let first = reg.select_worker(&policy, &workers, &info_t1).unwrap();
+        let t2 = headers_with_key("conv_t2");
+        let info_t2 = SelectWorkerInfo {
+            headers: Some(&t2),
+            ..Default::default()
+        };
+        for _ in 0..5 {
+            assert_eq!(reg.select_worker(&policy, &workers, &info_t2), Some(first));
+        }
+    }
+
+    #[test]
+    fn alternate_header_routes_stickily() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            override_with_headers(&["x-routing-key", "x-smg-routing-key"]),
+        );
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+            worker("http://w3", WorkerType::Regular),
+        ];
+        let headers = headers_with("x-routing-key", "session-A");
+        let info = SelectWorkerInfo {
+            headers: Some(&headers),
+            ..Default::default()
+        };
+        let first = reg.select_worker(&policy, &workers, &info).unwrap();
+        for _ in 0..5 {
+            assert_eq!(reg.select_worker(&policy, &workers, &info), Some(first));
+        }
+    }
+
+    #[test]
+    fn alternate_header_lifts_text_gate() {
+        let reg = PolicyRegistry::with_override(
+            cache_aware_config(),
+            override_with_headers(&["x-routing-key", "x-smg-routing-key"]),
+        );
+        assert!(
+            !reg.any_policy_needs_request_text(Some(&headers_with("x-routing-key", "session-A")))
+        );
+        // A name outside the configured list lifts nothing.
+        assert!(reg.any_policy_needs_request_text(Some(&headers_with("x-other-key", "session-A"))));
     }
 
     fn rid_override(assignment_mode: ManualAssignmentMode) -> RoutingKeyOverrideConfig {

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -44,14 +44,22 @@ pub fn parse_routing_tokens_hint(headers: Option<&HeaderMap>) -> Option<Vec<u32>
     Some(ids)
 }
 
-/// Extract the `x-smg-routing-key` hint: opaque non-empty UTF-8. Over-cap or
-/// non-UTF-8 values are ignored (`None`), never an error.
-pub fn extract_routing_key_hint(headers: Option<&HeaderMap>) -> Option<&str> {
-    let value = headers?.get(&HEADER_ROUTING_KEY)?.as_bytes();
+/// Extract a routing-key hint from `name`: opaque non-empty UTF-8. Over-cap
+/// or non-UTF-8 values are ignored (`None`), never an error.
+pub fn extract_routing_key_hint_named<'a>(
+    headers: Option<&'a HeaderMap>,
+    name: &HeaderName,
+) -> Option<&'a str> {
+    let value = headers?.get(name)?.as_bytes();
     if value.is_empty() || value.len() > ROUTING_KEY_HINT_MAX_BYTES {
         return None;
     }
     std::str::from_utf8(value).ok()
+}
+
+/// Extract the `x-smg-routing-key` hint (the default routing-key header).
+pub fn extract_routing_key_hint(headers: Option<&HeaderMap>) -> Option<&str> {
+    extract_routing_key_hint_named(headers, &HEADER_ROUTING_KEY)
 }
 
 fn extract_header_value<'a>(headers: Option<&'a HeaderMap>, name: &HeaderName) -> Option<&'a str> {
@@ -683,6 +691,19 @@ mod tests {
             HeaderValue::from_bytes("clé-café".as_bytes()).unwrap(),
         );
         assert_eq!(extract_routing_key_hint(Some(&headers)), Some("clé-café"));
+    }
+
+    #[test]
+    fn test_extract_routing_key_hint_named_reads_configured_header() {
+        let name = HeaderName::from_static("x-routing-key");
+        let mut headers = HeaderMap::new();
+        headers.insert("x-routing-key", "session-abc".parse().unwrap());
+        assert_eq!(
+            extract_routing_key_hint_named(Some(&headers), &name),
+            Some("session-abc")
+        );
+        // The default extractor stays bound to x-smg-routing-key.
+        assert_eq!(extract_routing_key_hint(Some(&headers)), None);
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -14,7 +14,6 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo, WorkerLeg},
     routers::{
-        common::header_utils::extract_routing_key_hint,
         error,
         grpc::{
             context::{EncodeWorkerAssignment, RequestContext, WorkerSelection},
@@ -96,9 +95,11 @@ impl PipelineStage for WorkerSelectionStage {
             .policy_registry
             .derive_rid_key(ctx.input.request_type.rid())
             .map(str::to_string);
-        ctx.state.sticky_key = rid_key
-            .clone()
-            .or_else(|| extract_routing_key_hint(headers).map(str::to_string));
+        ctx.state.sticky_key = rid_key.clone().or_else(|| {
+            self.policy_registry
+                .sticky_header_key(headers)
+                .map(str::to_string)
+        });
         let rid_key = rid_key.as_deref();
 
         let model_id = ctx.input.model_id.as_str();
@@ -275,7 +276,7 @@ impl WorkerSelectionStage {
                 request_text: text,
                 tokens,
                 headers,
-                routing_key: None,
+                routing_key: self.policy_registry.resolve_routing_key(headers),
                 rid_key,
                 hash_ring,
                 leg: WorkerLeg::Single,
@@ -402,7 +403,7 @@ impl WorkerSelectionStage {
             request_text: text,
             tokens,
             headers,
-            routing_key: None,
+            routing_key: self.policy_registry.resolve_routing_key(headers),
             rid_key,
             hash_ring,
             leg: WorkerLeg::Prefill,
@@ -582,7 +583,7 @@ impl WorkerSelectionStage {
             request_text: text,
             tokens,
             headers,
-            routing_key: None,
+            routing_key: self.policy_registry.resolve_routing_key(headers),
             rid_key,
             hash_ring: hash_ring.clone(),
             leg: WorkerLeg::Prefill,

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -634,7 +634,7 @@ impl PDRouter {
         let effective_key = context
             .rid_key
             .as_deref()
-            .or_else(|| header_utils::extract_routing_key_hint(headers));
+            .or_else(|| self.policy_registry.sticky_header_key(headers));
         let load_guards = vec![
             WorkerLoadGuard::with_key(prefill.clone(), effective_key),
             WorkerLoadGuard::with_key(decode.clone(), effective_key),
@@ -959,7 +959,7 @@ impl PDRouter {
                     request_text,
                     tokens,
                     headers,
-                    routing_key: None,
+                    routing_key: self.policy_registry.resolve_routing_key(headers),
                     rid_key,
                     hash_ring,
                     leg,

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -267,7 +267,7 @@ impl Router {
                 request_text: text,
                 tokens,
                 headers,
-                routing_key: header_utils::extract_routing_key_hint(headers),
+                routing_key: self.policy_registry.resolve_routing_key(headers),
                 rid_key,
                 hash_ring,
                 leg: crate::policies::WorkerLeg::Single,
@@ -508,7 +508,7 @@ impl Router {
         // rid-derived first, header fallback.
         let load_guard = WorkerLoadGuard::with_key(
             worker.clone(),
-            rid_key.or_else(|| header_utils::extract_routing_key_hint(headers)),
+            rid_key.or_else(|| self.policy_registry.sticky_header_key(headers)),
         );
 
         // Note: Using borrowed reference avoids heap allocation
@@ -784,7 +784,7 @@ impl Router {
                 request_text: text.as_deref(),
                 tokens: hinted_tokens.as_deref(),
                 headers,
-                routing_key: header_utils::extract_routing_key_hint(headers),
+                routing_key: self.policy_registry.resolve_routing_key(headers),
                 rid_key: None,
                 hash_ring,
                 leg: crate::policies::WorkerLeg::Single,
@@ -808,7 +808,11 @@ impl Router {
         );
         let worker = available[idx].clone();
 
-        let load_guard = WorkerLoadGuard::new(worker.clone(), headers);
+        // Streamed requests have no rid; the header is the whole sticky key.
+        let load_guard = WorkerLoadGuard::with_key(
+            worker.clone(),
+            self.policy_registry.sticky_header_key(headers),
+        );
 
         let mut headers_with_trace = headers.cloned().unwrap_or_default();
         inject_trace_context_http(&mut headers_with_trace);
@@ -1610,7 +1614,10 @@ impl Router {
             "false",
         );
 
-        let load_guard = WorkerLoadGuard::new(worker.clone(), Some(req.headers()));
+        let load_guard = WorkerLoadGuard::with_key(
+            worker.clone(),
+            self.policy_registry.sticky_header_key(Some(req.headers())),
+        );
         events::RequestSentEvent { url: worker.url() }.emit();
 
         let (parts, body) = req.into_parts();


### PR DESCRIPTION
### Description

**Problem:** The sticky routing-key header is hardcoded to `x-smg-routing-key`. A reference router in the same ecosystem reads the session key from `x-routing-key` with `x-smg-routing-key` as a legacy alias; lanes fronted by that ecosystem's proxies need the router to check the primary name first — today that requires a code change instead of config.

**Solution:** Make the name an ordered configurable list: `--routing-key-headers <name...>` / `routing_key_override.headers`. Names are validated at startup (clap value parser + ConfigValidator) and parsed once into the `PolicyRegistry`; the first header present with a valid value (non-empty UTF-8 within the 128-byte cap) wins. Resolved header keys get the same per-turn/per-retry lineage stripping as rid-derived keys when the override is enabled, so a proxy forwarding `conv_t2` as a header pins the same entry as the rid-derived `conv`, and keyed-load accounting plus the streaming text gate stay aligned with selection. Unset keeps today's behavior exactly.

### Changes

- `config/types.rs`: `RoutingKeyOverrideConfig.headers` with serde default `["x-smg-routing-key"]`
- `config/validation.rs`: reject invalid header names at startup
- `policies/registry.rs`: parsed `Vec<HeaderName>`, `resolve_routing_key` / `sticky_header_key`, header keys lineage-stripped in `effective_sticky_key`, streaming gate uses the configured list
- `routers/common/header_utils.rs`: `extract_routing_key_hint_named` primitive
- `routers/http/{router,pd_router}.rs`, `routers/grpc/common/stages/worker_selection.rs`: selection and keyed-load-guard sites resolve through the registry
- `main.rs`: `--routing-key-headers` (space-separated, validated, lowercased)
- Python bindings: `routing_key_headers` tail-appended through `_Router` and `RouterArgs`

### Test Plan

- Registry: resolution order (first present-and-valid wins, invalid value falls through), default config ignores unconfigured names, invalid configured names skipped, header-key stripping on/off, `conv_t1`/`conv_t2` pin one sticky entry, alternate-name sticky routing and text-gate lift
- Config: serde default + roundtrip; validator rejects malformed names
- CLI: list flows into `RouterConfig` ordered and lowercased; invalid names rejected at parse; defaults regression
- Python: arg parsing (set/default/bare), frozen field-order snapshot
- `cargo +nightly fmt --all --check`, targeted module suites, `cargo build -p smg-python`, `ruff format --check` on touched Python files

<details><summary>Checklist</summary>

- [x] Format your code: `make format`
- [x] Add unit tests
- [x] Update documentation as needed, including docstrings or example tutorials
</details>
