### PR TITLE
feat(policies): structured routing-decision debug logs

### DIFF
--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -615,13 +615,6 @@ impl CacheAwarePolicy {
         min_load_idx: Option<usize>,
         model_id: &str,
     ) -> Option<usize> {
-        // Log load balancing trigger (only compute worker loads if debug enabled)
-        if tracing::enabled!(tracing::Level::DEBUG) {
-            let worker_loads: Vec<(&str, usize)> =
-                workers.iter().map(|w| (w.url(), w.load())).collect();
-            debug!("Load balancing triggered | workers: {:?}", worker_loads);
-        }
-
         // Shortest queue when imbalanced. The min-load index is gathered upstream
         // in select_worker with the (load, processed_requests, idx) tie-break
         // from #1714 (spreads load when decode outpaces prefill).
@@ -696,6 +689,12 @@ impl CacheAwarePolicy {
         // Increment processed counter
         workers[min_load_idx].increment_processed();
 
+        debug!(
+            branch = "kv_pressure_min_load",
+            worker = worker_url,
+            model_id,
+            "Cache-aware selection"
+        );
         Some(min_load_idx)
     }
 }
@@ -1381,6 +1380,46 @@ impl CacheAwarePolicy {
         candidates.last().map(|c| c.idx)
     }
 
+    /// One decision line per tree-routed request. `selected_url == None`
+    /// means the caller fell back to `fallback_url` (first healthy).
+    fn log_tree_decision(
+        &self,
+        selected_url: Option<&str>,
+        fallback_url: Option<&str>,
+        matched_units: usize,
+        input_units: usize,
+        matched_tenants: &[TenantId],
+        model_id: &str,
+    ) {
+        if !tracing::enabled!(tracing::Level::DEBUG) {
+            return;
+        }
+        let matched_ratio = if input_units == 0 {
+            0.0
+        } else {
+            matched_units as f32 / input_units as f32
+        };
+        let branch = match selected_url {
+            None => "first_healthy_fallback",
+            Some(_) if matched_ratio <= self.config.cache_threshold => "min_load_fallback",
+            Some(url) => {
+                if matched_tenants.iter().any(|tenant| tenant.as_ref() == url) {
+                    "tree_match"
+                } else {
+                    "spill"
+                }
+            }
+        };
+        debug!(
+            branch,
+            worker = selected_url.or(fallback_url).unwrap_or("none"),
+            model_id,
+            matched_ratio = f64::from(matched_ratio),
+            threshold = f64::from(self.config.cache_threshold),
+            "Cache-aware selection"
+        );
+    }
+
     /// Select worker using token-based tree (gRPC path)
     fn select_worker_with_tokens(
         &self,
@@ -1443,6 +1482,15 @@ impl CacheAwarePolicy {
                 selected_idx.map(|idx| workers[idx].url())
             });
 
+            self.log_tree_decision(
+                selected_idx.map(|idx| workers[idx].url()),
+                healthy_indices.first().map(|&idx| workers[idx].url()),
+                result.matched_token_count,
+                result.input_token_count,
+                &result.matched_tenants,
+                model_id,
+            );
+
             if let Some(idx) = selected_idx {
                 // Record hash(full_tokens)→matched_prefix tokens.
                 // The hash key matches what sync_tree_operation
@@ -1488,13 +1536,14 @@ impl CacheAwarePolicy {
             // Stale entries will be cleaned up by LRU eviction
             healthy_indices.first().copied()
         } else {
+            let idx = healthy_indices[rand::rng().random_range(0..healthy_indices.len())];
             debug!(
-                "Warning: No token tree found for model '{}', using random worker selection",
-                model_id
+                branch = "no_tree_random",
+                worker = workers[idx].url(),
+                model_id,
+                "Cache-aware selection"
             );
-            let mut rng = rand::rng();
-            let random_idx = rng.random_range(0..healthy_indices.len());
-            Some(healthy_indices[random_idx])
+            Some(idx)
         }
     }
 
@@ -1550,6 +1599,15 @@ impl CacheAwarePolicy {
                 selected_idx.map(|idx| workers[idx].url())
             });
 
+            self.log_tree_decision(
+                selected_idx.map(|idx| workers[idx].url()),
+                healthy_indices.first().map(|&idx| workers[idx].url()),
+                result.matched_char_count,
+                result.input_char_count,
+                &result.matched_tenants,
+                model_id,
+            );
+
             if let Some(idx) = selected_idx {
                 // Record hash(full_text)→matched_prefix for mesh tenant delta
                 // resolution. The hash key matches what sync_tree_operation sends
@@ -1586,13 +1644,14 @@ impl CacheAwarePolicy {
             // Stale entries will be cleaned up by LRU eviction
             healthy_indices.first().copied()
         } else {
+            let idx = healthy_indices[rand::rng().random_range(0..healthy_indices.len())];
             debug!(
-                "Warning: No string tree found for model '{}', using random worker selection",
-                model_id
+                branch = "no_tree_random",
+                worker = workers[idx].url(),
+                model_id,
+                "Cache-aware selection"
             );
-            let mut rng = rand::rng();
-            let random_idx = rng.random_range(0..healthy_indices.len());
-            Some(healthy_indices[random_idx])
+            Some(idx)
         }
     }
 }
