### PR TITLE
feat(policies): TTL'd hash placement index mode for cache_aware

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -517,6 +517,9 @@ struct Router {
     stream_request_bodies_over: u64,
     stream_body_stall_timeout_secs: u64,
     routing_key_headers: Vec<String>,
+    cache_boundaries: Vec<usize>,
+    cache_index: String,
+    cache_ttl_secs: u64,
 }
 
 impl Router {
@@ -544,6 +547,18 @@ impl Router {
                 "Invalid value for {field}='{host}': invalid mesh socket address '{addr}': {e}"
             ))
         })
+    }
+
+    fn parse_cache_index(&self) -> Result<config::CacheIndexKind, config::ConfigError> {
+        match self.cache_index.as_str() {
+            "tree" => Ok(config::CacheIndexKind::Tree),
+            "hash" => Ok(config::CacheIndexKind::Hash),
+            other => Err(config::ConfigError::InvalidValue {
+                field: "cache_index".to_string(),
+                value: other.to_string(),
+                reason: "expected 'tree' or 'hash'".to_string(),
+            }),
+        }
     }
 
     fn parse_assignment_mode(
@@ -604,6 +619,9 @@ impl Router {
                     overload_token_usage_threshold: self.overload_token_usage_threshold,
                     overlap_decay: self.overlap_decay,
                     selection_temperature: self.selection_temperature,
+                    cache_index: self.parse_cache_index()?,
+                    cache_ttl_secs: self.cache_ttl_secs,
+                    cache_boundaries: self.cache_boundaries.clone(),
                 },
                 PolicyType::PowerOfTwo => ConfigPolicyConfig::PowerOfTwo {
                     load_check_interval_secs: self.load_monitor_interval,
@@ -798,6 +816,7 @@ impl Router {
         config::RouterConfig::builder()
             .mode(mode)
             .policy(policy)
+            .cache_boundaries(self.cache_boundaries.clone())
             .host(&self.host)
             .port(self.port)
             .health_check_port(self.health_check_port)
@@ -1042,6 +1061,9 @@ impl Router {
         stream_request_bodies_over = 0,
         stream_body_stall_timeout_secs = 300,
         routing_key_headers = vec![String::from("x-smg-routing-key")],
+        cache_boundaries = vec![],
+        cache_index = String::from("tree"),
+        cache_ttl_secs = 180,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1183,6 +1205,9 @@ impl Router {
         stream_request_bodies_over: u64,
         stream_body_stall_timeout_secs: u64,
         routing_key_headers: Vec<String>,
+        cache_boundaries: Vec<usize>,
+        cache_index: String,
+        cache_ttl_secs: u64,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1338,6 +1363,9 @@ impl Router {
             stream_request_bodies_over,
             stream_body_stall_timeout_secs,
             routing_key_headers,
+            cache_boundaries,
+            cache_index,
+            cache_ttl_secs,
         })
     }
 

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -165,6 +165,15 @@ class Router:
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to
             cached worker if the match rate exceeds threshold, otherwise routes to the
             worker with the smallest tree. Default: 0.5
+        cache_boundaries: Token positions at which serving engines retain reusable
+            prefix state; cache-affinity policies hash request heads at the deepest
+            applicable boundary. Default: []
+        cache_index: Index under-layer for cache_aware: 'tree' (radix prefix trees)
+            or 'hash' (TTL'd exact-match placement map keyed on request heads at
+            cache_boundaries; token-bearing requests only — untokenized requests
+            stay load-balanced). Default: 'tree'
+        cache_ttl_secs: Seconds a cache-affinity placement stays routable; should
+            approximate serving-engine cache retention. Default: 180
         prefix_token_count: Number of prefix tokens hashed by the prefix_hash
             policy, or four times as many characters of the prompt when the
             request is untokenized. Size it past any shared system prompt so

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -26,6 +26,11 @@ PREFILL_POLICY_CHOICES = [*COMMON_POLICY_CHOICES, "bucket"]
 ENCODE_POLICY_CHOICES = ["random", "round_robin", "consistent_hashing"]
 
 
+def _parse_int_csv(value: str) -> list[int]:
+    """Parse a comma-separated integer list (mirrors the CLI value_delimiter)."""
+    return [int(item) for item in value.split(",") if item]
+
+
 @dataclasses.dataclass
 class RouterArgs:
     # Worker configuration
@@ -221,6 +226,12 @@ class RouterArgs:
     routing_key_headers: list[str] = dataclasses.field(
         default_factory=lambda: ["x-smg-routing-key"]
     )
+    # Token positions at which serving engines retain reusable prefix state
+    cache_boundaries: list[int] = dataclasses.field(default_factory=list)
+    # cache_aware index under-layer: "tree" or "hash"
+    cache_index: str = "tree"
+    # Seconds a cache-affinity placement stays routable
+    cache_ttl_secs: int = 180
 
     @staticmethod
     def add_cli_args(
@@ -576,6 +587,37 @@ class RouterArgs:
             type=int,
             default=RouterArgs.block_size,
             help="KV cache block size for event-driven cache-aware routing (default: 16)",
+        )
+        routing_group.add_argument(
+            f"--{prefix}cache-boundaries",
+            type=_parse_int_csv,
+            default=[],
+            help=(
+                "Comma-separated token positions at which serving engines retain"
+                " reusable prefix state; cache-affinity policies hash request"
+                " heads at the deepest applicable boundary."
+            ),
+        )
+        routing_group.add_argument(
+            f"--{prefix}cache-index",
+            type=str,
+            choices=["tree", "hash"],
+            default=RouterArgs.cache_index,
+            help=(
+                "Index under-layer for cache_aware: 'tree' (radix prefix trees)"
+                " or 'hash' (TTL'd exact-match placement map keyed on request"
+                " heads at --cache-boundaries; token-bearing requests only —"
+                " untokenized requests stay load-balanced). Defaults to 'tree'."
+            ),
+        )
+        routing_group.add_argument(
+            f"--{prefix}cache-ttl-secs",
+            type=int,
+            default=RouterArgs.cache_ttl_secs,
+            help=(
+                "Seconds a cache-affinity placement stays routable; should"
+                " approximate serving-engine cache retention. Defaults to 180."
+            ),
         )
         routing_group.add_argument(
             f"--{prefix}max-idle-secs",

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -549,6 +549,27 @@ class TestParseRouterArgs:
         defaults = parse_router_args([])
         assert defaults.routing_key_headers == ["x-smg-routing-key"]
 
+    def test_parse_cache_index_args(self):
+        """Comma-separated boundaries plus the index/TTL knobs."""
+        router_args = parse_router_args(
+            [
+                "--cache-boundaries",
+                "2048,8192,32768",
+                "--cache-index",
+                "hash",
+                "--cache-ttl-secs",
+                "120",
+            ]
+        )
+        assert router_args.cache_boundaries == [2048, 8192, 32768]
+        assert router_args.cache_index == "hash"
+        assert router_args.cache_ttl_secs == 120
+
+        defaults = parse_router_args([])
+        assert defaults.cache_boundaries == []
+        assert defaults.cache_index == "tree"
+        assert defaults.cache_ttl_secs == 180
+
     def test_parse_pd_args(self):
         """Test parsing PD disaggregated mode arguments."""
         args = [
@@ -1284,6 +1305,9 @@ class TestRouterArgsFieldOrder:
         "stream_request_bodies_over",
         "stream_body_stall_timeout_secs",
         "routing_key_headers",
+        "cache_boundaries",
+        "cache_index",
+        "cache_ttl_secs",
     ]
 
     def test_complete_field_sequence_is_frozen(self):
@@ -1309,6 +1333,9 @@ class TestRouterArgsFieldOrder:
             "stream_request_bodies_over",
             "stream_body_stall_timeout_secs",
             "routing_key_headers",
+            "cache_boundaries",
+            "cache_index",
+            "cache_ttl_secs",
         ):
             assert names.index(appended) > marker, (
                 f"{appended} must be appended after worker_startup_delay to "

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -891,6 +891,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 1.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         });
         let builder = AppContextBuilder::new()
             .with_client(&config, 5)
@@ -931,6 +934,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         }));
     }
 
