### PR TITLE
feat(router): absolute worker overload vetoes with zero per-request cost

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -522,6 +522,8 @@ struct Router {
     cache_ttl_secs: u64,
     job_queue_capacity: usize,
     job_queue_concurrency: usize,
+    worker_overload_waiting_requests: Option<usize>,
+    worker_overload_token_usage: Option<f64>,
 }
 
 impl Router {
@@ -833,6 +835,8 @@ impl Router {
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
             .job_queue_capacity(self.job_queue_capacity)
             .job_queue_concurrency(self.job_queue_concurrency)
+            .worker_overload_waiting_requests(self.worker_overload_waiting_requests)
+            .worker_overload_token_usage(self.worker_overload_token_usage)
             .load_monitor_interval_secs(self.load_monitor_interval)
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
@@ -1071,6 +1075,8 @@ impl Router {
         cache_ttl_secs = 180,
         job_queue_capacity = 1000,
         job_queue_concurrency = 200,
+        worker_overload_waiting_requests = None,
+        worker_overload_token_usage = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1217,6 +1223,8 @@ impl Router {
         cache_ttl_secs: u64,
         job_queue_capacity: usize,
         job_queue_concurrency: usize,
+        worker_overload_waiting_requests: Option<usize>,
+        worker_overload_token_usage: Option<f64>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1377,6 +1385,8 @@ impl Router {
             cache_ttl_secs,
             job_queue_capacity,
             job_queue_concurrency,
+            worker_overload_waiting_requests,
+            worker_overload_token_usage,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -235,6 +235,9 @@ class RouterArgs:
     # Control-plane job queue sizing (worker registration/removal jobs)
     job_queue_capacity: int = 1000
     job_queue_concurrency: int = 200
+    # Absolute per-worker overload thresholds; both None disables the feature
+    worker_overload_waiting_requests: int | None = None
+    worker_overload_token_usage: float | None = None
 
     @staticmethod
     def add_cli_args(
@@ -540,6 +543,39 @@ class RouterArgs:
                 " exceeds it, shed load off that engine regardless of spread. A safety"
                 " valve for critically-saturated engines, best set high (e.g. 0.9)."
                 " Backend must report token_usage. Defaults to 1.0 (disabled)."
+            ),
+        )
+        routing_group.add_argument(
+            f"--{prefix}worker-overload-waiting-requests",
+            type=int,
+            default=RouterArgs.worker_overload_waiting_requests,
+            help=(
+                "Queued-request count AT OR ABOVE which a worker is considered"
+                " overloaded and excluded from routing until the signal recovers;"
+                " when every worker is overloaded, requests are shed immediately"
+                " rather than queued. Unset disables overload protection. This"
+                " signal is the queued (waiting) request count, summed across DP"
+                " ranks. Must be >= 1: the comparison is inclusive, so 0 would veto"
+                " every worker unconditionally."
+            ),
+        )
+        routing_group.add_argument(
+            f"--{prefix}worker-overload-token-usage",
+            type=float,
+            default=RouterArgs.worker_overload_token_usage,
+            help=(
+                "KV-cache token usage AT OR ABOVE which a worker is considered"
+                " overloaded and excluded from routing until the signal recovers;"
+                " when every worker is overloaded, requests are shed immediately"
+                " rather than queued. Unset disables overload protection. This"
+                " signal is mean KV-cache token usage across DP ranks, the same one"
+                " --balance-token-usage-threshold reads, applied as an absolute"
+                " per-worker CEILING rather than a fleet-relative spread. Backend"
+                " must report token_usage. Must be in (0.0, 1.0]: the comparison is"
+                " inclusive, so 0.0 would veto every worker unconditionally."
+                " Distinct from --overload-token-usage-threshold, which only"
+                " de-ranks the hottest backend within cache-aware affinity; this"
+                " flag removes the worker from routing entirely."
             ),
         )
         routing_group.add_argument(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -570,6 +570,47 @@ class TestParseRouterArgs:
         assert defaults.cache_index == "tree"
         assert defaults.cache_ttl_secs == 180
 
+    def test_parse_worker_overload_args(self):
+        """Both overload flags round-trip, and both default to unset.
+
+        The argparse names are built from an f-string prefix, so a typo or a
+        dest/field mismatch would leave the field at its default and silently
+        disable the feature from Python -- `from_cli_args` skips keys it cannot
+        find.
+        """
+        router_args = parse_router_args(
+            [
+                "--worker-overload-waiting-requests",
+                "64",
+                "--worker-overload-token-usage",
+                "0.9",
+            ]
+        )
+        assert router_args.worker_overload_waiting_requests == 64
+        assert router_args.worker_overload_token_usage == pytest.approx(0.9)
+
+        defaults = parse_router_args([])
+        assert defaults.worker_overload_waiting_requests is None
+        assert defaults.worker_overload_token_usage is None
+
+    def test_prefixed_worker_overload_args(self):
+        """The --router-prefixed aliases reach the same fields."""
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser, use_router_prefix=True)
+        namespace = parser.parse_args(
+            [
+                "--router-worker-overload-waiting-requests",
+                "8",
+                "--router-worker-overload-token-usage",
+                "0.75",
+            ]
+        )
+
+        router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
+
+        assert router_args.worker_overload_waiting_requests == 8
+        assert router_args.worker_overload_token_usage == pytest.approx(0.75)
+
     def test_parse_pd_args(self):
         """Test parsing PD disaggregated mode arguments."""
         args = [
@@ -1327,6 +1368,8 @@ class TestRouterArgsFieldOrder:
         "cache_ttl_secs",
         "job_queue_capacity",
         "job_queue_concurrency",
+        "worker_overload_waiting_requests",
+        "worker_overload_token_usage",
     ]
 
     def test_complete_field_sequence_is_frozen(self):
@@ -1355,6 +1398,8 @@ class TestRouterArgsFieldOrder:
             "cache_boundaries",
             "cache_index",
             "cache_ttl_secs",
+            "worker_overload_waiting_requests",
+            "worker_overload_token_usage",
         ):
             assert names.index(appended) > marker, (
                 f"{appended} must be appended after worker_startup_delay to "

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -26,7 +26,7 @@ use crate::{
         router_manager::RouterManager,
     },
     wasm::{config::WasmRuntimeConfig, module_manager::WasmModuleManager},
-    worker::{KvEventMonitor, WorkerMonitor, WorkerRegistry, WorkerService},
+    worker::{KvEventMonitor, OverloadThresholds, WorkerMonitor, WorkerRegistry, WorkerService},
     workflow::{JobQueue, WorkflowEngines},
 };
 
@@ -639,6 +639,10 @@ impl AppContextBuilder {
             client.clone(),
             config.load_monitor_interval_secs,
             config.engine_metrics,
+            OverloadThresholds {
+                waiting_requests: config.worker_overload_waiting_requests,
+                token_usage: config.worker_overload_token_usage,
+            },
         ));
         // Wire the backend load-snapshot feed into every policy that consumes
         // it; the monitor itself only polls while some policy reports needing

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -263,6 +263,16 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn worker_overload_waiting_requests(mut self, threshold: Option<usize>) -> Self {
+        self.config.worker_overload_waiting_requests = threshold;
+        self
+    }
+
+    pub fn worker_overload_token_usage(mut self, threshold: Option<f64>) -> Self {
+        self.config.worker_overload_token_usage = threshold;
+        self
+    }
+
     pub fn kv_indexer_ttl_secs(mut self, ttl: Option<u64>) -> Self {
         self.config.kv_indexer_ttl_secs = ttl;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -93,6 +93,21 @@ pub struct RouterConfig {
     pub job_queue_concurrency: usize,
     #[serde(default = "default_load_monitor_interval_secs")]
     pub load_monitor_interval_secs: u64,
+    /// Queued-request count at or above which a worker is considered
+    /// overloaded and excluded from routing until the signal recovers; when all
+    /// workers are overloaded, requests are shed immediately rather than
+    /// queued. Evaluated once per ingested load report, never per request.
+    /// `None` (default) disables this signal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_overload_waiting_requests: Option<usize>,
+    /// KV-cache token usage (0.0-1.0, averaged across DP ranks) at or above
+    /// which a worker is considered overloaded — the same signal
+    /// `balance_token_usage_threshold` reads, applied as an absolute per-worker
+    /// ceiling instead of a fleet-relative spread. `None` (default) disables
+    /// this signal; with both signals unset, overload protection is off and
+    /// routing behaves exactly as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_overload_token_usage: Option<f64>,
     /// TTL in seconds for entries in the event-driven cache-aware positional
     /// indexer: entries neither stored to nor read by a query within this
     /// window are evicted by a periodic background prune. Bounds index growth
@@ -1024,6 +1039,8 @@ impl Default for RouterConfig {
             job_queue_capacity: default_job_queue_capacity(),
             job_queue_concurrency: default_job_queue_concurrency(),
             load_monitor_interval_secs: 10,
+            worker_overload_waiting_requests: None,
+            worker_overload_token_usage: None,
             kv_indexer_ttl_secs: None,
             kv_indexer_max_entries: None,
             engine_metrics: false,

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -753,6 +753,27 @@ impl ConfigValidator {
             });
         }
 
+        // Overload thresholds are `>=` comparisons, so the excluded ends of
+        // these ranges are exactly the values that would veto every worker
+        // unconditionally. Mirrors the CLI parsers for the config-file and
+        // bindings paths.
+        if config.worker_overload_waiting_requests == Some(0) {
+            return Err(ConfigError::InvalidValue {
+                field: "worker_overload_waiting_requests".to_string(),
+                value: "0".to_string(),
+                reason: "Must be >= 1 (0 would mark every worker overloaded)".to_string(),
+            });
+        }
+        if let Some(threshold) = config.worker_overload_token_usage {
+            if !threshold.is_finite() || threshold <= 0.0 || threshold > 1.0 {
+                return Err(ConfigError::InvalidValue {
+                    field: "worker_overload_token_usage".to_string(),
+                    value: threshold.to_string(),
+                    reason: "Must be a fraction in (0.0, 1.0]".to_string(),
+                });
+            }
+        }
+
         // The body-limit layer rejects payloads above max_payload_size before
         // the streaming threshold is consulted, so a threshold at or above it
         // could never activate.
@@ -2106,6 +2127,44 @@ mod tests {
         config.health_check_port = Some(8081);
         assert!(ConfigValidator::validate(&config).is_ok());
         config.health_check_port = None;
+        assert!(ConfigValidator::validate(&config).is_ok());
+    }
+
+    /// The CLI parsers reject these, but TOML/JSON and the Python bindings
+    /// reach `RouterConfig` without going through clap.
+    #[test]
+    fn test_reject_degenerate_worker_overload_thresholds() {
+        let mut config = RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker1:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        );
+
+        // Unset is the default and always valid.
+        assert!(ConfigValidator::validate(&config).is_ok());
+
+        config.worker_overload_waiting_requests = Some(0);
+        assert!(matches!(
+            ConfigValidator::validate(&config),
+            Err(ConfigError::InvalidValue { ref field, .. })
+                if field == "worker_overload_waiting_requests"
+        ));
+        config.worker_overload_waiting_requests = Some(1);
+        assert!(ConfigValidator::validate(&config).is_ok());
+
+        for bad in [0.0, -0.1, 1.5, f64::NAN] {
+            config.worker_overload_token_usage = Some(bad);
+            assert!(
+                matches!(
+                    ConfigValidator::validate(&config),
+                    Err(ConfigError::InvalidValue { ref field, .. })
+                        if field == "worker_overload_token_usage"
+                ),
+                "{bad} must be rejected"
+            );
+        }
+        config.worker_overload_token_usage = Some(1.0);
         assert!(ConfigValidator::validate(&config).is_ok());
     }
 }

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -180,6 +180,18 @@ fn parse_usize_in_range(value: &str, max: usize) -> Result<usize, String> {
     }
 }
 
+/// Parse a ratio in `(0.0, 1.0]`. Zero is excluded because a `>=` threshold of
+/// 0.0 would mark every worker overloaded unconditionally.
+fn parse_unit_fraction(value: &str) -> Result<f64, String> {
+    match value.parse::<f64>() {
+        Ok(v) if v > 0.0 && v <= 1.0 => Ok(v),
+        Ok(_) => Err(format!(
+            "invalid value '{value}'; expected a fraction in (0.0, 1.0]"
+        )),
+        Err(err) => Err(format!("invalid value '{value}': {err}")),
+    }
+}
+
 fn parse_job_queue_capacity(value: &str) -> Result<usize, String> {
     parse_usize_in_range(value, 1_000_000)
 }
@@ -265,6 +277,33 @@ struct CliArgs {
     /// regardless of spread. Best set high (e.g. 0.9). >= 1.0 disables it.
     #[arg(long, default_value_t = 1.0, help_heading = "Routing Policy")]
     overload_token_usage_threshold: f32,
+
+    /// Queued-request count at or above which a worker is considered
+    /// overloaded and excluded from routing until the signal recovers; when
+    /// every worker is overloaded, requests are shed immediately rather than
+    /// queued. Unset disables overload protection.
+    ///
+    /// Queued (waiting) requests, summed across DP ranks. Must be >= 1: the
+    /// comparison is inclusive, so 0 would veto every worker unconditionally.
+    #[arg(long, value_parser = parse_positive_usize, help_heading = "Routing Policy")]
+    worker_overload_waiting_requests: Option<usize>,
+
+    /// KV-cache token usage at or above which a worker is considered
+    /// overloaded and excluded from routing until the signal recovers; when
+    /// every worker is overloaded, requests are shed immediately rather than
+    /// queued. Unset disables overload protection.
+    ///
+    /// Mean KV-cache token usage across DP ranks, the same signal
+    /// `--balance-token-usage-threshold` reads, applied as an absolute
+    /// per-worker ceiling rather than a fleet-relative spread. Backend must
+    /// report token_usage. Must be in (0.0, 1.0]: the comparison is inclusive,
+    /// so 0.0 would veto every worker unconditionally.
+    ///
+    /// Distinct from `--overload-token-usage-threshold`, which only de-ranks
+    /// the hottest backend within cache-aware affinity; this flag removes the
+    /// worker from routing entirely and sheds when every worker crosses it.
+    #[arg(long, value_parser = parse_unit_fraction, help_heading = "Routing Policy")]
+    worker_overload_token_usage: Option<f64>,
 
     /// Anti-hotspot decay: de-rank cache-affine candidates by their
     /// waiting-prefill backlog (overlap score divided by 1 + overlap_decay
@@ -1716,6 +1755,8 @@ impl CliArgs {
             .job_queue_capacity(self.job_queue_capacity)
             .job_queue_concurrency(self.job_queue_concurrency)
             .load_monitor_interval_secs(self.load_monitor_interval)
+            .worker_overload_waiting_requests(self.worker_overload_waiting_requests)
+            .worker_overload_token_usage(self.worker_overload_token_usage)
             .kv_indexer_ttl_secs(self.kv_indexer_ttl_secs)
             .kv_indexer_max_entries(self.kv_indexer_max_entries)
             .engine_metrics(self.engine_metrics)
@@ -2301,6 +2342,86 @@ mod tests {
             server_config.router_config.engine_metrics,
             "engine_metrics must survive into ServerConfig via to_server_config"
         );
+    }
+
+    /// The overload thresholds must reach `RouterConfig` and survive nesting
+    /// into `ServerConfig.router_config` — the consumer (load monitor) reads
+    /// them off `RouterConfig`. Two-path config-plumbing guard.
+    #[test]
+    fn worker_overload_thresholds_flow_into_both_configs() {
+        let cli = cli_args_from(&[
+            "--worker-overload-waiting-requests",
+            "64",
+            "--worker-overload-token-usage",
+            "0.9",
+        ]);
+
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(
+            router_config.worker_overload_waiting_requests,
+            Some(64),
+            "worker_overload_waiting_requests must reach RouterConfig via to_router_config"
+        );
+        assert_eq!(
+            router_config.worker_overload_token_usage,
+            Some(0.9),
+            "worker_overload_token_usage must reach RouterConfig via to_router_config"
+        );
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert_eq!(
+            server_config.router_config.worker_overload_waiting_requests,
+            Some(64),
+            "worker_overload_waiting_requests must survive into ServerConfig"
+        );
+        assert_eq!(
+            server_config.router_config.worker_overload_token_usage,
+            Some(0.9),
+            "worker_overload_token_usage must survive into ServerConfig"
+        );
+    }
+
+    /// Unset means off on both paths: the feature must be byte-identical to
+    /// pre-feature behavior until an operator opts in.
+    #[test]
+    fn worker_overload_thresholds_default_to_unset_in_both_configs() {
+        let cli = cli_args_from(&[]);
+
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(router_config.worker_overload_waiting_requests, None);
+        assert_eq!(router_config.worker_overload_token_usage, None);
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert_eq!(
+            server_config.router_config.worker_overload_waiting_requests,
+            None
+        );
+        assert_eq!(
+            server_config.router_config.worker_overload_token_usage,
+            None
+        );
+    }
+
+    /// Both thresholds are `>=` comparisons, so the excluded ends of their
+    /// ranges would veto every worker unconditionally. Reject them at parse
+    /// time rather than letting a typo shed all traffic.
+    #[test]
+    fn degenerate_worker_overload_thresholds_are_rejected_at_parse_time() {
+        for argv in [
+            vec!["smg", "--worker-overload-waiting-requests", "0"],
+            vec!["smg", "--worker-overload-token-usage", "0"],
+            vec!["smg", "--worker-overload-token-usage", "1.5"],
+            vec!["smg", "--worker-overload-token-usage", "-0.5"],
+        ] {
+            assert!(
+                Cli::try_parse_from(&argv).is_err(),
+                "{argv:?} must be rejected at parse time"
+            );
+        }
+
+        // The inclusive ends of the accepted ranges must still parse.
+        assert!(Cli::try_parse_from(["smg", "--worker-overload-waiting-requests", "1"]).is_ok());
+        assert!(Cli::try_parse_from(["smg", "--worker-overload-token-usage", "1.0"]).is_ok());
     }
 
     /// Cache-index flags must reach the cache_aware policy variant and the

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -346,6 +346,15 @@ pub(crate) fn init_metrics() {
          (panic, join_error, intern_failed)"
     );
     describe_gauge!(
+        "smg_workers_overloaded",
+        "Workers currently flagged overloaded and excluded from routing, by model"
+    );
+    describe_counter!(
+        "smg_worker_overload_shed_total",
+        "Requests shed because every worker for the model is overloaded, by stage \
+         (selection, dispatch)"
+    );
+    describe_gauge!(
         "smg_manual_policy_cache_entries",
         "Number of routing entries in manual policy cache"
     );
@@ -1332,6 +1341,23 @@ impl Metrics {
             "worker_type" => worker_type,
             "connection_mode" => connection_mode,
             "error_type" => error_type
+        )
+        .increment(1);
+    }
+
+    /// Set the count of workers a model currently has vetoed by the absolute
+    /// overload guard. Written only when a worker's flag transitions.
+    pub fn set_workers_overloaded(model_id: &str, count: usize) {
+        let model = intern_model_label(model_id);
+        gauge!("smg_workers_overloaded", "model" => model).set(count as f64);
+    }
+
+    /// Record a request shed because every worker for the model is overloaded.
+    /// `stage` is "selection" or "dispatch".
+    pub fn record_worker_overload_shed(stage: &'static str) {
+        counter!(
+            "smg_worker_overload_shed_total",
+            "stage" => stage
         )
         .increment(1);
     }

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -995,10 +995,10 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         let request_tokens = info.tokens;
 
         // Single O(workers) gather: read each worker once via routing_state()
