### PR TITLE
chore(deps): bump SGLang to 0.5.17

### DIFF
--- a/.github/workflows/nightly-engine-docker.yml
+++ b/.github/workflows/nightly-engine-docker.yml
@@ -46,8 +46,8 @@ jobs:
             base_image_ref: vllm/vllm-openai:v0.22.1
             engine_ver: v0.22.1
           - engine: sglang
-            base_image_ref: lmsysorg/sglang:v0.5.12.post1
-            engine_ver: v0.5.12.post1
+            base_image_ref: lmsysorg/sglang:v0.5.17
+            engine_ver: v0.5.17
           - engine: trtllm
             base_image_ref: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18
             engine_ver: 1.3.0rc18

--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -2,7 +2,7 @@ name: Release SMG+SGLang Docker Image
 
 run-name: >-
   SMG+SGLang |
-  ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.16' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.16') }} |
+  ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.17' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.17') }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
   smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. lmsysorg/sglang:v0.5.16)'
-        default: 'lmsysorg/sglang:v0.5.16'
+        description: 'Base image (e.g. lmsysorg/sglang:v0.5.17)'
+        default: 'lmsysorg/sglang:v0.5.17'
         required: true
         type: string
       sglang_repo:
@@ -47,7 +47,7 @@ on:
         default: 'v1.9.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.9.0-sglang-v0.5.16)'
+        description: 'Override image tag (e.g. v1.9.0-sglang-v0.5.17)'
         required: false
         type: string
 
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ${{ github.event_name == 'push' && fromJSON('["lmsysorg/sglang:v0.5.16"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.16')) }}
+        base_image: ${{ github.event_name == 'push' && fromJSON('["lmsysorg/sglang:v0.5.17"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.17')) }}
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: sglang

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 vllm = ["vllm>=0.19.0", "pyzmq>=25.0.0", "msgspec>=0.18.0"]
 # 0.5.13 is the first release with the shmem load snapshots that replaced
 # the WatchLoadUpdateReq piggyback path (removed upstream in v0.5.14).
-sglang = ["sglang>=0.5.16"]
+sglang = ["sglang>=0.5.17"]
 # smg-grpc-proto>=0.4.7 is the first release that ships mlx_engine_pb2;
 # without this floor, installing [mlx] against an older proto build would
 # crash at import time when smg_grpc_servicer.mlx.server runs.

--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -43,7 +43,7 @@ fi
 
 # Install SGLang with all dependencies
 echo "Installing SGLang..."
-uv pip install --prerelease=allow "sglang[all]==0.5.16"
+uv pip install --prerelease=allow "sglang[all]==0.5.17"
 
 # Install flashinfer-jit-cache: sglang bundles flashinfer_python but only for attention ops.
 # Multi-GPU models need trtllm_comm kernels (fused allreduce + layernorm) which FlashInfer


### PR DESCRIPTION
## Description

### Problem

SGLang surfaces pinned `0.5.16` while upstream's latest release is `0.5.17`, and the nightly engine matrix had drifted to a stale `v0.5.12.post1`.

### Solution

Bump every SGLang version surface together: the release image workflow, the CI e2e install (already exact-pinned), the servicer's optional-extra floor, and the nightly matrix.

## Changes

- `.github/workflows/release-sglang-docker.yml`: all base references and the tag example `v0.5.16` → `v0.5.17`
- `scripts/ci_install_sglang.sh`: `sglang[all]==0.5.16` → `==0.5.17`
- `grpc_servicer/pyproject.toml`: optional extra `sglang>=0.5.16` → `>=0.5.17`
- `.github/workflows/nightly-engine-docker.yml`: sglang entry `v0.5.12.post1` → `v0.5.17`

## Test Plan

- Workflow YAML parsed locally; `bash -n` on the install script; no `v0.5.16` references remain
- `v0.5.17` verified present on Docker Hub; `scripts/check_engine_versions.sh` reports sglang current after this change
- CI: sglang e2e lanes run against 0.5.17 (path filter on `ci_install_sglang.sh` triggers them on this PR) and validate the servicer against the new engine

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>