@@ -951,6 +957,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         };
 
         let mut config = config_with_policy(PolicyConfig::Random);

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -4,10 +4,10 @@ use openai_protocol::worker::TransportMode;
 use smg_mcp::McpConfig;
 
 use super::{
-    CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
-    HistoryBackend, MetricsConfig, OracleConfig, PolicyConfig, PostgresConfig, RedisConfig,
-    RetryConfig, RouterConfig, RoutingKeyOverrideConfig, RoutingMode, TenantApiKeyEntry,
-    TokenizerCacheConfig, TraceConfig,
+    CacheIndexKind, CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig,
+    HealthCheckConfig, HistoryBackend, MetricsConfig, OracleConfig, PolicyConfig, PostgresConfig,
+    RedisConfig, RetryConfig, RouterConfig, RoutingKeyOverrideConfig, RoutingMode,
+    TenantApiKeyEntry, TokenizerCacheConfig, TraceConfig,
 };
 use crate::worker::{ConnectionMode, RuntimeType};
 
@@ -107,6 +107,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn cache_boundaries(mut self, boundaries: Vec<usize>) -> Self {
+        self.config.cache_boundaries = boundaries;
+        self
+    }
+
     pub fn random_policy(mut self) -> Self {
         self.config.policy = PolicyConfig::Random;
         self
@@ -136,6 +141,9 @@ impl RouterConfigBuilder {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: CacheIndexKind::Tree,
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         };
         self
     }

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -34,6 +34,11 @@ pub struct RouterConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub zmq_engine_count: Option<usize>,
     pub policy: PolicyConfig,
+    /// Token positions at which serving engines retain reusable prefix state;
+    /// cache-affinity policies hash request heads at the deepest applicable
+    /// boundary. Ascending; empty disables boundary-based keying.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cache_boundaries: Vec<usize>,
     /// Per-request sticky-session routing (rid-lineage keys, header fallback).
     #[serde(default, alias = "sticky_sessions")]
     pub routing_key_override: RoutingKeyOverrideConfig,
@@ -513,6 +518,18 @@ impl Default for RoutingKeyOverrideConfig {
     }
 }
 
+/// Under-layer index the cache_aware policy keeps per model.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheIndexKind {
+    /// Radix prefix tree (default).
+    #[default]
+    Tree,
+    /// TTL'd exact-match placement map keyed on quantized request heads
+    /// (`cache_boundaries`); the radix tree is neither consulted nor populated.
+    Hash,
+}
+
 /// Policy configuration for routing
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -566,6 +583,18 @@ pub enum PolicyConfig {
         /// existing tie-breaks; larger values spread picks across candidates.
         #[serde(default = "default_selection_temperature")]
         selection_temperature: f32,
+        /// Index under-layer: `tree` (default) or `hash` (TTL'd exact-match
+        /// placement map over `cache_boundaries` heads).
+        #[serde(default)]
+        cache_index: CacheIndexKind,
+        /// Seconds a cache-affinity placement stays routable; should
+        /// approximate serving-engine cache retention.
+        #[serde(default = "default_cache_ttl_secs")]
+        cache_ttl_secs: u64,
+        /// Boundary token positions for the hash index (copied from the
+        /// shared `cache_boundaries` config).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        cache_boundaries: Vec<usize>,
     },
 
     /// Power-of-two choices policy: samples two workers and routes to the one
@@ -690,6 +719,10 @@ fn default_overlap_decay() -> f32 {
 
 fn default_selection_temperature() -> f32 {
     0.0
+}
+
+fn default_cache_ttl_secs() -> u64 {
+    180
 }
 
 fn default_prefix_token_count() -> usize {
@@ -954,6 +987,7 @@ impl Default for RouterConfig {
                 worker_urls: vec![],
             },
             policy: PolicyConfig::Random,
+            cache_boundaries: Vec::new(),
             routing_key_override: RoutingKeyOverrideConfig::default(),
             host: "0.0.0.0".to_string(),
             port: 3001,
@@ -1460,6 +1494,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         };
         assert_eq!(cache_aware.name(), "cache_aware");
 
@@ -1486,6 +1523,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         };
         let json = serde_json::to_string(&cache_aware).unwrap();
         assert!(json.contains("\"type\":\"cache_aware\""));
@@ -1513,6 +1553,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         };
 
         match cache_aware {
@@ -1558,6 +1601,85 @@ mod tests {
             }
             _ => panic!("Expected CacheAware"),
         }
+    }
+
+    #[test]
+    fn test_cache_aware_index_fields_default_when_absent() {
+        // Config files written before the hash index existed must keep
+        // parsing as tree mode with the default TTL and no boundaries.
+        let json = r#"{
+            "type": "cache_aware",
+            "cache_threshold": 0.5,
+            "balance_abs_threshold": 32,
+            "balance_rel_threshold": 1.1,
+            "eviction_interval_secs": 60,
+            "max_tree_size": 1000
+        }"#;
+        let policy: PolicyConfig = serde_json::from_str(json).unwrap();
+        match policy {
+            PolicyConfig::CacheAware {
+                cache_index,
+                cache_ttl_secs,
+                cache_boundaries,
+                ..
+            } => {
+                assert_eq!(cache_index, CacheIndexKind::Tree);
+                assert_eq!(cache_ttl_secs, 180);
+                assert!(cache_boundaries.is_empty());
+            }
+            _ => panic!("Expected CacheAware"),
+        }
+    }
+
+    #[test]
+    fn test_cache_aware_index_fields_round_trip() {
+        let json = r#"{
+            "type": "cache_aware",
+            "cache_threshold": 0.5,
+            "balance_abs_threshold": 32,
+            "balance_rel_threshold": 1.1,
+            "eviction_interval_secs": 60,
+            "max_tree_size": 1000,
+            "cache_index": "hash",
+            "cache_ttl_secs": 90,
+            "cache_boundaries": [2048, 8192]
+        }"#;
+        let policy: PolicyConfig = serde_json::from_str(json).unwrap();
+        let serialized = serde_json::to_string(&policy).unwrap();
+        assert!(serialized.contains("\"cache_index\":\"hash\""));
+        assert!(serialized.contains("\"cache_ttl_secs\":90"));
+        assert!(serialized.contains("\"cache_boundaries\":[2048,8192]"));
+        match serde_json::from_str::<PolicyConfig>(&serialized).unwrap() {
+            PolicyConfig::CacheAware {
+                cache_index,
+                cache_ttl_secs,
+                cache_boundaries,
+                ..
+            } => {
+                assert_eq!(cache_index, CacheIndexKind::Hash);
+                assert_eq!(cache_ttl_secs, 90);
+                assert_eq!(cache_boundaries, vec![2048, 8192]);
+            }
+            _ => panic!("Expected CacheAware"),
+        }
+    }
+
+    #[test]
+    fn test_router_config_cache_boundaries_default_and_skip() {
+        // Absent in old configs → empty; empty is skipped on serialize.
+        let config = RouterConfig::default();
+        assert!(config.cache_boundaries.is_empty());
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("cache_boundaries"));
+
+        let with_boundaries = RouterConfig {
+            cache_boundaries: vec![16, 64],
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&with_boundaries).unwrap();
+        assert!(json.contains("\"cache_boundaries\":[16,64]"));
+        let parsed: RouterConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.cache_boundaries, vec![16, 64]);
     }
 
     #[test]
@@ -1954,6 +2076,9 @@ mod tests {
                 overload_token_usage_threshold: 1.0,
                 overlap_decay: 0.0,
                 selection_temperature: 0.0,
+                cache_index: Default::default(),
+                cache_ttl_secs: 180,
+                cache_boundaries: Vec::new(),
             }),
             decode_policy: Some(PolicyConfig::PowerOfTwo {
                 load_check_interval_secs: 60,
@@ -1989,6 +2114,9 @@ mod tests {
                 overload_token_usage_threshold: 1.0,
                 overlap_decay: 0.0,
                 selection_temperature: 0.0,
+                cache_index: Default::default(),
+                cache_ttl_secs: 180,
+                cache_boundaries: Vec::new(),
             }),
             decode_policy: None,
         };