-        // (status + load + processed under one ArcSwap guard), replacing the
-        // former separate passes whose per-worker guard traffic dominated routing
-        // CPU at scale. Collects healthy indices, the load sum (for the
-        // per-request pressure gate), and the min-load index.
+        // (status + load + processed + overload veto under one ArcSwap guard),
+        // replacing the former separate passes whose per-worker guard traffic
+        // dominated routing CPU at scale. Collects eligible indices, the load
+        // sum (for the per-request pressure gate), and the min-load index.
         let mut healthy_indices: Vec<usize> = Vec::with_capacity(workers.len());
         let mut load_sum = 0usize;
         // Min-load worker, (load, processed_requests, idx) tie-break (#1714);
@@ -1007,7 +1007,9 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         let mut min_load_idx: Option<usize> = None;
         for (idx, worker) in workers.iter().enumerate() {
             let state = worker.routing_state();
-            if state.healthy && state.can_execute {
+            // The overload veto costs nothing here: `state` is the word this
+            // pass already loaded for health, circuit breaker and load.
+            if state.eligible() {
                 healthy_indices.push(idx);
                 load_sum += state.load;
                 let key = (state.load, state.processed, idx);
@@ -2035,6 +2037,59 @@ mod tests {
             )
             .unwrap();
         assert_eq!(idx1, idx3);
+    }
+
+    /// `RoutingState::overloaded` has exactly one production reader — the fused
+    /// gather below `select_worker`. Without this test nothing would fail if
+    /// `state.eligible()` were reverted to health + circuit breaker, or if
+    /// `BasicWorker::routing_state` stopped populating the field.
+    #[test]
+    fn overloaded_worker_is_vetoed_by_the_fused_gather() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        });
+        let workers: Vec<Arc<dyn Worker>> = ["http://w1:8000", "http://w2:8000"]
+            .into_iter()
+            .map(|url| {
+                Arc::new(
+                    BasicWorkerBuilder::new(url)
+                        .worker_type(WorkerType::Regular)
+                        .health_config(no_health_check())
+                        .build(),
+                ) as Arc<dyn Worker>
+            })
+            .collect();
+        policy.init_workers(&workers);
+
+        let info = SelectWorkerInfo {
+            request_text: Some("a stable prefix that pins one worker"),
+            ..Default::default()
+        };
+        let owner = policy.select_worker(&workers, &info).unwrap();
+        assert_eq!(
+            policy.select_worker(&workers, &info),
+            Some(owner),
+            "cache affinity holds while the worker is eligible"
+        );
+
+        workers[owner].set_overloaded(true);
+        assert_ne!(
+            policy.select_worker(&workers, &info),
+            Some(owner),
+            "affinity must not outrank the absolute veto"
+        );
+
+        // Every worker vetoed leaves nothing to select.
+        for worker in &workers {
+            worker.set_overloaded(true);
+        }
+        assert_eq!(policy.select_worker(&workers, &info), None);
+
+        for worker in &workers {
+            worker.set_overloaded(false);
+        }
+        assert!(policy.select_worker(&workers, &info).is_some());
     }
 
     #[test]

--- a/model_gateway/src/policies/consistent_hashing.rs
+++ b/model_gateway/src/policies/consistent_hashing.rs
@@ -74,7 +74,7 @@ impl ConsistentHashingPolicy {
         let healthy_url_to_idx: std::collections::HashMap<&str, usize> = workers
             .iter()
             .enumerate()
-            .filter(|(_, w)| w.is_healthy())
+            .filter(|(_, w)| w.is_healthy_and_eligible())
             .map(|(i, w)| (w.url(), i))
             .collect();
 
@@ -133,7 +133,7 @@ impl ConsistentHashingPolicy {
         // O(1) parse + O(1) bounds check + O(1) health check
         if let Some(idx_str) = target_worker {
             if let Ok(idx) = idx_str.parse::<usize>() {
-                if idx < workers.len() && workers[idx].is_healthy() {
+                if idx < workers.len() && workers[idx].is_healthy_and_eligible() {
                     return (Some(idx), Branch::TargetWorkerHit);
                 }
             }
@@ -165,7 +165,10 @@ impl ConsistentHashingPolicy {
         }
 
         // Fallback: random selection (truly anonymous client)
-        let healthy_count = workers.iter().filter(|w| w.is_healthy()).count();
+        let healthy_count = workers
+            .iter()
+            .filter(|w| w.is_healthy_and_eligible())
+            .count();
         if healthy_count == 0 {
             return (None, Branch::NoHealthyWorkers);
         }
@@ -174,7 +177,7 @@ impl ConsistentHashingPolicy {
         let idx = workers
             .iter()
             .enumerate()
-            .filter(|(_, w)| w.is_healthy())
+            .filter(|(_, w)| w.is_healthy_and_eligible())
             .nth(random_healthy_idx)
             .map(|(i, _)| i);
 
@@ -237,6 +240,54 @@ mod tests {
                 ) as Arc<dyn Worker>
             })
             .collect()
+    }
+
+    /// Every consistent-hashing entry point gathers on
+    /// `is_healthy_and_eligible()`, so a vetoed worker must drop out of the
+    /// ring, out of an explicit target-worker probe, and out of the random
+    /// fallback alike.
+    #[test]
+    fn overloaded_worker_is_skipped_by_every_selection_path() {
+        let policy = ConsistentHashingPolicy::new();
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+
+        let headers = headers_with_routing_key("user-veto");
+        let info = SelectWorkerInfo {
+            headers: Some(&headers),
+            ..Default::default()
+        };
+        let owner = policy.select_worker_impl(&workers, &info).0.unwrap();
+
+        workers[owner].set_overloaded(true);
+        let respilled = policy.select_worker_impl(&workers, &info).0.unwrap();
+        assert_ne!(respilled, owner, "the ring must skip a vetoed worker");
+
+        // Explicit target-worker probe: an operator pin does not beat the veto.
+        let target = headers_with_target_worker(owner);
+        let targeted_info = SelectWorkerInfo {
+            headers: Some(&target),
+            ..Default::default()
+        };
+        assert_ne!(
+            policy.select_worker_impl(&workers, &targeted_info).0,
+            Some(owner)
+        );
+
+        // Random fallback: no routing key at all.
+        let fallback_info = SelectWorkerInfo::default();
+        for _ in 0..32 {
+            assert_ne!(
+                policy.select_worker_impl(&workers, &fallback_info).0,
+                Some(owner)
+            );
+        }
+
+        workers[owner].set_overloaded(false);
+        assert_eq!(
+            policy.select_worker_impl(&workers, &info).0,
+            Some(owner),
+            "recovery re-admits the ring owner"
+        );
     }
 
     #[test]

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -215,12 +215,17 @@ impl Default for BucketConfig {
     }
 }
 
-/// Helper function to filter healthy workers and return their indices
+/// Helper function to filter routable workers and return their indices.
+///
+/// [`Worker::is_available`] folds the absolute overload veto into the health +
+/// circuit-breaker test it already performed, under the same guards and with
+/// the same short-circuit order — the veto is one more test on a word already
+/// in hand, never a second walk.
 pub(crate) fn get_healthy_worker_indices(workers: &[Arc<dyn Worker>]) -> Vec<usize> {
     workers
         .iter()
         .enumerate()
-        .filter(|(_, w)| w.is_healthy() && w.circuit_breaker_can_execute())
+        .filter(|(_, w)| w.is_available())
         .map(|(idx, _)| idx)
         .collect()
 }
@@ -376,6 +381,35 @@ mod tests {
                 }
             );
         }
+    }
+
+    /// The overload veto rides the same eligibility filter every walking policy
+    /// uses, so flagging a worker removes it everywhere at once — and clearing
+    /// the flag re-admits it.
+    #[test]
+    fn get_healthy_worker_indices_honors_the_overload_veto() {
+        let workers: Vec<Arc<dyn Worker>> = (0..3)
+            .map(|i| {
+                Arc::new(
+                    BasicWorkerBuilder::new(format!("http://w{i}:8000"))
+                        .worker_type(WorkerType::Regular)
+                        .health_config(no_health_check())
+                        .build(),
+                ) as Arc<dyn Worker>
+            })
+            .collect();
+
+        assert_eq!(get_healthy_worker_indices(&workers), vec![0, 1, 2]);
+
+        // A busy worker is still eligible: load alone is not the veto.
+        let _guard = crate::worker::WorkerLoadGuard::new(Arc::clone(&workers[1]), None);
+        assert_eq!(get_healthy_worker_indices(&workers), vec![0, 1, 2]);
+
+        workers[1].set_overloaded(true);
+        assert_eq!(get_healthy_worker_indices(&workers), vec![0, 2]);
+
+        workers[1].set_overloaded(false);
+        assert_eq!(get_healthy_worker_indices(&workers), vec![0, 1, 2]);
     }
 
     #[test]

--- a/model_gateway/src/policies/prefix_hash.rs
+++ b/model_gateway/src/policies/prefix_hash.rs
@@ -204,7 +204,7 @@ impl PrefixHashPolicy {
         workers
             .iter()
             .enumerate()
-            .filter(|(_, w)| w.is_healthy())
+            .filter(|(_, w)| w.is_healthy_and_eligible())
             .min_by_key(|(_, w)| w.load())
             .map(|(idx, _)| idx)
     }
@@ -244,7 +244,7 @@ impl PrefixHashPolicy {
         let healthy_workers: Vec<(usize, &Arc<dyn Worker>)> = workers
             .iter()
             .enumerate()
-            .filter(|(_, w)| w.is_healthy())
+            .filter(|(_, w)| w.is_healthy_and_eligible())
             .collect();
 
         if healthy_workers.is_empty() {
@@ -427,6 +427,35 @@ mod tests {
             let (result, _, _) = policy.select_worker_impl(&workers, &info);
             assert_eq!(result, Some(first_idx));
         }
+    }
+
+    /// The ring lookup routes on `is_healthy_and_eligible()`, so the absolute
+    /// overload veto must move a key off its ring owner and back on recovery.
+    #[test]
+    fn overloaded_worker_is_skipped_by_the_ring_lookup() {
+        let policy = PrefixHashPolicy::with_defaults();
+        let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
+
+        let tokens: Vec<u32> = vec![11, 22, 33, 44, 55, 66, 77, 88];
+        let info = SelectWorkerInfo {
+            tokens: Some(&tokens),
+            hash_ring: Some(ring),
+            ..Default::default()
+        };
+
+        let owner = policy.select_worker_impl(&workers, &info).0.unwrap();
+
+        workers[owner].set_overloaded(true);
+        let respilled = policy.select_worker_impl(&workers, &info).0.unwrap();
+        assert_ne!(respilled, owner, "a vetoed ring owner must not be selected");
+
+        workers[owner].set_overloaded(false);
+        assert_eq!(
+            policy.select_worker_impl(&workers, &info).0,
+            Some(owner),
+            "recovery re-admits the ring owner"
+        );
     }
 
     #[test]

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -1455,6 +1455,95 @@ mod tests {
         assert!(logs_contain("occupied_hit"));
     }
 
+    /// An overloaded pin must respill through the existing reassignment path.
+    ///
+    /// Every router hands `select_worker` a slice already filtered by
+    /// `is_available()`, so a vetoed worker is simply absent from the
+    /// candidates — the pin resolves to nothing and takes the same
+    /// `occupied_miss` respill a stale pin takes. The test mirrors that call
+    /// shape rather than passing a raw pool no router builds.
+    #[test]
+    #[traced_test]
+    fn overloaded_sticky_pin_respills_through_the_stale_path() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        let policy = reg.get_default_policy();
+        let fleet = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+        let available = |fleet: &[Arc<dyn Worker>]| -> Vec<Arc<dyn Worker>> {
+            fleet.iter().filter(|w| w.is_available()).cloned().collect()
+        };
+        let info = SelectWorkerInfo {
+            rid_key: Some("convOverload"),
+            ..Default::default()
+        };
+
+        let workers = available(&fleet);
+        let pinned_url = {
+            let idx = reg.select_worker(&policy, &workers, &info).unwrap();
+            assert_eq!(
+                reg.select_worker(&policy, &workers, &info),
+                Some(idx),
+                "the pin holds while the worker is eligible"
+            );
+            workers[idx].url().to_string()
+        };
+
+        fleet
+            .iter()
+            .find(|w| w.url() == pinned_url)
+            .unwrap()
+            .set_overloaded(true);
+        let workers = available(&fleet);
+        assert_eq!(workers.len(), 1, "the veto removes the pinned worker");
+        let respilled = reg.select_worker(&policy, &workers, &info).unwrap();
+        assert_ne!(
+            workers[respilled].url(),
+            pinned_url,
+            "an overloaded pin must be abandoned"
+        );
+        assert!(logs_contain("occupied_miss"));
+
+        // Recovery re-admits the worker as a candidate; the pin now follows the
+        // respill target, so only eligibility is asserted here.
+        fleet
+            .iter()
+            .find(|w| w.url() == pinned_url)
+            .unwrap()
+            .set_overloaded(false);
+        let workers = available(&fleet);
+        assert!(reg.select_worker(&policy, &workers, &info).is_some());
+    }
+
+    /// Every worker vetoed leaves the sticky selector with nothing to pin.
+    #[test]
+    #[traced_test]
+    fn all_overloaded_leaves_sticky_selection_empty() {
+        let reg = PolicyRegistry::with_override(
+            PolicyConfig::RoundRobin,
+            rid_override(ManualAssignmentMode::Delegate),
+        );
+        let policy = reg.get_default_policy();
+        let workers = vec![
+            worker("http://w1", WorkerType::Regular),
+            worker("http://w2", WorkerType::Regular),
+        ];
+        for w in &workers {
+            w.set_overloaded(true);
+        }
+        let info = SelectWorkerInfo {
+            rid_key: Some("convShed"),
+            ..Default::default()
+        };
+
+        assert_eq!(reg.select_worker(&policy, &workers, &info), None);
+        assert!(logs_contain("no_healthy_workers"));
+    }
+
     #[test]
     fn cap_respill_reassigns_and_pin_follows_strict_improvement() {
         let reg = PolicyRegistry::with_override(

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -13,6 +13,8 @@
 //!   helpers shared across the chat / responses / messages routes
 //! - [`realtime`] — Realtime API transport (WS/WebRTC/REST relay +
 //!   session registry) shared by the OpenAI and HTTP routers
+//! - [`overload`] — shed responses for the absolute worker-overload
+//!   guard, shared by the HTTP and gRPC selection paths
 //! - [`worker_selection`] — per-request worker-selection helpers used
 //!   by every routing path (regular, PD, fallback, external provider)
 //! - [`retry`] — generic async retry executor + backoff calculator,
@@ -25,6 +27,7 @@
 pub mod header_utils;
 pub mod mcp_utils;
 pub mod openai_bridge;
+pub mod overload;
 pub mod persistence_utils;
 pub mod realtime;
 pub mod retry;

--- a/model_gateway/src/routers/common/overload.rs
+++ b/model_gateway/src/routers/common/overload.rs
@@ -1,0 +1,187 @@
+//! Shed responses for the absolute worker-overload guard.
+//!
+//! Both helpers run only after routing has already failed to produce a worker,
+//! so nothing here is on the path of a served request. Their whole job is to
+//! turn "the pool emptied because every worker is vetoed" into the immediate
+//! 503 both transports use for `no_available_workers`, instead of the
+//! circuit-breaker wording (HTTP) or a misleading 404 (gRPC).
+//!
+//! The verdict is taken from the candidate pool the caller selected over, never
+//! from the model index: every selection site narrows by worker type and
+//! connection mode first, so a whole-model predicate would miss exactly the
+//! cases that matter — a saturated PD prefill leg, one transport of a
+//! mixed-transport model, or the model-less `/generate` wildcard, which selects
+//! across every model and has no model-index entry of its own.
+
+use std::sync::Arc;
+
+use axum::response::Response;
+use tracing::debug;
+
+use crate::{
+    observability::metrics::Metrics,
+    routers::{common::retry::mark_non_retryable, error},
+    worker::{
+        overload::{
+            BRANCH_ALL_OVERLOADED_SHED, BRANCH_OVERLOADED_AT_DISPATCH, STAGE_DISPATCH,
+            STAGE_SELECTION,
+        },
+        Worker,
+    },
+};
+
+/// Whether every worker in a non-empty candidate pool is vetoed.
+///
+/// `candidates` is the pool *before* the `is_available()` filter, narrowed by
+/// exactly the worker-type / connection-mode filter selection used.
+pub fn all_overloaded(candidates: &[Arc<dyn Worker>]) -> bool {
+    !candidates.is_empty() && candidates.iter().all(|w| w.is_overloaded())
+}
+
+/// Shed when every worker selection could have used is flagged overloaded.
+///
+/// `None` means the empty pool has some other cause, and the caller's existing
+/// not-found / unavailable answer stands.
+pub fn shed_if_all_overloaded(candidates: &[Arc<dyn Worker>], model_id: &str) -> Option<Response> {
+    if !all_overloaded(candidates) {
+        return None;
+    }
+    Some(shed(
+        BRANCH_ALL_OVERLOADED_SHED,
+        STAGE_SELECTION,
+        "none",
+        format!("All workers for model '{model_id}' are overloaded"),
+    ))
+}
+
+/// The dispatch-time re-check: one relaxed atomic read on the single worker
+/// already chosen, covering the window between selection and dispatch in which
+/// a load report can land.
+///
+/// Deliberately sheds rather than re-selecting. The flag moves once per
+/// `load_monitor_interval_secs`, so a flip landing inside one selection→dispatch
+/// gap is rare enough that the simpler answer costs nothing in aggregate — and
+/// unlike the selection shed, this one says only what it knows: *this* worker
+/// went over, not the fleet.
+pub fn shed_if_worker_overloaded(worker: &dyn Worker, model_id: &str) -> Option<Response> {
+    if !worker.is_overloaded() {
+        return None;
+    }
+    let url = worker.url();
+    Some(shed(
+        BRANCH_OVERLOADED_AT_DISPATCH,
+        STAGE_DISPATCH,
+        url,
+        format!("Worker '{url}' for model '{model_id}' became overloaded before dispatch"),
+    ))
+}
+
+/// One decision line, one counter, one response.
+///
+/// The response is marked non-retryable: the condition it reports clears at the
+/// load-poll interval, so the retry layer's backoff window cannot outlive it,
+/// and retrying would re-run the entire pipeline (rate limiting included) five
+/// more times to reach the same 503 ~400 ms later. Marking it terminal is also
+/// what makes `smg_worker_overload_shed_total` count sheds per request rather
+/// than per attempt.
+fn shed(branch: &'static str, stage: &'static str, worker: &str, message: String) -> Response {
+    Metrics::record_worker_overload_shed(stage);
+    debug!(branch, stage, worker, "Overload shed");
+    let mut response = error::service_unavailable("no_available_workers", message);
+    mark_non_retryable(&mut response);
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use openai_protocol::{model_card::ModelCard, worker::HealthCheckConfig};
+
+    use super::*;
+    use crate::{
+        routers::{
+            common::retry::{is_retryable_response, is_retryable_status},
+            error::extract_error_code_from_response,
+        },
+        worker::{BasicWorkerBuilder, ConnectionMode, WorkerType},
+    };
+
+    fn worker(url: &str, model_id: &str) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .model(ModelCard::new(model_id))
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Http)
+                .health_config(HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        )
+    }
+
+    /// The shed is the existing `no_available_workers` 503, taken from the
+    /// candidate pool rather than the model index.
+    #[test]
+    fn all_overloaded_sheds_with_no_available_workers_503() {
+        let a = worker("http://127.0.0.1:9801", "m");
+        let b = worker("http://127.0.0.1:9802", "m");
+        let pool = vec![Arc::clone(&a), Arc::clone(&b)];
+
+        a.set_overloaded(true);
+        assert!(
+            shed_if_all_overloaded(&pool, "m").is_none(),
+            "one eligible worker left is not a shed"
+        );
+
+        b.set_overloaded(true);
+        let response = shed_if_all_overloaded(&pool, "m").expect("shed");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "no_available_workers"
+        );
+    }
+
+    /// A shed must be terminal for the retry layer, or "shed immediately"
+    /// becomes six pipeline runs and ~400 ms of backoff per request.
+    #[test]
+    fn shed_responses_are_not_retried() {
+        let a = worker("http://127.0.0.1:9811", "m");
+        a.set_overloaded(true);
+
+        let selection = shed_if_all_overloaded(std::slice::from_ref(&a), "m").expect("shed");
+        assert!(
+            is_retryable_status(selection.status()),
+            "the status stays the retryable 503 clients already understand"
+        );
+        assert!(
+            !is_retryable_response(&selection),
+            "but the retry layer must decline it"
+        );
+
+        let dispatch = shed_if_worker_overloaded(a.as_ref(), "m").expect("shed");
+        assert!(!is_retryable_response(&dispatch));
+    }
+
+    /// An empty pool is a 404/unavailable question for the caller, not a shed.
+    #[test]
+    fn empty_pool_is_not_a_shed() {
+        assert!(shed_if_all_overloaded(&[], "nobody").is_none());
+        assert!(!all_overloaded(&[]));
+    }
+
+    #[test]
+    fn dispatch_recheck_sheds_only_for_a_flagged_worker() {
+        let w = worker("http://127.0.0.1:9803", "m");
+        assert!(shed_if_worker_overloaded(w.as_ref(), "m").is_none());
+
+        w.set_overloaded(true);
+        let response = shed_if_worker_overloaded(w.as_ref(), "m").expect("shed");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "no_available_workers"
+        );
+    }
+}

