### PR TITLE
feat(tool-parser): flush DSML terminal tool calls and held-back text at stream end

### DIFF
--- a/crates/tool_parser/src/parsers/deepseek_dsml.rs
+++ b/crates/tool_parser/src/parsers/deepseek_dsml.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 use serde_json::Value;
 
 use crate::{
-    errors::{ParserError, ParserResult},
+    errors::ParserResult,
     parsers::helpers,
     traits::ToolParser,
     types::{FunctionCall, StreamingParseResult, ToolCall, ToolCallItem},
@@ -59,11 +59,15 @@ pub struct DeepSeekDsmlParser {
     current_tool_name_sent: bool,
     /// Tracks raw JSON string content streamed to client for each tool's arguments
     streamed_args_for_tool: Vec<String>,
+    /// Calls whose invoke and argument object have both closed successfully.
+    completed_tool_call_count: usize,
 }
 
 /// Full DSML closing tags for suffix-based stripping during streaming.
 const DSML_PARAMETER_END_TAG: &str = "</｜DSML｜parameter>";
 const DSML_INVOKE_END_TAG: &str = "</｜DSML｜invoke>";
+const DSML_OPEN_SENTINEL: &str = "<｜DSML｜";
+const DSML_CLOSE_SENTINEL: &str = "</｜DSML｜";
 
 /// DeepSeek end-of-sentence marker. Some engines emit this as raw text at the
 /// end of a truncated turn; it must never bleed into tool-call argument bytes.
@@ -149,6 +153,7 @@ impl DeepSeekDsmlParser {
             current_tool_id: -1,
             current_tool_name_sent: false,
             streamed_args_for_tool: Vec::new(),
+            completed_tool_call_count: 0,
         }
     }
 
@@ -235,16 +240,28 @@ impl DeepSeekDsmlParser {
         serde_json::to_string(&Value::Object(params)).unwrap_or_else(|_| "{}".to_string())
     }
 
-    /// Parse a single complete invoke block into a ToolCall
-    fn parse_invoke(&self, name: &str, content: &str) -> ToolCall {
-        let arguments = self.parse_parameters_from_dsml(content, false);
+    fn arguments_are_valid_object(content: &str, arguments: &str) -> bool {
+        let candidate = if content.trim().starts_with('{') {
+            content.trim()
+        } else {
+            arguments
+        };
+        matches!(serde_json::from_str(candidate), Ok(Value::Object(_)))
+    }
 
-        ToolCall {
+    /// Parse a single complete invoke block into a ToolCall.
+    fn parse_invoke(&self, name: &str, content: &str) -> Option<ToolCall> {
+        let arguments = self.parse_parameters_from_dsml(content, false);
+        if !Self::arguments_are_valid_object(content, &arguments) {
+            return None;
+        }
+
+        Some(ToolCall {
             function: FunctionCall {
                 name: name.trim().to_string(),
                 arguments,
             },
-        }
+        })
     }
 }
 
@@ -257,29 +274,52 @@ impl ToolParser for DeepSeekDsmlParser {
             return Ok((text.to_string(), vec![]));
         }
 
-        let idx = text
-            .find(self.block_open.as_str())
-            .ok_or_else(|| ParserError::ParsingFailed("DSML marker not found".to_string()))?;
+        let Some(idx) = text.find(self.block_open.as_str()) else {
+            let marker_start = [DSML_OPEN_SENTINEL, DSML_CLOSE_SENTINEL]
+                .into_iter()
+                .filter_map(|marker| text.find(marker))
+                .min();
+            let Some(marker_start) = marker_start else {
+                return Ok((text.to_string(), Vec::new()));
+            };
+            return Ok((text[..marker_start].trim_end().to_string(), Vec::new()));
+        };
         let normal_text = text[..idx].trim_end().to_string();
 
         let mut tools = Vec::new();
+        let mut last_block_end = None;
 
         for fc_cap in self.tool_call_complete_regex.captures_iter(text) {
+            last_block_end = fc_cap.get(0).map(|outer| outer.end());
             let fc_content = fc_cap.get(1).map_or("", |m| m.as_str());
 
             for inv_cap in self.invoke_complete_regex.captures_iter(fc_content) {
                 let func_name = inv_cap.get(1).map_or("", |m| m.as_str());
                 let invoke_content = inv_cap.get(2).map_or("", |m| m.as_str());
 
-                tools.push(self.parse_invoke(func_name, invoke_content));
+                if let Some(tool) = self.parse_invoke(func_name, invoke_content) {
+                    tools.push(tool);
+                }
             }
         }
 