@@ -2050,6 +2178,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         };
 
         match pd.get_prefill_policy(&main_policy) {

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -92,6 +92,7 @@ impl ConfigValidator {
     pub(crate) fn validate(config: &RouterConfig) -> ConfigResult<()> {
         Self::validate_mode(&config.mode)?;
         Self::validate_policy(&config.policy)?;
+        Self::validate_cache_boundaries(&config.cache_boundaries)?;
         Self::validate_server_settings(config)?;
         Self::validate_storage_context_headers(config)?;
         Self::validate_routing_key_headers(config)?;
@@ -470,7 +471,28 @@ impl ConfigValidator {
                 overload_token_usage_threshold,
                 overlap_decay,
                 selection_temperature,
+                cache_index,
+                cache_ttl_secs,
+                cache_boundaries,
             } => {
+                Self::validate_cache_boundaries(cache_boundaries)?;
+
+                if *cache_ttl_secs == 0 {
+                    return Err(ConfigError::InvalidValue {
+                        field: "cache_ttl_secs".to_string(),
+                        value: cache_ttl_secs.to_string(),
+                        reason: "Must be > 0".to_string(),
+                    });
+                }
+
+                if *cache_index == CacheIndexKind::Hash && cache_boundaries.is_empty() {
+                    return Err(ConfigError::InvalidValue {
+                        field: "cache_index".to_string(),
+                        value: "hash".to_string(),
+                        reason: "cache_index=hash requires non-empty cache_boundaries".to_string(),
+                    });
+                }
+
                 if !overlap_decay.is_finite() || *overlap_decay < 0.0 {
                     return Err(ConfigError::InvalidValue {
                         field: "overlap_decay".to_string(),
@@ -642,6 +664,24 @@ impl ConfigValidator {
                     });
                 }
             }
+        }
+        Ok(())
+    }
+
+    fn validate_cache_boundaries(boundaries: &[usize]) -> ConfigResult<()> {
+        if boundaries.first() == Some(&0) {
+            return Err(ConfigError::InvalidValue {
+                field: "cache_boundaries".to_string(),
+                value: "0".to_string(),
+                reason: "Boundaries must be > 0".to_string(),
+            });
+        }
+        if boundaries.windows(2).any(|w| w[0] >= w[1]) {
+            return Err(ConfigError::InvalidValue {
+                field: "cache_boundaries".to_string(),
+                value: format!("{boundaries:?}"),
+                reason: "Boundaries must be strictly ascending".to_string(),
+            });
         }
         Ok(())
     }
@@ -1475,6 +1515,9 @@ mod tests {
                 overload_token_usage_threshold: 1.0,
                 overlap_decay: 0.0,
                 selection_temperature: 0.0,
+                cache_index: Default::default(),
+                cache_ttl_secs: 180,
+                cache_boundaries: Vec::new(),
             },
         );
 
@@ -1502,6 +1545,9 @@ mod tests {
                     overload_token_usage_threshold: 1.0,
                     overlap_decay,
                     selection_temperature,
+                    cache_index: Default::default(),
+                    cache_ttl_secs: 180,
+                    cache_boundaries: Vec::new(),
                 },
             )
         };
@@ -1514,6 +1560,58 @@ mod tests {
         assert!(ConfigValidator::validate(&make(0.0, -1.0)).is_err());
         assert!(ConfigValidator::validate(&make(f32::NAN, 0.0)).is_err());
         assert!(ConfigValidator::validate(&make(0.0, f32::INFINITY)).is_err());
+    }
+
+    #[test]
+    fn test_validate_cache_index_fields() {
+        let make = |cache_index: CacheIndexKind, cache_ttl_secs: u64, boundaries: Vec<usize>| {
+            RouterConfig::new(
+                RoutingMode::Regular {
+                    worker_urls: vec!["http://worker1:8000".to_string()],
+                },
+                PolicyConfig::CacheAware {
+                    cache_threshold: 0.5,
+                    balance_abs_threshold: 32,
+                    balance_rel_threshold: 1.1,
+                    eviction_interval_secs: 60,
+                    max_tree_size: 1000,
+                    block_size: 16,
+                    balance_token_usage_threshold: 1.0,
+                    overload_token_usage_threshold: 1.0,
+                    overlap_decay: 0.0,
+                    selection_temperature: 0.0,
+                    cache_index,
+                    cache_ttl_secs,
+                    cache_boundaries: boundaries,
+                },
+            )
+        };
+
+        assert!(ConfigValidator::validate(&make(CacheIndexKind::Tree, 180, vec![])).is_ok());
+        assert!(ConfigValidator::validate(&make(CacheIndexKind::Hash, 180, vec![16, 64])).is_ok());
+        // TTL must be positive.
+        assert!(ConfigValidator::validate(&make(CacheIndexKind::Tree, 0, vec![])).is_err());
+        // Hash mode without boundaries has nothing to key on.
+        assert!(ConfigValidator::validate(&make(CacheIndexKind::Hash, 180, vec![])).is_err());
+        // Boundaries must be strictly ascending and non-zero.
+        assert!(ConfigValidator::validate(&make(CacheIndexKind::Hash, 180, vec![64, 16])).is_err());
+        assert!(ConfigValidator::validate(&make(CacheIndexKind::Hash, 180, vec![16, 16])).is_err());
+        assert!(ConfigValidator::validate(&make(CacheIndexKind::Hash, 180, vec![0, 16])).is_err());
+    }
+
+    #[test]
+    fn test_validate_shared_cache_boundaries_field() {
+        let mut config = RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker1:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        );
+        config.cache_boundaries = vec![16, 64];
+        assert!(ConfigValidator::validate(&config).is_ok());
+
+        config.cache_boundaries = vec![64, 16];
+        assert!(ConfigValidator::validate(&config).is_err());
     }
 
     #[test]
@@ -1534,6 +1632,9 @@ mod tests {
                 overload_token_usage_threshold: 1.0,
                 overlap_decay: 0.0,
                 selection_temperature: 0.0,
+                cache_index: Default::default(),
+                cache_ttl_secs: 180,
+                cache_boundaries: Vec::new(),
             },
         );
 
@@ -1593,6 +1694,9 @@ mod tests {
                 overload_token_usage_threshold: 1.0,
                 overlap_decay: 0.0,
                 selection_temperature: 0.0,
+                cache_index: Default::default(),
+                cache_ttl_secs: 180,
+                cache_boundaries: Vec::new(),
             },
         );
 
