### PR TITLE
feat(policies): checkpoint-boundary levels for prefix_hash

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -649,6 +649,7 @@ impl Router {
                     prefix_token_count: self.prefix_token_count,
                     load_factor: self.prefix_hash_load_factor,
                     balance_abs_threshold: self.prefix_hash_balance_abs_threshold,
+                    cache_boundaries: self.cache_boundaries.clone(),
                 },
             })
         };

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1103,6 +1103,23 @@ class TestPrefixHashArgs:
         assert router_args.prefix_hash_load_factor == 2.0
 
 
+class TestCacheBoundariesArgs:
+    """Boundary-list parsing beyond the basic parse/default coverage."""
+
+    def test_router_prefix_flag(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser, use_router_prefix=True)
+        namespace = parser.parse_args(["--router-cache-boundaries", "4096"])
+        router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
+        assert router_args.cache_boundaries == [4096]
+
+    def test_non_numeric_rejected(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser)
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--cache-boundaries", "2048,big"])
+
+
 class TestFlagAliases:
     """Intent-revealing alias flags land on the same dests as the canonical names."""
 

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -702,6 +702,11 @@ pub enum PolicyConfig {
         /// before it counts as overloaded (default: 10)
         #[serde(default = "default_prefix_hash_balance_abs_threshold")]
         balance_abs_threshold: usize,
+        /// Resolved copy of `RouterConfig::cache_boundaries`: ascending token
+        /// positions; requests hash at the deepest boundary they reach.
+        /// Empty = hash at `prefix_token_count` only.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        cache_boundaries: Vec<usize>,
     },
 }
 

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -647,6 +647,7 @@ impl ConfigValidator {
                 prefix_token_count,
                 load_factor,
                 balance_abs_threshold: _,
+                cache_boundaries,
             } => {
                 if *prefix_token_count == 0 {
                     return Err(ConfigError::InvalidValue {
@@ -663,6 +664,8 @@ impl ConfigValidator {
                         reason: "Must be >= 1.0".to_string(),
                     });
                 }
+
+                Self::validate_cache_boundaries(cache_boundaries)?;
             }
         }
         Ok(())