-        if tools.is_empty() {
-            return Ok((normal_text, vec![]));
+        let mut normal_text = normal_text;
+        if let Some(end) = last_block_end {
+            normal_text.push_str(&text[end..].replace(EOS_TOKEN, ""));
         }
 
         Ok((normal_text, tools))
+    }
+
+    async fn parse_complete_with_tools(
+        &self,
+        output: &str,
+        tools: &[Tool],
+    ) -> ParserResult<(String, Vec<ToolCall>)> {
+        let (normal_text, mut calls) = self.parse_complete(output).await?;
+        let tool_indices = helpers::get_tool_indices(tools);
+        calls.retain(|call| tool_indices.contains_key(call.function.name.as_str()));
+        Ok((normal_text, calls))
     }
 
     async fn parse_incremental(
@@ -302,13 +342,19 @@ impl ToolParser for DeepSeekDsmlParser {
         // passthrough path and lose the sentinel, turning every subsequent
         // chunk into plain text. (See regression test
         // `test_deepseek_dsml_v4_streaming_bpe_chunked_opener`.)
-        let has_dsml = current_text.contains("<｜DSML｜");
-        let has_partial_prefix = current_text.ends_with('<')
-            || current_text.ends_with("<｜")
-            || current_text.ends_with("</")
-            || current_text.ends_with("</｜");
+        let has_dsml =
+            current_text.contains(DSML_OPEN_SENTINEL) || current_text.contains(DSML_CLOSE_SENTINEL);
+        let has_partial_prefix =
+            helpers::ends_with_partial_token(&current_text, DSML_OPEN_SENTINEL).is_some()
+                || helpers::ends_with_partial_token(&current_text, DSML_CLOSE_SENTINEL).is_some();
 
         if !has_dsml && !has_partial_prefix {
+            // DeepSeek V4 emits blank lines immediately before a DSML tool-call
+            // block. Hold whitespace until the next token tells us whether it
+            // belongs to normal text or is only block framing.
+            if current_text.trim().is_empty() {
+                return Ok(StreamingParseResult::default());
+            }
             let mut normal_text = std::mem::take(&mut self.buffer);
             for end_token in [
                 self.block_close.as_str(),
@@ -327,6 +373,12 @@ impl ToolParser for DeepSeekDsmlParser {
         // If we have partial prefix but no actual DSML content, buffer and wait
         if !has_dsml && has_partial_prefix {
             return Ok(StreamingParseResult::default());
+        }
+
+        let mut normal_text = String::new();
+        if let Some(start) = self.buffer.find(self.block_open.as_str()) {
+            normal_text = self.buffer[..start].trim_end().to_string();
+            self.buffer = self.buffer[start..].to_string();
         }
 
         let tool_indices = helpers::get_tool_indices(tools);
@@ -379,10 +431,23 @@ impl ToolParser for DeepSeekDsmlParser {
                         &self.prev_tool_call_arr,
                     );
                     return Ok(StreamingParseResult {
-                        normal_text: String::new(),
+                        normal_text,
                         calls: all_calls,
                     });
                 }
+            }
+
+            let current_args = self.parse_parameters_from_dsml(&invoke_content, !is_complete);
+            if is_complete && !Self::arguments_are_valid_object(&invoke_content, &current_args) {
+                tracing::debug!("Invalid arguments for tool '{}' - skipping", func_name);
+                if let Some(end) = match_end {
+                    self.buffer = self.buffer[end..].to_string();
+                }
+                if self.current_tool_name_sent {
+                    self.current_tool_id += 1;
+                }
+                self.current_tool_name_sent = false;
+                continue;
             }
 
             // Initialize state on first tool
@@ -418,8 +483,6 @@ impl ToolParser for DeepSeekDsmlParser {
                 });
             }
 
-            // Parse current arguments (partial or complete)
-            let current_args = self.parse_parameters_from_dsml(&invoke_content, !is_complete);
             let tool_id = self.current_tool_id as usize;
 
             // Compute diff against what we've already sent
@@ -492,6 +555,7 @@ impl ToolParser for DeepSeekDsmlParser {
                 } else {
                     self.buffer.clear();
                 }
+                self.completed_tool_call_count += 1;
                 self.current_tool_id += 1;
                 self.current_tool_name_sent = false;
                 continue;
@@ -500,18 +564,48 @@ impl ToolParser for DeepSeekDsmlParser {
             }
         }
 