@@ -1642,6 +1746,9 @@ mod tests {
                     overload_token_usage_threshold: 1.0,
                     overlap_decay: 0.0,
                     selection_temperature: 0.0,
+                    cache_index: Default::default(),
+                    cache_ttl_secs: 180,
+                    cache_boundaries: Vec::new(),
                 }),
                 decode_policy: Some(PolicyConfig::PowerOfTwo {
                     load_check_interval_secs: 60,
@@ -1770,6 +1877,9 @@ mod tests {
                     overload_token_usage_threshold: 1.0,
                     overlap_decay: 0.0,
                     selection_temperature: 0.0,
+                    cache_index: Default::default(),
+                    cache_ttl_secs: 180,
+                    cache_boundaries: Vec::new(),
                 }),
                 prefill_policy: None,
                 decode_policy: None,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -12,7 +12,7 @@ use openai_protocol::worker::TransportMode;
 use rand::{distr::Alphanumeric, RngExt};
 use smg::{
     config::{
-        validate_mesh_server_name, CircuitBreakerConfig, ConfigError, ConfigResult,
+        validate_mesh_server_name, CacheIndexKind, CircuitBreakerConfig, ConfigError, ConfigResult,
         DiscoveryConfig, HealthCheckConfig, HistoryBackend, ManualAssignmentMode, MetricsConfig,
         OracleConfig, PolicyConfig, PostgresConfig, RedisConfig, RetryConfig, RouterConfig,
         RoutingKeyOverrideConfig, RoutingMode, SchemaConfig, TenantApiKeyEntry,
@@ -277,6 +277,24 @@ struct CliArgs {
     /// size, and the KV block size assumed for event-driven selection
     #[arg(long, default_value_t = 16, help_heading = "Routing Policy")]
     block_size: usize,
+
+    /// Token positions at which serving engines retain reusable prefix
+    /// state; cache-affinity policies hash request heads at the deepest
+    /// applicable boundary.
+    #[arg(long, value_delimiter = ',', help_heading = "Routing Policy")]
+    cache_boundaries: Vec<usize>,
+
+    /// Index under-layer for cache_aware: "tree" (radix prefix trees) or
+    /// "hash" (TTL'd exact-match placement map keyed on request heads at
+    /// --cache-boundaries; token-bearing requests only — untokenized
+    /// requests stay load-balanced)
+    #[arg(long, default_value = "tree", value_parser = ["tree", "hash"], help_heading = "Routing Policy")]
+    cache_index: String,
+
+    /// Seconds a cache-affinity placement stays routable; should
+    /// approximate serving-engine cache retention
+    #[arg(long, default_value_t = 180, value_parser = clap::value_parser!(u64).range(1..), help_heading = "Routing Policy")]
+    cache_ttl_secs: u64,
 
     /// How long an unused sticky routing key stays pinned: keys idle beyond
     /// this many seconds are evicted from the manual-policy / sticky-session
@@ -1266,6 +1284,9 @@ impl CliArgs {
                 overload_token_usage_threshold: self.overload_token_usage_threshold,
                 overlap_decay: self.overlap_decay,
                 selection_temperature: self.selection_temperature,
+                cache_index: Self::parse_cache_index(&self.cache_index),
+                cache_ttl_secs: self.cache_ttl_secs,
+                cache_boundaries: self.cache_boundaries.clone(),
             },
             "power_of_two" => PolicyConfig::PowerOfTwo {
                 load_check_interval_secs: 5,
@@ -1297,6 +1318,18 @@ impl CliArgs {
                 ),
             },
             _ => PolicyConfig::RoundRobin,
+        }
+    }
+
+    #[expect(
+        clippy::panic,
+        reason = "unreachable: clap value_parser restricts valid cache index kinds"
+    )]
+    fn parse_cache_index(kind: &str) -> CacheIndexKind {
+        match kind {
+            "tree" => CacheIndexKind::Tree,
+            "hash" => CacheIndexKind::Hash,
+            other => panic!("Unknown cache index: {other}"),
         }
     }
 
@@ -1637,6 +1670,7 @@ impl CliArgs {
         let builder = RouterConfig::builder()
             .mode(mode)
             .policy(policy)
+            .cache_boundaries(self.cache_boundaries.clone())
             .connection_mode(connection_mode)
             .startup_worker_runtime_type(startup_worker_runtime_type)
             .zmq_engine_count(self.zmq_engine_count)
@@ -2196,6 +2230,64 @@ mod tests {
             server_config.router_config.engine_metrics,
             "engine_metrics must survive into ServerConfig via to_server_config"
         );
+    }
+
+    /// Cache-index flags must reach the cache_aware policy variant and the
+    /// shared `RouterConfig.cache_boundaries`, and survive into
+    /// `ServerConfig.router_config`. Two-path config-plumbing guard.
+    #[test]
+    fn cache_index_flags_flow_into_both_configs() {
+        let cli = cli_args_from(&[
+            "--cache-boundaries",
+            "2048,8192",
+            "--cache-index",
+            "hash",
+            "--cache-ttl-secs",
+            "60",
+        ]);
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(router_config.cache_boundaries, vec![2048, 8192]);
+        match &router_config.policy {
+            PolicyConfig::CacheAware {
+                cache_index,
+                cache_ttl_secs,
+                cache_boundaries,
+                ..
+            } => {
+                assert_eq!(*cache_index, CacheIndexKind::Hash);
+                assert_eq!(*cache_ttl_secs, 60);
+                assert_eq!(*cache_boundaries, vec![2048, 8192]);
+            }
+            other => panic!("expected cache_aware policy, got {other:?}"),
+        }
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert_eq!(
+            server_config.router_config.cache_boundaries,
+            vec![2048, 8192],
+            "cache_boundaries must survive into ServerConfig via to_server_config"
+        );
+
+        let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
+        assert!(defaults.cache_boundaries.is_empty());
+        match &defaults.policy {
+            PolicyConfig::CacheAware {
+                cache_index,
+                cache_ttl_secs,
+                cache_boundaries,
+                ..
+            } => {
+                assert_eq!(*cache_index, CacheIndexKind::Tree);
+                assert_eq!(*cache_ttl_secs, 180);
+                assert!(cache_boundaries.is_empty());
+            }
+            other => panic!("expected cache_aware policy, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cache_ttl_secs_zero_rejected_at_parse() {
+        assert!(Cli::try_parse_from(["smg", "--cache-ttl-secs", "0"]).is_err());
     }
 
     /// The multimodal transport flags must reach both `RouterConfig` and the

--- a/model_gateway/src/mesh/wiring.rs
+++ b/model_gateway/src/mesh/wiring.rs
@@ -472,6 +472,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         }
     }
 

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -361,6 +361,10 @@ pub(crate) fn init_metrics() {
         "smg_cache_tree_tenants",
         "Cache-aware tree tenant count by model and tree (string/token)"
     );