--- a/model_gateway/src/routers/common/overload.rs
+++ b/model_gateway/src/routers/common/overload.rs
@@ -1,17 +1,10 @@
-//! Shed responses for the absolute worker-overload guard.
-//!
-//! Both helpers run only after routing has already failed to produce a worker,
-//! so nothing here is on the path of a served request. Their whole job is to
-//! turn "the pool emptied because every worker is vetoed" into the immediate
-//! 503 both transports use for `no_available_workers`, instead of the
-//! circuit-breaker wording (HTTP) or a misleading 404 (gRPC).
+//! Shed responses for the absolute worker-overload guard. Failure paths only —
+//! nothing here runs for a served request.
 //!
 //! The verdict is taken from the candidate pool the caller selected over, never
-//! from the model index: every selection site narrows by worker type and
-//! connection mode first, so a whole-model predicate would miss exactly the
-//! cases that matter — a saturated PD prefill leg, one transport of a
-//! mixed-transport model, or the model-less `/generate` wildcard, which selects
-//! across every model and has no model-index entry of its own.
+//! from the model index: selection narrows by worker type and transport first,
+//! and a whole-model predicate would miss a saturated PD leg, a mixed-transport
+//! model, or the model-less wildcard.
 
 use std::sync::Arc;
 
@@ -54,15 +47,10 @@ pub fn shed_if_all_overloaded(candidates: &[Arc<dyn Worker>], model_id: &str) ->
     ))
 }
 
-/// The dispatch-time re-check: one relaxed atomic read on the single worker
-/// already chosen, covering the window between selection and dispatch in which
-/// a load report can land.
-///
-/// Deliberately sheds rather than re-selecting. The flag moves once per
-/// `load_monitor_interval_secs`, so a flip landing inside one selection→dispatch
-/// gap is rare enough that the simpler answer costs nothing in aggregate — and
-/// unlike the selection shed, this one says only what it knows: *this* worker
-/// went over, not the fleet.
+/// Dispatch-time re-check: one atomic read on the already-chosen worker,
+/// covering the selection→dispatch window. Deliberately sheds rather than
+/// re-selecting — the flag moves at the poll interval, so the window is rare —
+/// and reports only what it knows: this worker went over, not the fleet.
 pub fn shed_if_worker_overloaded(worker: &dyn Worker, model_id: &str) -> Option<Response> {
     if !worker.is_overloaded() {
         return None;
@@ -76,14 +64,9 @@ pub fn shed_if_worker_overloaded(worker: &dyn Worker, model_id: &str) -> Option<
     ))
 }
 
-/// One decision line, one counter, one response.
-///
-/// The response is marked non-retryable: the condition it reports clears at the
-/// load-poll interval, so the retry layer's backoff window cannot outlive it,
-/// and retrying would re-run the entire pipeline (rate limiting included) five
-/// more times to reach the same 503 ~400 ms later. Marking it terminal is also
-/// what makes `smg_worker_overload_shed_total` count sheds per request rather
-/// than per attempt.
+/// One decision line, one counter, one response — marked non-retryable: the
+/// veto clears at the poll interval, which no backoff window outlives, and a
+/// terminal shed is what keeps the counter per-request rather than per-attempt.
 fn shed(branch: &'static str, stage: &'static str, worker: &str, message: String) -> Response {
     Metrics::record_worker_overload_shed(stage);
     debug!(branch, stage, worker, "Overload shed");

--- a/model_gateway/src/routers/common/retry.rs
+++ b/model_gateway/src/routers/common/retry.rs
@@ -19,6 +19,31 @@ pub fn is_retryable_status(status: StatusCode) -> bool {
     )
 }
 
+/// Response extension marking a response terminal for the retry layer
+/// regardless of its status code.
+///
+/// Exists for outcomes whose cause provably cannot clear inside a backoff
+/// window, where a retry only re-runs the whole pipeline and adds wall clock
+/// to a failure the client is going to get anyway. The load-shed 503 is the
+/// case that motivated it: the veto it reports moves at the load-poll interval
+/// (seconds), not at the retry interval (tens of milliseconds).
+#[derive(Debug, Clone, Copy)]
+pub struct NonRetryable;
+
+/// Mark `response` terminal for [`is_retryable_response`].
+pub fn mark_non_retryable(response: &mut Response) {
+    response.extensions_mut().insert(NonRetryable);
+}
+
+/// Whether a response should be retried: a retryable status that has not been
+/// explicitly marked terminal by the code that produced it.
+///
+/// This is what `should_retry` predicates should call. `is_retryable_status`
+/// alone cannot see the marker and will retry a shed.
+pub fn is_retryable_response(response: &Response) -> bool {
+    response.extensions().get::<NonRetryable>().is_none() && is_retryable_status(response.status())
+}
+
 /// Computes exponential backoff with optional jitter.
 #[derive(Debug, Clone)]
 pub struct BackoffCalculator;

--- a/model_gateway/src/routers/common/retry.rs
+++ b/model_gateway/src/routers/common/retry.rs
@@ -20,13 +20,9 @@ pub fn is_retryable_status(status: StatusCode) -> bool {
 }
 
 /// Response extension marking a response terminal for the retry layer
-/// regardless of its status code.
-///
-/// Exists for outcomes whose cause provably cannot clear inside a backoff
-/// window, where a retry only re-runs the whole pipeline and adds wall clock
-/// to a failure the client is going to get anyway. The load-shed 503 is the
-/// case that motivated it: the veto it reports moves at the load-poll interval
-/// (seconds), not at the retry interval (tens of milliseconds).
+/// regardless of its status code — for outcomes whose cause cannot clear
+/// inside a backoff window (the load-shed 503: its veto moves at the poll
+/// interval, not the retry interval).
 #[derive(Debug, Clone, Copy)]
 pub struct NonRetryable;
 

--- a/model_gateway/src/routers/common/worker_selection.rs
+++ b/model_gateway/src/routers/common/worker_selection.rs
@@ -121,54 +121,47 @@ impl<'a> WorkerSelector<'a> {
         })
     }
 
