### PR TITLE
fix(gateway): keep worker registration linear at fleet scale

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -520,6 +520,8 @@ struct Router {
     cache_boundaries: Vec<usize>,
     cache_index: String,
     cache_ttl_secs: u64,
+    job_queue_capacity: usize,
+    job_queue_concurrency: usize,
 }
 
 impl Router {
@@ -828,6 +830,8 @@ impl Router {
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
             .worker_startup_delay_secs(self.worker_startup_delay)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
+            .job_queue_capacity(self.job_queue_capacity)
+            .job_queue_concurrency(self.job_queue_concurrency)
             .load_monitor_interval_secs(self.load_monitor_interval)
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
@@ -1064,6 +1068,8 @@ impl Router {
         cache_boundaries = vec![],
         cache_index = String::from("tree"),
         cache_ttl_secs = 180,
+        job_queue_capacity = 1000,
+        job_queue_concurrency = 200,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1208,6 +1214,8 @@ impl Router {
         cache_boundaries: Vec<usize>,
         cache_index: String,
         cache_ttl_secs: u64,
+        job_queue_capacity: usize,
+        job_queue_concurrency: usize,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1366,6 +1374,8 @@ impl Router {
             cache_boundaries,
             cache_index,
             cache_ttl_secs,
+            job_queue_capacity,
+            job_queue_concurrency,
         })
     }
 

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -162,6 +162,12 @@ class Router:
             every worker_startup_check_interval. Default: 0
         worker_startup_check_interval: Interval in seconds between checks for worker
             initialization. Default: 30
+        job_queue_capacity: Max pending control-plane jobs (worker add/remove,
+            tokenizer, MCP, WASM). Size to fleet scale so a service-discovery
+            reconcile pass can enqueue every worker without blocking.
+            Default: 1000
+        job_queue_concurrency: Max control-plane jobs dispatched concurrently.
+            Default: 200
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to
             cached worker if the match rate exceeds threshold, otherwise routes to the
             worker with the smallest tree. Default: 0.5

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -232,6 +232,9 @@ class RouterArgs:
     cache_index: str = "tree"
     # Seconds a cache-affinity placement stays routable
     cache_ttl_secs: int = 180
+    # Control-plane job queue sizing (worker registration/removal jobs)
+    job_queue_capacity: int = 1000
+    job_queue_concurrency: int = 200
 
     @staticmethod
     def add_cli_args(
@@ -762,6 +765,22 @@ class RouterArgs:
             type=int,
             default=RouterArgs.worker_startup_check_interval,
             help="Interval in seconds between checks for worker startup",
+        )
+        parser.add_argument(
+            f"--{prefix}job-queue-capacity",
+            type=int,
+            default=RouterArgs.job_queue_capacity,
+            help=(
+                "Max pending control-plane jobs (worker add/remove, tokenizer, MCP, WASM)."
+                " Size to fleet scale so a service-discovery reconcile pass can enqueue"
+                " every worker without blocking (default: 1000)"
+            ),
+        )
+        parser.add_argument(
+            f"--{prefix}job-queue-concurrency",
+            type=int,
+            default=RouterArgs.job_queue_concurrency,
+            help="Max control-plane jobs dispatched concurrently (default: 200)",
         )
 
         # Load monitoring

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1308,6 +1308,8 @@ class TestRouterArgsFieldOrder:
         "cache_boundaries",
         "cache_index",
         "cache_ttl_secs",
+        "job_queue_capacity",
+        "job_queue_concurrency",
     ]
 
     def test_complete_field_sequence_is_frozen(self):

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -248,6 +248,16 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn job_queue_capacity(mut self, capacity: usize) -> Self {
+        self.config.job_queue_capacity = capacity;
+        self
+    }
+
+    pub fn job_queue_concurrency(mut self, concurrency: usize) -> Self {
+        self.config.job_queue_concurrency = concurrency;
+        self
+    }
+
     pub fn load_monitor_interval_secs(mut self, interval: u64) -> Self {
         self.config.load_monitor_interval_secs = interval;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -84,6 +84,13 @@ pub struct RouterConfig {
     #[serde(default)]
     pub worker_startup_delay_secs: u64,
     pub worker_startup_check_interval_secs: u64,
+    /// Control-plane job queue: max pending jobs. Size to fleet scale so a
+    /// discovery reconcile pass can enqueue every worker without blocking.
+    #[serde(default = "default_job_queue_capacity")]
+    pub job_queue_capacity: usize,
+    /// Control-plane job queue: max jobs dispatched concurrently.
+    #[serde(default = "default_job_queue_concurrency")]
+    pub job_queue_concurrency: usize,
     #[serde(default = "default_load_monitor_interval_secs")]
     pub load_monitor_interval_secs: u64,
     /// TTL in seconds for entries in the event-driven cache-aware positional
@@ -289,6 +296,14 @@ pub struct TokenizerCacheConfig {
 
 fn default_load_monitor_interval_secs() -> u64 {
     10
+}
+
+fn default_job_queue_capacity() -> usize {
+    1000
+}
+
+fn default_job_queue_concurrency() -> usize {
+    200
 }
 
 fn default_enable_l0() -> bool {
@@ -1001,6 +1016,8 @@ impl Default for RouterConfig {
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading
             worker_startup_delay_secs: 0,
             worker_startup_check_interval_secs: 30,
+            job_queue_capacity: default_job_queue_capacity(),
+            job_queue_concurrency: default_job_queue_concurrency(),
             load_monitor_interval_secs: 10,
             kv_indexer_ttl_secs: None,
             kv_indexer_max_entries: None,
@@ -1260,6 +1277,44 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let with: RouterConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(with.stream_request_bodies_over, 4 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_job_queue_sizing_serde_default_and_roundtrip() {
+        // Config files predating the fields deserialize to today's values.
+        let mut json: serde_json::Value = serde_json::to_value(RouterConfig::default()).unwrap();
+        let obj = json.as_object_mut().unwrap();
+        obj.remove("job_queue_capacity").unwrap();
+        obj.remove("job_queue_concurrency").unwrap();
+        let without: RouterConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(without.job_queue_capacity, 1000);
+        assert_eq!(without.job_queue_concurrency, 200);
+
+        // When set, the values round-trip.
+        let config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .job_queue_capacity(20_000)
+            .job_queue_concurrency(500)
+            .build_unchecked();
+        let json = serde_json::to_string(&config).unwrap();
+        let with: RouterConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(with.job_queue_capacity, 20_000);
+        assert_eq!(with.job_queue_concurrency, 500);
+    }
+
+    #[test]
+    fn test_job_queue_sizing_rejects_zero() {
+        // Config-file values bypass the CLI parsers, so validation is the
+        // backstop against a zero-capacity channel panic at startup and
+        // mirrors the CLI upper bounds.
+        for (capacity, concurrency) in [(0, 200), (1000, 0), (1_000_001, 200), (1000, 100_001)] {
+            let config = RouterConfig::builder()
+                .regular_mode(vec![])
+                .job_queue_capacity(capacity)
+                .job_queue_concurrency(concurrency)
+                .build_unchecked();
+            assert!(config.validate().is_err());
+        }
     }
 
     #[test]

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -729,6 +729,27 @@ impl ConfigValidator {
             });
         }
 
+        // A zero-capacity job channel panics at construction and a
+        // zero-permit dispatcher never dequeues; reject both here so a
+        // config-file value fails as early as the CLI parsers do.
+        // Mirror the CLI parser bounds so config-file and bindings paths get
+        // the same guarantees (zero panics at channel construction; unbounded
+        // values are allocation hazards).
+        if !(1..=1_000_000).contains(&config.job_queue_capacity) {
+            return Err(ConfigError::InvalidValue {
+                field: "job_queue_capacity".to_string(),
+                value: config.job_queue_capacity.to_string(),
+                reason: "Must be in 1..=1000000".to_string(),
+            });
+        }
+        if !(1..=100_000).contains(&config.job_queue_concurrency) {
+            return Err(ConfigError::InvalidValue {
+                field: "job_queue_concurrency".to_string(),
+                value: config.job_queue_concurrency.to_string(),
+                reason: "Must be in 1..=100000".to_string(),
+            });
+        }
+
         // The body-limit layer rejects payloads above max_payload_size before
         // the streaming threshold is consulted, so a threshold at or above it
         // could never activate.

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -172,6 +172,22 @@ fn parse_positive_usize(value: &str) -> Result<usize, String> {
     }
 }
 
+fn parse_usize_in_range(value: &str, max: usize) -> Result<usize, String> {
+    match value.parse::<usize>() {
+        Ok(n) if (1..=max).contains(&n) => Ok(n),
+        Ok(n) => Err(format!("invalid value '{n}'; expected 1..={max}")),
+        Err(err) => Err(format!("invalid value '{value}': {err}")),
+    }
+}
+
+fn parse_job_queue_capacity(value: &str) -> Result<usize, String> {
+    parse_usize_in_range(value, 1_000_000)
+}
+
+fn parse_job_queue_concurrency(value: &str) -> Result<usize, String> {
+    parse_usize_in_range(value, 100_000)
+}
+
 #[derive(Parser, Debug)]
 struct CliArgs {
     // ==================== Worker Configuration ====================
@@ -419,6 +435,16 @@ struct CliArgs {
     /// Interval in seconds between worker startup checks
     #[arg(long, default_value_t = 30, help_heading = "PD Disaggregation")]
     worker_startup_check_interval: u64,
+
+    /// Max pending control-plane jobs (worker add/remove, tokenizer, MCP,
+    /// WASM). Size to fleet scale so a service-discovery reconcile pass can
+    /// enqueue every worker without blocking.
+    #[arg(long, default_value_t = 1000, value_parser = parse_job_queue_capacity, help_heading = "Worker Configuration")]
+    job_queue_capacity: usize,
+
+    /// Max control-plane jobs dispatched concurrently
+    #[arg(long, default_value_t = 200, value_parser = parse_job_queue_concurrency, help_heading = "Worker Configuration")]
+    job_queue_concurrency: usize,
 
     /// DP engines per startup ZMQ worker: each ipc:// worker becomes a grouped
     /// worker whose handshake awaits this many engines on one socket set.
@@ -1686,6 +1712,8 @@ impl CliArgs {
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
             .worker_startup_delay_secs(self.worker_startup_delay)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
+            .job_queue_capacity(self.job_queue_capacity)
+            .job_queue_concurrency(self.job_queue_concurrency)
             .load_monitor_interval_secs(self.load_monitor_interval)
             .kv_indexer_ttl_secs(self.kv_indexer_ttl_secs)
             .kv_indexer_max_entries(self.kv_indexer_max_entries)
@@ -2054,6 +2082,48 @@ mod tests {
         let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
         assert_eq!(defaults.kv_indexer_ttl_secs, None);
         assert_eq!(defaults.kv_indexer_max_entries, None);
+    }
+
+    /// Job queue sizing must flow through both conversion paths: into
+    /// `RouterConfig` and through the `RouterConfig` carried by
+    /// `ServerConfig`, which is what constructs the queue at startup.
+    #[test]
+    fn job_queue_flags_flow_into_both_config_paths() {
+        let cli = cli_args_from(&[
+            "--job-queue-capacity",
+            "20000",
+            "--job-queue-concurrency",
+            "500",
+        ]);
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(router_config.job_queue_capacity, 20_000);
+        assert_eq!(router_config.job_queue_concurrency, 500);
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert_eq!(server_config.router_config.job_queue_capacity, 20_000);
+        assert_eq!(server_config.router_config.job_queue_concurrency, 500);
+
+        let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(defaults.job_queue_capacity, 1000);
+        assert_eq!(defaults.job_queue_concurrency, 200);
+    }
+
+    /// A zero-capacity channel panics at construction and a zero-permit
+    /// dispatcher never dequeues; both bounds are enforced at parse time.
+    #[test]
+    fn job_queue_flags_reject_out_of_range_values() {
+        for (flag, bad) in [
+            ("--job-queue-capacity", "0"),
+            ("--job-queue-capacity", "1000001"),
+            ("--job-queue-concurrency", "0"),
+            ("--job-queue-concurrency", "100001"),
+        ] {
+            let argv = ["smg", flag, bad];
+            assert!(
+                Cli::try_parse_from(argv).is_err(),
+                "{flag} {bad} should be rejected"
+            );
+        }
     }
 
     /// The streamed-body stall timeout is a router-only setting and must

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -1131,7 +1131,13 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     }
 
     let weak_context = Arc::downgrade(&app_context);
-    let worker_job_queue = JobQueue::new(JobQueueConfig::default(), weak_context);
+    let worker_job_queue = JobQueue::new(
+        JobQueueConfig {
+            queue_capacity: config.router_config.job_queue_capacity,
+            max_concurrent_jobs: config.router_config.job_queue_concurrency,
+        },
+        weak_context,
+    );
     #[expect(
         clippy::expect_used,
         reason = "OnceLock initialization during startup; double-init is a fatal bug"

--- a/model_gateway/src/worker/hash_ring.rs
+++ b/model_gateway/src/worker/hash_ring.rs
@@ -1,16 +1,20 @@
 //! Consistent hash ring for O(log n) worker selection.
 //!
 //! The ring maps a routing key to a worker URL using consistent hashing over
-//! virtual nodes. The registry rebuilds one ring per model when workers are
-//! added or removed, so the build cost is amortized — individual lookups only
-//! pay an `O(log n)` binary search plus a small bounded dedupe set to skip
-//! virtual-node duplicates. See [`HashRing::find_healthy_url`] for details.
+//! virtual nodes. The registry reconciles one ring per model when workers are
+//! added or removed via [`HashRing::updated`], which rehashes only the URLs
+//! that changed — individual lookups only pay an `O(log n)` binary search plus
+//! a small bounded dedupe set to skip virtual-node duplicates. See
+//! [`HashRing::find_healthy_url`] for details.
 //!
 //! The type intentionally has no dependency on the `Worker` trait — it is
 //! constructed from URLs — so policies and tests can build rings without
 //! materializing fake workers.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 /// Number of virtual nodes per physical worker for even distribution.
 /// 150 is a common choice that provides good balance between memory and distribution.
@@ -27,18 +31,32 @@ const VIRTUAL_NODES_PER_WORKER: usize = 150;
 /// Uses blake3 for stable, fast hashing that is consistent across Rust versions.
 #[derive(Debug, Clone)]
 pub struct HashRing {
-    /// Sorted list of `(ring_position, worker_url)`.
+    /// Sorted list of `(ring_position, url_index)`.
     ///
     /// Multiple entries per worker (virtual nodes) for even distribution.
-    /// Uses `Arc<str>` to share each URL across all of its virtual nodes
-    /// (150 refs vs 150 copies).
-    entries: Arc<[(u64, Arc<str>)]>,
+    /// Entries index into `urls` so reconciliation copies plain data instead
+    /// of touching a refcount per virtual node.
+    entries: Arc<[(u64, u32)]>,
+    /// Unique worker URLs, indexed by the entries.
+    urls: Arc<[Arc<str>]>,
+}
+
+/// The `(position, url_index)` virtual nodes for one URL, unsorted.
+fn vnodes_for(url: &str, url_index: u32) -> impl Iterator<Item = (u64, u32)> + '_ {
+    (0..VIRTUAL_NODES_PER_WORKER).map(move |vnode| {
+        (
+            HashRing::hash_position(&format!("{url}#{vnode}")),
+            url_index,
+        )
+    })
 }
 
 impl HashRing {
     /// Build a hash ring from a collection of worker URLs.
     ///
-    /// Creates `VIRTUAL_NODES_PER_WORKER` entries per URL for even distribution.
+    /// Creates `VIRTUAL_NODES_PER_WORKER` entries per unique URL for even
+    /// distribution; repeated URLs keep only their first occurrence, matching
+    /// [`Self::updated`], so a duplicate never carries extra ring weight.
     /// Accepts any iterable of string-like items, so callers can pass the
     /// output of `workers.iter().map(|w| w.url())` without allocating a Vec.
     pub fn new<I>(urls: I) -> Self
@@ -48,16 +66,21 @@ impl HashRing {
     {
         let iter = urls.into_iter();
         let (lower, _) = iter.size_hint();
-        let mut entries: Vec<(u64, Arc<str>)> =
-            Vec::with_capacity(lower.saturating_mul(VIRTUAL_NODES_PER_WORKER));
-
+        let mut seen: HashSet<Arc<str>> = HashSet::with_capacity(lower);
+        let mut urls: Vec<Arc<str>> = Vec::with_capacity(lower);
         for url in iter {
             let url: Arc<str> = Arc::from(url.as_ref());
+            if seen.insert(Arc::clone(&url)) {
+                urls.push(url);
+            }
+        }
+        let mut entries: Vec<(u64, u32)> =
+            Vec::with_capacity(urls.len().saturating_mul(VIRTUAL_NODES_PER_WORKER));
 
+        for (index, url) in urls.iter().enumerate() {
             for vnode in 0..VIRTUAL_NODES_PER_WORKER {
                 let vnode_key = format!("{url}#{vnode}");
-                let pos = Self::hash_position(&vnode_key);
-                entries.push((pos, Arc::clone(&url)));
+                entries.push((Self::hash_position(&vnode_key), index as u32));
             }
         }
 
@@ -65,6 +88,77 @@ impl HashRing {
 
         Self {
             entries: Arc::from(entries.into_boxed_slice()),
+            urls: Arc::from(urls.into_boxed_slice()),
+        }
+    }
+
+    /// Reconcile this ring to exactly `urls`, rehashing only URLs the ring
+    /// does not already contain. Content-equivalent to `HashRing::new(urls)`
+    /// — retained URLs keep their virtual-node positions by construction —
+    /// but costs one merge pass instead of a full rehash and sort, which is
+    /// what keeps per-registration cost flat while a large fleet registers.
+    pub fn updated<I>(&self, urls: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        let mut desired: HashSet<String> = HashSet::new();
+        let mut added: Vec<Arc<str>> = Vec::new();
+        let existing: HashMap<&str, u32> = self
+            .urls
+            .iter()
+            .enumerate()
+            .map(|(index, url)| (&**url, index as u32))
+            .collect();
+        for url in urls {
+            let url = url.as_ref();
+            if desired.insert(url.to_string()) && !existing.contains_key(url) {
+                added.push(Arc::from(url));
+            }
+        }
+
+        if added.is_empty() && desired.len() == self.urls.len() {
+            return self.clone();
+        }
+
+        // Remap retained URLs to their new indices; u32::MAX marks removal.
+        let mut new_urls: Vec<Arc<str>> = Vec::with_capacity(desired.len());
+        let mut remap: Vec<u32> = vec![u32::MAX; self.urls.len()];
+        for (index, url) in self.urls.iter().enumerate() {
+            if desired.contains(&**url) {
+                remap[index] = new_urls.len() as u32;
+                new_urls.push(Arc::clone(url));
+            }
+        }
+
+        let mut added_vnodes: Vec<(u64, u32)> =
+            Vec::with_capacity(added.len().saturating_mul(VIRTUAL_NODES_PER_WORKER));
+        for url in added {
+            let index = new_urls.len() as u32;
+            added_vnodes.extend(vnodes_for(&url, index));
+            new_urls.push(url);
+        }
+        added_vnodes.sort_unstable_by_key(|(pos, _)| *pos);
+
+        // Single merge pass: retained entries (already sorted) + added vnodes.
+        let mut merged: Vec<(u64, u32)> =
+            Vec::with_capacity(new_urls.len().saturating_mul(VIRTUAL_NODES_PER_WORKER));
+        let mut pending = added_vnodes.into_iter().peekable();
+        for &(pos, index) in self.entries.iter() {
+            let new_index = remap[index as usize];
+            if new_index == u32::MAX {
+                continue;
+            }
+            while let Some(vnode) = pending.next_if(|&(added_pos, _)| added_pos <= pos) {
+                merged.push(vnode);
+            }
+            merged.push((pos, new_index));
+        }
+        merged.extend(pending);
+
+        Self {
+            entries: Arc::from(merged.into_boxed_slice()),
+            urls: Arc::from(new_urls.into_boxed_slice()),
         }
     }
 
@@ -115,8 +209,8 @@ impl HashRing {
         let mut checked_urls = HashSet::with_capacity(self.worker_count().min(16));
 
         for i in 0..self.entries.len() {
-            let (_, url) = &self.entries[(start + i) % self.entries.len()];
-            let url_str: &str = url;
+            let (_, index) = self.entries[(start + i) % self.entries.len()];
+            let url_str: &str = &self.urls[index as usize];
 
             if !checked_urls.insert(url_str) {
                 continue;
@@ -142,13 +236,24 @@ impl HashRing {
 
     /// Get the number of unique workers in the ring.
     pub fn worker_count(&self) -> usize {
-        self.entries.len() / VIRTUAL_NODES_PER_WORKER.max(1)
+        self.urls.len()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_same_selection(a: &HashRing, b: &HashRing, keys: usize) {
+        for i in 0..keys {
+            let key = format!("key-{i}");
+            assert_eq!(
+                a.find_healthy_url(&key, |_| true),
+                b.find_healthy_url(&key, |_| true),
+                "selection diverged for {key}"
+            );
+        }
+    }
 
     #[test]
     fn empty_ring_returns_none() {
@@ -194,5 +299,88 @@ mod tests {
         let urls = vec!["http://a".to_string(), "http://b".to_string()];
         let ring = HashRing::new(urls);
         assert_eq!(ring.worker_count(), 2);
+    }
+
+    #[test]
+    fn updated_with_addition_matches_full_rebuild() {
+        let base = HashRing::new(["http://a", "http://b"]);
+        let incremental = base.updated(["http://a", "http://b", "http://c"]);
+        let rebuilt = HashRing::new(["http://a", "http://b", "http://c"]);
+
+        assert_eq!(incremental.worker_count(), 3);
+        assert_eq!(incremental.len(), rebuilt.len());
+        assert_same_selection(&incremental, &rebuilt, 500);
+    }
+
+    #[test]
+    fn updated_with_removal_matches_full_rebuild() {
+        let base = HashRing::new(["http://a", "http://b", "http://c"]);
+        let incremental = base.updated(["http://a", "http://c"]);
+        let rebuilt = HashRing::new(["http://a", "http://c"]);
+
+        assert_eq!(incremental.worker_count(), 2);
+        assert_eq!(incremental.len(), rebuilt.len());
+        assert_same_selection(&incremental, &rebuilt, 500);
+    }
+
+    #[test]
+    fn updated_with_same_membership_is_a_cheap_clone() {
+        let base = HashRing::new(["http://a", "http://b"]);
+        let same = base.updated(["http://b", "http://a"]);
+        assert!(Arc::ptr_eq(&base.entries, &same.entries));
+        assert!(Arc::ptr_eq(&base.urls, &same.urls));
+    }
+
+    #[test]
+    fn updated_survives_a_registration_wave() {
+        // Grow one URL at a time — the registration pattern — and verify the
+        // final ring is indistinguishable from a single full build.
+        let urls: Vec<String> = (0..40).map(|i| format!("http://w{i}:8000")).collect();
+        let mut ring = HashRing::new(std::iter::empty::<&str>());
+        for i in 0..urls.len() {
+            ring = ring.updated(&urls[..=i]);
+        }
+        let rebuilt = HashRing::new(&urls);
+        assert_eq!(ring.len(), rebuilt.len());
+        assert_eq!(ring.worker_count(), rebuilt.worker_count());
+        assert_same_selection(&ring, &rebuilt, 1000);
+    }
+
+    #[test]
+    fn updated_to_empty_clears_the_ring() {
+        let base = HashRing::new(["http://a"]);
+        let cleared = base.updated(std::iter::empty::<&str>());
+        assert!(cleared.is_empty());
+        assert_eq!(cleared.worker_count(), 0);
+    }
+
+    #[test]
+    fn updated_dedupes_repeated_urls() {
+        let base = HashRing::new(["http://a"]);
+        let ring = base.updated(["http://a", "http://b", "http://b"]);
+        assert_eq!(ring.worker_count(), 2);
+        assert_eq!(ring.len(), 2 * VIRTUAL_NODES_PER_WORKER);
+    }
+
+    #[test]
+    fn new_dedupes_repeated_urls() {
+        // A repeated URL must not carry extra virtual-node weight.
+        let deduped = HashRing::new(["http://a", "http://a"]);
+        let single = HashRing::new(["http://a"]);
+        assert_eq!(deduped.worker_count(), 1);
+        assert_eq!(deduped.len(), VIRTUAL_NODES_PER_WORKER);
+        assert_eq!(deduped.len(), single.len());
+        assert_same_selection(&deduped, &single, 100);
+    }
+
+    #[test]
+    fn duplicate_inputs_build_the_same_ring_through_both_paths() {
+        let duplicated = ["http://a", "http://b", "http://b"];
+        let rebuilt = HashRing::new(duplicated);
+        let incremental = HashRing::new(["http://a"]).updated(duplicated);
+
+        assert_eq!(rebuilt.worker_count(), incremental.worker_count());
+        assert_eq!(rebuilt.len(), incremental.len());
+        assert_same_selection(&rebuilt, &incremental, 500);
     }
 }

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -1442,16 +1442,26 @@ impl WorkerRegistry {
         Some(worker_id)
     }
 
-    /// Rebuild the hash ring for a model based on current workers in the model index.
+    /// Reconcile the hash ring for a model to the current model index.
+    ///
+    /// Diffs against the cached ring so only changed URLs are rehashed: a
+    /// full rebuild is O(workers) hashing plus a sort on every mutation,
+    /// which at fleet scale turns a registration wave quadratic and
+    /// saturates the runtime.
     fn rebuild_hash_ring(&self, model_id: &str) {
-        let ring = self
-            .model_index
-            .get(model_id)
-            .map(|workers| Arc::new(HashRing::new(workers.value().iter().map(|w| w.url()))));
+        // Clone the copy-on-write slice out so the ring build never runs
+        // under the index shard guard.
+        let workers = self.model_index.get(model_id).map(|entry| entry.clone());
 
-        match ring {
-            Some(ring) => {
-                self.hash_rings.insert(model_id.to_string(), ring);
+        match workers {
+            Some(workers) => {
+                let previous = self.hash_rings.get(model_id).map(|ring| Arc::clone(&ring));
+                let urls = workers.iter().map(|w| w.url());
+                let ring = match previous {
+                    Some(previous) => previous.updated(urls),
+                    None => HashRing::new(urls),
+                };
+                self.hash_rings.insert(model_id.to_string(), Arc::new(ring));
             }
             None => {
                 // No workers for this model, remove the ring
@@ -1494,8 +1504,16 @@ impl WorkerRegistry {
                 for entry in self.model_index.iter() {
                     urls.extend(entry.value().iter().map(|w| w.url().to_string()));
                 }
+                let previous = self
+                    .hash_rings
+                    .get(UNKNOWN_MODEL_ID)
+                    .map(|ring| Arc::clone(&ring));
+                let ring = match previous {
+                    Some(previous) => previous.updated(&urls),
+                    None => HashRing::new(&urls),
+                };
                 self.hash_rings
-                    .insert(UNKNOWN_MODEL_ID.to_string(), Arc::new(HashRing::new(urls)));
+                    .insert(UNKNOWN_MODEL_ID.to_string(), Arc::new(ring));
             }
         }
     }

--- a/model_gateway/src/workflow/job_queue.rs
+++ b/model_gateway/src/workflow/job_queue.rs
@@ -723,7 +723,17 @@ impl JobQueue {
         }
     }
 
-    /// Cleanup old job statuses (TTL 5 minutes)
+    /// A status is reclaimed only once terminal and older than the TTL.
+    /// Pending/processing entries are the reconciler's in-flight guard: a
+    /// long registration wave holds jobs in those states well past any
+    /// fixed TTL, and purging them makes every discovery pass resubmit
+    /// duplicate jobs for workers already mid-registration.
+    fn status_expired(status: &JobStatus, now: u64, ttl: u64) -> bool {
+        !matches!(status.status.as_str(), "pending" | "processing")
+            && now.saturating_sub(status.timestamp) >= ttl
+    }
+
+    /// Cleanup old terminal job statuses (TTL 5 minutes)
     async fn cleanup_old_statuses(status_map: Arc<DashMap<String, JobStatus>>) {
         const CLEANUP_INTERVAL: Duration = Duration::from_secs(60); // Run every minute
         const STATUS_TTL: u64 = 300; // 5 minutes in seconds
@@ -736,8 +746,7 @@ impl JobQueue {
                 .unwrap_or_default()
                 .as_secs();
 
-            // Remove statuses older than TTL
-            status_map.retain(|_key, value| now - value.timestamp < STATUS_TTL);
+            status_map.retain(|_key, value| !Self::status_expired(value, now, STATUS_TTL));
 
             debug!(
                 "Cleaned up old job statuses, remaining: {}",
@@ -889,6 +898,56 @@ mod tests {
             spec_for("ipc:///tmp/smg/engine", &config).runtime_type,
             default_runtime
         );
+    }
+
+    /// Pending/processing statuses are the discovery reconciler's in-flight
+    /// guard: purging them mid-wave makes every pass resubmit duplicate jobs
+    /// for workers still registering, multiplying the wave's work.
+    #[test]
+    fn cleanup_never_expires_in_flight_statuses() {
+        let pending = JobStatus::pending("AddWorker", "http://w:8000");
+        let processing = JobStatus::processing("AddWorker", "http://w:8000");
+        let far_future = pending.timestamp + 100_000;
+
+        assert!(!JobQueue::status_expired(&pending, far_future, 300));
+        assert!(!JobQueue::status_expired(&processing, far_future, 300));
+    }
+
+    /// Terminal statuses still age out so a failed worker retries on a later
+    /// reconcile pass and the map stays bounded.
+    #[test]
+    fn cleanup_expires_terminal_statuses_after_the_ttl() {
+        let failed = JobStatus::failed("AddWorker", "http://w:8000", "boom".to_string());
+
+        assert!(!JobQueue::status_expired(
+            &failed,
+            failed.timestamp + 299,
+            300
+        ));
+        assert!(JobQueue::status_expired(
+            &failed,
+            failed.timestamp + 300,
+            300
+        ));
+    }
+
+    /// The queue channel and dispatch semaphore are sized from the config,
+    /// not hardcoded.
+    #[tokio::test]
+    async fn queue_sizing_comes_from_the_config() {
+        let context: Weak<AppContext> = Weak::new();
+        let queue = JobQueue::new(
+            JobQueueConfig {
+                queue_capacity: 7,
+                max_concurrent_jobs: 3,
+            },
+            context,
+        );
+
+        assert_eq!(queue.tx.max_capacity(), 7);
+        let (queue_depth, available_permits) = queue.get_load_info();
+        assert_eq!(queue_depth, 0);
+        assert_eq!(available_permits, 3);
     }
 
     /// The connection budget scales with the health-check success threshold,


### PR DESCRIPTION
## Description

### Problem

On a production deployment with ~10k discovered workers, each new router pod takes 20-30 minutes to register the fleet and go Ready, and its `/health` readiness probe times out for the entire window. Mid-wave measurements show three compounding causes:

- Every worker registration rebuilds the per-model and wildcard consistent-hash rings from scratch (`HashRing::new`: O(workers) blake3 hashing of 150 vnodes per worker plus a full sort, twice per mutation). At 10k workers that is ~2s of synchronous CPU per registration (`register_workers` step avg 2,064ms observed), the wave turns quadratic, and the rebuilds consume nearly the whole runtime CPU budget — starving every other task including the `/health` handler (probe failures: `context deadline exceeded` for the whole wave) and inflating pure-local steps like `classify_worker_type` to its 10s timeout, which fails workflows and triggers rediscovery.
- The job-status cleanup purges `pending`/`processing` statuses after a fixed 5-minute TTL. A fleet-scale wave holds jobs in those states far longer, so the discovery reconciler's in-flight guard evaporates and every pass resubmits duplicates (16,206 successful registration submissions observed for 10,000 workers — 62% duplicates, each re-triggering the ring rebuilds above).
- The control-plane job queue is hardcoded at capacity 1000 / concurrency 200; reconcile passes block inside `submit()` for minutes (45-480s pass durations observed) once the queue fills.

### Solution

- Reconcile hash rings instead of rebuilding them: `HashRing::updated(urls)` diffs the desired URL set against the cached ring and rehashes only changed URLs, merging in one pass. The result is content-equivalent to a full rebuild (retained URLs keep their vnode positions by construction; asserted in tests) and per-mutation cost stays flat while a fleet registers. Ring entries now index into a URL table so reconciliation copies plain data. The build also no longer runs under the model-index shard guard.
- Keep `pending`/`processing` job statuses out of the TTL sweep — they are the reconciler's in-flight guard; only terminal statuses age out (successes are still removed on completion), so failed workers still retry on a later pass and the map stays bounded.
- Make the queue sizing runtime-configurable: `--job-queue-capacity` and `--job-queue-concurrency` (CLI, config file, Python bindings), so operators can size the queue to fleet scale. Defaults are unchanged (1000/200); zero is rejected at parse time and by config validation.

## Changes

- `model_gateway/src/worker/hash_ring.rs`: index-based entry layout; `HashRing::updated()` incremental reconcile; equivalence tests against full rebuilds (add/remove/no-change/wave).
- `model_gateway/src/worker/registry.rs`: `rebuild_hash_ring` / `rebuild_wildcard_hash_ring` reconcile via the cached ring.
- `model_gateway/src/workflow/job_queue.rs`: `status_expired` exempts in-flight statuses from the TTL sweep; queue sizing tests.
- `model_gateway/src/config/{types,builder,validation}.rs`: `job_queue_capacity` / `job_queue_concurrency` with serde defaults preserving current values; validation rejects 0.
- `model_gateway/src/main.rs`: `--job-queue-capacity` / `--job-queue-concurrency` with bounded parsers; wired through `to_router_config()` and carried into `to_server_config()`; tests for both paths and bounds.
- `model_gateway/src/server.rs`: `JobQueueConfig` built from `RouterConfig`.
- `bindings/python/src/lib.rs`, `bindings/python/src/smg/{router_args,router}.py`: new parameters (tail-appended for positional compatibility).

## Test Plan

Reproduced with the in-tree `mock-worker` scale harness: 2000 mock HTTP workers on sequential ports, router with `--policy cache_aware`, INFO logs, `/health` probed every 500ms with a 2s timeout, per-step latencies taken from the workflow event log.

Before:
- fleet registration span 53s (and growing quadratically with fleet size); `register_workers` p50 315ms, max 1.3s at only 2000 workers
- 600 starvation-induced step failures / 598 retries
- 14 of 46 `/health` probes timed out at 2s during the wave

After:
- fleet registration span 3.0s; `register_workers` p50 1ms, max 13ms (flat at 4000 workers too)
- 0 step failures / 0 retries
- every `/health` probe after listener bind answered (p99 454ms)

Unit/integration:
- `cargo test -p smg --lib worker::` (287), `workflow::` (64), `config::` (134), `policies::` (208)
- `cargo test -p smg --bin smg` (20, incl. both-config-paths flow and parser bounds)
- `cargo +nightly fmt --all --check`, `cargo check -p smg --tests`, `cargo build -p smg-python`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