+    describe_gauge!(
+        "smg_cache_placement_entries",
+        "Cache-aware hash-index placement entries by model (keys with a live holder)"
+    );
 
     // Layer 3: Worker resilience metrics (circuit breaker)
     describe_gauge!(
@@ -1371,6 +1375,12 @@ impl Metrics {
     pub fn set_cache_tree_tenants(model_id: &str, tree: &'static str, count: usize) {
         let model = intern_model_label(model_id);
         gauge!("smg_cache_tree_tenants", "model" => model, "tree" => tree).set(count as f64);
+    }
+
+    /// Set cache-aware hash-index placement entry count for a model
+    pub fn set_cache_placement_entries(model_id: &str, count: usize) {
+        let model = intern_model_label(model_id);
+        gauge!("smg_cache_placement_entries", "model" => model).set(count as f64);
     }
 
     /// Record consistent hashing policy execution branch for routing decisions

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -31,15 +31,26 @@
     When the system is imbalanced, routes to the least busy worker regardless
     of cache affinity.
 
+    Hash Index Under-Layer (cache_index = hash)
+    -------------------------------------------
+    Replaces all three tree modes with a TTL'd exact-match placement map
+    keyed on request heads at the cache_boundaries token positions; the
+    radix trees are neither consulted nor populated. Selection probes
+    boundaries deepest-first for a live holder and records the dispatched
+    worker at every applicable boundary.
+
     Configuration Parameters:
     ------------------------
     cache_threshold:         Min prefix match ratio for highest-match routing (0.0-1.0)
     balance_abs_threshold:   Absolute load diff threshold for imbalance detection
     balance_rel_threshold:   Relative load ratio threshold for imbalance detection
-    eviction_interval_secs:  Interval between LRU eviction cycles
+    eviction_interval_secs:  Interval between LRU eviction / TTL sweep cycles
     max_tree_size:           Max total size (chars/tokens) of each model's approximate tree,
                              shared across all workers; enforced by eviction
     block_size:              Backend KV cache block size for event-driven routing
+    cache_index:             Under-layer: tree (radix trees) or hash (placement map)
+    cache_ttl_secs:          Seconds a hash-index placement stays routable
+    cache_boundaries:        Ascending token positions for hash-index keying
 */
 
 use std::{
@@ -48,6 +59,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+    time::{Duration, Instant},
 };
 
 use dashmap::DashMap;
@@ -64,6 +76,7 @@ use super::{
     SelectWorkerInfo,
 };
 use crate::{
+    config::CacheIndexKind,
     mesh::adapters::tree_sync::{RepairEntry, TreeDelta, TreeRepairPage, TreeSyncAdapter},
     observability::metrics::Metrics,
     worker::{KvEventMonitor, Worker},
@@ -133,6 +146,29 @@ pub struct CacheAwarePolicy {
     /// a still-in-flight delta with no local resolution; peers that
     /// repair against us will simply see the gap the next tick.
     mesh_tree_sync: RwLock<Option<Arc<TreeSyncAdapter>>>,
+    /// Hash-mode placement index (`cache_index = hash`): model →
+    /// (boundary, head hash) → live holders. Empty in tree mode.
+    placement_index: Arc<DashMap<String, PlacementMap>>,
+}
+
+/// Hash-mode per-model placement map: (boundary position, xxh3 of the token
+/// head up to that boundary) → workers recently routed that exact head.
+type PlacementMap = DashMap<(usize, u64), Vec<PlacementHolder>>;
+
+/// One worker's most recent dispatch of a head; live while `last_touch`
+/// is within `cache_ttl_secs`.
+#[derive(Debug, Clone)]
+struct PlacementHolder {
+    worker_url: String,
+    last_touch: Instant,
+}
+
+/// Max workers remembered per (boundary, head) key; recording a fourth
+/// evicts the stalest.
+const PLACEMENT_HOLDER_CAP: usize = 3;
+
+fn hash_token_head(head: &[u32]) -> u64 {
+    xxhash_rust::xxh3::xxh3_64(bytemuck::cast_slice(head))
 }
 
 /// Per-model inner container for [`CacheAwarePolicy::hash_index`].
@@ -166,13 +202,27 @@ impl CacheAwarePolicy {
         Self::with_config(CacheAwareConfig::default())
     }
 
-    pub fn with_config(config: CacheAwareConfig) -> Self {
+    pub fn with_config(mut config: CacheAwareConfig) -> Self {
+        // Deepest-first probing assumes sorted, deduped, non-zero boundaries.
+        config.cache_boundaries.retain(|&p| p > 0);
+        config.cache_boundaries.sort_unstable();
+        config.cache_boundaries.dedup();
+
         let string_trees = Arc::new(DashMap::<String, Arc<Tree>>::new());
         let token_trees = Arc::new(DashMap::<String, Arc<TokenTree>>::new());
         let hash_index = Arc::new(DashMap::<String, PerModelHashIndex>::new());
+        let placement_index = Arc::new(DashMap::<String, PlacementMap>::new());
 
         // Start background eviction thread if configured
-        let eviction_task = if config.eviction_interval_secs > 0 {
+        let eviction_task = if config.cache_index == CacheIndexKind::Hash {
+            (config.eviction_interval_secs > 0).then(|| {
+                let placement_clone = Arc::clone(&placement_index);
+                let ttl = Duration::from_secs(config.cache_ttl_secs);
+                PeriodicTask::spawn(config.eviction_interval_secs, "PlacementSweep", move || {
+                    Self::sweep_placement_index(&placement_clone, ttl, Instant::now());
+                })
+            })
+        } else if config.eviction_interval_secs > 0 {
             let string_trees_clone = Arc::clone(&string_trees);
             let token_trees_clone = Arc::clone(&token_trees);
             let hash_index_clone = Arc::clone(&hash_index);
@@ -273,6 +323,7 @@ impl CacheAwarePolicy {
             hash_index,
             populate_hash_index: AtomicBool::new(false),
             mesh_tree_sync: RwLock::new(None),
+            placement_index,
         }
     }
 
@@ -480,6 +531,10 @@ impl CacheAwarePolicy {
     /// Initialize the trees with worker URLs (used only during initial setup)
     /// Initializes both string trees (HTTP) and token trees (gRPC) for each model.
     pub fn init_workers(&self, workers: &[Arc<dyn Worker>]) {
+        // Hash mode keeps no tree state.
+        if self.config.cache_index == CacheIndexKind::Hash {
+            return;
+        }
         // Group workers by model
         let mut model_workers: HashMap<String, Vec<&Arc<dyn Worker>>> = HashMap::new();
         for worker in workers {
@@ -512,6 +567,9 @@ impl CacheAwarePolicy {
 
     /// Add a single worker to the trees (incremental update)
     pub fn add_worker(&self, worker: &dyn Worker) {
+        if self.config.cache_index == CacheIndexKind::Hash {
+            return;
+        }
         let tree_key = normalize_model_key(worker.model_id()).to_string();
         // Add to string tree (HTTP)
         let string_tree = self
@@ -529,6 +587,9 @@ impl CacheAwarePolicy {
 
     /// Add a worker by URL and model (for backward compatibility)
     pub fn add_worker_by_url(&self, url: &str, model_id: &str) {
+        if self.config.cache_index == CacheIndexKind::Hash {
+            return;
+        }
         let model_id_string = model_id.to_string();
         // Add to string tree (HTTP)
         let string_tree = self
@@ -559,6 +620,12 @@ impl CacheAwarePolicy {
         }
         for tree_ref in self.token_trees.iter() {
             tree_ref.value().remove_tenant_all(&tenant);
+        }
+        for model in self.placement_index.iter() {
+            model.value().retain(|_, holders| {
+                holders.retain(|h| h.worker_url != url);
+                !holders.is_empty()
+            });
         }
     }
 
@@ -962,6 +1029,19 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         // Determine the model for this set of workers (router pre-filters by model)
         // All workers should be from the same model
         let model_id = normalize_model_key(workers[healthy_indices[0]].model_id());
+
+        // Hash mode: TTL'd exact-match placement index; the radix trees are
+        // neither consulted nor populated.
+        if self.config.cache_index == CacheIndexKind::Hash {
+            return self.select_worker_hash(
+                workers,
+                info,
+                &healthy_indices,
+                min_load_idx,
+                avg_load,
+                model_id,
+            );
+        }
 
         // Abandon cache affinity fleet-wide only under backend KV pressure;
         // request-count pressure is applied per request to the selected
@@ -1411,6 +1491,7 @@ impl CacheAwarePolicy {
             }
         };
         debug!(
+            index = "tree",
             branch,
             worker = selected_url.or(fallback_url).unwrap_or("none"),
             model_id,
@@ -1418,6 +1499,210 @@ impl CacheAwarePolicy {
             threshold = f64::from(self.config.cache_threshold),
             "Cache-aware selection"
         );
+    }
+
+    /// One decision line per hash-mode selection. `level` is the matched
+    /// boundary (0 for the fallback branches).
+    fn log_hash_decision(branch: &'static str, level: usize, worker: &str, model_id: &str) {
+        debug!(
+            index = "hash",
+            branch, level, worker, model_id, "Cache-aware selection"
+        );
+    }
+
+    /// Hash-mode selection: probe the placement index deepest-boundary-first
+    /// for a live holder of this request's head, then record the dispatch at
+    /// every applicable boundary.
+    fn select_worker_hash(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        info: &SelectWorkerInfo,
+        healthy_indices: &[usize],
+        min_load_idx: Option<usize>,
+        avg_load: f64,
+        model_id: &str,
+    ) -> Option<usize> {
+        let now = Instant::now();
+
+        // Hash mode keys on token ids; untokenized requests stay load-balanced.
+        let Some(tokens) = info.tokens.filter(|t| !t.is_empty()) else {
+            return self.hash_min_load(
+                workers,
+                min_load_idx,
+                model_id,
+                "min_load_fallback",
+                &[],
+                &[],
+                now,
+            );
+        };
+
+        let applicable_end = self
+            .config
+            .cache_boundaries
+            .partition_point(|&p| p <= tokens.len());
+        let applicable = &self.config.cache_boundaries[..applicable_end];
+
+        // Head-only traffic must stay load-balanced.
+        if applicable.is_empty() {
+            return self.hash_min_load(
+                workers,
+                min_load_idx,
+                model_id,
+                "short_request",
+                tokens,
+                applicable,
+                now,
+            );
+        }
+
+        if self.is_kv_imbalanced(workers, healthy_indices) {
+            return self.hash_min_load(
+                workers,
+                min_load_idx,
+                model_id,
+                "kv_pressure_min_load",
+                tokens,
+                applicable,
+                now,
+            );
+        }
+
+        for &boundary in applicable.iter().rev() {
+            let key = (boundary, hash_token_head(&tokens[..boundary]));
+            let Some(holder_idx) =
+                self.live_holder_min_load(workers, healthy_indices, model_id, key, now)
+            else {
+                continue;
+            };
+            let selected =
+                self.gate_selected_candidate(workers, holder_idx, avg_load, min_load_idx)?;
+            let branch = if selected == holder_idx {
+                "hash_hit"
+            } else {
+                "hash_spill"
+            };
+            self.record_placement(model_id, tokens, applicable, workers[selected].url(), now);
+            Self::log_hash_decision(branch, boundary, workers[selected].url(), model_id);
+            workers[selected].increment_processed();
+            return Some(selected);
+        }
+
+        self.hash_min_load(
+            workers,
+            min_load_idx,
+            model_id,
+            "min_load_fallback",
+            tokens,
+            applicable,
+            now,
+        )
+    }
+
+    /// Min-load dispatch for the hash-path fallback branches; records the
+    /// placement when boundaries apply.
+    #[expect(clippy::too_many_arguments, reason = "hot-path plumbing, not state")]
+    fn hash_min_load(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        min_load_idx: Option<usize>,
+        model_id: &str,
+        branch: &'static str,
+        tokens: &[u32],
+        applicable: &[usize],
+        now: Instant,
+    ) -> Option<usize> {
+        let idx = min_load_idx?;
+        if !applicable.is_empty() {
+            self.record_placement(model_id, tokens, applicable, workers[idx].url(), now);
+        }
+        Self::log_hash_decision(branch, 0, workers[idx].url(), model_id);
+        workers[idx].increment_processed();
+        Some(idx)
+    }
+
+    /// Least-loaded live holder of `key` among healthy workers, or `None`.
+    /// Expired holders are pruned in place (lazy expiry on read).
+    fn live_holder_min_load(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        healthy_indices: &[usize],
+        model_id: &str,
+        key: (usize, u64),
+        now: Instant,
+    ) -> Option<usize> {
+        let ttl = Duration::from_secs(self.config.cache_ttl_secs);
+        let model = self.placement_index.get(model_id)?;
+        let mut holders = model.get_mut(&key)?;
+        holders.retain(|h| now.duration_since(h.last_touch) <= ttl);
+        healthy_indices
+            .iter()
+            .copied()
+            .filter(|&idx| {
+                let url = workers[idx].url();
+                holders.iter().any(|h| h.worker_url == url)
+            })
+            .min_by_key(|&idx| (workers[idx].load(), idx))
+    }
+
+    /// Record/touch `worker_url` at every applicable boundary of this
+    /// request; above the holder cap the stalest holder is evicted.
+    fn record_placement(
+        &self,
+        model_id: &str,
+        tokens: &[u32],
+        boundaries: &[usize],
+        worker_url: &str,
+        now: Instant,
+    ) {
+        let ttl = Duration::from_secs(self.config.cache_ttl_secs);
+        let model = self
+            .placement_index
+            .entry(model_id.to_string())
+            .or_default();
+        for &boundary in boundaries {
+            let key = (boundary, hash_token_head(&tokens[..boundary]));
+            let mut holders = model.entry(key).or_default();
+            holders.retain(|h| now.duration_since(h.last_touch) <= ttl);
+            if let Some(holder) = holders.iter_mut().find(|h| h.worker_url == worker_url) {
+                holder.last_touch = now;
+                continue;
+            }
+            if holders.len() >= PLACEMENT_HOLDER_CAP {
+                if let Some(stalest) = holders
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(_, h)| h.last_touch)
+                    .map(|(i, _)| i)
+                {
+                    holders.swap_remove(stalest);
+                }
+            }
+            holders.push(PlacementHolder {
+                worker_url: worker_url.to_string(),
+                last_touch: now,
+            });
+        }
+    }
+
+    /// Drop expired holders and empty keys; refresh the per-model entry
+    /// gauge. Returns total live entries across models.
+    fn sweep_placement_index(
+        index: &DashMap<String, PlacementMap>,
+        ttl: Duration,
+        now: Instant,
+    ) -> usize {
+        let mut total = 0usize;
+        for model in index {
+            model.value().retain(|_, holders| {
+                holders.retain(|h| now.duration_since(h.last_touch) <= ttl);
+                !holders.is_empty()
+            });
+            let entries = model.value().len();
+            total += entries;
+            Metrics::set_cache_placement_entries(model.key(), entries);
+        }
+        total
     }
 
     /// Select worker using token-based tree (gRPC path)
@@ -1765,6 +2050,7 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            ..Default::default()
         });
 
         let worker1 = BasicWorkerBuilder::new("http://w1:8000")
@@ -3525,5 +3811,335 @@ mod tests {
             )
             .unwrap();
         assert_eq!(idx, idx2); // token tree cache affinity preserved
+    }
+
+    // ---- hash placement index (cache_index = hash) ----
+
+    fn hash_config(boundaries: &[usize]) -> CacheAwareConfig {
+        CacheAwareConfig {
+            eviction_interval_secs: 0,
+            cache_index: CacheIndexKind::Hash,
+            cache_boundaries: boundaries.to_vec(),
+            ..Default::default()
+        }
+    }
+
+    fn route_tokens(
+        policy: &CacheAwarePolicy,
+        workers: &[Arc<dyn Worker>],
+        tokens: &[u32],
+    ) -> usize {
+        policy
+            .select_worker(
+                workers,
+                &SelectWorkerInfo {
+                    tokens: Some(tokens),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn hash_mode_never_touches_trees() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        policy.init_workers(&workers);
+        assert!(policy.string_trees.is_empty());
+        assert!(policy.token_trees.is_empty());
+
+        let tokens: Vec<u32> = (0..32).collect();
+        route_tokens(&policy, &workers, &tokens);
+        policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some("a text prompt long enough to insert"),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert!(policy.string_trees.is_empty());
+        assert!(policy.token_trees.is_empty());
+        assert!(!policy.placement_index.is_empty());
+    }
+
+    #[test]
+    fn hash_mode_repeat_head_sticks_to_holder() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+
+        let tokens: Vec<u32> = (0..32).collect();
+        let first = route_tokens(&policy, &workers, &tokens);
+        // Mild load on the holder must not break affinity (under the gate).
+        workers[first].increment_load();
+        workers[first].increment_load();
+        for _ in 0..5 {
+            assert_eq!(route_tokens(&policy, &workers, &tokens), first);
+        }
+
+        // A different head load-balances away from the loaded holder.
+        let other: Vec<u32> = (1000..1032).collect();
+        assert_ne!(route_tokens(&policy, &workers, &other), first);
+    }
+
+    #[test]
+    fn hash_mode_probes_deepest_boundary_first() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16, 32]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        let model = normalize_model_key(workers[0].model_id());
+        let tokens: Vec<u32> = (0..40).collect();
+        let now = Instant::now();
+
+        // w2 holds the 16-token head, w1 the deeper 32-token head.
+        policy.record_placement(model, &tokens, &[16], "http://w2:8000", now);
+        policy.record_placement(model, &tokens, &[32], "http://w1:8000", now);
+        // Even with the shallow holder strictly less loaded, the deeper
+        // boundary must win.
+        workers[0].increment_load();
+
+        assert_eq!(route_tokens(&policy, &workers, &tokens), 0);
+    }
+
+    #[test]
+    fn hash_mode_records_at_every_applicable_boundary() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16, 32, 64]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        let model = normalize_model_key(workers[0].model_id());
+
+        let tokens: Vec<u32> = (0..40).collect();
+        let selected = route_tokens(&policy, &workers, &tokens);
+
+        let placements = policy.placement_index.get(model).unwrap();
+        // 64 exceeds the request length: only the two applicable levels.
+        assert_eq!(placements.len(), 2);
+        for boundary in [16usize, 32] {
+            let key = (boundary, hash_token_head(&tokens[..boundary]));
+            let holders = placements.get(&key).unwrap();
+            assert_eq!(holders.len(), 1);
+            assert_eq!(holders[0].worker_url, workers[selected].url());
+        }
+    }
+
+    #[test]
+    fn hash_mode_short_request_stays_min_load() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        for _ in 0..3 {
+            workers[0].increment_load();
+        }
+
+        let tokens: Vec<u32> = (0..8).collect();
+        for _ in 0..5 {
+            assert_eq!(route_tokens(&policy, &workers, &tokens), 1);
+        }
+        assert!(policy.placement_index.is_empty());
+    }
+
+    #[test]
+    fn hash_mode_untokenized_text_stays_min_load() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        for _ in 0..3 {
+            workers[0].increment_load();
+        }
+
+        let info = SelectWorkerInfo {
+            request_text: Some("system prompt plus a user question"),
+            ..Default::default()
+        };
+        for _ in 0..5 {
+            assert_eq!(policy.select_worker(&workers, &info), Some(1));
+        }
+        assert!(policy.placement_index.is_empty());
+        assert!(policy.string_trees.is_empty());
+    }
+
+    #[test]
+    fn hash_mode_ttl_expires_holders_on_read() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        let model = normalize_model_key(workers[0].model_id());
+        let tokens: Vec<u32> = (0..16).collect();
+        let t0 = Instant::now();
+        let key = (16usize, hash_token_head(&tokens[..16]));
+
+        policy.record_placement(model, &tokens, &[16], "http://w1:8000", t0);
+
+        let healthy = vec![0usize, 1];
+        // Just inside the 180s default TTL: live.
+        let live_at = t0 + Duration::from_secs(179);
+        assert_eq!(
+            policy.live_holder_min_load(&workers, &healthy, model, key, live_at),
+            Some(0)
+        );
+        // Just past it: expired and pruned.
+        let expired_at = t0 + Duration::from_secs(181);
+        assert_eq!(
+            policy.live_holder_min_load(&workers, &healthy, model, key, expired_at),
+            None
+        );
+        assert!(policy
+            .placement_index
+            .get(model)
+            .unwrap()
+            .get(&key)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn hash_mode_expired_holder_falls_back_to_min_load() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            cache_ttl_secs: 1,
+            ..hash_config(&[16])
+        });
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+
+        let tokens: Vec<u32> = (0..16).collect();
+        let first = route_tokens(&policy, &workers, &tokens);
+        assert_eq!(route_tokens(&policy, &workers, &tokens), first);
+
+        // Let the placement lapse, then load the former holder: a live
+        // placement would still win, an expired one must load-balance away.
+        std::thread::sleep(Duration::from_millis(1300));
+        for _ in 0..3 {
+            workers[first].increment_load();
+        }
+        assert_ne!(route_tokens(&policy, &workers, &tokens), first);
+    }
+
+    #[test]
+    fn hash_mode_holder_cap_evicts_stalest() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let tokens: Vec<u32> = (0..16).collect();
+        let t0 = Instant::now();
+        let key = (16usize, hash_token_head(&tokens[..16]));
+
+        for (i, url) in [
+            "http://w1:8000",
+            "http://w2:8000",
+            "http://w3:8000",
+            "http://w4:8000",
+        ]
+        .iter()
+        .enumerate()
+        {
+            policy.record_placement("m", &tokens, &[16], url, t0 + Duration::from_secs(i as u64));
+        }
+
+        let placements = policy.placement_index.get("m").unwrap();
+        let holders = placements.get(&key).unwrap();
+        assert_eq!(holders.len(), PLACEMENT_HOLDER_CAP);
+        assert!(!holders.iter().any(|h| h.worker_url == "http://w1:8000"));
+    }
+
+    #[test]
+    fn hash_mode_gate_spills_and_replicates_placement() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        let model = normalize_model_key(workers[0].model_id());
+        let tokens: Vec<u32> = (0..16).collect();
+        let key = (16usize, hash_token_head(&tokens[..16]));
+
+        policy.record_placement(model, &tokens, &[16], "http://w1:8000", Instant::now());
+        // Past both gate margins (rel 1.1 of avg 50, abs avg+32): spill.
+        for _ in 0..100 {
+            workers[0].increment_load();
+        }
+
+        assert_eq!(route_tokens(&policy, &workers, &tokens), 1);
+        // The spill target becomes an additional holder of this head.
+        let placements = policy.placement_index.get(model).unwrap();
+        let holders = placements.get(&key).unwrap();
+        assert!(holders.iter().any(|h| h.worker_url == "http://w2:8000"));
+    }
+
+    #[test]
+    fn hash_mode_kv_pressure_abandons_affinity() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            balance_token_usage_threshold: 0.3,
+            overload_token_usage_threshold: 0.95,
+            ..hash_config(&[16])
+        });
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        let model = normalize_model_key(workers[0].model_id());
+        let tokens: Vec<u32> = (0..16).collect();
+
+        policy.record_placement(model, &tokens, &[16], "http://w1:8000", Instant::now());
+        workers[0].increment_load();
+        let _tx = inject_kv(&policy, &workers, &[0.9, 0.1]);
+
+        // KV spread 0.8 > 0.3: shortest queue wins over the placement.
+        assert_eq!(route_tokens(&policy, &workers, &tokens), 1);
+    }
+
+    #[test]
+    fn hash_mode_co_hashes_short_and_long_requests() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[2048]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+
+        // 3k- and 17k-token requests sharing the 2048-token head must land
+        // on the same worker via the shared boundary key.
+        let short: Vec<u32> = (0..3000).collect();
+        let mut long: Vec<u32> = (0..2048).collect();
+        long.extend(9_000_000..9_014_952);
+        assert_eq!(long.len(), 17_000);
+
+        let first = route_tokens(&policy, &workers, &short);
+        assert_eq!(route_tokens(&policy, &workers, &long), first);
+    }
+
+    #[test]
+    fn hash_mode_removed_worker_is_purged_from_placements() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let tokens: Vec<u32> = (0..16).collect();
+        let now = Instant::now();
+        policy.record_placement("m", &tokens, &[16], "http://w1:8000", now);
+        policy.record_placement("m", &tokens, &[16], "http://w2:8000", now);
+
+        policy.remove_worker_by_url("http://w1:8000");
+
+        let placements = policy.placement_index.get("m").unwrap();
+        let holders = placements
+            .get(&(16usize, hash_token_head(&tokens[..16])))
+            .unwrap();
+        assert_eq!(holders.len(), 1);
+        assert_eq!(holders[0].worker_url, "http://w2:8000");
+    }
+
+    #[test]
+    fn sweep_placement_index_drops_expired_and_empty_keys() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let fresh: Vec<u32> = (0..16).collect();
+        let stale: Vec<u32> = (500..516).collect();
+        let t0 = Instant::now();
+        policy.record_placement("m", &stale, &[16], "http://w1:8000", t0);
+        policy.record_placement(
+            "m",
+            &fresh,
+            &[16],
+            "http://w1:8000",
+            t0 + Duration::from_secs(120),
+        );
+
+        let live = CacheAwarePolicy::sweep_placement_index(
+            &policy.placement_index,
+            Duration::from_secs(180),
+            t0 + Duration::from_secs(200),
+        );
+        assert_eq!(live, 1);
+        let placements = policy.placement_index.get("m").unwrap();
+        assert_eq!(placements.len(), 1);
+        assert!(placements
+            .get(&(16usize, hash_token_head(&fresh[..16])))
+            .is_some());
+    }
+
+    #[test]
+    fn with_config_normalizes_boundaries() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[64, 16, 16, 0]));
+        assert_eq!(policy.config.cache_boundaries, vec![16, 64]);
     }
 }

