### PR TITLE
chore(deps): bump TensorRT-LLM to 1.3.0rc24

### DIFF
--- a/.github/workflows/nightly-engine-docker.yml
+++ b/.github/workflows/nightly-engine-docker.yml
@@ -49,8 +49,8 @@ jobs:
             base_image_ref: lmsysorg/sglang:v0.5.12.post1
             engine_ver: v0.5.12.post1
           - engine: trtllm
-            base_image_ref: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18
-            engine_ver: 1.3.0rc18
+            base_image_ref: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24
+            engine_ver: 1.3.0rc24
           - engine: tokenspeed
             base_image_ref: lightseekorg/tokenspeed:tml
             engine_ver: tml

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -2,7 +2,7 @@ name: Release SMG+TRTLLM Docker Image
 
 run-name: >-
   SMG+TRTLLM |
-  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22') }} |
+  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24') }} |
   engine=${{ inputs.trtllm_commit || 'latest' }} |
   smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22). Empty = build from source.'
-        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22'
+        description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24). Empty = build from source.'
+        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24'
         required: false
         type: string
       trtllm_repo:
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ${{ github.event_name == 'push' && fromJSON('["nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc21","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22')) }}
+        base_image: ${{ github.event_name == 'push' && fromJSON('["nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24')) }}
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: trtllm

--- a/scripts/ci_install_trtllm.sh
+++ b/scripts/ci_install_trtllm.sh
@@ -3,7 +3,7 @@
 #
 # The gRPC serve command from PR #11037 and the Harmony parser fixes (#12045,
 # #12467) referenced by SMG #801 first shipped in 1.3.0rc14 (released
-# 2026-05-07) and remain included in the pinned 1.3.0rc22 pre-release wheel.
+# 2026-05-07) and remain included in the pinned 1.3.0rc24 pre-release wheel.
 # We install it directly from PyPI instead of building TensorRT-LLM from
 # source, which saves ~30 min of CMake compile time per CI run. See git
 # history for the previous source-build logic.
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-TRTLLM_VERSION="1.3.0rc22"
+TRTLLM_VERSION="1.3.0rc24"
 NCCL_VERSION_CONSTRAINT="nvidia-nccl-cu13>=2.28.9,<=2.29.2"
 
 # Activate venv if it exists


### PR DESCRIPTION
## Description

### Problem

TensorRT-LLM surfaces pinned `1.3.0rc22` while the latest published pre-release is `1.3.0rc24`, and the nightly engine matrix had drifted to a stale `rc18`.

### Solution

Bump every TRT-LLM version surface together: release matrix to `rc24/rc23/rc22`, the CI wheel pin, and the nightly matrix. `rc24` was verified present on NGC by manifest probe (`rc25` does not exist yet). The scheduler fixes the install script's comment depends on (rc14+) remain included.

## Changes

- `.github/workflows/release-trtllm-docker.yml`: default/banner/description to `rc24`; matrix refreshed to `rc24/rc23/rc22`
- `scripts/ci_install_trtllm.sh`: `TRTLLM_VERSION` `1.3.0rc22` → `1.3.0rc24`, comment updated
- `.github/workflows/nightly-engine-docker.yml`: trtllm entry `rc18` → `rc24` (base image + engine_ver)

## Test Plan

- Workflow YAML parsed and matrix contents asserted locally; `bash -n` on the install script
- `rc24` verified on NGC (manifest 200; rc25 → 404); `scripts/check_engine_versions.sh` reports tensorrt-llm current after this change
- CI: trtllm e2e lanes run against rc24 (path filter on `ci_install_trtllm.sh` triggers them on this PR)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>