@@ -1159,6 +1162,23 @@ mod tests {
             ConfigValidator::validate(&at_cap),
             Err(ConfigError::InvalidValue { ref field, .. })
                 if field == "stream_request_bodies_over"
+        ));
+    }
+
+    #[test]
+    fn prefix_hash_policy_cache_boundaries_are_validated() {
+        let config = RouterConfig {
+            policy: PolicyConfig::PrefixHash {
+                prefix_token_count: 256,
+                load_factor: 1.25,
+                balance_abs_threshold: 10,
+                cache_boundaries: vec![8192, 2048],
+            },
+            ..Default::default()
+        };
+        assert!(matches!(
+            ConfigValidator::validate(&config),
+            Err(ConfigError::InvalidValue { ref field, .. }) if field == "cache_boundaries"
         ));
     }
 

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1307,6 +1307,7 @@ impl CliArgs {
                 prefix_token_count: self.prefix_token_count,
                 load_factor: self.prefix_hash_load_factor,
                 balance_abs_threshold: self.prefix_hash_balance_abs_threshold,
+                cache_boundaries: self.cache_boundaries.clone(),
             },
             "consistent_hashing" => PolicyConfig::ConsistentHashing,
             "manual" => PolicyConfig::Manual {
@@ -2437,6 +2438,52 @@ mod tests {
             router_config.startup_worker_runtime_type,
             Some(RuntimeType::Vllm)
         );
+    }
+
+    /// The shared `--cache-boundaries` flag must also reach the prefix_hash
+    /// policy's resolved copy (the shared-field flow is covered by
+    /// `cache_index_flags_flow_into_both_configs`).
+    #[test]
+    fn cache_boundaries_flow_into_prefix_hash_policy() {
+        let cli = cli_args_from(&[
+            "--policy",
+            "prefix_hash",
+            "--cache-boundaries",
+            "2048,8192,32768",
+        ]);
+
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        match &router_config.policy {
+            PolicyConfig::PrefixHash {
+                cache_boundaries, ..
+            } => assert_eq!(cache_boundaries, &vec![2048, 8192, 32768]),
+            other => panic!("expected prefix_hash policy, got {other:?}"),
+        }
+
+        let defaults = cli_args_from(&["--policy", "prefix_hash"])
+            .to_router_config(vec![], vec![])
+            .unwrap();
+        match &defaults.policy {
+            PolicyConfig::PrefixHash {
+                cache_boundaries, ..
+            } => assert!(cache_boundaries.is_empty()),
+            other => panic!("expected prefix_hash policy, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_ascending_cache_boundaries_are_rejected() {
+        for bad in ["8192,2048", "0,2048", "2048,2048"] {
+            let cli = cli_args_from(&["--cache-boundaries", bad]);
+            assert!(
+                matches!(
+                    cli.to_router_config(vec![], vec![]),
+                    Err(ConfigError::InvalidValue { ref field, .. })
+                        if field == "cache_boundaries"
+                ),
+                "--cache-boundaries {bad} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/model_gateway/src/policies/factory.rs
+++ b/model_gateway/src/policies/factory.rs
@@ -101,11 +101,13 @@ impl PolicyFactory {
                 prefix_token_count,
                 load_factor,
                 balance_abs_threshold,
+                cache_boundaries,
             } => {
                 let config = PrefixHashConfig {
                     prefix_token_count: *prefix_token_count,
                     load_factor: *load_factor,
                     balance_abs_threshold: *balance_abs_threshold,
+                    cache_boundaries: cache_boundaries.clone(),
                 };
                 Arc::new(PrefixHashPolicy::new(config))
             }
@@ -190,6 +192,7 @@ mod tests {
             prefix_token_count: 100,
             load_factor: 0.8,
             balance_abs_threshold: 10,
+            cache_boundaries: vec![2048, 8192],
         });
         assert_eq!(policy.name(), "prefix_hash");
     }

--- a/model_gateway/src/policies/prefix_hash.rs
+++ b/model_gateway/src/policies/prefix_hash.rs
@@ -7,11 +7,15 @@
 //! ## Algorithm
 //!
 //! 1. Extract first N tokens from the request (configurable prefix length),
-//!    or the equivalent span of routing text when the request is untokenized
+//!    or the equivalent span of routing text when the request is untokenized.
+//!    With `cache_boundaries` configured, N is instead the deepest boundary
+//!    the request reaches, so requests sharing a boundary-aligned head
+//!    co-hash regardless of their total length
 //! 2. Hash the prefix using xxhash for fast, stable hashing
 //! 3. Use consistent hash ring to find the target worker
 //! 4. If worker is overloaded (load above both the relative and absolute
-//!    margins over average), find least loaded
+//!    margins over average), retry each shallower boundary, then find least
+//!    loaded
 //! 5. Return least loaded worker that passes load check, or initial if all overloaded
 //!
 //! ## Complexity
@@ -32,6 +36,8 @@
 //! prefix_hash trades optimal cache utilization for predictable O(log n) performance.
 
 use std::sync::Arc;
+
+use tracing::debug;
 
 use super::{LoadBalancingPolicy, SelectWorkerInfo};
 use crate::{observability::metrics::Metrics, worker::Worker};
@@ -60,6 +66,12 @@ pub struct PrefixHashConfig {
     /// router replica observes a smaller share of a worker's true load.
     /// Default: 10 requests
     pub balance_abs_threshold: usize,
+
+    /// Resolved copy of the shared `cache_boundaries` setting: ascending
+    /// token positions at which serving engines retain reusable prefix
+    /// state. When non-empty, requests hash at the deepest boundary they
+    /// reach instead of at `prefix_token_count`.
+    pub cache_boundaries: Vec<usize>,
 }
 
 impl Default for PrefixHashConfig {
@@ -68,6 +80,7 @@ impl Default for PrefixHashConfig {
             prefix_token_count: 256,
             load_factor: 1.25,
             balance_abs_threshold: 10,
+            cache_boundaries: Vec::new(),
         }
     }
 }
@@ -120,24 +133,21 @@ impl PrefixHashPolicy {
         Self::new(PrefixHashConfig::default())
     }
 
-    /// Compute hash of prefix tokens using xxhash
+    /// Token prefix at the fixed legacy depth, as hashable bytes
     #[inline]
-    fn compute_prefix_hash(&self, tokens: &[u32]) -> u64 {
+    fn fixed_depth_token_prefix<'a>(&self, tokens: &'a [u32]) -> &'a [u8] {
         let prefix_len = tokens.len().min(self.config.prefix_token_count);
-        let prefix = &tokens[..prefix_len];
-
-        let bytes: &[u8] = bytemuck::cast_slice(prefix);
-        xxhash_rust::xxh3::xxh3_64(bytes)
+        bytemuck::cast_slice(&tokens[..prefix_len])
     }
 
-    /// Compute hash of the leading text of an untokenized request
+    /// Leading text of an untokenized request at the fixed legacy depth
     ///
     /// Only pre-tokenized requests carry token IDs; chat, completions and
     /// text-form generate requests reach the policy with routing text alone,
     /// and hashing it keeps them on a stable worker instead of leaving them
     /// unroutable.
     #[inline]
-    fn compute_text_prefix_hash(&self, text: &str) -> u64 {
+    fn fixed_depth_text_prefix<'a>(&self, text: &'a str) -> &'a [u8] {
         let budget = self
             .config
             .prefix_token_count
@@ -147,7 +157,46 @@ impl PrefixHashPolicy {
             .nth(budget)
             .map_or(text.len(), |(offset, _)| offset);
 
-        xxhash_rust::xxh3::xxh3_64(&text.as_bytes()[..end])
+        &text.as_bytes()[..end]
+    }
+
+    /// Boundary-aligned `(level, key bytes)` candidates, deepest boundary
+    /// first. Empty when no boundaries are configured or the request does
+    /// not reach the smallest one (such a head-only request has nothing to
+    /// group on; the caller keys it at the fixed legacy depth instead).
+    fn token_boundary_prefixes<'a>(&self, tokens: &'a [u32]) -> Vec<(usize, &'a [u8])> {
+        self.config
+            .cache_boundaries
+            .iter()
+            .rev()
+            .filter(|&&boundary| boundary <= tokens.len())
+            .map(|&boundary| (boundary, bytemuck::cast_slice(&tokens[..boundary])))
+            .collect()
+    }
+
+    /// Text analog of [`Self::token_boundary_prefixes`]: one pass over the
+    /// leading `CHARS_PER_TOKEN`-scaled span collects every boundary the
+    /// text reaches.
+    fn text_boundary_prefixes<'a>(&self, text: &'a str) -> Vec<(usize, &'a [u8])> {
+        let mut prefixes = Vec::new();
+        let mut chars = text.char_indices();
+        let mut consumed = 0usize;
+        for &boundary in &self.config.cache_boundaries {
+            let budget = boundary.saturating_mul(CHARS_PER_TOKEN);
+            while consumed < budget && chars.next().is_some() {
+                consumed += 1;
+            }
+            if consumed < budget {
+                break;
+            }
+            let end = chars
+                .clone()
+                .next()
+                .map_or(text.len(), |(offset, _)| offset);
+            prefixes.push((boundary, &text.as_bytes()[..end]));
+        }
+        prefixes.reverse();
+        prefixes
     }
 
     /// Index of the least loaded healthy worker