--- a/model_gateway/src/policies/factory.rs
+++ b/model_gateway/src/policies/factory.rs
@@ -51,6 +51,9 @@ impl PolicyFactory {
                 overload_token_usage_threshold,
                 overlap_decay,
                 selection_temperature,
+                cache_index,
+                cache_ttl_secs,
+                cache_boundaries,
             } => {
                 let config = CacheAwareConfig {
                     cache_threshold: *cache_threshold,
@@ -63,6 +66,9 @@ impl PolicyFactory {
                     overload_token_usage_threshold: *overload_token_usage_threshold,
                     overlap_decay: *overlap_decay,
                     selection_temperature: *selection_temperature,
+                    cache_index: *cache_index,
+                    cache_ttl_secs: *cache_ttl_secs,
+                    cache_boundaries: cache_boundaries.clone(),
                 };
                 Arc::new(CacheAwarePolicy::with_config(config))
             }
@@ -157,6 +163,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         });
         assert_eq!(policy.name(), "cache_aware");
 

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -7,7 +7,10 @@ use std::{fmt::Debug, sync::Arc};
 
 use openai_protocol::worker::WorkerLoadResponse;
 
-use crate::worker::{HashRing, Worker};
+use crate::{
+    config::CacheIndexKind,
+    worker::{HashRing, Worker},
+};
 
 mod bucket;
 mod cache_aware;
