### PR TITLE
fix(policies): sticky in-flight cap counts per-key load, not worker total

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -177,6 +177,10 @@ impl Worker for GrpcWorker {
         self.routing_key_load.value()
     }
 
+    fn routing_key_inflight(&self, routing_key: &str) -> usize {
+        self.routing_key_load.key_inflight(routing_key)
+    }
+
     fn increment_routing_key_load(&self, routing_key: &str) {
         self.routing_key_load.increment(routing_key);
     }

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -86,10 +86,10 @@ pub struct PolicyRegistry {
     routing_key_headers: Arc<Vec<HeaderName>>,
 }
 
-/// A pinned worker at or over this many router-local in-flight requests (all
-/// traffic on that worker, not just this key; counted per router replica, so
-/// the effective fleet threshold multiplies with replica count) is bypassed
-/// and the request reassigned.
+/// A sticky key with this many of its own requests already in flight on its
+/// pinned worker (router-local, counted per replica) is bypassed and the
+/// request reassigned. Guards one conversation stacking onto its pin; total
+/// worker load is not a respill trigger.
 const STICKY_INFLIGHT_CAP: usize = 2;
 
 /// `conv_t2_r1` -> `conv`: strip one trailing `_r<n>` retry suffix, then one
@@ -259,6 +259,9 @@ impl PolicyRegistry {
     ) -> Option<usize> {
         Metrics::record_routing_key_source(source);
 
+        // Keyed-load guards track the un-namespaced key on each worker.
+        let load_key = key;
+
         // PD legs namespace so prefill and decode stick independently.
         let namespaced;
         let key = if info.leg == WorkerLeg::Single {
@@ -268,7 +271,8 @@ impl PolicyRegistry {
             &namespaced
         };
 
-        let over_cap = |idx: usize| workers[idx].load() >= STICKY_INFLIGHT_CAP;
+        let over_cap =
+            |idx: usize| workers[idx].routing_key_inflight(load_key) >= STICKY_INFLIGHT_CAP;
         let finish = |result: Option<usize>, branch: ExecutionBranch| {
             Metrics::record_worker_manual_policy_branch(branch.as_str());
             Metrics::set_manual_policy_cache_entries(sticky.map_len());
@@ -935,7 +939,7 @@ mod tests {
     use super::*;
     use crate::{
         policies::{CacheAwareConfig, LeastLoadPolicy, SelectWorkerInfo},
-        worker::{BasicWorkerBuilder, Worker, WorkerType},
+        worker::{BasicWorkerBuilder, Worker, WorkerLoadGuard, WorkerType},
     };
 
     fn no_health_check() -> HealthCheckConfig {
@@ -1464,14 +1468,16 @@ mod tests {
         let pinned = reg.select_worker(&policy, &workers, &info).unwrap();
         assert_eq!(reg.select_worker(&policy, &workers, &info), Some(pinned));
 
-        // At the cap (2 in-flight) the key reassigns to the idle worker and
-        // the pin follows it, even after the original drains.
-        workers[pinned].increment_load();
-        workers[pinned].increment_load();
+        // At the cap (2 of this key in flight on its pin) the key reassigns
+        // to the idle worker and the pin follows it, even after the original
+        // drains.
+        let guards = [
+            WorkerLoadGuard::with_key(workers[pinned].clone(), Some("convA")),
+            WorkerLoadGuard::with_key(workers[pinned].clone(), Some("convA")),
+        ];
         let respilled = reg.select_worker(&policy, &workers, &info).unwrap();
         assert_ne!(respilled, pinned);
-        workers[pinned].decrement_load();
-        workers[pinned].decrement_load();
+        drop(guards);
         assert_eq!(reg.select_worker(&policy, &workers, &info), Some(respilled));
     }
 
@@ -1492,20 +1498,18 @@ mod tests {
         };
 
         let pinned = reg.select_worker(&policy, &workers, &info).unwrap();
-        // Saturate BOTH workers: the reassignment cannot strictly improve
-        // (every pick is at the cap), so the request dispatches wherever the
-        // policy says but the pin must survive.
+        // Saturate BOTH workers with this key: the reassignment cannot
+        // strictly improve (every pick is at the key cap), so the request
+        // dispatches wherever the policy says but the pin must survive.
+        let mut guards = Vec::new();
         for w in &workers {
-            w.increment_load();
-            w.increment_load();
+            guards.push(WorkerLoadGuard::with_key(w.clone(), Some("convB")));
+            guards.push(WorkerLoadGuard::with_key(w.clone(), Some("convB")));
         }
         for _ in 0..4 {
             reg.select_worker(&policy, &workers, &info).unwrap();
         }
-        for w in &workers {
-            w.decrement_load();
-            w.decrement_load();
-        }
+        drop(guards);
         assert_eq!(
             reg.select_worker(&policy, &workers, &info),
             Some(pinned),
@@ -1530,13 +1534,97 @@ mod tests {
         };
 
         let pinned = reg.select_worker(&policy, &workers, &info).unwrap();
-        workers[pinned].increment_load();
-        workers[pinned].increment_load();
+        let guards = [
+            WorkerLoadGuard::with_key(workers[pinned].clone(), Some("convC")),
+            WorkerLoadGuard::with_key(workers[pinned].clone(), Some("convC")),
+        ];
         let respilled = reg.select_worker(&policy, &workers, &info).unwrap();
         assert_ne!(respilled, pinned);
-        workers[pinned].decrement_load();
-        workers[pinned].decrement_load();
+        drop(guards);
         assert_eq!(reg.select_worker(&policy, &workers, &info), Some(respilled));
+    }
+
+    #[test]
+    #[traced_test]
+    fn busy_worker_does_not_respill_idle_key() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+        let info = SelectWorkerInfo {
+            rid_key: Some("convD"),
+            ..Default::default()
+        };
+
+        let pinned = reg.select_worker(&policy, &workers, &info).unwrap();
+        // Unrelated traffic on the pin, total load far past the cap: the
+        // returning key has nothing in flight and must keep its pin.
+        let _unrelated = [
+            WorkerLoadGuard::with_key(workers[pinned].clone(), Some("convZ")),
+            WorkerLoadGuard::with_key(workers[pinned].clone(), Some("convZ")),
+            WorkerLoadGuard::new(workers[pinned].clone(), None),
+            WorkerLoadGuard::new(workers[pinned].clone(), None),
+        ];
+        assert_eq!(reg.select_worker(&policy, &workers, &info), Some(pinned));
+        assert!(logs_contain("occupied_hit"));
+        assert!(!logs_contain("cap_respill"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn two_inflight_same_key_respill_the_third() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+        let info = SelectWorkerInfo {
+            rid_key: Some("convE"),
+            ..Default::default()
+        };
+
+        let pinned = reg.select_worker(&policy, &workers, &info).unwrap();
+        let _g1 = WorkerLoadGuard::with_key(workers[pinned].clone(), Some("convE"));
+        let _g2 = WorkerLoadGuard::with_key(workers[pinned].clone(), Some("convE"));
+        assert_ne!(reg.select_worker(&policy, &workers, &info), Some(pinned));
+        assert!(logs_contain("cap_respill"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn cap_lifts_when_key_inflight_drains() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        let policy = reg.get_default_policy();
+        // Single worker: the respill has nowhere to go, so the branch flips
+        // purely on the key's in-flight count.
+        let workers = vec![worker("http://w1", WorkerType::Regular)];
+        let info = SelectWorkerInfo {
+            rid_key: Some("convF"),
+            ..Default::default()
+        };
+
+        assert_eq!(reg.select_worker(&policy, &workers, &info), Some(0));
+        let guards = [
+            WorkerLoadGuard::with_key(workers[0].clone(), Some("convF")),
+            WorkerLoadGuard::with_key(workers[0].clone(), Some("convF")),
+        ];
+        assert_eq!(reg.select_worker(&policy, &workers, &info), Some(0));
+        assert!(logs_contain("cap_respill"));
+        drop(guards);
+        assert_eq!(reg.select_worker(&policy, &workers, &info), Some(0));
+        assert!(logs_contain("occupied_hit"));
     }
 
     #[test]

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -235,6 +235,13 @@ impl WorkerRoutingKeyLoad {
         self.active_routing_keys.len()
     }
 
+    /// In-flight requests for one routing key.
+    pub fn key_inflight(&self, routing_key: &str) -> usize {
+        self.active_routing_keys
+            .get(routing_key)
+            .map_or(0, |count| *count)
+    }
+
     pub fn increment(&self, routing_key: &str) {
         *self
             .active_routing_keys
@@ -377,6 +384,9 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
 
     /// Get the current routing-key load cardinality.
     fn routing_key_load(&self) -> usize;
+
+    /// In-flight requests for one routing key on this worker.
+    fn routing_key_inflight(&self, routing_key: &str) -> usize;
 
     /// Increment the routing-key load tracker for an active key.
     fn increment_routing_key_load(&self, routing_key: &str);
@@ -1069,6 +1079,10 @@ impl WorkerRuntime {
         self.worker_routing_key_load.value()
     }
 
+    pub fn routing_key_inflight(&self, routing_key: &str) -> usize {
+        self.worker_routing_key_load.key_inflight(routing_key)
+    }
+
     pub fn increment_routing_key_load(&self, routing_key: &str) {
         self.worker_routing_key_load.increment(routing_key);
     }
@@ -1380,6 +1394,10 @@ impl Worker for BasicWorker {
 
     fn routing_key_load(&self) -> usize {
         self.runtime.load().routing_key_load()
+    }
+
+    fn routing_key_inflight(&self, routing_key: &str) -> usize {
+        self.runtime.load().routing_key_inflight(routing_key)
     }
 
     fn increment_routing_key_load(&self, routing_key: &str) {


### PR DESCRIPTION
## Description

### Problem

The sticky routing-key override caps in-flight requests before honoring a
pin, but the cap compared the pinned worker's **total** router-local load
against `STICKY_INFLIGHT_CAP` (2). On small-fleet streaming deployments,
per-worker in-flight routinely sits at or above 2, so every returning
sticky key took the `cap_respill` branch — even a single conversation with
nothing else in flight for its key. Identity-sticky routing permanently
degraded to content-based selection (decision logs on such a fleet showed
`occupied_hit` collapsing to ~0 while `cap_respill` fired on nearly every
keyed return). Large fleets, where per-worker load rarely reaches 2, never
hit the cap — which masked the bug.

The cap was always meant to stop one conversation stacking requests onto
its pinned worker, not to act as a busy-worker test.

### Solution

Count the key's own in-flight requests on its pinned worker. The keyed
load guards (`WorkerLoadGuard::with_key`) already maintain a per-key
counter on each worker (bounded `DashMap`, entry removed at zero); expose
it as `Worker::routing_key_inflight` and have `over_cap` read it with the
un-namespaced effective key those guards track. The threshold stays 2, the
respill machinery (delegate reassignment, improvement-gated re-pin) and
the decision-log branch taxonomy are unchanged — `cap_respill` now fires
only when the same key has 2 requests in flight on its pin.

## Changes

- `Worker::routing_key_inflight(&str)`: per-key in-flight count, backed by
  the existing `WorkerRoutingKeyLoad` map (`BasicWorker` and the golang
  binding's `GrpcWorker`)
- `PolicyRegistry::select_sticky`: `over_cap` compares the key's in-flight
  on the candidate worker instead of the worker's total load; cap check
  uses the un-namespaced key (matching keyed-load accounting), pin map
  keeps PD-leg namespacing
- Tests: existing cap_respill tests converted to keyed load-guard
  pressure; new coverage for busy-worker/idle-key (regression), third
  concurrent request respilling, and the cap lifting when the key's
  in-flight drains

## Test Plan

Before: with two workers and a key pinned, unrelated load >= 2 on the pin
sent every keyed return through `cap_respill`. After: it stays
`occupied_hit` (new `busy_worker_does_not_respill_idle_key` fails on the
old code).

- `cargo test -p smg --lib -- policies::registry policies::manual routers::grpc::common::stages::worker_selection worker::worker` — 123 passed
- `cargo test -p smg --lib -- routers::http` — 53 passed
- `cargo test -p smg --test routing_tests` — 120 passed
- `cargo test -p smg --test load_guard_raii_test` — 6 passed
- `cargo build -p smg-golang` — trait change compiles in bindings

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