-    fn get_candidates(&self, req: &SelectWorkerRequest<'_>) -> Vec<Arc<dyn Worker>> {
+    /// The pool selection walks. `require_available` adds the `is_available()`
+    /// veto; the shed path takes the same pool without it, so the shed verdict
+    /// always describes exactly what selection saw.
+    fn candidate_pool(
+        &self,
+        req: &SelectWorkerRequest<'_>,
+        require_available: bool,
+    ) -> Vec<Arc<dyn Worker>> {
         let workers = self.registry.get_workers_filtered(
             None, // model_id index lookup not used — we filter via supports_model
             req.worker_type,
             req.connection_mode,
             req.runtime_type,
-            false, // we filter availability ourselves for consistent behavior
-        );
-
-        let candidates: Vec<_> = workers.into_iter().filter(|w| w.is_available()).collect();
-
-        match &req.provider {
-            Some(provider) => filter_by_provider(candidates, provider),
-            None => candidates,
-        }
-    }
-
-    fn find_best_worker(&self, req: &SelectWorkerRequest<'_>) -> Option<Arc<dyn Worker>> {
-        self.get_candidates(req)
-            .into_iter()
-            .filter(|w| w.supports_model(req.model_id))
-            .filter(|w| !req.require_realtime_capable || w.is_realtime_capable())
-            .min_by_key(|w| w.load())
-    }
-
-    /// Shed when every worker this request could have selected is vetoed.
-    ///
-    /// Rebuilds the pool `find_best_worker` walked — same type, transport,
-    /// runtime, provider, model-support and realtime filters — minus the
-    /// `is_available()` veto that emptied it, so the verdict describes exactly
-    /// what selection saw. Runs only on the miss path.
-    fn shed_if_all_overloaded(&self, req: &SelectWorkerRequest<'_>) -> Option<Response> {
-        let workers = self.registry.get_workers_filtered(
-            None,
-            req.worker_type,
-            req.connection_mode,
-            req.runtime_type,
             false,
         );
+        let workers: Vec<_> = if require_available {
+            workers.into_iter().filter(|w| w.is_available()).collect()
+        } else {
+            workers
+        };
         let candidates = match &req.provider {
             Some(provider) => filter_by_provider(workers, provider),
             None => workers,
         };
-        let candidates: Vec<_> = candidates
+        candidates
             .into_iter()
             .filter(|w| w.supports_model(req.model_id))
             .filter(|w| !req.require_realtime_capable || w.is_realtime_capable())
-            .collect();
+            .collect()
+    }
+
+    fn find_best_worker(&self, req: &SelectWorkerRequest<'_>) -> Option<Arc<dyn Worker>> {
+        self.candidate_pool(req, true)
+            .into_iter()
+            .min_by_key(|w| w.load())
+    }
+
+    /// Shed when every worker this request could have selected is vetoed.
+    /// Runs only on the miss path.
+    fn shed_if_all_overloaded(&self, req: &SelectWorkerRequest<'_>) -> Option<Response> {
+        let candidates = self.candidate_pool(req, false);
         overload::shed_if_all_overloaded(&candidates, req.model_id)
     }
 

--- a/model_gateway/src/routers/common/worker_selection.rs
+++ b/model_gateway/src/routers/common/worker_selection.rs
@@ -13,7 +13,10 @@ use openai_protocol::models::ListModelsResponse;
 
 use crate::{
     routers::{
-        common::header_utils::{apply_provider_headers, extract_auth_header},
+        common::{
+            header_utils::{apply_provider_headers, extract_auth_header},
+            overload,
+        },
         error,
     },
     worker::{ConnectionMode, ProviderType, RuntimeType, Worker, WorkerRegistry, WorkerType},
@@ -83,6 +86,17 @@ impl<'a> WorkerSelector<'a> {
             return Ok(worker);
         }
 
+        // Shed before the refresh, not after. Refresh-on-miss is the expensive
+        // branch — a second registry walk plus a `/v1/models` fan-out under a
+        // 5 s timeout — and a fleet whose every worker is vetoed will not be
+        // un-vetoed by re-reading model lists. Without this, saturation turns
+        // each of these requests into three registry walks and up to 5 s of
+        // network wait to reach a 503 that carries neither the shed error code
+        // nor the shed counter.
+        if let Some(shed) = self.shed_if_all_overloaded(req) {
+            return Err(shed);
+        }
+
         tracing::debug!(
             model = req.model_id,
             "No worker found, refreshing external worker models"
@@ -130,6 +144,32 @@ impl<'a> WorkerSelector<'a> {
             .filter(|w| w.supports_model(req.model_id))
             .filter(|w| !req.require_realtime_capable || w.is_realtime_capable())
             .min_by_key(|w| w.load())
+    }
+
+    /// Shed when every worker this request could have selected is vetoed.
+    ///
+    /// Rebuilds the pool `find_best_worker` walked — same type, transport,
+    /// runtime, provider, model-support and realtime filters — minus the
+    /// `is_available()` veto that emptied it, so the verdict describes exactly
+    /// what selection saw. Runs only on the miss path.
+    fn shed_if_all_overloaded(&self, req: &SelectWorkerRequest<'_>) -> Option<Response> {
+        let workers = self.registry.get_workers_filtered(
+            None,
+            req.worker_type,
+            req.connection_mode,
+            req.runtime_type,
+            false,
+        );
+        let candidates = match &req.provider {
+            Some(provider) => filter_by_provider(workers, provider),
+            None => workers,
+        };
+        let candidates: Vec<_> = candidates
+            .into_iter()
+            .filter(|w| w.supports_model(req.model_id))
+            .filter(|w| !req.require_realtime_capable || w.is_realtime_capable())
+            .collect();
+        overload::shed_if_all_overloaded(&candidates, req.model_id)
     }
 
     /// Check if any healthy worker supports the model (regardless of circuit breaker).

--- a/model_gateway/src/routers/gemini/router.rs
+++ b/model_gateway/src/routers/gemini/router.rs
@@ -15,7 +15,7 @@ use crate::{
     config::types::RetryConfig,
     middleware::TenantRequestMeta,
     routers::{
-        common::retry::{is_retryable_status, RetryExecutor},
+        common::retry::{is_retryable_response, RetryExecutor},
         RouterTrait,
     },
 };
@@ -105,7 +105,7 @@ impl RouterTrait for GeminiRouter {
                     driver::execute(&mut ctx).await
                 }
             },
-            |res, _attempt| is_retryable_status(res.status()),
+            |res, _attempt| is_retryable_response(res),
             |_delay, _attempt| {
                 // TODO: record retry metrics when Gemini metrics are added
             },

--- a/model_gateway/src/routers/grpc/common/stages/client_acquisition.rs
+++ b/model_gateway/src/routers/grpc/common/stages/client_acquisition.rs
@@ -9,6 +9,7 @@ use tracing::error;
 use super::PipelineStage;
 use crate::{
     routers::{
+        common::overload,
         error,
         grpc::{
             backend_client::BackendClient,
@@ -35,14 +36,41 @@ impl PipelineStage for ClientAcquisitionStage {
             )
         })?;
 
+        // Dispatch-time re-check: one relaxed atomic read per already-chosen
+        // worker, closing the window between selection and dispatch in which a
+        // load report can flip the veto.
+        let model_id = ctx.input.model_id.as_str();
         let clients = match workers {
             WorkerSelection::Single { worker } => {
+                if let Some(shed) = overload::shed_if_worker_overloaded(worker.as_ref(), model_id) {
+                    return Err(shed);
+                }
                 let client = get_backend_client_from_worker(worker).await?;
                 ClientSelection::Single { client }
             }
             WorkerSelection::Disaggregated {
-                prefill, decode, ..
+                encode_assignments,
+                prefill,
+                decode,
+                ..
             } => {
+                // Every assigned leg, encode included: an encode worker is
+                // vetoed at selection through the same filter, so leaving it out
+                // of the re-check would be the one dispatch path that can send
+                // to a worker known to be over the ceiling.
+                if let Some(shed) = overload::shed_if_worker_overloaded(prefill.as_ref(), model_id)
+                    .or_else(|| overload::shed_if_worker_overloaded(decode.as_ref(), model_id))
+                    .or_else(|| {
+                        encode_assignments.iter().flatten().find_map(|assignment| {
+                            overload::shed_if_worker_overloaded(
+                                assignment.worker.as_ref(),
+                                model_id,
+                            )
+                        })
+                    })
+                {
+                    return Err(shed);
+                }
                 let prefill_client = get_backend_client_from_worker(prefill).await?;
                 let decode_client = get_backend_client_from_worker(decode).await?;
 

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -14,6 +14,7 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo, WorkerLeg},
     routers::{
+        common::overload,
         error,
         grpc::{
             context::{EncodeWorkerAssignment, RequestContext, WorkerSelection},
@@ -107,15 +108,7 @@ impl PipelineStage for WorkerSelectionStage {
             WorkerSelectionMode::Regular => {
                 match self.select_single_worker(model_id, text, tokens, headers, rid_key) {
                     Some(w) => WorkerSelection::Single { worker: w },
-                    None => {
-                        error!(
-                            function = "WorkerSelectionStage::execute",
-                            mode = "Regular",
-                            model_id = %model_id,
-                            "No available workers for model"
-                        );
-                        return Err(error::model_not_found(model_id));
-                    }
+                    None => return Err(self.selection_failure(model_id)),
                 }
             }
             WorkerSelectionMode::PrefillDecode => {
@@ -126,15 +119,7 @@ impl PipelineStage for WorkerSelectionStage {
                         decode,
                         runtime_type,
                     },
-                    None => {
-                        error!(
-                            function = "WorkerSelectionStage::execute",
-                            mode = "PrefillDecode",
-                            model_id = %model_id,
-                            "No available PD worker pairs for model"
-                        );
-                        return Err(error::model_not_found(model_id));
-                    }
+                    None => return Err(self.selection_failure(model_id)),
                 }
             }
             WorkerSelectionMode::EncodePrefillDecode => {
@@ -172,15 +157,7 @@ impl PipelineStage for WorkerSelectionStage {
                             runtime_type,
                         }
                     }
-                    None => {
-                        error!(
-                            function = "WorkerSelectionStage::execute",
-                            mode = "EncodePrefillDecode",
-                            model_id = %model_id,
-                            "No available encode/prefill/decode worker set for model"
-                        );
-                        return Err(error::model_not_found(model_id));
-                    }
+                    None => return Err(self.selection_failure(model_id)),
                 }
             }
         };
@@ -226,6 +203,69 @@ fn selection_runtime(workers: &WorkerSelection) -> RuntimeType {
 }
 
 impl WorkerSelectionStage {
+    /// Response for a selection that produced nothing.
+    ///
+    /// An all-overloaded pool sheds with the same 503 `no_available_workers`
+    /// the HTTP router uses: the fleet is under pressure, not absent, and 404
+    /// would both misdescribe it and skip the retry path.
+    ///
+    /// The verdict is taken per leg, from the pool that leg selected over. A
+    /// whole-model predicate cannot express this: veto every prefill worker and
+    /// the model's decode workers are still unflagged, so "all workers for the
+    /// model are overloaded" is false exactly when the PD pair became
+    /// unselectable. Rebuilding the leg pools costs one registry walk each on a
+    /// path that has already failed.
+    ///
+    /// A shed is a designed load-shedding outcome that happens at full request
+    /// rate; it logs one `debug!` line inside the shed helper. The `error!`
+    /// below is reserved for what it was written for — a model with no workers
+    /// at all, which is a misconfiguration and rare.
+    fn selection_failure(&self, model_id: &str) -> Response {
+        let legs: &[WorkerType] = match self.mode {
+            WorkerSelectionMode::Regular => &[WorkerType::Regular],
+            WorkerSelectionMode::PrefillDecode => &[WorkerType::Prefill, WorkerType::Decode],
+            WorkerSelectionMode::EncodePrefillDecode => {
+                &[WorkerType::Prefill, WorkerType::Decode, WorkerType::Encode]
+            }
+        };
+        for leg in legs {
+            let candidates = self.leg_candidates(model_id, *leg);
+            if let Some(shed) = overload::shed_if_all_overloaded(&candidates, model_id) {
+                return shed;
+            }
+        }
+        error!(
+            function = "WorkerSelectionStage::execute",
+            mode = ?self.mode,
+            model_id = %model_id,
+            "No available workers for model"
+        );
+        error::model_not_found(model_id)
+    }
+
+    /// The pool one leg selected over, *before* the `is_available()` filter,
+    /// under the same worker-type and transport rules selection applied.
+    /// Failure path only.
+    fn leg_candidates(&self, model_id: &str, worker_type: WorkerType) -> Vec<Arc<dyn Worker>> {
+        // The wildcard model selects across every model, so its candidate pool
+        // is the unfiltered one — not the `unknown` model-index entry.
+        let model_filter = if model_id == UNKNOWN_MODEL_ID {
+            None
+        } else {
+            Some(model_id)
+        };
+        self.worker_registry
+            .get_workers_filtered(model_filter, Some(worker_type), None, None, false)
+            .into_iter()
+            .filter(|w| match worker_type {
+                // Regular selection takes either gRPC-pipeline transport; the
+                // disaggregated legs are gRPC-only (no KV rendezvous on ZMQ).
+                WorkerType::Regular => w.connection_mode().uses_grpc_pipeline(),
+                _ => *w.connection_mode() == ConnectionMode::Grpc,
+            })
+            .collect()
+    }
+
     fn select_single_worker(
         &self,
         model_id: &str,
@@ -705,12 +745,14 @@ fn hex_encode(bytes: &[u8]) -> String {
 mod tests {
     use std::collections::HashMap;
 
+    use axum::http::StatusCode;
     use openai_protocol::worker::HealthCheckConfig;
 
     use super::*;
     use crate::{
         config::types::PolicyConfig,
         policies::PolicyFactory,
+        routers::common::retry::is_retryable_response,
         worker::{BasicWorkerBuilder, ConnectionMode, ModelCard},
     };
 
@@ -805,6 +847,65 @@ mod tests {
             *decode_hits.entry(decode.url().to_string()).or_default() += 1;
         }
         (prefill_hits, decode_hits)
+    }
+
+    /// A saturated prefill leg is a pressure condition, not model absence.
+    ///
+    /// The model's decode workers stay unflagged, so a whole-model shed
+    /// predicate reads "not all overloaded" and the request would fall through
+    /// to 404 — the exact answer this feature exists to replace, and worse than
+    /// the pre-feature behaviour where the prefill worker still served.
+    #[test]
+    fn a_fully_vetoed_prefill_leg_sheds_rather_than_404s() {
+        let model_id = "test-model-prefill-veto";
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let (prefill_urls, _) = register_pd_workers(&worker_registry, model_id, 4);
+
+        let stage = WorkerSelectionStage::new(
+            Arc::clone(&worker_registry),
+            Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
+            WorkerSelectionMode::PrefillDecode,
+        );
+        assert!(stage
+            .select_pd_pair(model_id, None, None, None, None)
+            .is_some());
+
+        for url in &prefill_urls {
+            let worker = worker_registry.get_by_url(url).expect("registered");
+            worker_registry.set_worker_overloaded(&worker, true);
+        }
+
+        assert!(
+            stage
+                .select_pd_pair(model_id, None, None, None, None)
+                .is_none(),
+            "the veto empties the prefill pool"
+        );
+        let response = stage.selection_failure(model_id);
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            error::extract_error_code_from_response(&response),
+            "no_available_workers"
+        );
+        assert!(
+            !is_retryable_response(&response),
+            "a shed must be terminal for the retry layer"
+        );
+    }
+
+    /// A model nobody serves is still a 404 — the shed must not swallow real
+    /// misconfiguration.
+    #[test]
+    fn an_unserved_model_still_reports_not_found() {
+        let stage = WorkerSelectionStage::new(
+            Arc::new(WorkerRegistry::new()),
+            Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
+            WorkerSelectionMode::PrefillDecode,
+        );
+        assert_eq!(
+            stage.selection_failure("nobody").status(),
+            StatusCode::NOT_FOUND
+        );
     }
 
     #[test]
@@ -978,5 +1079,74 @@ mod tests {
                 .unwrap();
             assert_eq!(again.url(), first.url(), "follow-up must pin by rid key");
         }
+    }
+
+    /// The gRPC transport must shed an all-overloaded model with the same 503
+    /// `no_available_workers` the HTTP router uses. Its usual empty-pool answer
+    /// is a 404, which would both misreport pressure as model absence and skip
+    /// the retry path (404 is not retryable).
+    #[test]
+    fn grpc_all_overloaded_sheds_503_instead_of_404() {
+        use crate::routers::error::extract_error_code_from_response;
+
+        let model_id = "test-model-overload-shed";
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let mut workers = Vec::new();
+        for i in 0..2 {
+            let worker: Arc<dyn Worker> = Arc::new(
+                BasicWorkerBuilder::new(format!("grpc://127.0.0.1:{}", 8400 + i))
+                    .model(ModelCard::new(model_id))
+                    .worker_type(WorkerType::Regular)
+                    .connection_mode(ConnectionMode::Grpc)
+                    .health_config(no_health_check())
+                    .build(),
+            );
+            worker_registry.register(Arc::clone(&worker)).unwrap();
+            workers.push(worker);
+        }
+        let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin));
+        let stage = WorkerSelectionStage::new(
+            Arc::clone(&worker_registry),
+            policy_registry,
+            WorkerSelectionMode::Regular,
+        );
+
+        assert!(stage
+            .select_single_worker(model_id, None, None, None, None)
+            .is_some());
+
+        worker_registry.set_worker_overloaded(&workers[0], true);
+        assert!(
+            stage
+                .select_single_worker(model_id, None, None, None, None)
+                .is_some(),
+            "one eligible worker left still serves"
+        );
+
+        worker_registry.set_worker_overloaded(&workers[1], true);
+        assert!(
+            stage
+                .select_single_worker(model_id, None, None, None, None)
+                .is_none(),
+            "the veto empties the candidate pool"
+        );
+
+        let response = stage.selection_failure(model_id);
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "no_available_workers"
+        );
+
+        // Recovery re-admits, and the failure response goes back to 404 for a
+        // genuinely absent model.
+        worker_registry.set_worker_overloaded(&workers[0], false);
+        assert!(stage
+            .select_single_worker(model_id, None, None, None, None)
+            .is_some());
+        assert_eq!(
+            stage.selection_failure("no-such-model").status(),
+            StatusCode::NOT_FOUND
+        );
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -108,7 +108,7 @@ impl PipelineStage for WorkerSelectionStage {
             WorkerSelectionMode::Regular => {
                 match self.select_single_worker(model_id, text, tokens, headers, rid_key) {
                     Some(w) => WorkerSelection::Single { worker: w },
-                    None => return Err(self.selection_failure(model_id)),
+                    None => return Err(self.selection_failure(model_id, &[WorkerType::Regular])),
                 }
             }
             WorkerSelectionMode::PrefillDecode => {
@@ -119,7 +119,12 @@ impl PipelineStage for WorkerSelectionStage {
                         decode,
                         runtime_type,
                     },
-                    None => return Err(self.selection_failure(model_id)),
+                    None => {
+                        return Err(self.selection_failure(
+                            model_id,
+                            &[WorkerType::Prefill, WorkerType::Decode],
+                        ))
+                    }
                 }
             }
             WorkerSelectionMode::EncodePrefillDecode => {
@@ -157,7 +162,17 @@ impl PipelineStage for WorkerSelectionStage {
                             runtime_type,
                         }
                     }
-                    None => return Err(self.selection_failure(model_id)),
+                    None => {
+                        // Encode is a demanded leg only when the request
+                        // carries encode items; an idle-but-vetoed encode pool
+                        // must not shed a text-only request.
+                        let legs: &[WorkerType] = if encode_item_hashes.is_empty() {
+                            &[WorkerType::Prefill, WorkerType::Decode]
+                        } else {
+                            &[WorkerType::Prefill, WorkerType::Decode, WorkerType::Encode]
+                        };
+                        return Err(self.selection_failure(model_id, legs));
+                    }
                 }
             }
         };
