### PR TITLE
fix(grpc): abort backend streams on router string stops

### DIFF
--- a/crates/tokenizer/src/stop.rs
+++ b/crates/tokenizer/src/stop.rs
@@ -379,6 +379,8 @@ mod tests {
         // Process stop token
         let result = decoder.process_token(999).unwrap(); // <eos>
         assert_eq!(result, SequenceDecoderOutput::Stopped);
+        // Token-level stops don't record a matched string stop.
+        assert_eq!(decoder.matched_stop(), None);
 
         // Further tokens should also return Stopped
         let result = decoder.process_token(2).unwrap();
@@ -689,6 +691,7 @@ mod tests {
             decoder.is_stopped(),
             "Decoder should be stopped after the full stop sequence match"
         );
+        assert_eq!(decoder.matched_stop(), Some("Hello world"));
 
         // Any further tokens should also return Stopped
         let result3 = decoder.process_token(3).unwrap();

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -66,10 +66,12 @@ struct CompletionStreamOutcome {
     reasoning_tokens: u32,
     completion_tokens: u32,
     first_token_time: Option<Instant>,
-    /// Whether *every* expected `n>1` choice in this unit received a
-    /// `Complete` message (the only source of authoritative usage) -- a
-    /// clean EOF partway through leaves this `false` even if some choices
-    /// did complete, so a partial result is never mistaken for full usage.
+    /// Whether *every* expected `n>1` choice in this unit reached a terminal
+    /// state with authoritative usage: a `Complete` message, or a
+    /// router-matched string stop whose terminal chunk carries the prompt
+    /// count. A clean EOF partway through leaves this `false` even if some
+    /// choices did complete, so a partial result is never mistaken for full
+    /// usage.
     saw_complete: bool,
 }
 
@@ -1961,10 +1963,12 @@ impl StreamingProcessor {
         // Token tracking
         let mut completion_tokens = CompletionTokenTracker::new();
         let mut prompt_tokens: u32 = 0;
-        // Authoritative usage only ever arrives via a `Complete` message; a
-        // clean EOF without one leaves `prompt_tokens` at its 0 initializer,
-        // which is indistinguishable from a genuinely empty prompt -- track
-        // separately so settle can tell "no usage" from "zero tokens".
+        // Authoritative usage arrives via a `Complete` message, or — for a
+        // router-matched string stop — via the terminal chunk that triggers
+        // it; a clean EOF with neither leaves `prompt_tokens` at its 0
+        // initializer, which is indistinguishable from a genuinely empty
+        // prompt -- track separately so settle can tell "no usage" from
+        // "zero tokens".
         let mut saw_complete = false;
         let mut finish_reason_str = String::new();
         let mut matched_stop: Option<Value> = None;
@@ -2133,6 +2137,11 @@ impl StreamingProcessor {
                     let router_string_stop = should_stop && matched_stop.is_some();
                     if router_string_stop {
                         prompt_tokens = chunk.prompt_tokens();
+                        // The terminal chunk's prompt count stands in for the
+                        // Complete this request will never read; without this
+                        // the terminal usage emit reports no input tokens and
+                        // the reservation settles on the estimate.
+                        saw_complete = true;
                     }
 
                     if chunk_text.is_empty() {
@@ -3057,6 +3066,14 @@ impl StreamingProcessor {
                         stopped_indices.insert(index);
                         terminal_indices.insert(index);
                         has_router_stop |= matched_sequence;
+                        if matched_sequence {
+                            // No Complete will be read for a router-stopped
+                            // choice; count it as completed so this unit still
+                            // reports the terminal chunk's usage as
+                            // authoritative instead of settling on the
+                            // reserved estimate.
+                            completed_indices.insert(index);
+                        }
                         total_prompt = total_prompt.max(chunk.prompt_tokens());
                         total_cached = total_cached.max(chunk.cached_tokens());
                         reasoning_tokens.insert(index, chunk.reasoning_tokens());
@@ -3250,10 +3267,12 @@ impl StreamingProcessor {
             grpc_stream.mark_completed();
         }
 
-        // `completed_indices` counts distinct indices that finished cleanly
-        // via a `Complete` message. A clean EOF partway through this unit's
-        // `n>1` choices (some completed, others didn't) must not be treated
-        // as full usage.
+        // `completed_indices` counts distinct indices that reached a terminal
+        // state with authoritative usage: finished cleanly via a `Complete`
+        // message, or stopped on a router-matched string stop (whose terminal
+        // chunk carries the prompt count the skipped Complete would have).
+        // A clean EOF partway through this unit's `n>1` choices (some
+        // completed, others didn't) must not be treated as full usage.
         let expected_choices = completion_request.n.unwrap_or(1).max(1);
         let saw_complete = completed_indices.len() as u32 >= expected_choices;
 

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -293,6 +293,10 @@ impl StreamingProcessor {
         let mut completion_tokens = CompletionTokenTracker::new();
         let mut cached_tokens: HashMap<u32, u32> = HashMap::new();
         let mut reasoning_tokens: HashMap<u32, u32> = HashMap::new();
+        let mut terminal_indices: HashSet<u32> = HashSet::new();
+        let expected_choices = original_request.n.unwrap_or(1).max(1) as usize;
+        let mut has_router_stop = false;
+        let mut router_terminated = false;
 
         // Parser state (lazy initialization per index)
         type PooledReasoningParser = Arc<tokio::sync::Mutex<Box<dyn ReasoningParser>>>;
@@ -459,7 +463,26 @@ impl StreamingProcessor {
                         stopped_indices.insert(index);
                     }
 
+                    // A router-matched string stop is terminal for the public
+                    // request but not for the backend (it never saw the string).
+                    // Track it so the stream can be aborted — rather than drained —
+                    // once every choice is terminal.
+                    let router_string_stop = should_stop && stop_decoder.matched_stop().is_some();
+                    if router_string_stop {
+                        has_router_stop = true;
+                        prompt_tokens.insert(index, chunk.prompt_tokens());
+                        cached_tokens.insert(index, chunk.cached_tokens());
+                        reasoning_tokens.insert(index, chunk.reasoning_tokens());
+                        terminal_indices.insert(index);
+                    }
+                    let all_terminal =
+                        has_router_stop && terminal_indices.len() >= expected_choices;
+
                     if chunk_text.is_empty() {
+                        if all_terminal {
+                            router_terminated = true;
+                            break;
+                        }
                         continue;
                     }
 
@@ -498,6 +521,7 @@ impl StreamingProcessor {
                         finish_reasons.insert(index, complete.finish_reason().to_string());
                         matched_stops.insert(index, complete.matched_stop_json());
                     }
+                    terminal_indices.insert(index);
 
                     // Don't break - continue reading all Complete messages for n>1
                     flushed.map(|text| (index, text, None))
@@ -506,6 +530,13 @@ impl StreamingProcessor {
             };
 
             let Some((index, text, choice_logprobs)) = pending else {
+                // A Complete that releases no buffered text can still be the
+                // final terminal choice after a router-side string stop; abort
+                // rather than drain the backend's post-stop generation.
+                if has_router_stop && terminal_indices.len() >= expected_choices {
+                    router_terminated = true;
+                    break;
+                }
                 continue;
             };
 
@@ -606,6 +637,14 @@ impl StreamingProcessor {
                             .map_err(|_| "Failed to send tool call chunk".to_string())?;
                     }
 
+                    // A router-matched string stop is terminal for the public
+                    // request once every choice is done; the pre-stop text fed
+                    // to the parser above is the last input it sees.
+                    if has_router_stop && terminal_indices.len() >= expected_choices {
+                        router_terminated = true;
+                        break;
+                    }
+
                     // Always skip regular content when tool parsing is active
                     // Parser either emitted chunks or buffered content
                     continue;
@@ -623,6 +662,15 @@ impl StreamingProcessor {
                 tx.send(Ok(Bytes::from(sse_buffer.clone())))
                     .await
                     .map_err(|_| "Failed to send content chunk".to_string())?;
+            }
+
+            // A router-matched string stop is terminal for the public request
+            // but not for the backend (it never saw the string): once every
+            // choice is terminal, break and leave the stream to abort on drop
+            // instead of draining post-stop generation.
+            if has_router_stop && terminal_indices.len() >= expected_choices {
+                router_terminated = true;
+                break;
             }
         }
 
@@ -738,8 +786,12 @@ impl StreamingProcessor {
             }
         }
 
-        // Mark stream as completed successfully to prevent abort on drop
-        grpc_stream.mark_completed();
+        // A router-side string stop is terminal for the public request but not
+        // for the backend. Leave the stream unmarked so Drop sends its exact-ID
+        // Abort RPC instead of silently draining post-stop generation.
+        if !router_terminated {
+            grpc_stream.mark_completed();
+        }
 
         // Record streaming metrics
         let total_prompt: u32 = prompt_tokens.values().copied().max().unwrap_or(0);
@@ -1919,6 +1971,9 @@ impl StreamingProcessor {
         // Set once the local stop decoder fires: pins "stop" and ignores later
         // engine output (the backend has no stop-string detection over ZMQ).
         let mut stopped = false;
+        // Set when a router-matched string stop terminates the request: the
+        // backend stream is left unmarked so Drop aborts it instead of draining.
+        let mut router_terminated = false;
 
         // Per-request effective parser names (model-card override → configured).
         let reasoning_parser_name = self.parser_resolver.reasoning_parser(model);
@@ -2069,7 +2124,22 @@ impl StreamingProcessor {
                             .map(|s| Value::String(s.to_string()));
                     }
 
+                    // A router-matched string stop is terminal for the public
+                    // request but not for the backend (it never saw the string):
+                    // emit any pre-stop text below, then break and leave the
+                    // stream to abort on drop instead of draining it. No
+                    // Complete will be read after the abort, so capture usage
+                    // from the terminal chunk itself.
+                    let router_string_stop = should_stop && matched_stop.is_some();
+                    if router_string_stop {
+                        prompt_tokens = chunk.prompt_tokens();
+                    }
+
                     if chunk_text.is_empty() {
+                        if router_string_stop {
+                            router_terminated = true;
+                            break;
+                        }
                         continue;
                     }
 
@@ -2330,6 +2400,14 @@ impl StreamingProcessor {
                         }
                     }
                 }
+
+                // A router-matched string stop fired on this chunk: the
+                // pre-stop text fed to the parser above is the last input it
+                // sees; abort rather than drain the backend.
+                if stopped && matched_stop.is_some() {
+                    router_terminated = true;
+                    break;
+                }
                 continue;
             }
 
@@ -2359,6 +2437,14 @@ impl StreamingProcessor {
                     },
                 )
                 .await?;
+            }
+
+            // A router-matched string stop is terminal for the public request
+            // but not for the backend (it never saw the string): break and
+            // leave the stream to abort on drop instead of draining it.
+            if stopped && matched_stop.is_some() {
+                router_terminated = true;
+                break;
             }
         }
 
