### PR TITLE
chore(deps): bump vLLM to 0.27.1 and refresh docker matrix

### DIFF
--- a/.github/workflows/nightly-engine-docker.yml
+++ b/.github/workflows/nightly-engine-docker.yml
@@ -43,8 +43,8 @@ jobs:
       matrix:
         include:
           - engine: vllm
-            base_image_ref: vllm/vllm-openai:v0.22.1
-            engine_ver: v0.22.1
+            base_image_ref: vllm/vllm-openai:v0.27.1
+            engine_ver: v0.27.1
           - engine: sglang
             base_image_ref: lmsysorg/sglang:v0.5.12.post1
             engine_ver: v0.5.12.post1

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -2,7 +2,7 @@ name: Release SMG+vLLM Docker Image
 
 run-name: >-
   SMG+vLLM |
-  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.26.0') }} |
+  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.27.1') }} |
   engine=${{ inputs.vllm_commit || 'latest' }} |
   smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. vllm/vllm-openai:v0.26.0)'
-        default: 'vllm/vllm-openai:v0.26.0'
+        description: 'Base image (e.g. vllm/vllm-openai:v0.27.1)'
+        default: 'vllm/vllm-openai:v0.27.1'
         required: true
         type: string
       vllm_repo:
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ${{ github.event_name == 'push' && fromJSON('["vllm/vllm-openai:v0.26.0","vllm/vllm-openai:v0.25.0","vllm/vllm-openai:v0.23.0"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'vllm/vllm-openai:v0.26.0')) }}
+        base_image: ${{ github.event_name == 'push' && fromJSON('["vllm/vllm-openai:v0.27.1","vllm/vllm-openai:v0.26.0","vllm/vllm-openai:v0.25.0"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'vllm/vllm-openai:v0.27.1')) }}
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: vllm

--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -19,12 +19,15 @@ fi
 
 echo "Using uv version: $(uv --version)"
 
-# Floor 0.26.0: older vllm releases do not guarantee torchcodec, while the
-# import canary below deliberately validates it, and 0.26 caps
-# fastapi<0.137 (0.137 breaks the prometheus-fastapi-instrumentator health route).
+# Pinned to the release-matrix default so the CI lane tests the same engine
+# version the images ship (and stays deterministic like the sglang/trtllm
+# installs). 0.27.1 keeps the properties the lane depends on: torchcodec is
+# guaranteed (the import canary below deliberately validates it) and fastapi
+# is capped <0.137 (0.137 breaks the prometheus-fastapi-instrumentator health
+# route; verified in 0.27.1's dependency constraints).
 # --torch-backend=auto matches the torch CUDA variant to the pod's driver.
 echo "Installing vLLM..."
-uv pip install "vllm>=0.26.0" --torch-backend=auto
+uv pip install "vllm==0.27.1" --torch-backend=auto
 
 # vLLM >=0.25 eagerly imports torchcodec, which dlopens the FFmpeg shared
 # libraries (libavutil/libavcodec/libavformat/...) at import time. The runner


### PR DESCRIPTION
## Description

### Problem

The vLLM release image matrix pinned `v0.26.0` while upstream's latest release is `v0.27.1`; the nightly engine matrix had drifted further (stale `v0.22.1`); and the CI e2e lane installed from a floating `vllm>=0.26.0` floor, so it tested whatever the resolver picked rather than the version the images ship.

### Solution

Bump every vLLM version surface in one pass: release matrix to `v0.27.1`/`v0.26.0`/`v0.25.0`, nightly matrix to the release default, and the CI install pinned to `vllm==0.27.1` for determinism (matching the exact-pin style of the sglang/trtllm installs). The old floor's rationale — torchcodec guaranteed, `fastapi<0.137` capped — was verified to hold in 0.27.1's dependency constraints.

## Changes

- `.github/workflows/release-vllm-docker.yml`: default/banner/description to `v0.27.1`; matrix refreshed to `v0.27.1/v0.26.0/v0.25.0`
- `.github/workflows/nightly-engine-docker.yml`: vllm entry `v0.22.1` → `v0.27.1`
- `scripts/ci_install_vllm.sh`: `vllm>=0.26.0` floor → `vllm==0.27.1` pin, comment updated

## Test Plan

- Workflow YAML parsed and matrix contents asserted locally; `bash -n` on the install script
- `v0.27.1` verified present on Docker Hub; `scripts/check_engine_versions.sh` reports vllm current after this change
- CI: release/nightly image builds exercise the new base; vllm e2e lanes run against the pinned 0.27.1 (path filter on `ci_install_vllm.sh` triggers them on this PR)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>