@@ -179,12 +228,18 @@ impl PrefixHashPolicy {
     }
 
     /// Find worker using consistent hash ring with load balancing
+    ///
+    /// `candidates` holds `(level, key bytes)` pairs to try in order —
+    /// deepest boundary first, level 0 for a fixed-depth key. The first
+    /// candidate whose ring target passes the load check wins; when every
+    /// target is overloaded, fall to the least loaded acceptable worker,
+    /// then to the deepest target regardless.
     fn find_worker_with_load_balance(
         &self,
         workers: &[Arc<dyn Worker>],
         info: &SelectWorkerInfo,
-        prefix_hash: u64,
-    ) -> (Option<usize>, Branch) {
+        candidates: &[(usize, &[u8])],
+    ) -> (Option<usize>, Branch, usize) {
         // Build healthy worker URL to index map
         let healthy_workers: Vec<(usize, &Arc<dyn Worker>)> = workers
             .iter()
@@ -193,7 +248,7 @@ impl PrefixHashPolicy {
             .collect();
 
         if healthy_workers.is_empty() {
-            return (None, Branch::NoHealthyWorkers);
+            return (None, Branch::NoHealthyWorkers, 0);
         }
 
         // Calculate total load for load balancing
@@ -202,9 +257,6 @@ impl PrefixHashPolicy {
 
         // Use pre-computed ring if available
         if let Some(ref ring) = info.hash_ring {
-            // Convert prefix hash to a ring key string for lookup
-            let key = format!("{prefix_hash:016x}");
-
             // Build URL to (index, worker) map for healthy workers
             let healthy_url_map: std::collections::HashMap<&str, (usize, &Arc<dyn Worker>)> =
                 healthy_workers
@@ -212,32 +264,46 @@ impl PrefixHashPolicy {
                     .map(|(idx, w)| (w.url(), (*idx, *w)))
                     .collect();
 
-            // Find initial worker from ring
-            if let Some(initial_url) =
-                ring.find_healthy_url(&key, |url| healthy_url_map.contains_key(url))
-            {
-                if let Some(&(idx, worker)) = healthy_url_map.get(initial_url) {
-                    let worker_load = worker.load();
+            // Deepest ring target, kept as the all-overloaded fallback.
+            let mut initial: Option<(usize, usize)> = None;
+            for &(level, key_bytes) in candidates {
+                let prefix_hash = xxhash_rust::xxh3::xxh3_64(key_bytes);
+                // Convert prefix hash to a ring key string for lookup
+                let key = format!("{prefix_hash:016x}");
 
-                    // Check if initial worker has acceptable load
-                    if self.load_ok(worker_load, total_load, num_workers) {
-                        return (Some(idx), Branch::RingHit);
-                    }
+                // Find this level's worker from the ring
+                let Some(initial_url) =
+                    ring.find_healthy_url(&key, |url| healthy_url_map.contains_key(url))
+                else {
+                    continue;
+                };
+                let Some(&(idx, worker)) = healthy_url_map.get(initial_url) else {
+                    continue;
+                };
 
-                    // Initial worker overloaded, find least loaded healthy worker
-                    // This is a simpler approach than walking the ring
-                    let least_loaded = healthy_workers
-                        .iter()
-                        .filter(|(_, w)| self.load_ok(w.load(), total_load, num_workers))
-                        .min_by_key(|(_, w)| w.load());
-
-                    if let Some(&(idx, _)) = least_loaded {
-                        return (Some(idx), Branch::LoadBalanceWalk);
-                    }
-
-                    // All workers overloaded, use initial worker anyway
-                    return (Some(idx), Branch::LoadBalanceWalk);
+                // Check if this level's worker has acceptable load
+                if self.load_ok(worker.load(), total_load, num_workers) {
+                    return (Some(idx), Branch::RingHit, level);
                 }
+                if initial.is_none() {
+                    initial = Some((idx, level));
+                }
+            }
+
+            if let Some((initial_idx, initial_level)) = initial {
+                // Every level's target overloaded, find least loaded healthy
+                // worker. This is a simpler approach than walking the ring
+                let least_loaded = healthy_workers
+                    .iter()
+                    .filter(|(_, w)| self.load_ok(w.load(), total_load, num_workers))
+                    .min_by_key(|(_, w)| w.load());
+
+                if let Some(&(idx, _)) = least_loaded {
+                    return (Some(idx), Branch::LoadBalanceWalk, 0);
+                }
+
+                // All workers overloaded, use the deepest target anyway
+                return (Some(initial_idx), Branch::LoadBalanceWalk, initial_level);
             }
         }
 
@@ -245,6 +311,7 @@ impl PrefixHashPolicy {
         (
             Self::least_loaded_healthy(workers),
             Branch::FallbackLeastLoad,
+            0,
         )
     }
 
@@ -252,34 +319,57 @@ impl PrefixHashPolicy {
         &self,
         workers: &[Arc<dyn Worker>],
         info: &SelectWorkerInfo,
-    ) -> (Option<usize>, Branch) {
+    ) -> (Option<usize>, Branch, usize) {
         if workers.is_empty() {
-            return (None, Branch::NoHealthyWorkers);
+            return (None, Branch::NoHealthyWorkers, 0);
         }
 
         // A validated x-smg-routing-key hint overrides token/text keying.
         // Otherwise pre-tokenized requests hash their token prefix, the rest
         // hash the equivalent span of routing text.
-        let prefix_hash = if let Some(key) = info.routing_key {
-            xxhash_rust::xxh3::xxh3_64(key.as_bytes())
-        } else {
-            match (info.tokens, info.request_text) {
-                (Some(tokens), _) if !tokens.is_empty() => self.compute_prefix_hash(tokens),
-                (_, Some(text)) if !text.is_empty() => self.compute_text_prefix_hash(text),
-                // Nothing to hash: stay serviceable by falling back to load.
-                _ => return (Self::least_loaded_healthy(workers), Branch::NoRoutingKey),
+        if let Some(key) = info.routing_key {
+            return self.find_worker_with_load_balance(workers, info, &[(0, key.as_bytes())]);
+        }
+        match (info.tokens, info.request_text) {
+            (Some(tokens), _) if !tokens.is_empty() => {
+                let candidates = self.token_boundary_prefixes(tokens);
+                if candidates.is_empty() {
+                    return self.find_worker_with_load_balance(
+                        workers,
+                        info,
+                        &[(0, self.fixed_depth_token_prefix(tokens))],
+                    );
+                }
+                self.find_worker_with_load_balance(workers, info, &candidates)
             }
-        };
-
-        // Find worker using ring with load balancing
-        self.find_worker_with_load_balance(workers, info, prefix_hash)
+            (_, Some(text)) if !text.is_empty() => {
+                let candidates = self.text_boundary_prefixes(text);
+                if candidates.is_empty() {
+                    return self.find_worker_with_load_balance(
+                        workers,
+                        info,
+                        &[(0, self.fixed_depth_text_prefix(text))],
+                    );
+                }
+                self.find_worker_with_load_balance(workers, info, &candidates)
+            }
+            // Nothing to hash: stay serviceable by falling back to load.
+            _ => (Self::least_loaded_healthy(workers), Branch::NoRoutingKey, 0),
+        }
     }
 }
 
 impl LoadBalancingPolicy for PrefixHashPolicy {
     fn select_worker(&self, workers: &[Arc<dyn Worker>], info: &SelectWorkerInfo) -> Option<usize> {
-        let (result, branch) = self.select_worker_impl(workers, info);
+        let (result, branch, level) = self.select_worker_impl(workers, info);
         Metrics::record_worker_prefix_hash_policy_branch(branch.as_str());
+        debug!(
+            branch = branch.as_str(),
+            level,
+            worker = result.map_or("none", |idx| workers[idx].url()),
+            model_id = result.map_or("none", |idx| workers[idx].model_id()),
+            "Prefix-hash selection"
+        );
         result
     }
 
@@ -329,12 +419,12 @@ mod tests {
             ..Default::default()
         };
 
-        let (first_result, _) = policy.select_worker_impl(&workers, &info);
+        let (first_result, _, _) = policy.select_worker_impl(&workers, &info);
         let first_idx = first_result.unwrap();
 
         // Verify consistency
         for _ in 0..10 {
-            let (result, _) = policy.select_worker_impl(&workers, &info);
+            let (result, _, _) = policy.select_worker_impl(&workers, &info);
             assert_eq!(result, Some(first_idx));
         }
     }
@@ -356,7 +446,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let (result, _) = policy.select_worker_impl(&workers, &info);
+            let (result, _, _) = policy.select_worker_impl(&workers, &info);
             *distribution.entry(result.unwrap()).or_insert(0) += 1;
         }
 
@@ -390,8 +480,8 @@ mod tests {
             ..Default::default()
         };
 
-        let (result1, _) = policy.select_worker_impl(&workers, &info1);
-        let (result2, _) = policy.select_worker_impl(&workers, &info2);
+        let (result1, _, _) = policy.select_worker_impl(&workers, &info1);
+        let (result2, _, _) = policy.select_worker_impl(&workers, &info2);
 
         assert_eq!(result1, result2, "Same prefix should route to same worker");
     }
@@ -410,12 +500,12 @@ mod tests {
             ..Default::default()
         };
 
-        let (first_result, branch) = policy.select_worker_impl(&workers, &info);
+        let (first_result, branch, _) = policy.select_worker_impl(&workers, &info);
         assert!(first_result.is_some(), "text alone must be routable");
         assert_eq!(branch, Branch::RingHit);
 
         for _ in 0..10 {
-            let (result, _) = policy.select_worker_impl(&workers, &info);
+            let (result, _, _) = policy.select_worker_impl(&workers, &info);
             assert_eq!(result, first_result);
         }
     }
@@ -440,8 +530,8 @@ mod tests {
             ..Default::default()
         };
 
-        let (result1, _) = policy.select_worker_impl(&workers, &info1);
-        let (result2, _) = policy.select_worker_impl(&workers, &info2);
+        let (result1, _, _) = policy.select_worker_impl(&workers, &info1);
+        let (result2, _, _) = policy.select_worker_impl(&workers, &info2);
 
         assert_eq!(
             result1, result2,
@@ -464,7 +554,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (result, branch) = policy.select_worker_impl(&workers, &info);
+        let (result, branch, _) = policy.select_worker_impl(&workers, &info);
         assert!(result.is_some());
         assert_eq!(branch, Branch::RingHit);
     }
@@ -488,8 +578,8 @@ mod tests {
             ..Default::default()
         };
 
-        let (result1, _) = policy.select_worker_impl(&workers, &tokens_only);
-        let (result2, _) = policy.select_worker_impl(&workers, &tokens_and_text);
+        let (result1, _, _) = policy.select_worker_impl(&workers, &tokens_only);
+        let (result2, _, _) = policy.select_worker_impl(&workers, &tokens_and_text);
 
         assert_eq!(result1, result2);
     }
@@ -505,7 +595,7 @@ mod tests {
             hash_ring: Some(ring.clone()),
             ..Default::default()
         };
-        let (key_only_result, branch) = policy.select_worker_impl(&workers, &key_only);
+        let (key_only_result, branch, _) = policy.select_worker_impl(&workers, &key_only);
         assert!(key_only_result.is_some(), "a key alone must be routable");
         assert_eq!(branch, Branch::RingHit);
 
@@ -518,7 +608,7 @@ mod tests {
                 hash_ring: Some(ring.clone()),
                 ..Default::default()
             };
-            let (result, _) = policy.select_worker_impl(&workers, &info);
+            let (result, _, _) = policy.select_worker_impl(&workers, &info);
             assert_eq!(result, key_only_result, "the routing key must win");
         }
     }