@@ -203,31 +218,15 @@ fn selection_runtime(workers: &WorkerSelection) -> RuntimeType {
 }
 
 impl WorkerSelectionStage {
-    /// Response for a selection that produced nothing.
+    /// Response for a selection that produced nothing: a 503 shed when a leg's
+    /// whole candidate pool is vetoed, the existing 404 otherwise.
     ///
-    /// An all-overloaded pool sheds with the same 503 `no_available_workers`
-    /// the HTTP router uses: the fleet is under pressure, not absent, and 404
-    /// would both misdescribe it and skip the retry path.
-    ///
-    /// The verdict is taken per leg, from the pool that leg selected over. A
-    /// whole-model predicate cannot express this: veto every prefill worker and
-    /// the model's decode workers are still unflagged, so "all workers for the
-    /// model are overloaded" is false exactly when the PD pair became
-    /// unselectable. Rebuilding the leg pools costs one registry walk each on a
-    /// path that has already failed.
-    ///
-    /// A shed is a designed load-shedding outcome that happens at full request
-    /// rate; it logs one `debug!` line inside the shed helper. The `error!`
-    /// below is reserved for what it was written for — a model with no workers
-    /// at all, which is a misconfiguration and rare.
-    fn selection_failure(&self, model_id: &str) -> Response {
-        let legs: &[WorkerType] = match self.mode {
-            WorkerSelectionMode::Regular => &[WorkerType::Regular],
-            WorkerSelectionMode::PrefillDecode => &[WorkerType::Prefill, WorkerType::Decode],
-            WorkerSelectionMode::EncodePrefillDecode => {
-                &[WorkerType::Prefill, WorkerType::Decode, WorkerType::Encode]
-            }
-        };
+    /// `legs` must be exactly the legs this selection demanded — the verdict is
+    /// per leg because a whole-model predicate is false exactly when one
+    /// saturated leg made the set unselectable, and an undemanded leg (EPD
+    /// without encode items) must not be able to shed a request that never
+    /// needed it.
+    fn selection_failure(&self, model_id: &str, legs: &[WorkerType]) -> Response {
         for leg in legs {
             let candidates = self.leg_candidates(model_id, *leg);
             if let Some(shed) = overload::shed_if_all_overloaded(&candidates, model_id) {
@@ -881,7 +880,8 @@ mod tests {
                 .is_none(),
             "the veto empties the prefill pool"
         );
-        let response = stage.selection_failure(model_id);
+        let response =
+            stage.selection_failure(model_id, &[WorkerType::Prefill, WorkerType::Decode]);
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             error::extract_error_code_from_response(&response),
@@ -891,6 +891,44 @@ mod tests {
             !is_retryable_response(&response),
             "a shed must be terminal for the retry layer"
         );
+    }
+
+    /// An undemanded leg cannot shed: a text-only EPD request that fails for a
+    /// non-overload reason must not 503 just because the (unused) encode pool
+    /// is saturated.
+    #[test]
+    fn an_undemanded_encode_leg_cannot_shed() {
+        let model_id = "test-model-encode-veto";
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let encode: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("grpc://127.0.0.1:8460")
+                .model(ModelCard::new(model_id))
+                .worker_type(WorkerType::Encode)
+                .connection_mode(ConnectionMode::Grpc)
+                .health_config(no_health_check())
+                .build(),
+        );
+        worker_registry.register(Arc::clone(&encode)).unwrap();
+        worker_registry.set_worker_overloaded(&encode, true);
+
+        let stage = WorkerSelectionStage::new(
+            Arc::clone(&worker_registry),
+            Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
+            WorkerSelectionMode::EncodePrefillDecode,
+        );
+
+        // No prefill/decode workers registered: with encode undemanded this is
+        // model absence (404), not pressure.
+        let text_only =
+            stage.selection_failure(model_id, &[WorkerType::Prefill, WorkerType::Decode]);
+        assert_eq!(text_only.status(), StatusCode::NOT_FOUND);
+
+        // With encode demanded, the saturated encode pool is a shed.
+        let with_encode = stage.selection_failure(
+            model_id,
+            &[WorkerType::Prefill, WorkerType::Decode, WorkerType::Encode],
+        );
+        assert_eq!(with_encode.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     /// A model nobody serves is still a 404 — the shed must not swallow real
@@ -903,7 +941,9 @@ mod tests {
             WorkerSelectionMode::PrefillDecode,
         );
         assert_eq!(
-            stage.selection_failure("nobody").status(),
+            stage
+                .selection_failure("nobody", &[WorkerType::Prefill, WorkerType::Decode])
+                .status(),
             StatusCode::NOT_FOUND
         );
     }
@@ -1131,7 +1171,7 @@ mod tests {
             "the veto empties the candidate pool"
         );
 
-        let response = stage.selection_failure(model_id);
+        let response = stage.selection_failure(model_id, &[WorkerType::Regular]);
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             extract_error_code_from_response(&response),
@@ -1145,7 +1185,9 @@ mod tests {
             .select_single_worker(model_id, None, None, None, None)
             .is_some());
         assert_eq!(
-            stage.selection_failure("no-such-model").status(),
+            stage
+                .selection_failure("no-such-model", &[WorkerType::Regular])
+                .status(),
             StatusCode::NOT_FOUND
         );
     }

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -41,7 +41,7 @@ use crate::{
     middleware::TenantRequestMeta,
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::retry::{is_retryable_status, RetryExecutor},
+        common::retry::{is_retryable_response, RetryExecutor},
         error, RouterTrait,
     },
     worker::{WorkerRegistry, WorkerType},
@@ -607,7 +607,7 @@ impl GrpcRouter {
                 if Self::reservation_denied(&rate_limit_cell) {
                     return false;
                 }
-                is_retryable_status(res.status())
+                is_retryable_response(res)
             },
             // On backoff: record retry metrics
             |delay, attempt| {
@@ -678,7 +678,7 @@ impl GrpcRouter {
                 if Self::reservation_denied(&rate_limit_cell) {
                     return false;
                 }
-                is_retryable_status(res.status())
+                is_retryable_response(res)
             },
             // On backoff: record retry metrics
             |delay, attempt| {
@@ -845,7 +845,7 @@ impl GrpcRouter {
                 if Self::reservation_denied(&rate_limit_cell) {
                     return false;
                 }
-                is_retryable_status(res.status())
+                is_retryable_response(res)
             },
             |delay, attempt| {
                 self.record_retry(metrics_labels::ENDPOINT_MESSAGES);
@@ -913,7 +913,7 @@ impl GrpcRouter {
                 if Self::reservation_denied(&rate_limit_cell) {
                     return false;
                 }
-                is_retryable_status(res.status())
+                is_retryable_response(res)
             },
             |delay, attempt| {
                 self.record_retry(metrics_labels::ENDPOINT_COMPLETIONS);

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -35,8 +35,8 @@ use crate::{
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
     routers::{
         common::{
-            header_utils,
-            retry::{is_retryable_status, RetryExecutor},
+            header_utils, overload,
+            retry::{is_retryable_response, is_retryable_status, RetryExecutor},
             sse::{SseEncoder, SSE_CHANNEL_BUFFER},
         },
         error,
@@ -46,6 +46,20 @@ use crate::{
     },
     worker::{HashRing, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType, UNKNOWN_MODEL_ID},
 };
+
+/// Why PD pair selection produced nothing.
+///
+/// Split so the overload shed keeps its own error code, message and counter
+/// instead of being reworded as a circuit-breaker failure by
+/// [`PDRouter::handle_server_selection_error`].
+#[derive(Debug)]
+enum PdSelectionFailure {
+    /// Every worker on one leg is vetoed: a ready-made, already-counted 503.
+    Shed(Response),
+    /// The pre-existing string: no workers configured, all unhealthy or
+    /// circuit-broken, or the policy declined.
+    Unavailable(String),
+}
 
 #[derive(Debug)]
 pub struct PDRouter {
@@ -175,12 +189,35 @@ impl PDRouter {
         })
     }
 
-    fn handle_server_selection_error(error: String) -> Response {
-        error!("Failed to select PD pair error={}", error);
-        error::service_unavailable(
-            "server_selection_failed",
-            format!("No available servers: {error}"),
-        )
+    fn handle_server_selection_error(failure: PdSelectionFailure) -> Response {
+        match failure {
+            // Already a decision-logged 503 with the overload error code and
+            // counter; re-describing it as a circuit-breaker/health failure is
+            // exactly the misdiagnosis this path used to hand operators.
+            PdSelectionFailure::Shed(shed) => shed,
+            PdSelectionFailure::Unavailable(error) => {
+                error!("Failed to select PD pair error={}", error);
+                error::service_unavailable(
+                    "server_selection_failed",
+                    format!("No available servers: {error}"),
+                )
+            }
+        }
+    }
+
+    /// Classify one leg's selection miss. `candidates` is the leg pool before
+    /// the `is_available()` filter, so the verdict describes the pool that
+    /// actually emptied rather than the model's whole registry entry — a
+    /// saturated prefill leg leaves the decode workers unflagged.
+    fn leg_failure(
+        candidates: &[Arc<dyn Worker>],
+        model_id: &str,
+        error: String,
+    ) -> PdSelectionFailure {
+        match overload::shed_if_all_overloaded(candidates, model_id) {
+            Some(shed) => PdSelectionFailure::Shed(shed),
+            None => PdSelectionFailure::Unavailable(error),
+        }
     }
 
     fn handle_serialization_error(error: impl std::fmt::Display) -> Response {
@@ -340,8 +377,8 @@ impl PDRouter {
                             .await
                         {
                             Ok(pair) => pair,
-                            Err(e) => {
-                                return Self::handle_server_selection_error(e);
+                            Err(failure) => {
+                                return Self::handle_server_selection_error(failure);
                             }
                         };
 
@@ -469,7 +506,7 @@ impl PDRouter {
                     }
                 }
             },
-            |res, _attempt| is_retryable_status(res.status()),
+            |res, _attempt| is_retryable_response(res),
             |delay, attempt| {
                 // Layer 3 worker metrics (PD mode uses both prefill and decode workers)
                 Metrics::record_worker_retry(metrics_labels::WORKER_PREFILL, endpoint);
@@ -635,6 +672,14 @@ impl PDRouter {
             .rid_key
             .as_deref()
             .or_else(|| self.policy_registry.sticky_header_key(headers));
+        // Dispatch-time re-check of both legs, the same one the regular HTTP
+        // and gRPC paths take just before their load guards.
+        if let Some(shed) = overload::shed_if_worker_overloaded(prefill.as_ref(), context.model_id)
+            .or_else(|| overload::shed_if_worker_overloaded(decode.as_ref(), context.model_id))
+        {
+            return shed;
+        }
+
         let load_guards = vec![
             WorkerLoadGuard::with_key(prefill.clone(), effective_key),
             WorkerLoadGuard::with_key(decode.clone(), effective_key),
@@ -831,7 +876,7 @@ impl PDRouter {
         rid_key: Option<&str>,
         model_id: &str,
         headers: Option<&HeaderMap>,
-    ) -> Result<(Arc<dyn Worker>, Arc<dyn Worker>), String> {
+    ) -> Result<(Arc<dyn Worker>, Arc<dyn Worker>), PdSelectionFailure> {
         debug!("Selecting PD pair: model_id={:?}", model_id);
 
         let is_unknown_model = model_id == UNKNOWN_MODEL_ID;
@@ -874,29 +919,33 @@ impl PDRouter {
         // Get cached hash ring for consistent hashing
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
 
-        let prefill = self.pick_worker_by_policy_arc(
-            &prefill_workers,
-            &prefill_policy,
-            request_text,
-            tokens,
-            rid_key,
-            headers,
-            hash_ring.clone(),
-            "prefill",
-            crate::policies::WorkerLeg::Prefill,
-        )?;
+        let prefill = self
+            .pick_worker_by_policy_arc(
+                &prefill_workers,
+                &prefill_policy,
+                request_text,
+                tokens,
+                rid_key,
+                headers,
+                hash_ring.clone(),
+                "prefill",
+                crate::policies::WorkerLeg::Prefill,
+            )
+            .map_err(|e| Self::leg_failure(&prefill_workers, model_id, e))?;
 
-        let decode = self.pick_worker_by_policy_arc(
-            &decode_workers,
-            &decode_policy,
-            request_text,
-            tokens,
-            rid_key,
-            headers,
-            hash_ring,
-            "decode",
-            crate::policies::WorkerLeg::Decode,
-        )?;
+        let decode = self
+            .pick_worker_by_policy_arc(
+                &decode_workers,
+                &decode_policy,
+                request_text,
+                tokens,
+                rid_key,
+                headers,
+                hash_ring,
+                "decode",
+                crate::policies::WorkerLeg::Decode,
+            )
+            .map_err(|e| Self::leg_failure(&decode_workers, model_id, e))?;
 
         // Record worker selection metrics (Layer 3)
         let model = model_id;
@@ -1355,7 +1404,11 @@ impl RouterTrait for PDRouter {
             .await
         {
             Ok(pair) => pair,
-            Err(e) => {
+            // A deep probe that generates gets the same answer routing does:
+            // an all-vetoed fleet fails the probe, exactly as an all-circuit-
+            // broken one already did.
+            Err(PdSelectionFailure::Shed(shed)) => return shed,
+            Err(PdSelectionFailure::Unavailable(e)) => {
                 return error::service_unavailable(
                     "no_healthy_worker_pair",
                     format!("No healthy worker pair available: {e}"),
@@ -1801,7 +1854,14 @@ mod tests {
             .await;
 
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("No prefill workers available"));
+        // No workers at all is the pre-existing unavailable string, not a shed:
+        // an empty pool has nothing to be overloaded.
+        match result.unwrap_err() {
+            PdSelectionFailure::Unavailable(error) => {
+                assert!(error.contains("No prefill workers available"));
+            }
+            PdSelectionFailure::Shed(_) => panic!("an empty fleet is not an overload shed"),
+        }
     }
 
     #[test]

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -36,7 +36,7 @@ use crate::{
     routers::{
         common::{
             header_utils, overload,
-            retry::{is_retryable_response, is_retryable_status, RetryExecutor},
+            retry::{is_retryable_response, RetryExecutor},
             sse::{SseEncoder, SSE_CHANNEL_BUFFER},
         },
         error,
@@ -531,7 +531,7 @@ impl PDRouter {
                 endpoint,
                 duration,
             );
-        } else if !is_retryable_status(response.status()) {
+        } else if !is_retryable_response(&response) {
             Metrics::record_router_error(
                 metrics_labels::ROUTER_HTTP,
                 metrics_labels::BACKEND_PD,

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -447,7 +447,7 @@ impl Router {
                 endpoint,
                 duration,
             );
-        } else if !is_retryable_status(response.status()) {
+        } else if !is_retryable_response(&response) {
             Metrics::record_router_error(
                 metrics_labels::ROUTER_HTTP,
                 metrics_labels::BACKEND_REGULAR,
@@ -727,7 +727,9 @@ impl Router {
                 rstatus.as_u16(),
                 extract_error_code_from_response(response),
             );
-            if !is_retryable_status(rstatus) {
+            // Response-aware: a terminal shed carries a retryable status but
+            // must still count as a router error.
+            if !is_retryable_response(response) {
                 Metrics::record_router_error(
                     metrics_labels::ROUTER_HTTP,
                     metrics_labels::BACKEND_REGULAR,

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -53,12 +53,12 @@ use crate::{
     policies::{PolicyRegistry, SelectWorkerInfo},
     routers::{
         common::{
-            header_utils,
+            header_utils, overload,
             realtime::{
                 rest::forward_realtime_rest, webrtc, webrtc::handle_realtime_webrtc,
                 ws::handle_realtime_ws, RealtimeLabels, RealtimeRegistry,
             },
-            retry::{is_retryable_status, RetryExecutor},
+            retry::{is_retryable_response, is_retryable_status, RetryExecutor},
             sse::SSE_CHANNEL_BUFFER,
             worker_selection::{SelectWorkerRequest, WorkerSelector},
         },
@@ -423,7 +423,7 @@ impl Router {
                 res
             },
             // should_retry predicate
-            |res, _attempt| is_retryable_status(res.status()),
+            |res, _attempt| is_retryable_response(res),
             // on_backoff hook
             |delay, attempt| {
                 // Layer 3 worker metrics
@@ -493,8 +493,14 @@ impl Router {
                     None,
                     false,
                 );
+                // `total` is exactly the pool selection drew from, wildcard
+                // model included — classifying from it rather than from the
+                // model index is what makes the shed fire for a model-less
+                // `/generate` and for a model that is also served over gRPC.
                 return if total.is_empty() {
                     error::model_not_found(model_id)
+                } else if let Some(shed) = overload::shed_if_all_overloaded(&total, model_id) {
+                    shed
                 } else {
                     error::service_unavailable(
                         "no_available_workers",
@@ -503,6 +509,13 @@ impl Router {
                 };
             }
         };
+
+        // Dispatch-time re-check of the one chosen worker: O(1), and the only
+        // thing that closes the window between selection and dispatch in which
+        // a load report can flip the veto.
+        if let Some(shed) = overload::shed_if_worker_overloaded(worker.as_ref(), model_id) {
+            return shed;
+        }
 
         // Keyed-load accounting uses the same effective key as selection:
         // rid-derived first, header fallback.
@@ -767,10 +780,13 @@ impl Router {
             .cloned()
             .collect();
         if available.is_empty() {
-            let resp = error::service_unavailable(
-                "no_available_workers",
-                "All workers are unavailable (circuit breaker open or unhealthy)",
-            );
+            let resp =
+                overload::shed_if_all_overloaded(&non_dp_workers, model_id).unwrap_or_else(|| {
+                    error::service_unavailable(
+                        "no_available_workers",
+                        "All workers are unavailable (circuit breaker open or unhealthy)",
+                    )
+                });
             record_pre_send_error(&resp);
             return resp;
         }
@@ -807,6 +823,15 @@ impl Router {
             policy.name(),
         );
         let worker = available[idx].clone();
+
+        // Same dispatch-time re-check the regular path takes. A transcription
+        // occupies its worker for far longer than a chat completion, so a
+        // report landing in the selection→dispatch window is the one case where
+        // dispatching anyway is measurably worse.
+        if let Some(resp) = overload::shed_if_worker_overloaded(worker.as_ref(), model_id) {
+            record_pre_send_error(&resp);
+            return resp;
+        }
 
         // Streamed requests have no rid; the header is the whole sticky key.
         let load_guard = WorkerLoadGuard::with_key(

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -25,7 +25,7 @@ use crate::{
     routers::{
         common::{
             header_utils::{apply_provider_headers, extract_auth_header},
-            retry::{is_retryable_status, RetryExecutor},
+            retry::{is_retryable_response, RetryExecutor},
             sse::SSE_CHANNEL_BUFFER,
             worker_selection::{SelectWorkerRequest, WorkerSelector},
         },
@@ -240,7 +240,7 @@ pub(super) async fn route_chat(
                 }
             }
         },
-        |res, _attempt| is_retryable_status(res.status()),
+        |res, _attempt| is_retryable_response(res),
         |delay, attempt| {
             Metrics::record_worker_retry(
                 metrics_labels::BACKEND_EXTERNAL,

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -11,6 +11,7 @@ pub mod kv_event_monitor;
 pub mod manager;
 pub mod metrics_aggregator;
 pub mod monitor;
+pub mod overload;
 pub mod registry;
 pub mod resilience;
 pub mod sampling_defaults;
@@ -41,6 +42,7 @@ pub use openai_protocol::{
     model_type::{Endpoint, ModelType},
     worker::{ProviderType, WorkerGroupKey},
 };
+pub use overload::OverloadThresholds;
 pub use registry::{WorkerOrigin, WorkerRegistry};
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};
 pub use sampling_defaults::DEFAULT_SAMPLING_PARAMS_LABEL;

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -67,7 +67,9 @@ use tracing::{debug, info, warn};
 use crate::{
     observability::metrics::Metrics,
     policies::PolicyRegistry,
-    worker::{event::WorkerEvent, ConnectionMode, Worker, WorkerRegistry},
+    worker::{
+        event::WorkerEvent, overload::OverloadThresholds, ConnectionMode, Worker, WorkerRegistry,
+    },
 };
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -224,6 +226,10 @@ pub struct WorkerMonitor {
     /// When set, poll loads and re-export `smg_engine_*` gauges even if no
     /// load-aware routing policy is active (`--engine-metrics`).
     engine_metrics: bool,
+    /// Absolute per-worker overload thresholds. When enabled, every ingested
+    /// load report is scored once here and the verdict latched onto the worker,
+    /// which is what keeps selection free of any per-request predicate.
+    overload: OverloadThresholds,
     load_tx: watch::Sender<HashMap<String, WorkerLoadResponse>>,
     load_rx: watch::Receiver<HashMap<String, WorkerLoadResponse>>,
     /// Worker URLs that answered definitively that they do not serve
@@ -255,6 +261,7 @@ impl WorkerMonitor {
         client: reqwest::Client,
         default_interval_secs: u64,
         engine_metrics: bool,
+        overload: OverloadThresholds,
     ) -> Self {
         let (load_tx, load_rx) = watch::channel(HashMap::new());
         Self {
@@ -264,6 +271,7 @@ impl WorkerMonitor {
             client,
             default_interval: Duration::from_secs(default_interval_secs.max(1)),
             engine_metrics,
+            overload,
             load_tx,
             load_rx,
             native_loads_absent: Arc::new(DashSet::new()),
@@ -357,6 +365,21 @@ impl WorkerMonitor {
         self.load_tx.send_modify(|map| map.clear());
         self.worker_load_manager.clear();
         self.native_loads_absent.clear();
+        // Same reset rule for the overload vetoes: the feed that would clear
+        // them is being torn down, so nothing else would. Fail open, but say so
+        // — on the lag-recovery path this is the fleet going un-vetoed for up to
+        // one poll interval, and the gauge dropping to zero is otherwise
+        // indistinguishable from a genuine recovery.
+        if self.overload.is_enabled() {
+            let cleared = self.worker_registry.clear_all_overload_flags();
+            if cleared > 0 {
+                warn!(
+                    vetoes_cleared = cleared,
+                    "Overload vetoes cleared with the load feed; every worker is routable again \
+                     until its next poll"
+                );
+            }
+        }
     }
 
     /// Recompute the polling state for every currently-known group.
@@ -458,6 +481,10 @@ impl WorkerMonitor {
     /// re-export is on, since metrics-rs cannot delete series.
     fn evict_worker_loads(&self, worker: &Arc<dyn Worker>) {
         let url = worker.url();
+        // A worker with no load feed has no overload verdict: leaving the flag
+        // set would strand it out of routing until it happened to be polled
+        // again, which for a non-`Ready` worker never happens.
+        self.worker_registry.set_worker_overloaded(worker, false);
         self.load_tx.send_modify(|map| {
             map.remove(url);
         });
@@ -871,12 +898,15 @@ async fn group_monitor_loop(
             return;
         };
 
-        // Poll when a load-aware policy needs the data OR engine-metrics
-        // re-export is on; the latter decouples observability from routing.
+        // Poll when a load-aware policy needs the data, when engine-metrics
+        // re-export is on, or when overload protection is configured. The last
+        // two decouple the poll from routing policy: overload vetoes apply
+        // under every policy, including ones that never read loads.
         let load_aware_policies = monitor.policy_registry.get_all_load_aware_policies();
         let routing_needs_load = !load_aware_policies.is_empty()
             || monitor.policy_registry.get_dp_rank_policy().is_some();
-        if !routing_needs_load && !monitor.engine_metrics {
+        let overload = monitor.overload;
+        if !routing_needs_load && !monitor.engine_metrics && !overload.is_enabled() {
             debug!("No load-aware policies and engine metrics off, skipping load fetch for group {group_key}");
             drop(monitor);
             continue;
@@ -924,7 +954,7 @@ async fn group_monitor_loop(
                             WorkerMonitor::fetch_backend_load(&worker).await
                         }
                     };
-                    (worker.url().to_string(), response)
+                    (worker, response)
                 }
             })
             .collect();
@@ -934,7 +964,21 @@ async fn group_monitor_loop(
         let mut group_loads: HashMap<String, WorkerLoadResponse> = HashMap::new();
         let mut group_dp_loads: HashMap<String, HashMap<isize, isize>> = HashMap::new();
         let mut dp_evict: Vec<String> = Vec::new();
-        for (url, response) in results {
+        for (worker, response) in results {
+            let url = worker.url().to_string();
+            // The overload predicate runs exactly here, once per report: O(1)
+            // per worker per poll interval, and never on a request path. A
+            // worker whose fetch failed has no fresh signal, so it is treated
+            // as not overloaded — the same "absent means no opinion" rule the
+            // watch-map consumers follow.
+            if overload.is_enabled() {
+                let verdict = response
+                    .as_ref()
+                    .is_some_and(|load| overload.is_overloaded(load));
+                monitor
+                    .worker_registry
+                    .set_worker_overloaded(&worker, verdict);
+            }
             if let Some(load) = response {
                 // Only feed the DP-rank cache from responses that carry real
                 // absolute per-rank token counts. Ratio-only snapshots,
@@ -1120,6 +1164,7 @@ mod worker_monitor_tests {
             reqwest::Client::new(),
             5,
             false,
+            OverloadThresholds::default(),
         ));
         (registry, monitor)
     }
@@ -1568,6 +1613,13 @@ mod native_loads_tests {
     }
 
     fn monitor_with_policy(config: PolicyConfig) -> (Arc<WorkerRegistry>, Arc<WorkerMonitor>) {
+        monitor_with(config, OverloadThresholds::default())
+    }
+
+    fn monitor_with(
+        config: PolicyConfig,
+        overload: OverloadThresholds,
+    ) -> (Arc<WorkerRegistry>, Arc<WorkerMonitor>) {
         let registry = Arc::new(WorkerRegistry::new());
         let policy_registry = Arc::new(PolicyRegistry::new(config));
         let monitor = Arc::new(WorkerMonitor::new(
@@ -1576,8 +1628,188 @@ mod native_loads_tests {
             reqwest::Client::new(),
             1,
             false,
+            overload,
         ));
         (registry, monitor)
+    }
+
+    /// Poll `condition` until it holds or the timeout expires. The group loop
+    /// writes the flag out of band, so there is nothing to await directly.
+    async fn wait_until(label: &str, mut condition: impl FnMut() -> bool) {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while !condition() {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {label}"));
+    }
+
+    /// `NATIVE_BODY` reports 4 waiting requests, so a threshold of 4 vetoes and
+    /// a threshold of 5 does not — the ingestion path must latch the verdict on
+    /// the worker itself, under a policy (round-robin) that reads no loads at
+    /// all.
+    #[tokio::test]
+    async fn load_ingestion_flags_worker_over_waiting_threshold() {
+        let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
+        let (registry, monitor) = monitor_with(
+            PolicyConfig::RoundRobin,
+            OverloadThresholds {
+                waiting_requests: Some(4),
+                token_usage: None,
+            },
+        );
+        let worker = vllm_worker(&stub.url);
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(Arc::clone(&worker)).unwrap();
+        monitor.start_event_loop();
+
+        wait_until("worker to be flagged overloaded", || worker.is_overloaded()).await;
+        assert_eq!(registry.overloaded_worker_count("a"), 1);
+        assert!(
+            !worker.is_available(),
+            "an overloaded worker is not routable"
+        );
+    }
+
+    /// A worker with real queueing that stays under the threshold must keep
+    /// serving: the veto is absolute, not comparative.
+    #[tokio::test]
+    async fn busy_worker_under_threshold_stays_eligible() {
+        let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
+        let (registry, monitor) = monitor_with(
+            PolicyConfig::RoundRobin,
+            OverloadThresholds {
+                waiting_requests: Some(5),
+                token_usage: None,
+            },
+        );
+        let worker = vllm_worker(&stub.url);
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(Arc::clone(&worker)).unwrap();
+        monitor.start_event_loop();
+
+        // Wait for the feed to actually land, then assert the verdict.
+        let mut rx = monitor.subscribe();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while !rx.borrow().contains_key(&stub.url) {
+                rx.changed().await.expect("watch sender alive");
+            }
+        })
+        .await
+        .expect("load feed must reach the watch channel");
+
+        assert!(!worker.is_overloaded());
+        assert!(worker.is_available());
+        assert_eq!(registry.overloaded_worker_count("a"), 0);
+    }
+
+    /// Overload protection alone must open the poll gate: without it the
+    /// feature would silently never engage under a load-blind policy.
+    #[tokio::test]
+    async fn overload_thresholds_alone_start_load_polling() {
+        let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
+        let (registry, monitor) = monitor_with(
+            PolicyConfig::RoundRobin,
+            OverloadThresholds {
+                waiting_requests: None,
+                token_usage: Some(0.2),
+            },
+        );
+        let worker = vllm_worker(&stub.url);
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(Arc::clone(&worker)).unwrap();
+        monitor.start_event_loop();
+
+        wait_until("the engine to be polled", || {
+            stub.probes.load(Ordering::SeqCst) > 0
+        })
+        .await;
+        wait_until("token usage 0.25 to trip the 0.2 ceiling", || {
+            worker.is_overloaded()
+        })
+        .await;
+    }
+
+    /// With both thresholds unset the feature is off: an engine reporting a
+    /// load that would trip either signal must still leave the flag, the
+    /// counters and every routing verdict exactly where they were.
+    #[tokio::test]
+    async fn unconfigured_thresholds_never_write_the_flag() {
+        let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
+        // cache_aware with overlap_decay on, so loads are polled and ingested
+        // for reasons unrelated to overload protection.
+        let (registry, monitor) = monitor_with(
+            cache_aware_policy_config(1.0),
+            OverloadThresholds::default(),
+        );
+        let worker = vllm_worker(&stub.url);
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(Arc::clone(&worker)).unwrap();
+        monitor.start_event_loop();
+
+        let mut rx = monitor.subscribe();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while !rx.borrow().contains_key(&stub.url) {
+                rx.changed().await.expect("watch sender alive");
+            }
+        })
+        .await
+        .expect("load feed must reach the watch channel");
+        // A second tick, so this is not just "the first poll had not landed".
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+
+        assert!(!worker.is_overloaded());
+        assert!(worker.is_available());
+        assert_eq!(registry.overloaded_worker_count("a"), 0);
+    }
+
+    /// A worker whose feed goes away has no verdict at all, so it must be
+    /// re-admitted rather than stranded out of routing forever.
+    #[tokio::test]
+    async fn losing_the_load_feed_clears_the_veto() {
+        let (registry, monitor) = monitor_with(
+            PolicyConfig::RoundRobin,
+            OverloadThresholds {
+                waiting_requests: Some(1),
+                token_usage: None,
+            },
+        );
+        // Never-registered address: every fetch fails, so the report is absent.
+        let worker = vllm_worker("http://127.0.0.1:1");
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(Arc::clone(&worker)).unwrap();
+        registry.set_worker_overloaded(&worker, true);
+        assert_eq!(registry.overloaded_worker_count("a"), 1);
+
+        monitor.start_event_loop();
+        wait_until("the absent feed to clear the veto", || {
+            !worker.is_overloaded()
+        })
+        .await;
+        assert_eq!(registry.overloaded_worker_count("a"), 0);
+    }
+
+    /// `stop_all_groups` tears down the only writer that could clear the flag,
+    /// so it must clear it itself — same rule the load snapshot follows.
+    #[tokio::test]
+    async fn stop_all_groups_clears_overload_flags() {
+        let (registry, monitor) = monitor_with(
+            PolicyConfig::RoundRobin,
+            OverloadThresholds {
+                waiting_requests: Some(1),
+                token_usage: None,
+            },
+        );
+        let worker = vllm_worker("http://127.0.0.1:1");
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(Arc::clone(&worker)).unwrap();
+        registry.set_worker_overloaded(&worker, true);
+
+        monitor.stop_all_groups();
+
+        assert!(!worker.is_overloaded());
+        assert_eq!(registry.overloaded_worker_count("a"), 0);
     }
 
     #[tokio::test]

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -365,11 +365,9 @@ impl WorkerMonitor {
         self.load_tx.send_modify(|map| map.clear());
         self.worker_load_manager.clear();
         self.native_loads_absent.clear();
-        // Same reset rule for the overload vetoes: the feed that would clear
-        // them is being torn down, so nothing else would. Fail open, but say so
-        // — on the lag-recovery path this is the fleet going un-vetoed for up to
-        // one poll interval, and the gauge dropping to zero is otherwise
-        // indistinguishable from a genuine recovery.
+        // The feed that would clear the vetoes is being torn down: fail open,
+        // but say so — a wiped gauge is otherwise indistinguishable from a
+        // genuine recovery.
         if self.overload.is_enabled() {
             let cleared = self.worker_registry.clear_all_overload_flags();
             if cleared > 0 {
@@ -481,9 +479,8 @@ impl WorkerMonitor {
     /// re-export is on, since metrics-rs cannot delete series.
     fn evict_worker_loads(&self, worker: &Arc<dyn Worker>) {
         let url = worker.url();
-        // A worker with no load feed has no overload verdict: leaving the flag
-        // set would strand it out of routing until it happened to be polled
-        // again, which for a non-`Ready` worker never happens.
+        // No load feed, no verdict: a flag left set would strand the worker
+        // out of routing with nothing to ever clear it.
         self.worker_registry.set_worker_overloaded(worker, false);
         self.load_tx.send_modify(|map| {
             map.remove(url);
@@ -966,11 +963,9 @@ async fn group_monitor_loop(
         let mut dp_evict: Vec<String> = Vec::new();
         for (worker, response) in results {
             let url = worker.url().to_string();
-            // The overload predicate runs exactly here, once per report: O(1)
-            // per worker per poll interval, and never on a request path. A
-            // worker whose fetch failed has no fresh signal, so it is treated
-            // as not overloaded — the same "absent means no opinion" rule the
-            // watch-map consumers follow.
+            // The overload predicate runs exactly here, once per report, never
+            // on a request path. A failed fetch means no fresh signal, which
+            // clears the flag — absent means no opinion.
             if overload.is_enabled() {
                 let verdict = response
                     .as_ref()

--- a/model_gateway/src/worker/overload.rs
+++ b/model_gateway/src/worker/overload.rs
@@ -1,10 +1,7 @@
 //! Absolute per-worker overload protection.
 //!
-//! The predicate below is evaluated exactly once per ingested load report (see
-//! `WorkerMonitor`'s group loop), never per request. Its verdict is latched into
-//! the worker's routing state, where selection reads it for free: every gather
-//! pass already loads that word for health, circuit-breaker and load, so the
-//! veto is one more test on a value already in hand.
+//! The predicate is evaluated once per ingested load report, never per request;
+//! the verdict is latched into routing state, which selection already reads.
 
 use openai_protocol::worker::WorkerLoadResponse;
 

--- a/model_gateway/src/worker/overload.rs
+++ b/model_gateway/src/worker/overload.rs
@@ -1,0 +1,146 @@
+//! Absolute per-worker overload protection.
+//!
+//! The predicate below is evaluated exactly once per ingested load report (see
+//! `WorkerMonitor`'s group loop), never per request. Its verdict is latched into
+//! the worker's routing state, where selection reads it for free: every gather
+//! pass already loads that word for health, circuit-breaker and load, so the
+//! veto is one more test on a value already in hand.
+
+use openai_protocol::worker::WorkerLoadResponse;
+
+/// Decision-log branch: every worker selection could have used is overloaded,
+/// so the request is shed immediately instead of queued.
+pub const BRANCH_ALL_OVERLOADED_SHED: &str = "all_overloaded_shed";
+
+/// Decision-log branch: the single worker already chosen crossed the threshold
+/// between selection and dispatch. Distinct from the fleet-wide shed above —
+/// here every other worker may well be idle.
+pub const BRANCH_OVERLOADED_AT_DISPATCH: &str = "overloaded_at_dispatch";
+
+/// Shed detected while assembling the candidate pool.
+pub const STAGE_SELECTION: &str = "selection";
+
+/// Shed detected by the dispatch-time re-check of the chosen worker.
+pub const STAGE_DISPATCH: &str = "dispatch";
+
+/// Absolute thresholds above which a worker is vetoed from routing.
+///
+/// Both fields unset disables the feature entirely: the flag is never written,
+/// so every routing path behaves exactly as it did before.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct OverloadThresholds {
+    /// Queued (waiting) requests summed across DP ranks, `>= 1` when set.
+    pub waiting_requests: Option<usize>,
+    /// Mean KV-cache token usage across DP ranks, in `(0.0, 1.0]` when set.
+    /// `f64` to match the reported signal exactly: widening an `f32` threshold
+    /// would put `0.8` just above the `0.8` an engine reports.
+    pub token_usage: Option<f64>,
+}
+
+impl OverloadThresholds {
+    /// Whether any signal is configured. Gates both the monitor's polling
+    /// requirement and every write to the flag.
+    pub const fn is_enabled(&self) -> bool {
+        self.waiting_requests.is_some() || self.token_usage.is_some()
+    }
+
+    /// Evaluate the veto for one load report. O(DP ranks), i.e. O(1) per report.
+    ///
+    /// Both comparisons are `>=` so that the excluded ends of the validated
+    /// ranges (`0` waiting requests, `0.0` token usage) are exactly the values
+    /// that would mark every worker overloaded unconditionally.
+    pub fn is_overloaded(&self, load: &WorkerLoadResponse) -> bool {
+        if let Some(threshold) = self.waiting_requests {
+            if load.total_waiting_reqs() >= threshold as i64 {
+                return true;
+            }
+        }
+        if let Some(threshold) = self.token_usage {
+            if load.effective_token_usage() >= threshold {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::worker::SchedulerLoadSnapshot;
+
+    use super::*;
+
+    fn response(waiting: i32, token_usage: f64) -> WorkerLoadResponse {
+        WorkerLoadResponse {
+            loads: vec![SchedulerLoadSnapshot {
+                num_waiting_reqs: waiting,
+                token_usage,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn unset_thresholds_never_veto() {
+        let thresholds = OverloadThresholds::default();
+        assert!(!thresholds.is_enabled());
+        assert!(!thresholds.is_overloaded(&response(10_000, 1.0)));
+    }
+
+    #[test]
+    fn waiting_requests_vetoes_at_and_above_threshold() {
+        let thresholds = OverloadThresholds {
+            waiting_requests: Some(8),
+            token_usage: None,
+        };
+        assert!(!thresholds.is_overloaded(&response(7, 0.0)));
+        assert!(thresholds.is_overloaded(&response(8, 0.0)));
+        assert!(thresholds.is_overloaded(&response(9, 0.0)));
+    }
+
+    #[test]
+    fn token_usage_vetoes_at_and_above_threshold() {
+        let thresholds = OverloadThresholds {
+            waiting_requests: None,
+            token_usage: Some(0.9),
+        };
+        assert!(!thresholds.is_overloaded(&response(0, 0.89)));
+        assert!(thresholds.is_overloaded(&response(0, 0.9)));
+        assert!(thresholds.is_overloaded(&response(0, 0.95)));
+    }
+
+    #[test]
+    fn signals_are_independent_and_either_vetoes() {
+        let thresholds = OverloadThresholds {
+            waiting_requests: Some(4),
+            token_usage: Some(0.8),
+        };
+        assert!(!thresholds.is_overloaded(&response(3, 0.7)));
+        assert!(thresholds.is_overloaded(&response(4, 0.1)));
+        assert!(thresholds.is_overloaded(&response(0, 0.8)));
+    }
+
+    #[test]
+    fn token_usage_averages_across_dp_ranks() {
+        let thresholds = OverloadThresholds {
+            waiting_requests: None,
+            token_usage: Some(0.9),
+        };
+        let load = WorkerLoadResponse {
+            loads: vec![
+                SchedulerLoadSnapshot {
+                    token_usage: 1.0,
+                    ..Default::default()
+                },
+                SchedulerLoadSnapshot {
+                    token_usage: 0.5,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        // Mean 0.75 — one saturated rank does not veto the whole worker.
+        assert!(!thresholds.is_overloaded(&load));
+    }
+}

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -14,7 +14,10 @@
 
 use std::{
     collections::{BTreeSet, HashSet},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
 
 use dashmap::{mapref::entry::Entry, DashMap};
@@ -123,6 +126,19 @@ pub struct WorkerRegistry {
     /// Only held during the in-memory model index diff (no I/O, microseconds).
     worker_mutation_locks: Arc<DashMap<WorkerId, Arc<parking_lot::Mutex<()>>>>,
 
+    /// Count of workers currently flagged overloaded, per model-index key.
+    /// Moved only on flag transitions and on registry membership changes, so
+    /// reading it costs one map probe and no worker walk.
+    model_overloaded: Arc<DashMap<String, AtomicUsize>>,
+
+    /// Serializes overload *edges* so a flag flip and its counter adjustment
+    /// land as one step. Two group loops flipping the same worker in opposite
+    /// directions would otherwise be free to apply their deltas in the reverse
+    /// order and leave the counter disagreeing with the flag. Never taken when
+    /// the verdict is unchanged, which is every poll but the crossing ones, and
+    /// never taken on a request path.
+    overload_transitions: Arc<parking_lot::Mutex<()>>,
+
     /// Per-model retry config (last write wins).
     /// Updated when a worker with non-empty retry overrides registers.
     /// Cleaned up when the last worker for a model is removed.
@@ -172,6 +188,8 @@ impl WorkerRegistry {
             connection_workers: Arc::new(DashMap::new()),
             url_to_id: Arc::new(DashMap::new()),
             worker_mutation_locks: Arc::new(DashMap::new()),
+            model_overloaded: Arc::new(DashMap::new()),
+            overload_transitions: Arc::new(parking_lot::Mutex::new(())),
             model_retry_configs: Arc::new(DashMap::new()),
             worker_origins: Arc::new(DashMap::new()),
             // Sized for fleet-scale bursts (startup registration, probe
@@ -359,6 +377,131 @@ impl WorkerRegistry {
                     .map(|workers| Arc::clone(&workers))
             })
             .unwrap_or_else(|| Arc::from(Self::EMPTY_WORKERS))
+    }
+
+    // ── Overload veto ──────────────────────────────────────────────────
+
+    /// Apply the absolute overload veto to `worker`, returning `true` when the
+    /// flag transitioned.
+    ///
+    /// The only sanctioned writer of [`Worker::set_overloaded`]: per-model
+    /// counters and the `smg_workers_overloaded` gauge move exactly once per
+    /// edge, which is what keeps the cost proportional to the load-report rate
+    /// rather than to request rate.
+    ///
+    /// Writes through a handle the registry no longer holds are dropped. The
+    /// monitor snapshots `Arc`s at tick start and writes its verdict after a
+    /// multi-second fetch await, by which time the worker may have been removed
+    /// or replaced; attributing that write to `worker`'s own model card would
+    /// move a counter for a worker no reset path can ever reach again.
+    pub fn set_worker_overloaded(&self, worker: &Arc<dyn Worker>, overloaded: bool) -> bool {
+        // Lock-free fast path for the common case: the poll re-asserted a
+        // verdict the worker already carries, so there is no edge to record.
+        if worker.is_overloaded() == overloaded {
+            return false;
+        }
+        // Allocate the keys before taking the edge lock: the invariant it
+        // protects is "flag flip and counter delta land together", which does
+        // not need the string clones or the gauge publish inside it.
+        let model_ids = Self::worker_model_ids(worker);
+        let mut updates = Vec::with_capacity(model_ids.len());
+        {
+            let _edge = self.overload_transitions.lock();
+            if !self.is_current_handle(worker) {
+                return false;
+            }
+            if !worker.set_overloaded(overloaded) {
+                return false;
+            }
+            for model_id in model_ids {
+                let updated = self.adjust_model_overloaded(&model_id, overloaded);
+                updates.push((model_id, updated));
+            }
+        }
+        // Gauge publish and counter GC reach into the metrics recorder and
+        // re-lock a `model_overloaded` shard; neither belongs under a
+        // registry-wide mutex that every group loop's edges serialize on.
+        for (model_id, updated) in updates {
+            Metrics::set_workers_overloaded(&model_id, updated);
+            if updated == 0 {
+                self.model_overloaded
+                    .remove_if(&model_id, |_, count| count.load(Ordering::Acquire) == 0);
+            }
+        }
+        true
+    }
+
+    /// Whether `worker` is the `Arc` the registry currently holds for its URL.
+    ///
+    /// The identity check is by pointer, not by URL: a `replace()` keeps the URL
+    /// and the shared runtime but installs a new worker object with a possibly
+    /// different model card, and the replaced handle must not be allowed to
+    /// attribute a counter move to the model set it used to carry.
+    fn is_current_handle(&self, worker: &Arc<dyn Worker>) -> bool {
+        let Some(worker_id) = self.url_to_id.get(worker.url()).map(|id| id.clone()) else {
+            return false;
+        };
+        self.workers
+            .get(&worker_id)
+            .is_some_and(|current| Arc::ptr_eq(current.value(), worker))
+    }
+
+    /// Clear the veto on every registered worker, returning how many were
+    /// flagged. Used by the load monitor's reset paths, where the feed that
+    /// would otherwise clear the flags is itself being torn down.
+    pub fn clear_all_overload_flags(&self) -> usize {
+        let workers: Vec<Arc<dyn Worker>> = self
+            .workers
+            .iter()
+            .map(|entry| Arc::clone(entry.value()))
+            .collect();
+        workers
+            .iter()
+            .filter(|worker| self.set_worker_overloaded(worker, false))
+            .count()
+    }
+
+    /// Workers of `model_id` currently flagged overloaded. O(1).
+    pub fn overloaded_worker_count(&self, model_id: &str) -> usize {
+        if let Some(count) = self.model_overloaded.get(model_id) {
+            return count.load(Ordering::Acquire);
+        }
+        self.model_alias_index
+            .get(model_id)
+            .and_then(|canonical_id| {
+                self.model_overloaded
+                    .get(canonical_id.as_ref())
+                    .map(|count| count.load(Ordering::Acquire))
+            })
+            .unwrap_or(0)
+    }
+
+    /// Move one worker in or out of `model_id`'s overloaded count, returning the
+    /// updated count. Caller publishes the gauge and GCs the entry outside the
+    /// edge lock.
+    ///
+    /// The counter feeds `smg_workers_overloaded{model}` only. The shed verdict
+    /// itself is a walk of the caller's candidate pool
+    /// ([`crate::routers::common::overload::all_overloaded`]), because every
+    /// selection site narrows by worker type and connection mode and a
+    /// per-model counter cannot describe a sub-pool.
+    fn adjust_model_overloaded(&self, model_id: &str, overloaded: bool) -> usize {
+        let entry = self
+            .model_overloaded
+            .entry(model_id.to_string())
+            .or_default();
+        if overloaded {
+            entry.fetch_add(1, Ordering::AcqRel) + 1
+        } else {
+            // Saturating: a double-clear must never wrap the counter into a
+            // permanent all-overloaded verdict for the model.
+            entry
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                    Some(current.saturating_sub(1))
+                })
+                .unwrap_or(0)
+                .saturating_sub(1)
+        }
     }
 
     /// Resolve an alias to its canonical model ID without copying the string.
@@ -897,6 +1040,16 @@ impl WorkerRegistry {
             return false;
         }
 
+        // Release the overload verdict while `old_worker` is still the handle
+        // this registry holds, i.e. while the counter keys derived from its
+        // model card are the ones the increment used. The replacement inherits
+        // the shared runtime below, so a verdict left set here would be carried
+        // onto a possibly different model set with no matching counter move,
+        // and the monitor's `Replaced` eviction — which clears through the old
+        // handle — could not put it back. The next poll re-derives the verdict
+        // for the URL either way.
+        self.set_worker_overloaded(&old_worker, false);
+
         if !new_worker.inherit_shared_state_from(&*old_worker) {
             tracing::warn!(
                 worker_id = %worker_id.as_str(),
@@ -913,7 +1066,9 @@ impl WorkerRegistry {
         // against the new worker's connect.
         old_worker.abort_background_tasks();
 
-        // Diff model indexes: remove stale, add new
+        // Diff model indexes: remove stale, add new. No overload bookkeeping
+        // here — the verdict was released above, so there is nothing to carry
+        // across the membership change.
         for removed_model in old_models.difference(&new_models) {
             self.remove_worker_from_model_index(removed_model, old_worker.url());
             // Mirror `remove()`: drop any per-model retry override when
@@ -1167,6 +1322,18 @@ impl WorkerRegistry {
             }
         }
 
+        // Release the overload count before the worker leaves `self.workers`:
+        // `set_worker_overloaded` ignores writes through a handle the registry
+        // no longer holds, so clearing after the removal would leak the count
+        // rather than release it. Clearing rather than merely decrementing also
+        // makes the monitor's `Removed` eviction a no-op instead of a second
+        // decrement.
+        if let Some(entry) = self.workers.get(worker_id) {
+            let worker = Arc::clone(entry.value());
+            drop(entry);
+            self.set_worker_overloaded(&worker, false);
+        }
+
         if let Some((_, worker)) = self.workers.remove(worker_id) {
             self.url_to_id.remove(worker.url());
             // We hold _guard; drop the DashMap entry but the Mutex stays alive via Arc.
@@ -1408,6 +1575,10 @@ impl WorkerRegistry {
         self.workers.insert(worker_id.clone(), worker.clone());
 
         // Update model index for O(1) lookups using copy-on-write.
+        // No overload bookkeeping here: a freshly built `WorkerRuntime` is never
+        // vetoed, so registration has nothing to carry. Adding a defensive `+1`
+        // would only risk double-counting against a concurrent flip, and an
+        // over-count is the one direction that can shed a servable request.
         for model_id in Self::worker_model_ids(&worker) {
             self.add_worker_to_model_index(&model_id, worker.clone());
             self.rebuild_hash_ring(&model_id);
@@ -3717,5 +3888,199 @@ mod tests {
             worker.zmq_connect_abort.load_full().is_none(),
             "replacement must abort the replaced worker's handshake driver"
         );
+    }
+
+    // ── Overload veto ──────────────────────────────────────────────────
+
+    fn overload_worker(url: &str, model_id: &str) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .model(ModelCard::new(model_id))
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Http)
+                .health_config(no_health_check())
+                .build(),
+        )
+    }
+
+    /// The counters and the gauge must move on edges only, so a repeated
+    /// verdict from the same poll cannot inflate them.
+    #[test]
+    fn overload_counters_move_only_on_transitions() {
+        let registry = WorkerRegistry::new();
+        let a = overload_worker("http://127.0.0.1:9401", "m");
+        let b = overload_worker("http://127.0.0.1:9402", "m");
+        registry.register(Arc::clone(&a)).unwrap();
+        registry.register(Arc::clone(&b)).unwrap();
+
+        assert_eq!(registry.overloaded_worker_count("m"), 0);
+
+        assert!(
+            registry.set_worker_overloaded(&a, true),
+            "first set is an edge"
+        );
+        assert!(
+            !registry.set_worker_overloaded(&a, true),
+            "re-asserting the same verdict is not an edge"
+        );
+        assert_eq!(registry.overloaded_worker_count("m"), 1);
+
+        registry.set_worker_overloaded(&b, true);
+        assert_eq!(registry.overloaded_worker_count("m"), 2);
+
+        // Recovery re-admits.
+        assert!(registry.set_worker_overloaded(&a, false));
+        assert!(!registry.set_worker_overloaded(&a, false));
+        assert_eq!(registry.overloaded_worker_count("m"), 1);
+        assert!(a.is_available(), "a recovered worker is routable again");
+    }
+
+    /// A model with no workers has nothing flagged — the shed helper reads
+    /// "empty pool", which its callers answer with a 404, not a shed.
+    #[test]
+    fn empty_model_has_no_overloaded_workers() {
+        let registry = WorkerRegistry::new();
+        assert_eq!(registry.overloaded_worker_count("nobody"), 0);
+    }
+
+    /// Removing a flagged worker must give its count back, or the model would
+    /// stay stuck at "all overloaded" with live workers left.
+    #[test]
+    fn removing_a_flagged_worker_releases_its_count() {
+        let registry = WorkerRegistry::new();
+        let a = overload_worker("http://127.0.0.1:9411", "m");
+        let b = overload_worker("http://127.0.0.1:9412", "m");
+        let a_id = registry.register(Arc::clone(&a)).unwrap();
+        registry.register(Arc::clone(&b)).unwrap();
+        registry.set_worker_overloaded(&a, true);
+        registry.set_worker_overloaded(&b, true);
+        assert_eq!(registry.overloaded_worker_count("m"), 2);
+
+        registry.remove(&a_id);
+
+        // b is still flagged, so the model is still shedding — but on one
+        // worker's count, not two.
+        assert_eq!(registry.overloaded_worker_count("m"), 1);
+
+        registry.set_worker_overloaded(&b, false);
+        assert_eq!(registry.overloaded_worker_count("m"), 0);
+    }
+
+    /// The monitor snapshots worker `Arc`s at tick start and writes its verdict
+    /// after a multi-second fetch await. A worker removed inside that window
+    /// must not be able to move the live model's counter through its detached
+    /// handle: nothing would ever decrement it again, since every reset path
+    /// walks the registry's own worker map.
+    #[test]
+    fn a_removed_worker_cannot_move_the_counter_through_a_stale_handle() {
+        let registry = WorkerRegistry::new();
+        let a = overload_worker("http://127.0.0.1:9421", "m");
+        let b = overload_worker("http://127.0.0.1:9422", "m");
+        let a_id = registry.register(Arc::clone(&a)).unwrap();
+        registry.register(Arc::clone(&b)).unwrap();
+
+        registry.remove(&a_id);
+        assert!(
+            !registry.set_worker_overloaded(&a, true),
+            "a detached handle records no edge"
+        );
+        assert_eq!(registry.overloaded_worker_count("m"), 0);
+
+        // And the same in the clearing direction, which would otherwise
+        // under-count a live worker's flag.
+        registry.set_worker_overloaded(&b, true);
+        assert!(!registry.set_worker_overloaded(&a, false));
+        assert_eq!(registry.overloaded_worker_count("m"), 1);
+    }
+
+    /// The counter is written from the monitor's per-report loop, which runs
+    /// concurrently across groups. Flipping the same worker from many threads
+    /// must leave the count consistent with the flag.
+    #[test]
+    fn overload_counter_is_consistent_under_concurrent_transitions() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let workers: Vec<Arc<dyn Worker>> = (0..8)
+            .map(|i| {
+                let w = overload_worker(&format!("http://127.0.0.1:{}", 9500 + i), "m");
+                registry.register(Arc::clone(&w)).unwrap();
+                w
+            })
+            .collect();
+
+        let mut handles = Vec::new();
+        for worker in &workers {
+            for _ in 0..4 {
+                let registry = Arc::clone(&registry);
+                let worker = Arc::clone(worker);
+                handles.push(std::thread::spawn(move || {
+                    for i in 0..200 {
+                        registry.set_worker_overloaded(&worker, i % 2 == 0);
+                    }
+                }));
+            }
+        }
+        for handle in handles {
+            handle.join().expect("worker flip thread");
+        }
+
+        // Whatever the interleaving settled on, the counter must equal the
+        // number of workers actually carrying the flag.
+        let flagged = workers.iter().filter(|w| w.is_overloaded()).count();
+        assert_eq!(registry.overloaded_worker_count("m"), flagged);
+
+        for worker in &workers {
+            registry.set_worker_overloaded(worker, false);
+        }
+        assert_eq!(registry.overloaded_worker_count("m"), 0);
+    }
+
+    /// A same-URL replacement shares its runtime with the worker it replaces,
+    /// so a verdict left set would be carried onto a possibly different model
+    /// set — and the monitor's `Replaced` eviction, which clears through the
+    /// *old* handle, could not put the counter back. The verdict is therefore
+    /// released before the handover and re-derived by the next poll.
+    #[test]
+    fn replacement_releases_the_verdict_and_leaves_no_counter_behind() {
+        let registry = WorkerRegistry::new();
+        let original = overload_worker("http://127.0.0.1:9601", "old");
+        let id = registry.register(Arc::clone(&original)).unwrap();
+        registry.set_worker_overloaded(&original, true);
+        assert_eq!(registry.overloaded_worker_count("old"), 1);
+
+        let replacement = overload_worker("http://127.0.0.1:9601", "new");
+        assert!(registry.replace(&id, Arc::clone(&replacement)));
+
+        assert!(
+            !replacement.is_overloaded(),
+            "the replacement starts unvetoed and is routable until its next poll"
+        );
+        assert_eq!(registry.overloaded_worker_count("old"), 0);
+        assert_eq!(registry.overloaded_worker_count("new"), 0);
+
+        // The monitor's `Replaced` handler clears through the old handle. That
+        // handle is detached now, so it must be a no-op rather than a second
+        // decrement against a model it no longer belongs to.
+        registry.set_worker_overloaded(&replacement, true);
+        assert!(!registry.set_worker_overloaded(&original, false));
+        assert_eq!(registry.overloaded_worker_count("new"), 1);
+        assert_eq!(registry.overloaded_worker_count("old"), 0);
+    }
+
+    #[test]
+    fn clear_all_overload_flags_resets_every_model() {
+        let registry = WorkerRegistry::new();
+        let a = overload_worker("http://127.0.0.1:9701", "m1");
+        let b = overload_worker("http://127.0.0.1:9702", "m2");
+        registry.register(Arc::clone(&a)).unwrap();
+        registry.register(Arc::clone(&b)).unwrap();
+        registry.set_worker_overloaded(&a, true);
+        registry.set_worker_overloaded(&b, true);
+
+        assert_eq!(registry.clear_all_overload_flags(), 2);
+
+        assert!(!a.is_overloaded());
+        assert!(!b.is_overloaded());
+        assert_eq!(registry.overloaded_worker_count("m1"), 0);
+        assert_eq!(registry.overloaded_worker_count("m2"), 0);
     }
 }

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -379,30 +379,26 @@ impl WorkerRegistry {
             .unwrap_or_else(|| Arc::from(Self::EMPTY_WORKERS))
     }
 
-    // ── Overload veto ──────────────────────────────────────────────────
-
     /// Apply the absolute overload veto to `worker`, returning `true` when the
-    /// flag transitioned.
+    /// flag transitioned. The only sanctioned writer of
+    /// [`Worker::set_overloaded`]: counters and gauge move once per edge.
     ///
-    /// The only sanctioned writer of [`Worker::set_overloaded`]: per-model
-    /// counters and the `smg_workers_overloaded` gauge move exactly once per
-    /// edge, which is what keeps the cost proportional to the load-report rate
-    /// rather than to request rate.
-    ///
-    /// Writes through a handle the registry no longer holds are dropped. The
-    /// monitor snapshots `Arc`s at tick start and writes its verdict after a
-    /// multi-second fetch await, by which time the worker may have been removed
-    /// or replaced; attributing that write to `worker`'s own model card would
-    /// move a counter for a worker no reset path can ever reach again.
+    /// Writes through a handle the registry no longer holds are dropped — the
+    /// monitor writes its verdict after a multi-second fetch await, by which
+    /// time the worker may have been removed or replaced, and a stale write
+    /// would move a counter no reset path can reach again.
     pub fn set_worker_overloaded(&self, worker: &Arc<dyn Worker>, overloaded: bool) -> bool {
         // Lock-free fast path for the common case: the poll re-asserted a
         // verdict the worker already carries, so there is no edge to record.
         if worker.is_overloaded() == overloaded {
             return false;
         }
-        // Allocate the keys before taking the edge lock: the invariant it
-        // protects is "flag flip and counter delta land together", which does
-        // not need the string clones or the gauge publish inside it.
+        // Allocate the keys before taking the edge lock; only the flag flip,
+        // the counter deltas and the gauge publish go inside it. The publish
+        // must share the critical section: published after release, two edges
+        // on one model can land their gauge writes in the reverse order and
+        // pin a stale value until the next transition. Counter GC re-locks a
+        // `model_overloaded` shard, so it stays outside.
         let model_ids = Self::worker_model_ids(worker);
         let mut updates = Vec::with_capacity(model_ids.len());
         {
@@ -415,14 +411,11 @@ impl WorkerRegistry {
             }
             for model_id in model_ids {
                 let updated = self.adjust_model_overloaded(&model_id, overloaded);
+                Metrics::set_workers_overloaded(&model_id, updated);
                 updates.push((model_id, updated));
             }
         }
-        // Gauge publish and counter GC reach into the metrics recorder and
-        // re-lock a `model_overloaded` shard; neither belongs under a
-        // registry-wide mutex that every group loop's edges serialize on.
         for (model_id, updated) in updates {
-            Metrics::set_workers_overloaded(&model_id, updated);
             if updated == 0 {
                 self.model_overloaded
                     .remove_if(&model_id, |_, count| count.load(Ordering::Acquire) == 0);
@@ -476,15 +469,10 @@ impl WorkerRegistry {
             .unwrap_or(0)
     }
 
-    /// Move one worker in or out of `model_id`'s overloaded count, returning the
-    /// updated count. Caller publishes the gauge and GCs the entry outside the
-    /// edge lock.
-    ///
-    /// The counter feeds `smg_workers_overloaded{model}` only. The shed verdict
-    /// itself is a walk of the caller's candidate pool
-    /// ([`crate::routers::common::overload::all_overloaded`]), because every
-    /// selection site narrows by worker type and connection mode and a
-    /// per-model counter cannot describe a sub-pool.
+    /// Move one worker in or out of `model_id`'s overloaded count, returning
+    /// the updated count. Feeds the gauge only — the shed verdict walks the
+    /// caller's candidate pool, since a per-model counter cannot describe a
+    /// type/transport-narrowed sub-pool.
     fn adjust_model_overloaded(&self, model_id: &str, overloaded: bool) -> usize {
         let entry = self
             .model_overloaded
@@ -1040,14 +1028,10 @@ impl WorkerRegistry {
             return false;
         }
 
-        // Release the overload verdict while `old_worker` is still the handle
-        // this registry holds, i.e. while the counter keys derived from its
-        // model card are the ones the increment used. The replacement inherits
-        // the shared runtime below, so a verdict left set here would be carried
-        // onto a possibly different model set with no matching counter move,
-        // and the monitor's `Replaced` eviction — which clears through the old
-        // handle — could not put it back. The next poll re-derives the verdict
-        // for the URL either way.
+        // Release the verdict while `old_worker` is still the current handle:
+        // the replacement inherits the shared runtime, and a flag carried onto
+        // a possibly different model set would leak its counter. The next poll
+        // re-derives the verdict for the URL.
         self.set_worker_overloaded(&old_worker, false);
 
         if !new_worker.inherit_shared_state_from(&*old_worker) {
@@ -1066,9 +1050,7 @@ impl WorkerRegistry {
         // against the new worker's connect.
         old_worker.abort_background_tasks();
 
-        // Diff model indexes: remove stale, add new. No overload bookkeeping
-        // here — the verdict was released above, so there is nothing to carry
-        // across the membership change.
+        // Diff model indexes: remove stale, add new.
         for removed_model in old_models.difference(&new_models) {
             self.remove_worker_from_model_index(removed_model, old_worker.url());
             // Mirror `remove()`: drop any per-model retry override when
@@ -1322,12 +1304,8 @@ impl WorkerRegistry {
             }
         }
 
-        // Release the overload count before the worker leaves `self.workers`:
-        // `set_worker_overloaded` ignores writes through a handle the registry
-        // no longer holds, so clearing after the removal would leak the count
-        // rather than release it. Clearing rather than merely decrementing also
-        // makes the monitor's `Removed` eviction a no-op instead of a second
-        // decrement.
+        // Release the overload count before the worker leaves `self.workers` —
+        // stale-handle writes are dropped, so clearing afterwards would leak it.
         if let Some(entry) = self.workers.get(worker_id) {
             let worker = Arc::clone(entry.value());
             drop(entry);
@@ -1575,10 +1553,6 @@ impl WorkerRegistry {
         self.workers.insert(worker_id.clone(), worker.clone());
 
         // Update model index for O(1) lookups using copy-on-write.
-        // No overload bookkeeping here: a freshly built `WorkerRuntime` is never
-        // vetoed, so registration has nothing to carry. Adding a defensive `+1`
-        // would only risk double-counting against a concurrent flip, and an
-        // over-count is the one direction that can shed a servable request.
         for model_id in Self::worker_model_ids(&worker) {
             self.add_worker_to_model_index(&model_id, worker.clone());
             self.rebuild_hash_ring(&model_id);
@@ -3889,8 +3863,6 @@ mod tests {
             "replacement must abort the replaced worker's handshake driver"
         );
     }
-
-    // ── Overload veto ──────────────────────────────────────────────────
 
     fn overload_worker(url: &str, model_id: &str) -> Arc<dyn Worker> {
         Arc::new(

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -443,22 +443,48 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
     /// Record a request outcome against the circuit breaker.
     fn record_circuit_breaker_outcome(&self, success: bool);
 
-    /// Check if the worker is available (healthy + circuit closed/half-open)
+    /// Check if the worker is available (healthy + circuit closed/half-open +
+    /// not vetoed by the absolute overload guard).
     fn is_available(&self) -> bool {
-        self.is_healthy() && self.circuit_breaker_can_execute()
+        self.is_healthy() && self.circuit_breaker_can_execute() && !self.is_overloaded()
+    }
+
+    /// [`Self::is_healthy`] fused with the overload veto. For the hash policies,
+    /// which route on health alone and never consult the circuit breaker;
+    /// `BasicWorker` overrides it to read both under a single runtime guard.
+    fn is_healthy_and_eligible(&self) -> bool {
+        self.is_healthy() && !self.is_overloaded()
+    }
+
+    /// Whether the absolute overload guard currently vetoes this worker.
+    ///
+    /// Written only by the load monitor, once per ingested load report, and
+    /// always `false` while overload protection is unconfigured.
+    fn is_overloaded(&self) -> bool {
+        false
+    }
+
+    /// Set the overload veto, returning `true` when the flag actually changed.
+    ///
+    /// Route writes through [`WorkerRegistry::set_worker_overloaded`] instead of
+    /// calling this directly: the per-model counters and the
+    /// `smg_workers_overloaded` gauge move only on transitions.
+    fn set_overloaded(&self, _overloaded: bool) -> bool {
+        false
     }
 
     /// One-shot routing snapshot for the per-request O(workers) selection loops:
-    /// reads status, load and processed together so the hot path takes one
-    /// `ArcSwap` guard per backing cell per worker instead of one per accessor
-    /// (that guard traffic is a large share of routing CPU at scale). `BasicWorker`
-    /// overrides this to share the runtime guard.
+    /// reads status, load, processed and the overload veto together so the hot
+    /// path takes one `ArcSwap` guard per backing cell per worker instead of one
+    /// per accessor (that guard traffic is a large share of routing CPU at
+    /// scale). `BasicWorker` overrides this to share the runtime guard.
     fn routing_state(&self) -> RoutingState {
         RoutingState {
             healthy: self.is_healthy(),
             can_execute: self.circuit_breaker_can_execute(),
             load: self.load(),
             processed: self.processed_requests(),
+            overloaded: self.is_overloaded(),
         }
     }
 
@@ -976,6 +1002,17 @@ pub struct RoutingState {
     pub load: usize,
     /// Lifetime processed-request count (min-load tie-break).
     pub processed: usize,
+    /// Absolute overload veto, set by the load monitor at ingestion time.
+    pub overloaded: bool,
+}
+
+impl RoutingState {
+    /// The full routing eligibility test. Costs nothing beyond the reads the
+    /// gather pass already performed: every field rides the one guard
+    /// [`Worker::routing_state`] took.
+    pub const fn eligible(self) -> bool {
+        self.healthy && self.can_execute && !self.overloaded
+    }
 }
 
 /// Shared mutable worker state preserved across same-URL replacements.
@@ -989,6 +1026,10 @@ pub struct WorkerRuntime {
     processed_counter: AtomicUsize,
     worker_routing_key_load: WorkerRoutingKeyLoad,
     revision: AtomicU64,
+    /// Absolute overload veto. Lives here rather than in the load-snapshot map
+    /// so selection reads it under the guard it already holds, and so a
+    /// same-URL replacement inherits it with the rest of the shared runtime.
+    overloaded: AtomicBool,
 }
 
 impl WorkerRuntime {
@@ -1002,6 +1043,7 @@ impl WorkerRuntime {
             processed_counter: AtomicUsize::new(0),
             worker_routing_key_load: WorkerRoutingKeyLoad::new(url),
             revision: AtomicU64::new(0),
+            overloaded: AtomicBool::new(false),
         }
     }
 
@@ -1099,6 +1141,18 @@ impl WorkerRuntime {
 
     pub fn increment_processed(&self) {
         self.processed_counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    // ── Overload veto ───────────────────────────────────────────────
+
+    pub fn is_overloaded(&self) -> bool {
+        self.overloaded.load(Ordering::Relaxed)
+    }
+
+    /// Returns `true` when the flag transitioned, so the caller can move the
+    /// per-model counters and gauge exactly once per edge.
+    pub fn set_overloaded(&self, overloaded: bool) -> bool {
+        self.overloaded.swap(overloaded, Ordering::Relaxed) != overloaded
     }
 }
 
@@ -1428,16 +1482,39 @@ impl Worker for BasicWorker {
         self.circuit_breaker.load().can_execute()
     }
 
+    fn is_overloaded(&self) -> bool {
+        self.runtime.load().is_overloaded()
+    }
+
+    fn set_overloaded(&self, overloaded: bool) -> bool {
+        self.runtime.load().set_overloaded(overloaded)
+    }
+
+    fn is_available(&self) -> bool {
+        // Same two guards the pre-veto version took (`is_healthy` +
+        // `circuit_breaker_can_execute`): the veto rides the runtime guard.
+        let rt = self.runtime.load();
+        rt.status() == WorkerStatus::Ready
+            && !rt.is_overloaded()
+            && self.circuit_breaker.load().can_execute()
+    }
+
+    fn is_healthy_and_eligible(&self) -> bool {
+        let rt = self.runtime.load();
+        rt.status() == WorkerStatus::Ready && !rt.is_overloaded()
+    }
+
     fn routing_state(&self) -> RoutingState {
-        // One runtime guard covers status + load + processed (all live in
-        // `self.runtime`); the circuit breaker is a separate ArcSwap, so it needs
-        // its own guard.
+        // One runtime guard covers status + load + processed + the overload veto
+        // (all live in `self.runtime`); the circuit breaker is a separate
+        // ArcSwap, so it needs its own guard.
         let rt = self.runtime.load();
         RoutingState {
             healthy: rt.status() == WorkerStatus::Ready,
             can_execute: self.circuit_breaker.load().can_execute(),
             load: rt.load(),
             processed: rt.processed_requests(),
+            overloaded: rt.is_overloaded(),
         }
     }
 

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -1143,8 +1143,6 @@ impl WorkerRuntime {
         self.processed_counter.fetch_add(1, Ordering::Relaxed);
     }
 
-    // ── Overload veto ───────────────────────────────────────────────
-
     pub fn is_overloaded(&self) -> bool {
         self.overloaded.load(Ordering::Relaxed)
     }

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -31,8 +31,8 @@ use smg::{
     policies::PolicyRegistry,
     routers::{router_manager::RouterManager, RouterFactory, RouterTrait},
     worker::{
-        BasicWorkerBuilder, ModelCard, RuntimeType, Worker, WorkerMonitor, WorkerRegistry,
-        WorkerType,
+        BasicWorkerBuilder, ModelCard, OverloadThresholds, RuntimeType, Worker, WorkerMonitor,
+        WorkerRegistry, WorkerType,
     },
     workflow::Job,
 };
@@ -362,6 +362,7 @@ async fn build_test_app_context(
         client.clone(),
         config.load_monitor_interval_secs,
         config.engine_metrics,
+        OverloadThresholds::default(),
     )));
 
     // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator

--- a/model_gateway/tests/common/test_app.rs
+++ b/model_gateway/tests/common/test_app.rs
@@ -12,8 +12,8 @@ use smg::{
     routers::RouterTrait,
     server::{build_app, AppState},
     worker::{
-        BasicWorkerBuilder, ModelCard, RuntimeType, Worker, WorkerMonitor, WorkerRegistry,
-        WorkerType,
+        BasicWorkerBuilder, ModelCard, OverloadThresholds, RuntimeType, Worker, WorkerMonitor,
+        WorkerRegistry, WorkerType,
     },
 };
 use smg_data_connector::{
@@ -64,6 +64,7 @@ pub fn create_test_app(
         client.clone(),
         router_config.load_monitor_interval_secs,
         router_config.engine_metrics,
+        OverloadThresholds::default(),
     )));
 
     // Create empty OnceLock for worker job queue and workflow engines

--- a/model_gateway/tests/routing/test_pd_routing.rs
+++ b/model_gateway/tests/routing/test_pd_routing.rs
@@ -221,7 +221,7 @@ mod pd_routing_unit_tests {
                 use smg::{
                     middleware::TokenBucket,
                     policies::PolicyRegistry,
-                    worker::{WorkerMonitor, WorkerRegistry},
+                    worker::{OverloadThresholds, WorkerMonitor, WorkerRegistry},
                 };
                 use smg_data_connector::{
                     MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
@@ -250,6 +250,7 @@ mod pd_routing_unit_tests {
                     client.clone(),
                     config.load_monitor_interval_secs,
                     config.engine_metrics,
+                    OverloadThresholds::default(),
                 )));
 
                 // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator

--- a/model_gateway/tests/wasm_test.rs
+++ b/model_gateway/tests/wasm_test.rs
@@ -31,7 +31,7 @@ use smg::{
         },
         module_manager::WasmModuleManager,
     },
-    worker::{WorkerMonitor, WorkerRegistry},
+    worker::{OverloadThresholds, WorkerMonitor, WorkerRegistry},
 };
 use smg_data_connector::{
     MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
@@ -70,6 +70,7 @@ async fn create_test_context_with_wasm() -> Arc<AppContext> {
         client.clone(),
         config.load_monitor_interval_secs,
         config.engine_metrics,
+        OverloadThresholds::default(),
     )));
 
     // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator


### PR DESCRIPTION
## Description

### Problem

SMG has no absolute per-worker overload protection. Load balancing spreads load relatively: under fleet saturation every engine's queue deepens evenly until latency collapses, and nothing sheds. The previous attempt (#2118) added a per-request filter loop inside selection and was rejected for its O(n) per-request cost.

### Solution

Evaluate the overload predicate at signal-write time, not selection time. The load monitor scores each ingested load report once and latches an `overloaded` bit into the `WorkerRuntime` word selection already reads — the veto is one more test on a value already in hand. Per-model counters move only on flag transitions. When every worker a request could have used is vetoed, it sheds immediately with the existing 503 `no_available_workers` (marked non-retryable so the retry layer doesn't turn "shed immediately" into ~400 ms of backoff), and an O(1) dispatch-time re-check covers the selection→dispatch window.

**Cost accounting at 10k workers:** predicate evaluation scales with load-report rate (O(n) per poll interval), not with rps. Selection performs exactly the same number of worker reads as today. With both flags unset the feature is off and behavior is unchanged.

Relation to #2118: label-based filtering is request-dependent and stays out; its eventual fix is a label→worker-set index maintained at registration, a separate PR.

## Changes

- `--worker-overload-waiting-requests` (≥1) and `--worker-overload-token-usage` ((0.0, 1.0]) — full plumbing: config/types, both conversion paths, `ConfigValidator` (all construction paths validated, incl. Python), Python bindings tail-appended.
- `overloaded: AtomicBool` on `WorkerRuntime`; `RoutingState::eligible()`; veto folded into `is_available()` and the fused gathers; O(1)-probe policies test only their candidates; overloaded sticky pins respill through the existing stale-pin path.
- Ingestion in the monitor group loop (all three load feeds); per-model counters + `smg_workers_overloaded{model}` gauge on transitions; shed counter `smg_worker_overload_shed_total{stage}`; decision-log branches `all_overloaded_shed` / `overloaded_at_dispatch`.
- Shed wired on both transports (HTTP regular/PD/transcription, gRPC single + PD/EPD legs — per demanded leg, replacing a misleading 404); dispatch re-checks before every send.
- `NonRetryable` response extension honored by all retry predicates; terminal sheds count in router error metrics.

Decisions: no hysteresis (flag follows the signal at poll cadence); dispatch re-check sheds rather than re-selects.

## Test Plan

- `cargo test -p smg --lib` — 1764 passed, 0 failed (25+ feature tests: threshold transitions, busy-under-threshold stays eligible, sticky respill, per-leg shed vs 404, counter consistency under concurrent transitions, recovery, feature-off no-op, both transports).
- `cargo +nightly fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (local fallback without `--all-features`; no system OpenCV).
- `pytest tests/test_arg_parser.py` — 54 passed (frozen field sequences).
- Validation is unit-level; no live-fleet before/after was run.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