+        // Once the outer close tag is complete, discard all DSML framing and
+        // release only genuine trailing assistant text. In live V4 streams the
+        // closing sentinel is one token followed by the block-name pieces, so
+        // treating only the opening sentinel as DSML leaks the close tag.
+        if let Some(start) = self.buffer.find(self.block_close.as_str()) {
+            let tail = self.buffer[start + self.block_close.len()..].replace(EOS_TOKEN, "");
+            self.buffer.clear();
+            normal_text.push_str(&tail);
+        }
+
         Ok(StreamingParseResult {
-            normal_text: String::new(),
+            normal_text,
             calls: all_calls,
         })
     }
 
     fn has_tool_markers(&self, text: &str) -> bool {
-        text.contains(self.block_open.as_str())
+        text.contains(DSML_OPEN_SENTINEL) || text.contains(DSML_CLOSE_SENTINEL)
     }
 
     fn get_unstreamed_tool_args(&self) -> Option<Vec<ToolCallItem>> {
         helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
+    }
+
+    fn completed_tool_call_count(&self) -> Option<usize> {
+        Some(self.completed_tool_call_count)
+    }
+
+    fn finish_incremental(&mut self) -> StreamingParseResult {
+        let marker_start = [DSML_OPEN_SENTINEL, DSML_CLOSE_SENTINEL]
+            .into_iter()
+            .filter_map(|marker| self.buffer.find(marker))
+            .min();
+        let normal_text = match marker_start {
+            Some(start) => self.buffer[..start].trim_end().to_string(),
+            None => std::mem::take(&mut self.buffer),
+        };
+        self.buffer.clear();
+        StreamingParseResult {
+            normal_text,
+            calls: Vec::new(),
+        }
     }
 
     fn reset(&mut self) {
@@ -520,5 +614,6 @@ impl ToolParser for DeepSeekDsmlParser {
         self.current_tool_id = -1;
         self.current_tool_name_sent = false;
         self.streamed_args_for_tool.clear();
+        self.completed_tool_call_count = 0;
     }
 }

--- a/crates/tool_parser/src/traits.rs
+++ b/crates/tool_parser/src/traits.rs
@@ -45,6 +45,20 @@ pub trait ToolParser: Send + Sync {
         None
     }
 
+    /// Number of structurally complete, valid calls observed by an incremental
+    /// parser. `None` means the parser cannot distinguish completion from
+    /// provisional deltas and preserves the legacy finish-reason behavior.
+    fn completed_tool_call_count(&self) -> Option<usize> {
+        None
+    }
+
+    /// Finalize buffered incremental input at the Engine terminal boundary.
+    /// Parsers use this to release ordinary text that was retained only to
+    /// disambiguate a split structural marker.
+    fn finish_incremental(&mut self) -> StreamingParseResult {
+        StreamingParseResult::default()
+    }
+
     /// Take any text still buffered by the streaming parser that never became
     /// a tool call, transferring ownership to the caller.
     ///

--- a/crates/tool_parser/tests/tool_parser_deepseek_dsml.rs
+++ b/crates/tool_parser/tests/tool_parser_deepseek_dsml.rs
@@ -371,6 +371,27 @@ async fn test_deepseek_v4_complete_mixed_types() {
     assert_eq!(args["enabled"], true);
 }
 
