### PR TITLE
fix(worker): reject malformed ZMQ handshake overrides at registration

### DIFF
--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -243,8 +243,8 @@ fn derive_handshake_port(path: &str) -> u16 {
 /// `ts serve --headless` with a manually registered worker.
 /// Returns `(handshake, input, output)`.
 ///
-/// [`zmq_handshake_address`] exposes just the handshake half, for collision
-/// checks at registration time.
+/// [`zmq_handshake_address`] exposes just the handshake half, for the
+/// registration-time validation of that address.
 fn zmq_socket_addresses(
     base_url: &str,
     handshake_override: Option<&str>,
@@ -269,15 +269,17 @@ fn zmq_socket_addresses(
     Ok((handshake, input, output))
 }
 
-/// The TCP handshake address a ZMQ worker will bind, or `None` when the URL is
-/// not a usable `ipc://` base (connect reports that with its own error).
+/// The TCP handshake address a ZMQ worker will bind.
+///
+/// Carries [`zmq_socket_addresses`]'s error verbatim rather than flattening it
+/// to "no address": an unusable `ipc://` base or a non-`tcp://` override is a
+/// misconfiguration registration must reject, not a value to skip past and
+/// rediscover at every later connect attempt.
 pub(crate) fn zmq_handshake_address(
     base_url: &str,
     handshake_override: Option<&str>,
-) -> Option<String> {
-    zmq_socket_addresses(base_url, handshake_override)
-        .ok()
-        .map(|(handshake, _, _)| handshake)
+) -> Result<String, String> {
+    zmq_socket_addresses(base_url, handshake_override).map(|(handshake, _, _)| handshake)
 }
 
 /// Create the parent directory for a worker's `ipc://` sockets. Kept off the

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -175,7 +175,7 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
         // Normalize URL
         let url = normalize_url(&config.url, *connection_mode);
 
-        validate_zmq_handshake_collision(
+        validate_zmq_handshake_address(
             &app_context.worker_registry,
             &url,
             config.zmq_handshake_address.as_deref(),
@@ -536,13 +536,19 @@ fn validate_zmq_handshake_override(
     Ok(())
 }
 
-/// Reject a ZMQ worker whose TCP handshake address is already claimed.
+/// Reject a ZMQ worker whose TCP handshake address is unusable or already
+/// claimed.
 ///
-/// The handshake port is a hash of the ipc path, so a collision between two
-/// worker URLs is deterministic and permanent: the second worker's handshake
-/// bind fails on every connect attempt with a bare transport error, hours
-/// after registration. Detect it here, where the fix can be named.
-fn validate_zmq_handshake_collision(
+/// Both failures strand the worker the same way — its handshake bind fails on
+/// every connect attempt with a bare transport error, hours after a
+/// registration that reported success — so both are named here instead.
+///
+/// *Unusable*: the base URL is not an `ipc://` path, or the
+/// `zmq_handshake_address` override is not a `tcp://` address.
+///
+/// *Claimed*: the handshake port is a hash of the ipc path, so a collision
+/// between two worker URLs is deterministic and permanent.
+fn validate_zmq_handshake_address(
     registry: &WorkerRegistry,
     url: &str,
     handshake_override: Option<&str>,
@@ -551,10 +557,7 @@ fn validate_zmq_handshake_collision(
     if connection_mode != ConnectionMode::Zmq {
         return Ok(());
     }
-    // An unparsable URL fails later with its own message; nothing to compare.
-    let Some(handshake) = zmq_handshake_address(url, handshake_override) else {
-        return Ok(());
-    };
+    let handshake = zmq_handshake_address(url, handshake_override)?;
     for existing in registry.get_all() {
         let metadata = existing.metadata();
         // Sockets are bound against the base URL (a dp-expanded worker carries
@@ -563,10 +566,15 @@ fn validate_zmq_handshake_collision(
         if *existing.connection_mode() != ConnectionMode::Zmq || existing_url == url {
             continue;
         }
-        if zmq_handshake_address(existing_url, metadata.spec.zmq_handshake_address.as_deref())
-            .as_deref()
-            == Some(handshake.as_str())
-        {
+        // A peer that reached the registry with an unusable address (some other
+        // path registered it) has no address to collide with — that is its own
+        // problem, not a reason to reject this registration.
+        let Ok(existing_handshake) =
+            zmq_handshake_address(existing_url, metadata.spec.zmq_handshake_address.as_deref())
+        else {
+            continue;
+        };
+        if existing_handshake == handshake {
             return Err(format!(
                 "ZMQ worker {url} would bind handshake address {handshake}, already claimed by \
                  worker {existing_url}: the derived port is a hash of the ipc path, so rename \
@@ -818,7 +826,7 @@ mod tests {
         registry.register(zmq_worker(first, None)).unwrap();
 
         // Same derived address reached through an explicit override.
-        let err = validate_zmq_handshake_collision(
+        let err = validate_zmq_handshake_address(
             &registry,
             "ipc:///tmp/smg-zmq/b.ipc",
             Some(&handshake),
@@ -830,22 +838,71 @@ mod tests {
 
         // A distinct path derives a distinct address; re-registering the same
         // URL (update path) is not a collision with itself.
-        validate_zmq_handshake_collision(
+        validate_zmq_handshake_address(
             &registry,
             "ipc:///tmp/smg-zmq/b.ipc",
             None,
             ConnectionMode::Zmq,
         )
         .expect("a distinct ipc path must be accepted");
-        validate_zmq_handshake_collision(&registry, first, None, ConnectionMode::Zmq)
+        validate_zmq_handshake_address(&registry, first, None, ConnectionMode::Zmq)
             .expect("re-registering the same worker URL must be accepted");
-        validate_zmq_handshake_collision(
+        validate_zmq_handshake_address(&registry, "grpc://worker:8080", None, ConnectionMode::Grpc)
+            .expect("non-ZMQ workers are not affected");
+    }
+
+    #[test]
+    fn malformed_zmq_handshake_address_is_rejected_at_registration() {
+        // A handshake address that can never bind must fail here, with the
+        // reason named — not silently register a worker whose every connect
+        // attempt dies on a bare transport error.
+        let registry = WorkerRegistry::new();
+
+        // The engine dials a TCP handshake, so an ipc:// override is unusable.
+        let err = validate_zmq_handshake_address(
             &registry,
-            "grpc://worker:8080",
-            None,
-            ConnectionMode::Grpc,
+            "ipc:///tmp/smg-zmq/a.ipc",
+            Some("ipc:///tmp/smg-zmq/handshake.sock"),
+            ConnectionMode::Zmq,
         )
-        .expect("non-ZMQ workers are not affected");
+        .expect_err("a non-tcp:// handshake override must be rejected");
+        assert!(err.contains("tcp://"), "message was: {err}");
+        assert!(
+            err.contains("ipc:///tmp/smg-zmq/handshake.sock"),
+            "message was: {err}"
+        );
+
+        // A ZMQ worker whose base URL is not an ipc:// path derives nothing.
+        let err = validate_zmq_handshake_address(
+            &registry,
+            "http://worker:8080",
+            None,
+            ConnectionMode::Zmq,
+        )
+        .expect_err("a non-ipc:// ZMQ base URL must be rejected");
+        assert!(err.contains("ipc://"), "message was: {err}");
+
+        // A well-formed tcp:// override on an ipc:// base is the supported form.
+        validate_zmq_handshake_address(
+            &registry,
+            "ipc:///tmp/smg-zmq/a.ipc",
+            Some("tcp://127.0.0.1:30500"),
+            ConnectionMode::Zmq,
+        )
+        .expect("a tcp:// override must be accepted");
+
+        // A peer that reached the registry with an unusable address is skipped,
+        // not inherited: it cannot claim a handshake address to collide with.
+        registry
+            .register(zmq_worker("http://peer:8080", None))
+            .expect("registering the malformed peer");
+        validate_zmq_handshake_address(
+            &registry,
+            "ipc:///tmp/smg-zmq/a.ipc",
+            None,
+            ConnectionMode::Zmq,
+        )
+        .expect("an unusable peer address must not block a valid registration");
     }
 
     #[test]

--- a/model_gateway/src/workflow/steps/shared/update_policies.rs
+++ b/model_gateway/src/workflow/steps/shared/update_policies.rs
@@ -197,3 +197,55 @@ impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for UpdatePolicie
         false
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tracing_test::traced_test;
+
+    use super::*;
+    use crate::worker::BasicWorkerBuilder;
+
+    fn worker(url: &str, connection_mode: ConnectionMode) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .connection_mode(connection_mode)
+                .build(),
+        )
+    }
+
+    #[traced_test]
+    #[test]
+    fn cache_aware_over_zmq_warns_that_kv_events_are_missing() {
+        // The ZMQ wire carries no KV-event stream, so this worker's cache
+        // tracking is the approximate prefix tree alone. Degrading a policy the
+        // operator asked for is fine; doing it silently is not.
+        UpdatePoliciesStep::warn_on_cache_aware_without_kv_events(
+            "glm-5.2",
+            &worker("ipc:///tmp/smg-zmq/a.ipc", ConnectionMode::Zmq),
+            true,
+        );
+
+        assert!(logs_contain("has no KV-event stream"));
+        assert!(logs_contain("glm-5.2"));
+        assert!(logs_contain("ipc:///tmp/smg-zmq/a.ipc"));
+    }
+
+    #[traced_test]
+    #[test]
+    fn kv_event_capable_and_non_cache_aware_workers_stay_quiet() {
+        // gRPC has the KV-event stream, so cache_aware is served in full...
+        UpdatePoliciesStep::warn_on_cache_aware_without_kv_events(
+            "glm-5.2",
+            &worker("grpc://worker:8080", ConnectionMode::Grpc),
+            true,
+        );
+        // ...and a ZMQ worker under any other policy loses nothing to warn about.
+        UpdatePoliciesStep::warn_on_cache_aware_without_kv_events(
+            "glm-5.2",
+            &worker("ipc:///tmp/smg-zmq/a.ipc", ConnectionMode::Zmq),
+            false,
+        );
+
+        assert!(!logs_contain("has no KV-event stream"));
+    }
+}


### PR DESCRIPTION
## Description

### Problem

Follow-up to #2181 (merged while review feedback was in flight). CodeRabbit flagged that `zmq_handshake_address` returns `Option`, so a present-but-malformed handshake override (e.g. a non-`tcp://` address) silently yields `None`: the registration-time collision check skips it, and the misconfiguration only surfaces later as a connect failure. It also asked for test coverage of the new `UpdatePoliciesStep` cache_aware-over-ZMQ warning path.

### Solution

Fix the silent `.ok()` at the source rather than adding a second validator that would restate the `tcp://` rule and drift from it: `zmq_handshake_address` now returns `Result<String, String>`, propagating `zmq_socket_addresses`'s error verbatim. The registration check (renamed `validate_zmq_handshake_collision` → `validate_zmq_handshake_address`, since it now covers usability as well as collisions) propagates the incoming worker's error into the existing `StepFailed` mapping — a misconfigured override now fails loudly at registration.

One deliberate asymmetry: an already-registered peer with an unusable address is still skipped (`let Ok(..) else continue`) rather than propagated — a peer that claims no handshake address has nothing to collide with, and its misconfiguration must not block an unrelated valid registration. Covered by a test.

The registry-level handshake reservation index CodeRabbit also suggested (making the collision check atomic with registration) is intentionally out of scope — it is an architectural change deserving its own PR.

## Changes

- `model_gateway/src/routers/grpc/zmq_client.rs`: `zmq_handshake_address` returns `Result<String, String>` (was `Option<String>`); both call sites updated.
- `model_gateway/src/workflow/steps/local/create_worker.rs`: check renamed to `validate_zmq_handshake_address`; incoming worker's address error propagates via `?`; unusable registered peers still skipped.
- `model_gateway/src/workflow/steps/shared/update_policies.rs`: new test module for the cache_aware-over-ZMQ warning.

## Test Plan

- `cargo test -p smg --lib -- create_worker update_policies zmq` → 96 passed, 0 failed, including:
  - `malformed_zmq_handshake_address_is_rejected_at_registration` (rejects non-`tcp://` override naming the offending address; rejects non-`ipc://` ZMQ base URL; accepts well-formed override; unusable peer does not block a valid registration)
  - `cache_aware_over_zmq_warns_that_kv_events_are_missing` and `kv_event_capable_and_non_cache_aware_workers_stay_quiet` (`#[traced_test]`/`logs_contain` pattern)
- `cargo +nightly fmt --all` → clean
- `cargo clippy -p smg --all-targets -- -D warnings` → clean (local run without `--all-features` per the CONTRIBUTING-sanctioned fallback; no system OpenCV)
- codespell 2.4.1 with the repo's `.pre-commit-config.yaml` word list → clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