@@ -159,6 +162,16 @@ pub struct CacheAwareConfig {
     /// score spread matters): small values mostly follow the best candidate,
     /// large values approach uniform.
     pub selection_temperature: f32,
+    /// Index under-layer: `Tree` (default, radix prefix trees) or `Hash`
+    /// (TTL'd exact-match placement map over `cache_boundaries` heads; the
+    /// radix trees are neither consulted nor populated).
+    pub cache_index: CacheIndexKind,
+    /// Seconds a hash-index placement stays routable; should approximate
+    /// serving-engine cache retention.
+    pub cache_ttl_secs: u64,
+    /// Ascending token positions at which serving engines retain reusable
+    /// prefix state; the hash index keys request heads at these boundaries.
+    pub cache_boundaries: Vec<usize>,
 }
 
 impl Default for CacheAwareConfig {
@@ -178,6 +191,9 @@ impl Default for CacheAwareConfig {
             // to pre-knob selection until explicitly tuned.
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: CacheIndexKind::Tree,
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         }
     }
 }

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -1039,6 +1039,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         }
     }
 
@@ -1369,6 +1372,9 @@ mod tests {
                 overload_token_usage_threshold: 1.0,
                 overlap_decay: 0.0,
                 selection_temperature: 0.0,
+                cache_index: Default::default(),
+                cache_ttl_secs: 180,
+                cache_boundaries: Vec::new(),
             },
             rid_override(ManualAssignmentMode::Delegate),
         );