+#[tokio::test]
+async fn test_deepseek_v4_complete_with_tools_omits_invalid_calls() {
+    let parser = DeepSeekDsmlParser::v4();
+    let tools = create_test_tools();
+    let input = concat!(
+        "Visible answer.\n\n",
+        "<｜DSML｜tool_calls>\n",
+        "<｜DSML｜invoke name=\"not_supplied\">{\"value\":1}</｜DSML｜invoke>\n",
+        "<｜DSML｜invoke name=\"get_weather\">{not-json}</｜DSML｜invoke>\n",
+        "</｜DSML｜tool_calls>",
+        "Ordinary trailing answer.",
+    );
+
+    let (normal_text, calls) = parser
+        .parse_complete_with_tools(input, &tools)
+        .await
+        .unwrap();
+    assert_eq!(normal_text, "Visible answer.Ordinary trailing answer.");
+    assert!(calls.is_empty());
+}
+
 #[test]
 fn test_deepseek_v4_format_detection() {
     let parser = DeepSeekDsmlParser::v4();
@@ -378,22 +399,23 @@ fn test_deepseek_v4_format_detection() {
     assert!(parser.has_tool_markers("<｜DSML｜tool_calls>"));
     assert!(parser.has_tool_markers("text <｜DSML｜tool_calls> marker"));
 
-    // V4 parser must NOT fire on the V3.2 block name.
-    assert!(!parser.has_tool_markers("<｜DSML｜function_calls>"));
+    // Any DSML sentinel is structural and must not leak as ordinary content,
+    // even when the block name is malformed for the selected model family.
+    assert!(parser.has_tool_markers("<｜DSML｜function_calls>"));
     assert!(!parser.has_tool_markers("plain text"));
 }
 
 #[test]
 fn test_deepseek_v32_does_not_match_v4_block() {
-    // Guardrail: a V3.2 parser must NOT treat a V4-shaped payload as a tool call.
+    // A cross-variant sentinel is structural even though it cannot form a call.
     let parser = DeepSeekDsmlParser::v32();
-    assert!(!parser.has_tool_markers("<｜DSML｜tool_calls>"));
+    assert!(parser.has_tool_markers("<｜DSML｜tool_calls>"));
 }
 
 #[tokio::test]
-async fn test_deepseek_v4_cross_variant_payload_passthrough() {
-    // A V4 parser given a V3.2-shaped payload must not parse calls; the input
-    // should flow through as normal text (has_tool_markers returns false).
+async fn test_deepseek_v4_cross_variant_payload_is_not_a_call() {
+    // A V4 parser given a V3.2-shaped payload must not parse calls or expose
+    // the foreign DSML framing as normal content.
     let parser = DeepSeekDsmlParser::v4();
     let v32_input = concat!(
         "<｜DSML｜function_calls>\n",
@@ -404,7 +426,7 @@ async fn test_deepseek_v4_cross_variant_payload_passthrough() {
     );
     let (normal_text, tools) = parser.parse_complete(v32_input).await.unwrap();
     assert!(tools.is_empty(), "V4 parser must not parse V3.2 block");
-    assert_eq!(normal_text, v32_input);
+    assert!(normal_text.is_empty());
 }
 
 #[tokio::test]
@@ -440,6 +462,7 @@ async fn test_deepseek_v4_streaming_single_tool() {
 
     assert!(found_name, "Should have found tool name during streaming");
     assert!(!collected_args.is_empty(), "Should have streamed arguments");
+    assert_eq!(parser.completed_tool_call_count(), Some(1));
 }
 
 #[tokio::test]
@@ -531,6 +554,57 @@ async fn test_deepseek_dsml_v4_streaming_strips_eos_from_partial_parameter() {
         !collected_args.contains("<｜end▁of▁sentence｜>"),
         "EOS must not leak into V4 streamed argument bytes, got: {collected_args:?}"
     );
+    assert_eq!(parser.completed_tool_call_count(), Some(0));
+}
+
+#[tokio::test]
+async fn test_deepseek_dsml_v4_terminal_invalid_call_is_not_complete() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekDsmlParser::v4();
+    let result = parser
+        .parse_incremental(
+            concat!(
+                "Visible answer.\n\n",
+                "<｜DSML｜tool_calls>",
+                "<｜DSML｜invoke name=\"get_weather\">{not-json}</｜DSML｜invoke>",
+                "</｜DSML｜tool_calls>",
+                "Ordinary trailing answer.",
+            ),
+            &tools,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.normal_text,
+        "Visible answer.Ordinary trailing answer."
+    );
+    assert!(result.calls.is_empty());
+    assert_eq!(parser.completed_tool_call_count(), Some(0));
+}
+
+#[tokio::test]
+async fn test_deepseek_dsml_v4_terminal_partial_preserves_only_prefix_text() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekDsmlParser::v4();
+    let result = parser
+        .parse_incremental(
+            concat!(
+                "Visible answer.\n\n",
+                "<｜DSML｜tool_calls>",
+                "<｜DSML｜invoke name=\"get_weather\">",
+                "<｜DSML｜parameter name=\"city\" string=\"true\">Ber",
+            ),
+            &tools,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.normal_text, "Visible answer.");
+    assert_eq!(parser.completed_tool_call_count(), Some(0));
+
+    let terminal = parser.finish_incremental();
+    assert!(terminal.normal_text.is_empty());
+    assert!(terminal.calls.is_empty());
 }
 
 /// A malformed complete invoke with `name=""` must not stall the buffer.
@@ -674,8 +748,8 @@ async fn test_deepseek_dsml_v4_streaming_bpe_chunked_opener() {
         "argument bytes must be emitted, got: {collected_args:?}"
     );
     assert!(
-        !normal_text.contains("<｜DSML｜"),
-        "DSML sentinel must not leak into normal_text, got: {normal_text:?}"
+        normal_text.is_empty(),
+        "DSML framing and its leading whitespace must not leak into normal_text, got: {normal_text:?}"
     );
 }
 