@@ -534,9 +624,9 @@ mod tests {
             hash_ring: Some(ring.clone()),
             ..Default::default()
         };
-        let (first, _) = policy.select_worker_impl(&workers, &info);
+        let (first, _, _) = policy.select_worker_impl(&workers, &info);
         for _ in 0..10 {
-            let (result, _) = policy.select_worker_impl(&workers, &info);
+            let (result, _, _) = policy.select_worker_impl(&workers, &info);
             assert_eq!(result, first);
         }
 
@@ -548,7 +638,7 @@ mod tests {
                 hash_ring: Some(ring.clone()),
                 ..Default::default()
             };
-            let (result, _) = policy.select_worker_impl(&workers, &info);
+            let (result, _, _) = policy.select_worker_impl(&workers, &info);
             *distribution.entry(result.unwrap()).or_insert(0) += 1;
         }
         assert!(
@@ -573,7 +663,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (result, branch) = policy.select_worker_impl(&workers, &info);
+        let (result, branch, _) = policy.select_worker_impl(&workers, &info);
         assert_eq!(result, Some(1), "a keyless request still has to be served");
         assert_eq!(branch, Branch::NoRoutingKey);
 
@@ -584,7 +674,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (result2, branch2) = policy.select_worker_impl(&workers, &info_empty);
+        let (result2, branch2, _) = policy.select_worker_impl(&workers, &info_empty);
         assert_eq!(result2, Some(1));
         assert_eq!(branch2, Branch::NoRoutingKey);
     }