@@ -2540,8 +2626,9 @@ impl StreamingProcessor {
         // Phase 5: Emit message_stop
         Self::send_messages_event(tx, &mut sse_buffer, &MessageStreamEvent::MessageStop).await?;
 
-        // Mark stream completed
-        grpc_stream.mark_completed();
+        if !router_terminated {
+            grpc_stream.mark_completed();
+        }
 
         if let Some(handle) = reservation {
             if saw_complete {
@@ -2871,6 +2958,10 @@ impl StreamingProcessor {
         let mut stop_decoders: HashMap<u32, StopSequenceDecoder> = HashMap::new();
         let mut is_firsts: HashMap<u32, bool> = HashMap::new();
         let mut stopped_indices: HashSet<u32> = HashSet::new();
+        let mut terminal_indices: HashSet<u32> = HashSet::new();
+        let expected_choices = completion_request.n.unwrap_or(1).max(1) as usize;
+        let mut has_router_stop = false;
+        let mut router_terminated = false;
         let mut sse_buffer = Vec::with_capacity(512);
         let mut chunk_text = String::new();
         // For n>1, each index shares the same prompt — use max across Complete
@@ -2924,6 +3015,9 @@ impl StreamingProcessor {
 
                     let (decoded_text, stopped) =
                         Self::process_chunk_tokens(stop_decoder, chunk.token_ids())?;
+                    // `matched_stop` is only set for router-matched string stops;
+                    // token-level stops leave the backend to terminate itself.
+                    let matched_sequence = stopped && stop_decoder.matched_stop().is_some();
                     chunk_text.clear();
                     chunk_text.push_str(&decoded_text);
 
@@ -2961,6 +3055,11 @@ impl StreamingProcessor {
                         // the backend's eventual Complete carries "length". This is
                         // intentional — the local stop sequence fired first.
                         stopped_indices.insert(index);
+                        terminal_indices.insert(index);
+                        has_router_stop |= matched_sequence;
+                        total_prompt = total_prompt.max(chunk.prompt_tokens());
+                        total_cached = total_cached.max(chunk.cached_tokens());
+                        reasoning_tokens.insert(index, chunk.reasoning_tokens());
 
                         if let Some(sfx) = suffix {
                             let suffix_chunk = CompletionStreamResponse {
@@ -3001,6 +3100,11 @@ impl StreamingProcessor {
                         tx.send(Ok(Bytes::from(sse_buffer.clone())))
                             .await
                             .map_err(|_| "Channel closed".to_string())?;
+
+                        if has_router_stop && terminal_indices.len() >= expected_choices {
+                            router_terminated = true;
+                            break;
+                        }
                     }
                 }
                 ProtoResponseVariant::Complete(complete) => {
@@ -3131,12 +3235,20 @@ impl StreamingProcessor {
                     tx.send(Ok(Bytes::from(sse_buffer.clone())))
                         .await
                         .map_err(|_| "Channel closed".to_string())?;
+
+                    terminal_indices.insert(index);
+                    if has_router_stop && terminal_indices.len() >= expected_choices {
+                        router_terminated = true;
+                        break;
+                    }
                 }
                 ProtoResponseVariant::None => continue,
             }
         }
 
-        grpc_stream.mark_completed();
+        if !router_terminated {
+            grpc_stream.mark_completed();
+        }
 
         // `completed_indices` counts distinct indices that finished cleanly
         // via a `Complete` message. A clean EOF partway through this unit's


### PR DESCRIPTION
## Motivation

SMG's gRPC routers run a local `StopSequenceDecoder` over decoded text (needed because SGLang workers with `skip_tokenizer_init=True` cannot match string stops themselves). When a *string* stop sequence matches router-side, the public SSE stream ends — but the backend never saw the string and keeps generating. The old code unconditionally called `grpc_stream.mark_completed()`, so the stream's `Drop` silently **drained** all post-stop generation instead of aborting it, wasting backend compute.

## What this changes

- Track router-matched string stops: `router_string_stop = should_stop && stop_decoder.matched_stop().is_some()`, with `has_router_stop` / `router_terminated` state.
- Chat and completion processors are n>1-aware: `terminal_indices` is checked against `expected_choices`, and the stream loop breaks early once every choice is terminal.
- The trailing `mark_completed()` is guarded by `if !router_terminated`, so Drop sends its exact-ID Abort RPC only for router-terminated streams.
- The chat/messages tool-parser blocks no longer end in `continue`; a `tool_parser_active` flag gates regular content emission so the post-emission termination check stays reachable.
- Token-level stops deliberately do **not** trigger router termination — the backend terminates itself there.

Builds on upstream's existing `matched_stop()` and stop pinning; adds two `matched_stop()` assertions in `crates/tokenizer/src/stop.rs`.

## Validation

`cargo check`/`clippy`/`test` (release) on `smg` + `llm-tokenizer`: streaming lib tests 14/0, tokenizer lib tests 173/0, including the two updated stop tests. (Strict clippy trips on a pre-existing upstream lint at `monitor.rs:825` under clippy 1.97; untouched by this PR.)