@@ -1614,6 +1620,9 @@ mod tests {
                 overload_token_usage_threshold,
                 overlap_decay,
                 selection_temperature: 0.0,
+                cache_index: Default::default(),
+                cache_ttl_secs: 180,
+                cache_boundaries: Vec::new(),
             }
         }
 
@@ -1660,6 +1669,9 @@ mod tests {
             overload_token_usage_threshold: 0.8,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         });
 
         // Hinted policy is a fresh per-model instance, not the shared default.
@@ -1729,6 +1741,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         }));
 
         for round in 0..64 {

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -2321,6 +2321,9 @@ mod tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay: 0.0,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         }
     }
 

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -1561,6 +1561,9 @@ mod native_loads_tests {
             overload_token_usage_threshold: 1.0,
             overlap_decay,
             selection_temperature: 0.0,
+            cache_index: Default::default(),
+            cache_ttl_secs: 180,
+            cache_boundaries: Vec::new(),
         }
     }
 

--- a/model_gateway/tests/routing/cache_aware_backward_compat_test.rs
+++ b/model_gateway/tests/routing/cache_aware_backward_compat_test.rs
@@ -28,6 +28,7 @@ fn test_backward_compatibility_with_empty_model_id() {
         overload_token_usage_threshold: 1.0,
         overlap_decay: 0.0,
         selection_temperature: 0.0,
+        ..Default::default()
     };
 
     let policy = CacheAwarePolicy::with_config(config);
@@ -84,6 +85,7 @@ fn test_mixed_model_ids() {
         overload_token_usage_threshold: 1.0,
         overlap_decay: 0.0,
         selection_temperature: 0.0,
+        ..Default::default()
     };
 
     let policy = CacheAwarePolicy::with_config(config);

--- a/model_gateway/tests/routing/stream_request_body_test.rs
+++ b/model_gateway/tests/routing/stream_request_body_test.rs
@@ -81,6 +81,9 @@ fn cache_aware_policy() -> PolicyConfig {
         overload_token_usage_threshold: 1.0,
         overlap_decay: 0.0,
         selection_temperature: 0.0,
+        cache_index: Default::default(),
+        cache_ttl_secs: 180,
+        cache_boundaries: Vec::new(),
     }
 }
 

--- a/model_gateway/tests/routing/test_pd_routing.rs
+++ b/model_gateway/tests/routing/test_pd_routing.rs
@@ -170,6 +170,9 @@ mod pd_routing_unit_tests {
                     overload_token_usage_threshold: 1.0,
                     overlap_decay: 0.0,
                     selection_temperature: 0.0,
+                    cache_index: Default::default(),
+                    cache_ttl_secs: 180,
+                    cache_boundaries: Vec::new(),
                 },
             ),
             (


### PR DESCRIPTION
## Description

### Problem

The `cache_aware` radix trees remember two kinds of affinity that serving
engines cannot honor: partial prefix overlaps (engines credit reuse only at
fixed checkpoint token positions, all-or-nothing) and placements of
unbounded age (engines retain cache state for only a few minutes). Routing
on that state pins requests to workers whose cache advantage no longer
exists, while the trees grow without a time bound.

### Solution

A selectable under-layer for `cache_aware`: `--cache-index tree|hash`
(default `tree`, byte-identical legacy behavior). In `hash` mode the radix
trees are neither consulted nor populated; selection uses a per-model,
TTL'd exact-match placement map keyed on request heads at the shared
`--cache-boundaries` token positions — time- and quantization-faithful to
what engines can still credit.

Selection probes boundaries deepest-first for a live holder (healthy,
circuit-breaker-ok), picks the least-loaded one, and applies the policy's
existing per-request load gate; every dispatch records/touches the chosen
worker at each applicable boundary (3 holders per key, stalest evicted).
Requests below the smallest boundary and untokenized requests stay
load-balanced. Placements expire after `--cache-ttl-secs` (default 180),
lazily on read plus a periodic sweep.

## Changes

- `--cache-index tree|hash` on the cache_aware policy; `tree` default keeps
  legacy behavior untouched
- Shared `--cache-boundaries` (ascending token positions) and
  `--cache-ttl-secs` (>0) config, wired through both conversion paths,
  serde-back-compatible, validated at config time
- Hash placement index in `CacheAwarePolicy`: DashMap keyed by
  `(boundary, xxh3 of ids[0..boundary])` -> capped holder list with
  `last_touch`; TTL sweep reuses the periodic-task pattern and exports a
  per-model `smg_cache_placement_entries` gauge
- Decision logs: `index="hash"` line with branch/level/worker/model per
  hash selection; `index="tree"` added to the existing tree decision line
- Python bindings: `cache_boundaries`, `cache_index`, `cache_ttl_secs`
  tail-appended across `_Router`, `RouterArgs`, and argparse

## Test Plan

- `cargo test -p smg --lib -- policies::cache_aware policies::manual config::`
  — 218 passed (all pre-existing tree-mode tests green and unmodified)
- `cargo test -p smg --bin smg cache` — CLI two-path flow, clap rejection of
  `--cache-ttl-secs 0`
- `cargo test -p smg --test routing_tests -- cache_aware backward_compat header_routing`
  — 10 passed
- New hash-mode unit tests: deepest-first probing, TTL expiry (injected
  clock + selection-level), holder-cap eviction, short-request and
  untokenized fallbacks, record-at-all-levels, gate spill replicating the
  placement, KV-pressure abandon, worker-removal purge, sweep, boundary
  normalization, 3k/17k co-hash at a 2048 boundary, serde/CLI roundtrips
- `cargo build -p smg-python`; `pytest tests/test_arg_parser.py
  tests/test_router_config.py tests/test_validation.py` — 111 passed

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