--- a/crates/tool_parser/tests/tool_parser_deepseek_dsml.rs
+++ b/crates/tool_parser/tests/tool_parser_deepseek_dsml.rs
@@ -607,6 +607,53 @@ async fn test_deepseek_dsml_v4_terminal_partial_preserves_only_prefix_text() {
     assert!(terminal.calls.is_empty());
 }
 
+/// Regression for the router terminal-flush finding: an invoke that streams
+/// provisional name/argument deltas while still incomplete, then closes with
+/// invalid JSON arguments, must not count as a completed call. The streaming
+/// routers rely on `completed_tool_call_count()` staying zero here to degrade
+/// the terminal finish/stop reason instead of pinning "tool_calls"/"tool_use".
+#[tokio::test]
+async fn test_deepseek_dsml_v4_split_invalid_invoke_stays_uncompleted() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekDsmlParser::v4();
+
+    // Chunk 1: incomplete invoke — provisional deltas stream before the
+    // arguments can be validated.
+    let first = parser
+        .parse_incremental(
+            "<｜DSML｜tool_calls><｜DSML｜invoke name=\"get_weather\">{\"city\": \"Ber",
+            &tools,
+        )
+        .await
+        .unwrap();
+    assert!(
+        first
+            .calls
+            .iter()
+            .any(|call| call.name.as_deref() == Some("get_weather")),
+        "provisional tool name delta should stream before validation, got: {:?}",
+        first.calls
+    );
+    assert_eq!(parser.completed_tool_call_count(), Some(0));
+
+    // Chunk 2 closes the invoke with invalid JSON arguments; the parser
+    // skips the call, so the completed count stays zero and only genuine
+    // trailing text is released.
+    let second = parser
+        .parse_incremental(
+            "lin\" oops}</｜DSML｜invoke></｜DSML｜tool_calls>Trailing answer.",
+            &tools,
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.normal_text, "Trailing answer.");
+    assert_eq!(parser.completed_tool_call_count(), Some(0));
+
+    let terminal = parser.finish_incremental();
+    assert!(terminal.normal_text.is_empty());
+    assert!(terminal.calls.is_empty());
+}
+
 /// A malformed complete invoke with `name=""` must not stall the buffer.
 /// Previously the streaming `invoke_regex` required `[^"]+` so `name=""`
 /// never matched, leaving the bad block stuck at the head of the buffer —

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -626,12 +626,29 @@ impl StreamingProcessor {
             }
         }
 