@@ -1607,6 +1666,7 @@ impl Default for CacheAwarePolicy {
 mod tests {
     use kv_index::{compute_content_hash, SequenceHash, StoredBlock, WorkerBlockMap};
     use openai_protocol::worker::{HealthCheckConfig, SchedulerLoadSnapshot, WorkerStatus};
+    use tracing_test::traced_test;
 
     use super::*;
 
@@ -2007,6 +2067,39 @@ mod tests {
                 .any(|tenant| tenant.as_ref() == "http://w2:8000"),
             "spill target must become a tenant of the hot prefix"
         );
+    }
+
+    #[test]
+    #[traced_test]
+    fn token_tree_selection_emits_decision_line() {
+        let policy = CacheAwarePolicy::with_config(test_config());
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        let tokens: Vec<u32> = (0..32).collect();
+        seed_token_tenants(&policy, &workers, &tokens, &["http://w1:8000"]);
+
+        policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    tokens: Some(&tokens),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(logs_contain("Cache-aware selection"));
+        assert!(logs_contain("tree_match"));
+
+        let novel: Vec<u32> = (1000..1064).collect();
+        policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    tokens: Some(&novel),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(logs_contain("min_load_fallback"));
     }
 
     #[test]

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -215,6 +215,14 @@ impl PolicyRegistry {
         let finish = |result: Option<usize>, branch: ExecutionBranch| {
             Metrics::record_worker_manual_policy_branch(branch.as_str());
             Metrics::set_manual_policy_cache_entries(sticky.map_len());
+            debug!(
+                source,
+                key,
+                branch = branch.as_str(),
+                worker = result.map_or("none", |idx| workers[idx].url()),
+                model_id = result.map_or("none", |idx| workers[idx].model_id()),
+                "Sticky routing decision"
+            );
             result
         };
 
@@ -865,6 +873,7 @@ impl std::fmt::Debug for PolicyRegistry {
 #[cfg(test)]
 mod tests {
     use openai_protocol::worker::HealthCheckConfig;
+    use tracing_test::traced_test;
 
     use super::*;
     use crate::{
@@ -1204,6 +1213,29 @@ mod tests {
             reg.select_worker(&policy, &workers, &keyed_turn2),
             Some(seeded)
         );
+    }
+
+    #[test]
+    #[traced_test]
+    fn sticky_selection_emits_decision_line_per_request() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+        let info = SelectWorkerInfo {
+            rid_key: Some("conv1"),
+            ..Default::default()
+        };
+        reg.select_worker(&policy, &workers, &info).unwrap();
+        assert!(logs_contain("Sticky routing decision"));
+        assert!(logs_contain("vacant"));
+        reg.select_worker(&policy, &workers, &info).unwrap();
+        assert!(logs_contain("occupied_hit"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

Running the router at `--log-level debug` with `--policy cache_aware` and the routing-key
override, the worker-selection path emits no logs at all: a production deployment at debug
level showed zero lines from the policies module across ~1,500 routed requests. The sticky
gate records only metrics, and the cache-aware token/string tree paths have no per-decision
line — the existing debug lines belong to the event-driven KV-event path, which this
configuration never takes. Operators cannot attribute why any given request landed on a
given worker.

### Solution

Emit one structured `debug!` line per selection decision, at the points where each decision
is actually finalized, on both HTTP and gRPC transports:

- Sticky gate (`PolicyRegistry::select_sticky`): logged from the single `finish` funnel so
  every branch is covered — `source` (rid|header), effective key, `branch`
  (`occupied_hit` | `occupied_miss` | `vacant` | `cap_respill` | `no_healthy_workers`),
  routed worker, model id.
- Cache-aware tree paths: `branch` (`tree_match` | `spill` | `min_load_fallback` |
  `first_healthy_fallback` | `no_tree_random` | `kv_pressure_min_load`), routed worker,
  model id, plus matched ratio and threshold when the tree was consulted.

All logged fields are borrows or Copy values (zero allocations for logging); the ratio and
tenant-membership computation is gated behind `tracing::enabled!(DEBUG)`. At most one line
per request per layer; the per-worker load-vector dump on the KV-pressure path is replaced
by the decision line.

## Changes

- `model_gateway/src/policies/registry.rs`: sticky decision line in the `finish` funnel of
  `select_sticky`.
- `model_gateway/src/policies/cache_aware.rs`: `log_tree_decision` helper called once per
  request from the token- and string-tree paths; structured decision lines on the
  KV-pressure min-load and missing-tree fallbacks (replacing the prose warnings and the
  load-vector dump).
- Log-emission tests with `tracing_test` for the sticky and token-tree lines.

## Test Plan

- `cargo +nightly fmt --all --check`
- `cargo test -p smg --lib policies::` — 186 passed, including the two new
  `#[traced_test]` tests (`sticky_selection_emits_decision_line_per_request`,
  `token_tree_selection_emits_decision_line`)
- `cargo test -p smg --lib worker_selection` / `routers::http::` — selection stages green
- Manual: with `--log-level debug`, each routed request now produces exactly one
  `Sticky routing decision` line (keyed requests) and/or one `Cache-aware selection` line
  (policy-consulted requests), e.g.
  `Cache-aware selection branch="tree_match" worker="http://w1:8000" model_id="llama-3" matched_ratio=0.87 threshold=0.5`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>