@@ -603,7 +693,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (result, branch) = policy.select_worker_impl(&workers, &info);
+        let (result, branch, _) = policy.select_worker_impl(&workers, &info);
         assert_eq!(result, None);
         assert_eq!(branch, Branch::NoHealthyWorkers);
     }
@@ -662,5 +752,245 @@ mod tests {
     fn test_policy_name() {
         let policy = PrefixHashPolicy::with_defaults();
         assert_eq!(policy.name(), "prefix_hash");
+    }
+
+    #[test]
+    fn test_boundary_hashing_selects_deepest_applicable() {
+        let policy = PrefixHashPolicy::new(PrefixHashConfig {
+            cache_boundaries: vec![16, 64],
+            ..Default::default()
+        });
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
+
+        // 70 and 100 tokens sharing the first 64: both key at boundary 64,
+        // so the divergent tails cannot split them.
+        let tokens1: Vec<u32> = (0..70).collect();
+        let tokens2: Vec<u32> = (0..64).chain(9000..9036).collect();
+        let info1 = SelectWorkerInfo {
+            tokens: Some(&tokens1),
+            hash_ring: Some(ring.clone()),
+            ..Default::default()
+        };
+        let info2 = SelectWorkerInfo {
+            tokens: Some(&tokens2),
+            hash_ring: Some(ring.clone()),
+            ..Default::default()
+        };
+
+        let (result1, branch1, level1) = policy.select_worker_impl(&workers, &info1);
+        let (result2, _, level2) = policy.select_worker_impl(&workers, &info2);
+        assert_eq!(result1, result2, "shared boundary head must co-hash");
+        assert_eq!(branch1, Branch::RingHit);
+        assert_eq!((level1, level2), (64, 64));
+
+        // 63 tokens fall short of the deeper boundary and key at 16.
+        let tokens3: Vec<u32> = (0..63).collect();
+        let info3 = SelectWorkerInfo {
+            tokens: Some(&tokens3),
+            hash_ring: Some(ring),
+            ..Default::default()
+        };
+        let (result3, _, level3) = policy.select_worker_impl(&workers, &info3);
+        assert!(result3.is_some());
+        assert_eq!(level3, 16);
+    }
+
+    #[test]
+    fn test_below_smallest_boundary_keeps_fixed_depth_keying() {
+        let boundaries = PrefixHashPolicy::new(PrefixHashConfig {
+            cache_boundaries: vec![16, 64],
+            ..Default::default()
+        });
+        let legacy = PrefixHashPolicy::with_defaults();
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
+
+        let tokens: Vec<u32> = (0..15).collect();
+        let info = SelectWorkerInfo {
+            tokens: Some(&tokens),
+            hash_ring: Some(ring),
+            ..Default::default()
+        };
+
+        let (result, branch, level) = boundaries.select_worker_impl(&workers, &info);
+        let (legacy_result, _, _) = legacy.select_worker_impl(&workers, &info);
+        assert_eq!(result, legacy_result);
+        assert_eq!(branch, Branch::RingHit);
+        assert_eq!(level, 0);
+    }
+
+    #[test]
+    fn test_short_turn_and_long_followup_co_hash_at_shared_boundary() {
+        // A short first turn and its much longer follow-up share only the
+        // head; no single fixed depth can co-hash both, the boundary does.
+        let policy = PrefixHashPolicy::new(PrefixHashConfig {
+            cache_boundaries: vec![2048, 32768],
+            ..Default::default()
+        });
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
+
+        let head: Vec<u32> = (0..2048).map(|i| i * 7 % 50000).collect();
+        let turn1: Vec<u32> = head.iter().copied().chain(200_000..201_000).collect();
+        let turn2: Vec<u32> = head.iter().copied().chain(500_000..514_952).collect();
+        assert_eq!(turn1.len(), 3048);
+        assert_eq!(turn2.len(), 17_000);
+
+        let info1 = SelectWorkerInfo {
+            tokens: Some(&turn1),
+            hash_ring: Some(ring.clone()),
+            ..Default::default()
+        };
+        let info2 = SelectWorkerInfo {
+            tokens: Some(&turn2),
+            hash_ring: Some(ring),
+            ..Default::default()
+        };
+
+        let (result1, branch1, level1) = policy.select_worker_impl(&workers, &info1);
+        let (result2, branch2, level2) = policy.select_worker_impl(&workers, &info2);
+        assert_eq!(result1, result2, "turns sharing the head must co-hash");
+        assert_eq!((branch1, branch2), (Branch::RingHit, Branch::RingHit));
+        assert_eq!((level1, level2), (2048, 2048));
+    }
+
+    #[test]
+    fn test_overloaded_deep_target_retries_shallower_boundary() {
+        let policy = PrefixHashPolicy::new(PrefixHashConfig {
+            load_factor: 1.0,
+            balance_abs_threshold: 0,
+            cache_boundaries: vec![16, 32],
+            ..Default::default()
+        });
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
+
+        // Find a stream whose level-32 and level-16 ring targets differ.
+        let mut tokens: Vec<u32> = Vec::new();
+        let mut deep_idx = usize::MAX;
+        let mut shallow_idx = usize::MAX;
+        for seed in 0..1000u32 {
+            tokens = (seed..seed + 32).collect();
+            let full = SelectWorkerInfo {
+                tokens: Some(&tokens),
+                hash_ring: Some(ring.clone()),
+                ..Default::default()
+            };
+            let head = SelectWorkerInfo {
+                tokens: Some(&tokens[..16]),
+                hash_ring: Some(ring.clone()),
+                ..Default::default()
+            };
+            deep_idx = policy.select_worker_impl(&workers, &full).0.unwrap();
+            shallow_idx = policy.select_worker_impl(&workers, &head).0.unwrap();
+            if deep_idx != shallow_idx {
+                break;
+            }
+        }
+        assert_ne!(deep_idx, shallow_idx, "no split stream found");
+
+        let info = SelectWorkerInfo {
+            tokens: Some(&tokens),
+            hash_ring: Some(ring),
+            ..Default::default()
+        };
+
+        // Overloaded level-32 target: retry lands on the level-16 target.
+        let _deep_busy = [
+            WorkerLoadGuard::new(workers[deep_idx].clone(), None),
+            WorkerLoadGuard::new(workers[deep_idx].clone(), None),
+        ];
+        let (result, branch, level) = policy.select_worker_impl(&workers, &info);
+        assert_eq!(result, Some(shallow_idx));
+        assert_eq!(branch, Branch::RingHit);
+        assert_eq!(level, 16);
+
+        // Both targets overloaded: the load-balance walk takes over.
+        let _shallow_busy = [
+            WorkerLoadGuard::new(workers[shallow_idx].clone(), None),
+            WorkerLoadGuard::new(workers[shallow_idx].clone(), None),
+        ];
+        let (result, branch, level) = policy.select_worker_impl(&workers, &info);
+        let spare = (0..3)
+            .find(|i| *i != deep_idx && *i != shallow_idx)
+            .unwrap();
+        assert_eq!(result, Some(spare));
+        assert_eq!(branch, Branch::LoadBalanceWalk);
+        assert_eq!(level, 0);
+    }
+
+    #[test]
+    fn test_text_boundary_co_hashing() {
+        let policy = PrefixHashPolicy::new(PrefixHashConfig {
+            cache_boundaries: vec![4], // 16 characters of text
+            ..Default::default()
+        });
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
+
+        let info1 = SelectWorkerInfo {
+            request_text: Some("shared-16-chars! then a question about tides"),
+            hash_ring: Some(ring.clone()),
+            ..Default::default()
+        };
+        let info2 = SelectWorkerInfo {
+            request_text: Some("shared-16-chars! and an unrelated follow-up about currents"),
+            hash_ring: Some(ring.clone()),
+            ..Default::default()
+        };
+        let (result1, _, level1) = policy.select_worker_impl(&workers, &info1);
+        let (result2, _, level2) = policy.select_worker_impl(&workers, &info2);
+        assert_eq!(result1, result2, "shared scaled head must co-hash");
+        assert_eq!((level1, level2), (4, 4));
+
+        // Shorter than the scaled boundary: fixed-depth keying.
+        let short = SelectWorkerInfo {
+            request_text: Some("hi there"),
+            hash_ring: Some(ring.clone()),
+            ..Default::default()
+        };
+        let (short_result, short_branch, short_level) = policy.select_worker_impl(&workers, &short);
+        assert!(short_result.is_some());
+        assert_eq!(short_branch, Branch::RingHit);
+        assert_eq!(short_level, 0);
+
+        // Scaled boundary landing mid-way through a multibyte run stays on
+        // a character boundary.
+        let emoji = SelectWorkerInfo {
+            request_text: Some("🌊🌊🌊🌊🌊🌊 tide report"),
+            hash_ring: Some(ring),
+            ..Default::default()
+        };
+        let (emoji_result, emoji_branch, emoji_level) = policy.select_worker_impl(&workers, &emoji);
+        assert!(emoji_result.is_some());
+        assert_eq!(emoji_branch, Branch::RingHit);
+        assert_eq!(emoji_level, 4);
+    }
+
+    #[test]
+    fn test_unset_boundaries_key_at_fixed_depth() {
+        // Empty boundaries: the ring key is exactly the fixed-depth hash.
+        let policy = PrefixHashPolicy::new(PrefixHashConfig {
+            prefix_token_count: 5,
+            ..Default::default()
+        });
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
+
+        let tokens: Vec<u32> = (0..40).collect();
+        let info = SelectWorkerInfo {
+            tokens: Some(&tokens),
+            hash_ring: Some(ring.clone()),
+            ..Default::default()
+        };
+        let (result, branch, level) = policy.select_worker_impl(&workers, &info);
+        assert_eq!(branch, Branch::RingHit);
+        assert_eq!(level, 0);
+
+        let hash = xxhash_rust::xxh3::xxh3_64(bytemuck::cast_slice(&tokens[..5]));
+        let key = format!("{hash:016x}");
+        let expected_url = ring.find_healthy_url(&key, |_| true).unwrap();
+        assert_eq!(workers[result.unwrap()].url(), expected_url);
     }
 }