-        // Phase 3: End-of-stream parser flush: first any text still buffered
-        // as a prospective tool call that never materialized (dropping it
-        // produced fully-empty streams), then any parsed-but-unstreamed tool
-        // arguments.
+        // Phase 3: End-of-stream parser flush. First parser-specific
+        // finalization (DSML: text held back to disambiguate a split
+        // structural marker, plus structurally complete calls), then any
+        // text still buffered as a prospective tool call that never
+        // materialized (dropping it produced fully-empty streams), then any
+        // parsed-but-unstreamed tool arguments.
         for (index, parser) in &tool_parsers {
             let mut parser_guard = parser.lock().await;
+
+            let finalized = parser_guard.finish_incremental();
+            if !finalized.normal_text.is_empty() {
+                let content_chunk = ChatCompletionStreamResponse::builder(request_id, model)
+                    .created(created)
+                    .add_choice_content(*index, "assistant", finalized.normal_text)
+                    .maybe_system_fingerprint(system_fingerprint)
+                    .build();
+                let sse_chunk = sse_encoder
+                    .encode_data(&content_chunk)
+                    .map_err(|e| format!("Failed to serialize terminal content chunk: {e}"))?;
+                tx.send(Ok(sse_chunk))
+                    .await
+                    .map_err(|_| "Failed to send terminal content chunk".to_string())?;
+            }
 
             let leftover_text = parser_guard.take_unstreamed_normal_text();
             if !leftover_text.is_empty() {
@@ -649,35 +666,42 @@ impl StreamingProcessor {
                     .map_err(|_| "Failed to send flushed content chunk".to_string())?;
             }
 
-            if let Some(unstreamed_items) = parser_guard.get_unstreamed_tool_args() {
-                for tool_call_item in unstreamed_items {
-                    let tool_call_delta = ToolCallDelta {
-                        index: tool_call_item.tool_index as u32,
-                        id: None,
-                        tool_type: None,
-                        function: Some(FunctionCallDelta {
-                            name: None,
-                            arguments: if tool_call_item.parameters.is_empty() {
-                                None
-                            } else {
-                                Some(tool_call_item.parameters)
-                            },
-                        }),
-                    };
+            let terminal_items = finalized.calls.into_iter().chain(
+                parser_guard
+                    .get_unstreamed_tool_args()
+                    .into_iter()
+                    .flatten(),
+            );
+            for tool_call_item in terminal_items {
+                let tool_call_delta = ToolCallDelta {
+                    index: tool_call_item.tool_index as u32,
+                    id: None,
+                    tool_type: None,
+                    function: Some(FunctionCallDelta {
+                        name: None,
+                        arguments: if tool_call_item.parameters.is_empty() {
+                            None
+                        } else {
+                            Some(tool_call_item.parameters)
+                        },
+                    }),
+                };
 
-                    let tool_chunk = ChatCompletionStreamResponse::builder(request_id, model)
-                        .created(created)
-                        .add_choice_tool_call_delta(*index, tool_call_delta)
-                        .maybe_system_fingerprint(system_fingerprint)
-                        .build();
+                let tool_chunk = ChatCompletionStreamResponse::builder(request_id, model)
+                    .created(created)
+                    .add_choice_tool_call_delta(*index, tool_call_delta)
+                    .maybe_system_fingerprint(system_fingerprint)
+                    .build();
 
-                    let sse_chunk = sse_encoder
-                        .encode_data(&tool_chunk)
-                        .map_err(|e| format!("Failed to serialize tool chunk: {e}"))?;
-                    tx.send(Ok(sse_chunk))
-                        .await
-                        .map_err(|_| "Failed to send unstreamed tool args".to_string())?;
-                }
+                let sse_chunk = sse_encoder
+                    .encode_data(&tool_chunk)
+                    .map_err(|e| format!("Failed to serialize tool chunk: {e}"))?;
+                tx.send(Ok(sse_chunk))
+                    .await
+                    .map_err(|_| "Failed to send unstreamed tool args".to_string())?;
+            }
+            if let Some(completed_call_count) = parser_guard.completed_tool_call_count() {
+                has_tool_calls.insert(*index, completed_call_count > 0);
             }
         }
 

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -2426,47 +2426,11 @@ impl StreamingProcessor {
         // does not pin stop_reason to "tool_use".
         if let Some(ref mut parser) = streaming_tool_parser {
             let finalized = parser.finish_incremental();
-            if !finalized.normal_text.is_empty() {
-                if tool_block_open {
-                    Self::send_messages_event(
-                        tx,
-                        &mut sse_buffer,
-                        &MessageStreamEvent::ContentBlockStop {
-                            index: current_block_index,
-                        },
-                    )
-                    .await?;
-                    tool_block_open = false;
-                    current_block_index += 1;
-                }
-                if !text_block_open {
-                    Self::send_messages_event(
-                        tx,
-                        &mut sse_buffer,
-                        &MessageStreamEvent::ContentBlockStart {
-                            index: current_block_index,
-                            content_block: ContentBlock::Text {
-                                text: String::new(),
-                                citations: None,
-                            },
-                        },
-                    )
-                    .await?;
-                    text_block_open = true;
-                }
-                Self::send_messages_event(
-                    tx,
-                    &mut sse_buffer,
-                    &MessageStreamEvent::ContentBlockDelta {
-                        index: current_block_index,
-                        delta: ContentBlockDelta::TextDelta {
-                            text: finalized.normal_text,
-                        },
-                    },
-                )
-                .await?;
-            }
 
+            // Flush terminal tool-call items first, while a tool_use block is
+            // still open: emitting text first would close the block and send
+            // trailing InputJsonDelta inside a text block, which the
+            // content-block contract forbids.
             let terminal_items = finalized.calls.into_iter().chain(
                 parser.get_unstreamed_tool_args().into_iter().flatten(),
             );
@@ -2534,6 +2498,47 @@ impl StreamingProcessor {
                     )
                     .await?;
                 }
+            }
+
+            if !finalized.normal_text.is_empty() {
+                if tool_block_open {
+                    Self::send_messages_event(
+                        tx,
+                        &mut sse_buffer,
+                        &MessageStreamEvent::ContentBlockStop {
+                            index: current_block_index,
+                        },
+                    )
+                    .await?;
+                    tool_block_open = false;
+                    current_block_index += 1;
+                }
+                if !text_block_open {
+                    Self::send_messages_event(
+                        tx,
+                        &mut sse_buffer,
+                        &MessageStreamEvent::ContentBlockStart {
+                            index: current_block_index,
+                            content_block: ContentBlock::Text {
+                                text: String::new(),
+                                citations: None,
+                            },
+                        },
+                    )
+                    .await?;
+                    text_block_open = true;
+                }
+                Self::send_messages_event(
+                    tx,
+                    &mut sse_buffer,
+                    &MessageStreamEvent::ContentBlockDelta {
+                        index: current_block_index,
+                        delta: ContentBlockDelta::TextDelta {
+                            text: finalized.normal_text,
+                        },
+                    },
+                )
+                .await?;
             }
 
             // Provisional deltas from a complete-but-invalid call were

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -2420,73 +2420,127 @@ impl StreamingProcessor {
             }
         }
 
-        if let Some(ref parser) = streaming_tool_parser {
-            if let Some(unstreamed_items) = parser.get_unstreamed_tool_args() {
-                for tool_call_item in unstreamed_items {
-                    has_tool_calls = true;
-
-                    if let Some(ref name) = tool_call_item.name {
-                        // Close text block if open before starting tool block
-                        if text_block_open {
-                            Self::send_messages_event(
-                                tx,
-                                &mut sse_buffer,
-                                &MessageStreamEvent::ContentBlockStop {
-                                    index: current_block_index,
-                                },
-                            )
-                            .await?;
-                            text_block_open = false;
-                            current_block_index += 1;
-                        }
-                        if tool_block_open {
-                            Self::send_messages_event(
-                                tx,
-                                &mut sse_buffer,
-                                &MessageStreamEvent::ContentBlockStop {
-                                    index: current_block_index,
-                                },
-                            )
-                            .await?;
-                            current_block_index += 1;
-                        }
-
-                        let tool_call_id = utils::generate_tool_call_id(
-                            model,
-                            name,
-                            tool_call_item.tool_index,
-                            history_tool_calls_count,
-                        );
-                        Self::send_messages_event(
-                            tx,
-                            &mut sse_buffer,
-                            &MessageStreamEvent::ContentBlockStart {
-                                index: current_block_index,
-                                content_block: ContentBlock::ToolUse {
-                                    id: message_utils::anthropic_tool_use_id(&tool_call_id),
-                                    name: name.clone(),
-                                    input: Value::Object(serde_json::Map::new()),
-                                },
-                            },
-                        )
-                        .await?;
-                        tool_block_open = true;
-                    }
-
-                    if !tool_call_item.parameters.is_empty() {
-                        Self::send_messages_event(
-                            tx,
-                            &mut sse_buffer,
-                            &MessageStreamEvent::ContentBlockDelta {
-                                index: current_block_index,
-                                delta: ContentBlockDelta::InputJsonDelta {
-                                    partial_json: tool_call_item.parameters,
-                                },
-                            },
-                        )
-                        .await?;
-                    }
+        // Phase 3: Finalize the incremental parser — flush held-back text,
+        // emit finalized/unstreamed tool args, then reconcile has_tool_calls
+        // with the count of completed valid calls so an all-invalid stream
+        // does not pin stop_reason to "tool_use".
+        if let Some(ref mut parser) = streaming_tool_parser {
+            let finalized = parser.finish_incremental();
+            if !finalized.normal_text.is_empty() {
+                if tool_block_open {
+                    Self::send_messages_event(
+                        tx,
+                        &mut sse_buffer,
+                        &MessageStreamEvent::ContentBlockStop {
+                            index: current_block_index,
+                        },
+                    )
+                    .await?;
+                    tool_block_open = false;
+                    current_block_index += 1;
                 }
+                if !text_block_open {
+                    Self::send_messages_event(
+                        tx,
+                        &mut sse_buffer,
+                        &MessageStreamEvent::ContentBlockStart {
+                            index: current_block_index,
+                            content_block: ContentBlock::Text {
+                                text: String::new(),
+                                citations: None,
+                            },
+                        },
+                    )
+                    .await?;
+                    text_block_open = true;
+                }
+                Self::send_messages_event(
+                    tx,
+                    &mut sse_buffer,
+                    &MessageStreamEvent::ContentBlockDelta {
+                        index: current_block_index,
+                        delta: ContentBlockDelta::TextDelta {
+                            text: finalized.normal_text,
+                        },
+                    },
+                )
+                .await?;
+            }
+
+            let terminal_items = finalized.calls.into_iter().chain(
+                parser.get_unstreamed_tool_args().into_iter().flatten(),
+            );
+            for tool_call_item in terminal_items {
+                has_tool_calls = true;
+
+                if let Some(ref name) = tool_call_item.name {
+                    // Close text block if open before starting tool block
+                    if text_block_open {
+                        Self::send_messages_event(
+                            tx,
+                            &mut sse_buffer,
+                            &MessageStreamEvent::ContentBlockStop {
+                                index: current_block_index,
+                            },
+                        )
+                        .await?;
+                        text_block_open = false;
+                        current_block_index += 1;
+                    }
+                    if tool_block_open {
+                        Self::send_messages_event(
+                            tx,
+                            &mut sse_buffer,
+                            &MessageStreamEvent::ContentBlockStop {
+                                index: current_block_index,
+                            },
+                        )
+                        .await?;
+                        current_block_index += 1;
+                    }
+
+                    let tool_call_id = utils::generate_tool_call_id(
+                        model,
+                        name,
+                        tool_call_item.tool_index,
+                        history_tool_calls_count,
+                    );
+                    Self::send_messages_event(
+                        tx,
+                        &mut sse_buffer,
+                        &MessageStreamEvent::ContentBlockStart {
+                            index: current_block_index,
+                            content_block: ContentBlock::ToolUse {
+                                id: message_utils::anthropic_tool_use_id(&tool_call_id),
+                                name: name.clone(),
+                                input: Value::Object(serde_json::Map::new()),
+                            },
+                        },
+                    )
+                    .await?;
+                    tool_block_open = true;
+                }
+
+                if !tool_call_item.parameters.is_empty() {
+                    Self::send_messages_event(
+                        tx,
+                        &mut sse_buffer,
+                        &MessageStreamEvent::ContentBlockDelta {
+                            index: current_block_index,
+                            delta: ContentBlockDelta::InputJsonDelta {
+                                partial_json: tool_call_item.parameters,
+                            },
+                        },
+                    )
+                    .await?;
+                }
+            }
+
+            // Provisional deltas from a complete-but-invalid call were
+            // skipped by the parser; if no call actually completed, degrade
+            // the terminal stop_reason from "tool_use" to "end_turn".
+            if let Some(completed_call_count) = parser.completed_tool_call_count() {
+                has_tool_calls = completed_call_count > 0;
             }
         }
 

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -2431,9 +2431,10 @@ impl StreamingProcessor {
             // still open: emitting text first would close the block and send
             // trailing InputJsonDelta inside a text block, which the
             // content-block contract forbids.
-            let terminal_items = finalized.calls.into_iter().chain(
-                parser.get_unstreamed_tool_args().into_iter().flatten(),
-            );
+            let terminal_items = finalized
+                .calls
+                .into_iter()
+                .chain(parser.get_unstreamed_tool_args().into_iter().flatten());
             for tool_call_item in terminal_items {
                 has_tool_calls = true;
 


### PR DESCRIPTION
## Motivation

When a DeepSeek DSML model ends its stream immediately after a tool-call block, the incremental parser can hold a finalized tool call (and text buffered before/after the DSML sentinels) hostage: stream end was reached with nothing left to parse incrementally, so the terminal chunk went out without the pending tool call and with held-back text dropped.

## What this changes

**tool_parser (deepseek_dsml):**
- DSML open/close sentinels are treated as structural — `has_tool_markers` fires on both.
- An `arguments_are_valid_object` gate keeps invalid invokes from ever completing.
- New `completed_tool_call_count` state; `reset()` clears it.
- Leading whitespace before DSML blocks is held back; trailing text after `</｜DSML｜tool_calls>` is released with EOS stripped.
- Two new defaulted trait methods (non-breaking for other parsers): `completed_tool_call_count()` and `finish_incremental()`, which flushes the buffer up to the first sentinel.
- `parse_complete_with_tools` filters emitted calls to the tools supplied in the request.

**chat streaming (model_gateway):** on stream end, the Phase-3 path calls `finish_incremental()`, emits any finalized held-back text as a content chunk, chains the finalized calls with `get_unstreamed_tool_args()` into the terminal items, and derives `has_tool_calls` from `completed_tool_call_count()` so the finish reason maps to `tool_calls` correctly.

## Tests

4 new DSML integration tests (terminal flush, held-back text, invalid-argument gating, request-tool filtering); `tool-parser` suite 29/0, smg streaming lib tests 14/0.