### PR TITLE
refactor(worker): shared bucketed HTTP clients with h2c parity

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -60,7 +60,7 @@ pub struct GrpcWorker {
     pub(crate) metadata: WorkerMetadata,
     pub(crate) routing_key_load: WorkerRoutingKeyLoad,
     pub(crate) api_key: Option<String>,
-    pub(crate) http_client: reqwest::Client,
+    pub(crate) http_client: Arc<reqwest::Client>,
     pub(crate) resilience: ResolvedResilience,
 }
 
@@ -85,7 +85,7 @@ impl GrpcWorker {
             circuit_breaker: CircuitBreaker::new(),
             metadata,
             api_key: None,
-            http_client: reqwest::Client::new(),
+            http_client: Arc::new(reqwest::Client::new()),
             resilience: ResolvedResilience::default(),
         }
     }
@@ -219,6 +219,10 @@ impl Worker for GrpcWorker {
 
     fn http_client(&self) -> &reqwest::Client {
         &self.http_client
+    }
+
+    fn http_client_handle_if_initialized(&self) -> Option<Arc<reqwest::Client>> {
+        Some(Arc::clone(&self.http_client))
     }
 
     async fn get_backend_client(&self) -> WorkerResult<Option<Arc<BackendClient>>> {

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -26,7 +26,10 @@ use crate::{
         router_manager::RouterManager,
     },
     wasm::{config::WasmRuntimeConfig, module_manager::WasmModuleManager},
-    worker::{KvEventMonitor, OverloadThresholds, WorkerMonitor, WorkerRegistry, WorkerService},
+    worker::{
+        http_client::apply_upstream_http2, KvEventMonitor, OverloadThresholds,
+        WorkerHttpClientCache, WorkerMonitor, WorkerRegistry, WorkerService,
+    },
     workflow::{JobQueue, WorkflowEngines},
 };
 
@@ -73,6 +76,9 @@ pub struct AppContext {
     pub mcp_format_registry: FormatRegistry,
     pub wasm_manager: Option<Arc<WasmModuleManager>>,
     pub worker_service: Arc<WorkerService>,
+    /// Worker-directed HTTP clients, shared across workers with the same
+    /// effective connection config.
+    pub worker_client_cache: Arc<WorkerHttpClientCache>,
     pub inflight_tracker: Arc<InFlightRequestTracker>,
     pub kv_event_monitor: Option<Arc<KvEventMonitor>>,
     pub realtime_registry: Arc<RealtimeRegistry>,
@@ -355,6 +361,8 @@ impl AppContextBuilder {
             router_config.clone(),
         ));
 
+        let worker_client_cache = Arc::new(WorkerHttpClientCache::new(&router_config));
+
         Ok(AppContext {
             client: self
                 .client
@@ -395,6 +403,7 @@ impl AppContextBuilder {
             mcp_format_registry: self.mcp_format_registry.unwrap_or_default(),
             wasm_manager: self.wasm_manager,
             worker_service,
+            worker_client_cache,
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: self.kv_event_monitor,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
@@ -472,19 +481,7 @@ impl AppContextBuilder {
             .tcp_keepalive(Some(Duration::from_secs(30)));
 
         if config.upstream_http2 {
-            // Multiplex everything to a worker over one HTTP/2 connection.
-            // The default 64KB flow-control windows would let concurrent token
-            // streams throttle each other, so start large and let the adaptive
-            // window take over; h2 PING keepalives replace idle-connection
-            // churn and detect dead peers under long-lived streams.
-            client_builder = client_builder
-                .http2_prior_knowledge()
-                .http2_initial_stream_window_size(2 * 1024 * 1024)
-                .http2_initial_connection_window_size(16 * 1024 * 1024)
-                .http2_adaptive_window(true)
-                .http2_keep_alive_interval(Duration::from_secs(30))
-                .http2_keep_alive_timeout(Duration::from_secs(20))
-                .http2_keep_alive_while_idle(true);
+            client_builder = apply_upstream_http2(client_builder);
         }
 
         // Force rustls backend when TLS is configured

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -243,10 +243,11 @@ pub struct RouterConfig {
     /// PEM format, loaded from ca_cert_paths during config creation
     #[serde(default)]
     pub ca_certificates: Vec<Vec<u8>>,
-    /// Speak HTTP/2 to workers via prior knowledge (h2c on cleartext),
-    /// multiplexing every request to a worker over one connection instead of
-    /// one TCP connection per in-flight request. Requires every HTTP worker
-    /// to serve HTTP/2 without an upgrade handshake.
+    /// Speak HTTP/2 to workers via prior knowledge (h2c on cleartext) on all
+    /// engine-directed connections — request dispatch and health/probe traffic
+    /// alike — multiplexing every request to a worker over one connection
+    /// instead of one TCP connection per in-flight request. Requires every
+    /// HTTP worker to serve HTTP/2 without an upgrade handshake.
     #[serde(default)]
     pub upstream_http2: bool,
     /// Loaded from mcp_config_path during config creation

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -490,9 +490,10 @@ struct CliArgs {
     #[arg(long, value_parser = parse_positive_usize, help_heading = "Worker Configuration")]
     zmq_engine_count: Option<usize>,
 
-    /// Speak HTTP/2 to workers via prior knowledge (h2c on cleartext),
-    /// multiplexing every request to a worker over one connection. Requires
-    /// every HTTP worker to serve HTTP/2 without an upgrade handshake.
+    /// Speak HTTP/2 to workers via prior knowledge (h2c on cleartext) on all
+    /// engine-directed connections — request dispatch and health/probe traffic
+    /// alike — multiplexing every request to a worker over one connection.
+    /// Requires every HTTP worker to serve HTTP/2 without an upgrade handshake.
     #[arg(long, default_value_t = false, help_heading = "Worker Configuration")]
     upstream_http2: bool,
 

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1159,6 +1159,9 @@ mod tests {
             tokenizer_registry: Arc::new(llm_tokenizer::registry::TokenizerRegistry::new()),
             multimodal_config_registry: Arc::new(MultimodalConfigRegistry::new()),
             wasm_manager: None,
+            worker_client_cache: Arc::new(crate::worker::WorkerHttpClientCache::new(
+                &router_config,
+            )),
             worker_service: Arc::new(WorkerService::new(
                 worker_registry,
                 worker_job_queue,

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use arc_swap::{ArcSwap, ArcSwapOption};
 use openai_protocol::{
@@ -30,8 +30,8 @@ pub struct BasicWorkerBuilder {
     health_endpoint: String,
     circuit_breaker_config: CircuitBreakerConfig,
     backend_client: Option<BackendClient>,
-    /// Pre-built per-worker HTTP client (if not set, a default is created).
-    http_client: Option<reqwest::Client>,
+    /// Pre-built worker-directed HTTP client (if not set, a default is created).
+    http_client: Option<Arc<reqwest::Client>>,
     /// Resolved resilience config (if not set, defaults are used).
     resilience: Option<ResolvedResilience>,
     /// Initial lifecycle status. If unset, defaults to `Pending` for
@@ -188,8 +188,9 @@ impl BasicWorkerBuilder {
         self
     }
 
-    /// Set a pre-built per-worker HTTP client.
-    pub fn http_client(mut self, client: reqwest::Client) -> Self {
+    /// Set a pre-built worker-directed HTTP client. The strong handle keeps
+    /// the client's shared cache entry alive for the worker's lifetime.
+    pub fn http_client(mut self, client: Arc<reqwest::Client>) -> Self {
         self.http_client = Some(client);
         self
     }
@@ -264,7 +265,7 @@ impl BasicWorkerBuilder {
 
     /// Build the BasicWorker instance
     pub fn build(mut self) -> BasicWorker {
-        use std::sync::{atomic::AtomicBool, Arc};
+        use std::sync::atomic::AtomicBool;
 
         use tokio::sync::OnceCell;
 
@@ -425,7 +426,7 @@ mod tests {
     #[test]
     fn provided_http_client_is_used_as_is() {
         let worker = BasicWorkerBuilder::new("http://localhost:8080")
-            .http_client(reqwest::Client::new())
+            .http_client(Arc::new(reqwest::Client::new()))
             .build();
         assert!(!worker.http_client.cell_is_empty());
     }

--- a/model_gateway/src/worker/http_client.rs
+++ b/model_gateway/src/worker/http_client.rs
@@ -1,110 +1,327 @@
-//! Per-worker HTTP client construction.
+//! Shared worker-directed HTTP clients.
 //!
-//! Builds a `reqwest::Client` for each worker by merging per-worker
-//! `HttpPoolConfig` overrides with router-level TLS and timeout defaults.
+//! One `reqwest::Client` per distinct effective connection config instead of
+//! one per worker: a uniform fleet shares a single connector, pool, and DNS
+//! cache regardless of worker count.
 
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, PoisonError, Weak},
+    time::Duration,
+};
 
 use openai_protocol::worker::HttpPoolConfig;
 use tracing::debug;
 
 use crate::config::RouterConfig;
 
-/// Default pool settings for per-worker HTTP clients.
+/// Default pool settings for worker-directed HTTP clients.
 const DEFAULT_POOL_MAX_IDLE_PER_HOST: usize = 8;
 const DEFAULT_POOL_IDLE_TIMEOUT_SECS: u64 = 50;
 const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
 
-/// Build a per-worker `reqwest::Client`.
+/// HTTP/2 prior-knowledge tuning for `--upstream-http2`, shared by the
+/// dispatch client and the worker client cache.
 ///
-/// Merges `HttpPoolConfig` overrides with router-level TLS settings.
-/// Each worker gets its own connection pool, isolated from other workers.
-pub fn build_worker_http_client(
-    pool_config: &HttpPoolConfig,
-    router_config: &RouterConfig,
-) -> Result<reqwest::Client, String> {
-    let timeout_secs = pool_config
-        .timeout_secs
-        .unwrap_or(router_config.request_timeout_secs);
-    let connect_timeout_secs = pool_config
-        .connect_timeout_secs
-        .unwrap_or(DEFAULT_CONNECT_TIMEOUT_SECS);
-    let pool_max_idle = pool_config
-        .pool_max_idle_per_host
-        .unwrap_or(DEFAULT_POOL_MAX_IDLE_PER_HOST);
-    let pool_idle_timeout = pool_config
-        .pool_idle_timeout_secs
-        .unwrap_or(DEFAULT_POOL_IDLE_TIMEOUT_SECS);
-
-    let has_tls =
-        router_config.client_identity.is_some() || !router_config.ca_certificates.is_empty();
-
-    let mut builder = reqwest::Client::builder()
-        .pool_max_idle_per_host(pool_max_idle)
-        .pool_idle_timeout(Some(Duration::from_secs(pool_idle_timeout)))
-        .timeout(Duration::from_secs(timeout_secs))
-        .connect_timeout(Duration::from_secs(connect_timeout_secs))
-        .tcp_nodelay(true)
-        .tcp_keepalive(Some(Duration::from_secs(30)));
-
-    if has_tls {
-        builder = builder.use_rustls_tls();
-    }
-
-    if let Some(identity_pem) = &router_config.client_identity {
-        let identity = reqwest::Identity::from_pem(identity_pem)
-            .map_err(|e| format!("Failed to create client identity: {e}"))?;
-        builder = builder.identity(identity);
-    }
-
-    for ca_cert in &router_config.ca_certificates {
-        let cert = reqwest::Certificate::from_pem(ca_cert)
-            .map_err(|e| format!("Failed to add CA certificate: {e}"))?;
-        builder = builder.add_root_certificate(cert);
-    }
-
-    debug!(
-        pool_max_idle = pool_max_idle,
-        timeout_secs = timeout_secs,
-        "Building per-worker HTTP client"
-    );
-
+/// Multiplex everything to a worker over one HTTP/2 connection. The default
+/// 64KB flow-control windows would let concurrent token streams throttle each
+/// other, so start large and let the adaptive window take over; h2 PING
+/// keepalives replace idle-connection churn and detect dead peers under
+/// long-lived streams.
+pub(crate) fn apply_upstream_http2(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
     builder
-        .build()
-        .map_err(|e| format!("Failed to create per-worker HTTP client: {e}"))
+        .http2_prior_knowledge()
+        .http2_initial_stream_window_size(2 * 1024 * 1024)
+        .http2_initial_connection_window_size(16 * 1024 * 1024)
+        .http2_adaptive_window(true)
+        .http2_keep_alive_interval(Duration::from_secs(30))
+        .http2_keep_alive_timeout(Duration::from_secs(20))
+        .http2_keep_alive_while_idle(true)
+}
+
+/// The `HttpPoolConfig` settings reqwest only honors client-wide, with
+/// defaults applied.
+///
+/// Client-level (buckets the cache): connect timeout, pool sizing, pool idle
+/// timeout. Router TLS identity/roots and the h2c mode are also client-level
+/// but process-constant, so they apply to every entry instead of keying it.
+/// Request-level (never buckets): total timeout — every worker-client call
+/// site sets `RequestBuilder::timeout`, which overrides the client default.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct ClientKey {
+    connect_timeout_secs: u64,
+    pool_max_idle_per_host: usize,
+    pool_idle_timeout_secs: u64,
+}
+
+impl ClientKey {
+    fn from_pool_config(pool_config: &HttpPoolConfig) -> Self {
+        Self {
+            connect_timeout_secs: pool_config
+                .connect_timeout_secs
+                .unwrap_or(DEFAULT_CONNECT_TIMEOUT_SECS),
+            pool_max_idle_per_host: pool_config
+                .pool_max_idle_per_host
+                .unwrap_or(DEFAULT_POOL_MAX_IDLE_PER_HOST),
+            pool_idle_timeout_secs: pool_config
+                .pool_idle_timeout_secs
+                .unwrap_or(DEFAULT_POOL_IDLE_TIMEOUT_SECS),
+        }
+    }
+}
+
+/// Cache of worker-directed HTTP clients, keyed by effective client-level
+/// config. Entries are weak: pool settings can be worker-supplied, so a
+/// client lives exactly as long as some worker holds its handle, dead entries
+/// are pruned on the next build, and cardinality is bounded by live distinct
+/// configs — a churning fleet cannot grow the map.
+pub struct WorkerHttpClientCache {
+    client_identity: Option<Vec<u8>>,
+    ca_certificates: Vec<Vec<u8>>,
+    upstream_http2: bool,
+    request_timeout_secs: u64,
+    clients: Mutex<HashMap<ClientKey, Weak<reqwest::Client>>>,
+}
+
+impl WorkerHttpClientCache {
+    pub fn new(router_config: &RouterConfig) -> Self {
+        Self {
+            client_identity: router_config.client_identity.clone(),
+            ca_certificates: router_config.ca_certificates.clone(),
+            upstream_http2: router_config.upstream_http2,
+            request_timeout_secs: router_config.request_timeout_secs,
+            clients: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The shared client for a worker's effective pool config, rebuilt when
+    /// no live worker holds it anymore.
+    pub fn get(&self, pool_config: &HttpPoolConfig) -> Result<Arc<reqwest::Client>, String> {
+        let key = ClientKey::from_pool_config(pool_config);
+        let mut clients = self.clients.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(client) = clients.get(&key).and_then(Weak::upgrade) {
+            return Ok(client);
+        }
+        let client = Arc::new(self.build(&key)?);
+        clients.retain(|_, entry| entry.strong_count() > 0);
+        debug!(?key, "built shared worker HTTP client");
+        clients.insert(key, Arc::downgrade(&client));
+        Ok(client)
+    }
+
+    /// Live + not-yet-pruned dead entries (test observation of bounds).
+    #[cfg(test)]
+    fn cached_len(&self) -> usize {
+        self.clients
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .len()
+    }
+
+    fn build(&self, key: &ClientKey) -> Result<reqwest::Client, String> {
+        let has_tls = self.client_identity.is_some() || !self.ca_certificates.is_empty();
+
+        let mut builder = reqwest::Client::builder()
+            .pool_max_idle_per_host(key.pool_max_idle_per_host)
+            .pool_idle_timeout(Some(Duration::from_secs(key.pool_idle_timeout_secs)))
+            .timeout(Duration::from_secs(self.request_timeout_secs))
+            .connect_timeout(Duration::from_secs(key.connect_timeout_secs))
+            .tcp_nodelay(true)
+            .tcp_keepalive(Some(Duration::from_secs(30)));
+
+        if self.upstream_http2 {
+            builder = apply_upstream_http2(builder);
+        }
+
+        if has_tls {
+            builder = builder.use_rustls_tls();
+        }
+
+        if let Some(identity_pem) = &self.client_identity {
+            let identity = reqwest::Identity::from_pem(identity_pem)
+                .map_err(|e| format!("Failed to create client identity: {e}"))?;
+            builder = builder.identity(identity);
+        }
+
+        for ca_cert in &self.ca_certificates {
+            let cert = reqwest::Certificate::from_pem(ca_cert)
+                .map_err(|e| format!("Failed to add CA certificate: {e}"))?;
+            builder = builder.add_root_certificate(cert);
+        }
+
+        builder
+            .build()
+            .map_err(|e| format!("Failed to create worker HTTP client: {e}"))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::types::{PolicyConfig, RoutingMode};
 
-    fn test_router_config() -> RouterConfig {
-        RouterConfig::new(
-            RoutingMode::Regular {
-                worker_urls: vec![],
-            },
-            PolicyConfig::Random,
-        )
+    fn cache(config: RouterConfig) -> WorkerHttpClientCache {
+        WorkerHttpClientCache::new(&config)
+    }
+
+    /// Loopback echo server; axum::serve accepts HTTP/1.1 and prior-knowledge
+    /// h2c on the same listener, mirroring a dual-protocol engine.
+    async fn spawn_echo_server() -> String {
+        let app = axum::Router::new().route("/probe", axum::routing::get(|| async { "ok" }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind echo server");
+        let addr = listener.local_addr().expect("echo server address");
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test server lives for the duration of the test process"
+        )]
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("echo serve");
+        });
+        format!("http://{addr}/probe")
     }
 
     #[test]
-    fn test_build_client_with_defaults() {
-        let pool = HttpPoolConfig::default();
-        let config = test_router_config();
-        let client = build_worker_http_client(&pool, &config);
-        assert!(client.is_ok());
+    fn same_effective_config_shares_one_client() {
+        let cache = cache(RouterConfig::default());
+        let a = cache.get(&HttpPoolConfig::default()).expect("client");
+        // Explicit values equal to the defaults are the same effective config.
+        let b = cache
+            .get(&HttpPoolConfig {
+                connect_timeout_secs: Some(DEFAULT_CONNECT_TIMEOUT_SECS),
+                ..Default::default()
+            })
+            .expect("client");
+        assert!(Arc::ptr_eq(&a, &b));
     }
 
     #[test]
-    fn test_build_client_with_overrides() {
-        let pool = HttpPoolConfig {
-            pool_max_idle_per_host: Some(16),
-            timeout_secs: Some(60),
-            ..Default::default()
-        };
-        let config = test_router_config();
-        let client = build_worker_http_client(&pool, &config);
-        assert!(client.is_ok());
+    fn client_level_override_gets_its_own_client() {
+        let cache = cache(RouterConfig::default());
+        let default = cache.get(&HttpPoolConfig::default()).expect("client");
+        let overridden = cache
+            .get(&HttpPoolConfig {
+                connect_timeout_secs: Some(3),
+                ..Default::default()
+            })
+            .expect("client");
+        assert!(!Arc::ptr_eq(&default, &overridden));
+        // The override bucket is itself cached.
+        let again = cache
+            .get(&HttpPoolConfig {
+                connect_timeout_secs: Some(3),
+                ..Default::default()
+            })
+            .expect("client");
+        assert!(Arc::ptr_eq(&overridden, &again));
+    }
+
+    #[test]
+    fn entry_lives_exactly_as_long_as_worker_handles() {
+        use crate::worker::BasicWorkerBuilder;
+
+        let cache = cache(RouterConfig::default());
+        let handle = cache.get(&HttpPoolConfig::default()).expect("client");
+        let probe = Arc::downgrade(&handle);
+        let worker_a = BasicWorkerBuilder::new("http://a:1")
+            .http_client(handle.clone())
+            .build();
+        let worker_b = BasicWorkerBuilder::new("http://b:1")
+            .http_client(handle)
+            .build();
+
+        drop(worker_a);
+        assert!(
+            probe.upgrade().is_some(),
+            "entry survives while another worker holds it"
+        );
+
+        drop(worker_b);
+        assert!(
+            probe.upgrade().is_none(),
+            "last worker drop releases the entry"
+        );
+
+        // The dead entry cannot be upgraded, so the next get rebuilds.
+        let rebuilt = cache.get(&HttpPoolConfig::default()).expect("client");
+        assert!(probe.upgrade().is_none());
+        assert_eq!(cache.cached_len(), 1);
+        drop(rebuilt);
+    }
+
+    #[test]
+    fn dead_entries_are_pruned_on_insert() {
+        let cache = cache(RouterConfig::default());
+        let dropped = cache.get(&HttpPoolConfig::default()).expect("client");
+        drop(dropped);
+
+        let _live = cache
+            .get(&HttpPoolConfig {
+                connect_timeout_secs: Some(3),
+                ..Default::default()
+            })
+            .expect("client");
+        assert_eq!(cache.cached_len(), 1);
+    }
+
+    #[test]
+    fn request_level_timeout_override_never_buckets() {
+        let cache = cache(RouterConfig::default());
+        let a = cache.get(&HttpPoolConfig::default()).expect("client");
+        let b = cache
+            .get(&HttpPoolConfig {
+                timeout_secs: Some(600),
+                ..Default::default()
+            })
+            .expect("client");
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[tokio::test]
+    async fn per_request_timeout_overrides_client_default() {
+        let url = spawn_echo_server().await;
+        // A zero client-level total timeout fails every request that relies
+        // on the client default...
+        let client = cache(RouterConfig {
+            request_timeout_secs: 0,
+            ..RouterConfig::default()
+        })
+        .get(&HttpPoolConfig::default())
+        .expect("client");
+        let err = client.get(&url).send().await.expect_err("default applies");
+        assert!(err.is_timeout());
+        // ...while a per-request timeout replaces it entirely.
+        let resp = client
+            .get(&url)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .expect("per-request timeout wins");
+        assert_eq!(resp.text().await.expect("body"), "ok");
+    }
+
+    #[tokio::test]
+    async fn upstream_http2_worker_client_speaks_h2c_prior_knowledge() {
+        let url = spawn_echo_server().await;
+        let client = cache(RouterConfig {
+            upstream_http2: true,
+            ..RouterConfig::default()
+        })
+        .get(&HttpPoolConfig::default())
+        .expect("client");
+        let resp = client.get(&url).send().await.expect("h2c request");
+        assert_eq!(resp.version(), http::Version::HTTP_2);
+        assert_eq!(resp.text().await.expect("body"), "ok");
+    }
+
+    #[tokio::test]
+    async fn default_worker_client_stays_http1() {
+        let url = spawn_echo_server().await;
+        let client = cache(RouterConfig::default())
+            .get(&HttpPoolConfig::default())
+            .expect("client");
+        let resp = client.get(&url).send().await.expect("h1 request");
+        assert_eq!(resp.version(), http::Version::HTTP_11);
+        assert_eq!(resp.text().await.expect("body"), "ok");
     }
 }

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -31,7 +31,7 @@ pub use capacity::{CapacitySource, CapacityTrackerSettings, WorkerCapacity};
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 pub use error::{WorkerError, WorkerResult};
 pub use hash_ring::HashRing;
-pub use http_client::build_worker_http_client;
+pub use http_client::WorkerHttpClientCache;
 pub use kv_event_monitor::KvEventMonitor;
 pub use manager::WorkerManager;
 pub use monitor::{WorkerLoadManager, WorkerMonitor};

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -40,20 +40,21 @@ use crate::{
 /// Default HTTP client timeout for worker requests (in seconds)
 pub const DEFAULT_WORKER_HTTP_TIMEOUT_SECS: u64 = 30;
 
-/// Per-worker HTTP client with an isolated connection pool, materialized on
-/// first use.
+/// A worker's HTTP client handle, materialized on first use.
 ///
-/// A worker whose connection mode never speaks HTTP (ZMQ: local health check,
-/// admin ops rejected up front) would otherwise pay for a connector and idle
-/// pool it can never use, so the fallback client is built only when a caller
-/// actually asks for it.
+/// Registration hands in a shared client from the worker client cache. A
+/// worker built without one whose connection mode never speaks HTTP (ZMQ:
+/// local health check, admin ops rejected up front) would otherwise pay for a
+/// connector and idle pool it can never use, so the fallback client is built
+/// only when a caller actually asks for it.
 pub struct LazyHttpClient {
-    cell: OnceLock<reqwest::Client>,
+    cell: OnceLock<Arc<reqwest::Client>>,
 }
 
 impl LazyHttpClient {
     /// Wrap an already-built client (the registration paths hand one in).
-    pub fn ready(client: reqwest::Client) -> Self {
+    /// The strong handle is what keeps the client's cache entry alive.
+    pub fn ready(client: Arc<reqwest::Client>) -> Self {
         let cell = OnceLock::new();
         let _ = cell.set(client);
         Self { cell }
@@ -74,19 +75,32 @@ impl LazyHttpClient {
 
     /// The client, building the default one on first use.
     pub fn client(&self) -> &reqwest::Client {
+        self.init()
+    }
+
+    /// A strong handle to the client if one was materialized, for a
+    /// replacement worker to adopt. Never forces the lazy cell: a worker
+    /// that never spoke HTTP hands its replacement a still-deferred slot.
+    pub fn handle_if_initialized(&self) -> Option<Arc<reqwest::Client>> {
+        self.cell.get().map(Arc::clone)
+    }
+
+    fn init(&self) -> &Arc<reqwest::Client> {
         self.cell.get_or_init(|| {
-            reqwest::Client::builder()
-                .timeout(Duration::from_secs(DEFAULT_WORKER_HTTP_TIMEOUT_SECS))
-                .pool_max_idle_per_host(8)
-                .build()
-                .unwrap_or_else(|e| {
-                    tracing::warn!(
-                        error = %e,
-                        "failed to build the default per-worker HTTP client; \
-                         falling back to reqwest defaults (no request timeout)"
-                    );
-                    reqwest::Client::new()
-                })
+            Arc::new(
+                reqwest::Client::builder()
+                    .timeout(Duration::from_secs(DEFAULT_WORKER_HTTP_TIMEOUT_SECS))
+                    .pool_max_idle_per_host(8)
+                    .build()
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(
+                            error = %e,
+                            "failed to build the default per-worker HTTP client; \
+                             falling back to reqwest defaults (no request timeout)"
+                        );
+                        reqwest::Client::new()
+                    }),
+            )
         })
     }
 }
@@ -520,6 +534,12 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
 
     /// Get the per-worker HTTP client.
     fn http_client(&self) -> &reqwest::Client;
+
+    /// Strong handle to the worker's HTTP client, if one was materialized.
+    /// Must not force a deferred client into existence; cache-fed workers
+    /// return the shared handle so a replacement worker keeps the cache
+    /// entry alive.
+    fn http_client_handle_if_initialized(&self) -> Option<Arc<reqwest::Client>>;
 
     // ── Metadata convenience delegates ──────────────────────────────
     //
@@ -1182,8 +1202,8 @@ pub struct BasicWorker {
     /// When not `Wildcard`, overrides metadata.models for routing decisions.
     /// Uses `ArcSwap` for lock-free reads on the hot path (`supports_model`).
     pub models_override: Arc<ArcSwap<WorkerModels>>,
-    /// Per-worker HTTP client with isolated connection pool, built on first
-    /// use (see [`LazyHttpClient`]).
+    /// Worker-directed HTTP client, shared across same-config workers, built
+    /// on first use (see [`LazyHttpClient`]).
     pub http_client: Arc<LazyHttpClient>,
     /// Resolved resilience config (retry + circuit breaker settings).
     pub resilience: ResolvedResilience,
@@ -1526,6 +1546,10 @@ impl Worker for BasicWorker {
 
     fn http_client(&self) -> &reqwest::Client {
         self.http_client.client()
+    }
+
+    fn http_client_handle_if_initialized(&self) -> Option<Arc<reqwest::Client>> {
+        self.http_client.handle_if_initialized()
     }
 
     fn supports_model(&self, model_id: &str) -> bool {

--- a/model_gateway/src/workflow/steps/external/create_workers.rs
+++ b/model_gateway/src/workflow/steps/external/create_workers.rs
@@ -9,7 +9,6 @@ use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, Wo
 use crate::{
     worker::{
         circuit_breaker::CircuitBreakerConfig,
-        http_client::build_worker_http_client,
         resilience::resolve_resilience,
         worker::{RuntimeType, WorkerType},
         BasicWorkerBuilder, ConnectionMode, Worker,
@@ -67,11 +66,13 @@ impl StepExecutor<WorkerWorkflowData> for CreateExternalWorkersStep {
             &config.resilience,
         );
 
-        let http_client = build_worker_http_client(&config.http_pool, &app_context.router_config)
+        let http_client = app_context
+            .worker_client_cache
+            .get(&config.http_pool)
             .map_err(|e| WorkflowError::StepFailed {
-            step_id: StepId::new("create_external_workers"),
-            message: e,
-        })?;
+                step_id: StepId::new("create_external_workers"),
+                message: e,
+            })?;
 
         let (health_config, health_endpoint) = {
             let base = app_context.router_config.health_check.to_protocol_config();

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -14,9 +14,8 @@ use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, Wo
 use crate::{
     routers::grpc::zmq_client::zmq_handshake_address,
     worker::{
-        circuit_breaker::CircuitBreakerConfig, http_client::build_worker_http_client,
-        resilience::resolve_resilience, worker::RuntimeType, BasicWorkerBuilder, ConnectionMode,
-        Worker, WorkerRegistry, UNKNOWN_MODEL_ID,
+        circuit_breaker::CircuitBreakerConfig, resilience::resolve_resilience, worker::RuntimeType,
+        BasicWorkerBuilder, ConnectionMode, Worker, WorkerRegistry, UNKNOWN_MODEL_ID,
     },
     workflow::data::{WorkerKind, WorkerRegistrationMode, WorkerWorkflowData},
 };
@@ -204,11 +203,13 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
             &config.resilience,
         );
 
-        let http_client = build_worker_http_client(&config.http_pool, &app_context.router_config)
+        let http_client = app_context
+            .worker_client_cache
+            .get(&config.http_pool)
             .map_err(|e| WorkflowError::StepFailed {
-            step_id: StepId::new("create_worker"),
-            message: e,
-        })?;
+                step_id: StepId::new("create_worker"),
+                message: e,
+            })?;
 
         let health_base = app_context.router_config.health_check.to_protocol_config();
         let health_config =

--- a/model_gateway/src/workflow/steps/local/drain_workers.rs
+++ b/model_gateway/src/workflow/steps/local/drain_workers.rs
@@ -172,6 +172,9 @@ mod tests {
             tokenizer_registry: Arc::new(llm_tokenizer::registry::TokenizerRegistry::new()),
             multimodal_config_registry: Arc::new(MultimodalConfigRegistry::new()),
             wasm_manager: None,
+            worker_client_cache: Arc::new(crate::worker::WorkerHttpClientCache::new(
+                &router_config,
+            )),
             worker_service: Arc::new(WorkerService::new(registry, job_queue, router_config)),
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: None,

--- a/model_gateway/src/workflow/steps/local/update_worker_properties.rs
+++ b/model_gateway/src/workflow/steps/local/update_worker_properties.rs
@@ -95,11 +95,17 @@ impl StepExecutor<WorkerUpdateWorkflowData> for UpdateWorkerPropertiesStep {
                 .health_config(updated_health_config.clone())
                 .health_endpoint(&health_endpoint)
                 .models(worker.metadata().spec.models.clone())
-                .http_client(worker.http_client().clone())
                 .resilience(worker.resilience().clone())
                 .priority(updated_priority)
                 .cost(updated_cost)
                 .status(next_status);
+
+            // Adopt the old worker's client only if it was materialized: a
+            // never-HTTP worker (ZMQ) keeps a deferred slot instead of having
+            // a client it will never use built for the replacement.
+            if let Some(client) = worker.http_client_handle_if_initialized() {
+                builder = builder.http_client(client);
+            }
 
             if let Some(ref api_key) = updated_api_key {
                 builder = builder.api_key(api_key.clone());
@@ -243,6 +249,9 @@ mod tests {
             tokenizer_registry: Arc::new(llm_tokenizer::registry::TokenizerRegistry::new()),
             multimodal_config_registry: Arc::new(MultimodalConfigRegistry::new()),
             wasm_manager: None,
+            worker_client_cache: Arc::new(crate::worker::WorkerHttpClientCache::new(
+                &router_config,
+            )),
             worker_service: Arc::new(WorkerService::new(registry, job_queue, router_config)),
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: None,
@@ -363,5 +372,35 @@ mod tests {
             .expect("replacement must inherit the connected client");
         assert!(Arc::ptr_eq(&adopted, &client));
         assert_eq!(new.status(), WorkerStatus::Ready);
+
+        // Neither side of a ZMQ replacement may materialize an HTTP client
+        // it will never use.
+        assert!(old.http_client.cell_is_empty());
+        assert!(new.http_client.cell_is_empty());
+    }
+
+    /// An HTTP worker's replacement must adopt the same shared client — a
+    /// fresh client would silently detach it from the worker-client cache
+    /// entry the old worker was keeping alive.
+    #[tokio::test]
+    async fn http_update_adopts_the_materialized_shared_client() {
+        let client = Arc::new(reqwest::Client::new());
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8080")
+                .http_client(Arc::clone(&client))
+                .status(WorkerStatus::Ready)
+                .build(),
+        );
+        let app_ctx = make_app_context(std::slice::from_ref(&worker));
+        let mut ctx = make_context(app_ctx, Arc::clone(&worker), HashMap::new());
+
+        let result = UpdateWorkerPropertiesStep.execute(&mut ctx).await.unwrap();
+        assert_eq!(result, StepResult::Success);
+
+        let updated = &ctx.data.updated_workers.as_ref().expect("updated workers")[0];
+        let adopted = updated
+            .http_client_handle_if_initialized()
+            .expect("materialized client is adopted");
+        assert!(Arc::ptr_eq(&adopted, &client));
     }
 }


### PR DESCRIPTION
## Description

### Problem

Worker registration builds a dedicated `reqwest::Client` per worker. On a 10k-worker fleet that is 10k connectors, connection pools, and DNS caches serving only health checks and admin calls. These clients are also HTTP/1.1-only: `--upstream-http2` tunes the shared dispatch client, but the worker-directed path cannot speak h2c even though engines negotiate h1+h2c on one listener across all endpoints.

### Solution

Cache worker-directed clients by effective connection-level config. Workers with identical config (the common case) share one client; genuine overrides get their own cached entry. Settings reqwest honors per-request — the total timeout — never force a separate client: every worker-client call site already sets `RequestBuilder::timeout` (health checks use the health-check timeout, admin ops their operation deadlines), which overrides the client default. The `upstream_http2` builder block moves into a shared helper applied to both the dispatch client and worker-cache builds, so the existing flag now covers all engine-directed connections.

## Changes

- Add `WorkerHttpClientCache`: worker clients keyed by effective client-level config (connect timeout, pool sizing, pool idle timeout); router TLS and h2c mode apply to every entry. Entries are weak references — workers hold the strong handles — so a client lives exactly as long as some worker references it, dead entries are pruned on the next build, and cardinality is bounded by live distinct configs even when workers supply unique pool settings.
- Expose the cache on `AppContext`; local and external worker creation steps fetch from it instead of calling the removed `build_worker_http_client`.
- Extract `apply_upstream_http2` as the single source of truth for h2c prior-knowledge tuning; apply it to worker clients when `--upstream-http2` is set.
- Update `--upstream-http2` help text: covers all engine-directed connections (dispatch and health/probe).

With the flag unset, worker clients keep the previous defaults (HTTP/1.1, 8 idle per host, 50s idle timeout, 10s connect, same TLS handling).

## Test Plan

- `worker::http_client`: same effective config -> same `Arc`; distinct connect timeout -> distinct client; `timeout_secs`-only override -> same client; entry released when the last worker holding it drops (Weak upgrade fails, next get rebuilds) while surviving removal of one of two workers; dead entries pruned on insert; per-request timeout overrides the client default against a live server; `--upstream-http2` worker client speaks h2c prior knowledge (response negotiates HTTP/2); default stays HTTP/1.1.
- Existing suites: `app_context` (dispatch h2c/h1 tests unchanged), `workflow::` create/update/drain steps, `worker::`, `service_discovery`, `routers::http`, worker API integration tests, `k8s_discovery_test` end-to-end register/remove.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