--- a/model_gateway/tests/common/test_config.rs
+++ b/model_gateway/tests/common/test_config.rs
@@ -123,6 +123,7 @@ impl TestRouterConfig {
                     prefix_token_count,
                     load_factor: 1.25,
                     balance_abs_threshold: 10,
+                    cache_boundaries: vec![],
                 })
                 .host(defaults::HOST)
                 .port(port)


### PR DESCRIPTION
## Description

### Problem

The `prefix_hash` policy hashes every request at one fixed token depth (`--prefix-token-count`, default 256). Serving engines only retain reusable prefix state at fixed token positions, and one depth cannot model that: a small depth makes every request behind a fleet-shared system prompt co-hash onto a single ring point (the policy degenerates into pure bounded-load spill), while any single larger depth guarantees a short first turn and its longer follow-up never co-hash, forfeiting the reuse the policy exists to capture.

### Solution

Consume the shared `--cache-boundaries` setting (#2213) in `prefix_hash`: when boundaries are configured, each request head is hashed at the deepest boundary the request reaches, so a short turn and its long follow-up sharing a boundary-aligned head co-hash at that level. When bounded-load rejects the ring target at one level, the next-shallower boundary is retried before falling back to least-load. Untokenized requests apply the same boundary logic through the existing chars-per-token scaling. Requests shorter than the smallest boundary — and all requests when the setting is unset — keep the existing fixed-depth keying byte-for-byte.

`PolicyConfig::PrefixHash` carries a resolved copy of the shared config, validated with the same helper.

## Changes

- `prefix_hash`: boundary-aligned multi-level key derivation for tokens and text, with bounded-load retry across levels and unchanged behavior when unset
- Resolved `cache_boundaries` copy on the prefix_hash policy config, wired through the CLI and Python conversion paths and validated at startup
- One structured `debug!` decision line per selection (`branch`, `level`, `worker`, `model_id`), matching the sticky-routing and cache-aware decision logs; metrics labels unchanged
- Tests: deepest-applicable derivation, below-smallest fallback, short-turn/long-follow-up co-hashing, bounded-load level retry, byte-identical legacy keying, policy-copy validation, CLI plumbing guards, Python arg parsing

## Test Plan

- `cargo test -p smg --lib policies::prefix_hash` — 22 passed (6 new)
- `cargo test -p smg --lib config::` — 135 passed (new prefix_hash boundary-validation test)
- `cargo test -p smg --bin smg` — 22 passed (2 new plumbing guards)
- `cargo test -p smg --test routing_tests prefix_hash` — 3 passed
- `cargo build -p smg-python`; `pytest bindings/python/tests/test_arg_parser.py` — 52 passed
- Legacy guard: `test_unset_boundaries_key_at_fixed_depth` recomputes the pre-change hash and ring key by hand and asserts the policy selects that exact worker; existing prefix_hash tests run unchanged

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
