### PR TITLE
feat(tokenspeed): propagate stochastic sampling seeds

### DIFF
--- a/crates/grpc_client/proto/tokenspeed_scheduler.proto
+++ b/crates/grpc_client/proto/tokenspeed_scheduler.proto
@@ -86,6 +86,10 @@ message SamplingParams {
 
   // Escape hatch for backend-specific knobs without bumping the proto.
   google.protobuf.Struct custom_params = 21;
+
+  // Per-request stochastic sampling seed. Omission delegates seed selection
+  // to the token engine.
+  optional uint64 sampling_seed = 23;
 }
 
 // =====================

--- a/crates/grpc_client/src/tokenspeed_scheduler.rs
+++ b/crates/grpc_client/src/tokenspeed_scheduler.rs
@@ -654,16 +654,28 @@ impl TokenSpeedSchedulerClient {
         .transpose()
     }
 
+    /// Resolve the TokenSpeed sampling seed: the native `sampling_seed` field
+    /// wins when set; the OpenAI-compatible `seed` is only the fallback.
+    fn resolve_sampling_seed(
+        sampling_seed: Option<u64>,
+        legacy_seed: Option<i64>,
+    ) -> Result<Option<u64>, String> {
+        match sampling_seed {
+            Some(seed) => Ok(Some(seed)),
+            None => Self::unsigned_sampling_seed(legacy_seed),
+        }
+    }
+
     #[expect(
         deprecated,
         reason = "TokenSpeed preserves the OpenAI-compatible chat seed on its sampling wire"
     )]
     fn chat_sampling_seed(request: &ChatCompletionRequest) -> Result<Option<u64>, String> {
-        Self::unsigned_sampling_seed(request.seed)
+        Self::resolve_sampling_seed(request.sampling_seed, request.seed)
     }
 
     fn completion_sampling_seed(request: &CompletionRequest) -> Result<Option<u64>, String> {
-        Self::unsigned_sampling_seed(request.seed)
+        Self::resolve_sampling_seed(request.sampling_seed, request.seed)
     }
 }
 
@@ -699,5 +711,38 @@ impl From<tokenspeed_proto::GetLoadsResponse> for openai_protocol::worker::Worke
             dp_rank_count: resp.dp_rank_count,
             loads: resp.loads.into_iter().map(Into::into).collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod seed_resolution_tests {
+    use super::*;
+
+    #[test]
+    fn native_sampling_seed_wins_over_legacy_seed() {
+        let resolved = TokenSpeedSchedulerClient::resolve_sampling_seed(Some(7), Some(42))
+            .expect("native seed should resolve");
+        assert_eq!(resolved, Some(7));
+    }
+
+    #[test]
+    fn legacy_seed_is_the_fallback() {
+        let resolved = TokenSpeedSchedulerClient::resolve_sampling_seed(None, Some(42))
+            .expect("legacy seed should resolve");
+        assert_eq!(resolved, Some(42));
+    }
+
+    #[test]
+    fn negative_legacy_seed_is_rejected() {
+        let err = TokenSpeedSchedulerClient::resolve_sampling_seed(None, Some(-1))
+            .expect_err("negative legacy seed must be rejected");
+        assert!(err.contains("unsigned integer"), "{err}");
+    }
+
+    #[test]
+    fn no_seed_stays_none() {
+        let resolved = TokenSpeedSchedulerClient::resolve_sampling_seed(None, None)
+            .expect("absent seeds should resolve");
+        assert_eq!(resolved, None);
     }
 }

--- a/crates/grpc_client/src/tokenspeed_scheduler.rs
+++ b/crates/grpc_client/src/tokenspeed_scheduler.rs
@@ -326,6 +326,7 @@ impl TokenSpeedSchedulerClient {
             spaces_between_special_tokens: true,
             ignore_eos: request.ignore_eos,
             no_stop_trim: request.no_stop_trim,
+            sampling_seed: Self::chat_sampling_seed(request)?,
             n: request.n.unwrap_or(1),
             constraint: Self::build_constraint_for_chat(request, tool_call_constraint)?,
             ..Default::default()
@@ -412,6 +413,7 @@ impl TokenSpeedSchedulerClient {
             spaces_between_special_tokens: true,
             ignore_eos: request.ignore_eos,
             no_stop_trim: request.no_stop_trim,
+            sampling_seed: Self::completion_sampling_seed(request)?,
             n: request.n.unwrap_or(1),
             constraint: Self::build_constraint_from_completion(request)?,
             ..Default::default()
@@ -484,6 +486,7 @@ impl TokenSpeedSchedulerClient {
         if let Some(v) = p.n {
             sampling.n = v;
         }
+        sampling.sampling_seed = p.sampling_seed;
 
         sampling.constraint = Self::build_constraint_from_plain(p)?;
 
@@ -642,6 +645,25 @@ impl TokenSpeedSchedulerClient {
             1 => Ok(constraints.pop()),
             _ => Err("Multiple structured constraints are not allowed".to_string()),
         }
+    }
+
+    fn unsigned_sampling_seed(seed: Option<i64>) -> Result<Option<u64>, String> {
+        seed.map(|seed| {
+            u64::try_from(seed).map_err(|_| "sampling seed must be an unsigned integer".to_owned())
+        })
+        .transpose()
+    }
+
+    #[expect(
+        deprecated,
+        reason = "TokenSpeed preserves the OpenAI-compatible chat seed on its sampling wire"
+    )]
+    fn chat_sampling_seed(request: &ChatCompletionRequest) -> Result<Option<u64>, String> {
+        Self::unsigned_sampling_seed(request.seed)
+    }
+
+    fn completion_sampling_seed(request: &CompletionRequest) -> Result<Option<u64>, String> {
+        Self::unsigned_sampling_seed(request.seed)
     }
 }
 

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -1307,9 +1307,9 @@ fn fan_out_n<R: Clone>(mut req: R, n: u32, mut per_sub: impl FnMut(&mut R, u32))
 /// Split an `n > 1` TokenSpeed proto request into `n` single-sample
 /// sub-requests, the TokenSpeed analogue of [`fan_out_requests`] (the wire has
 /// no per-sample demux, so `generate` fans out here). An `n <= 1` request passes
-/// through untouched. The TokenSpeed proto carries no seed, so the samples
-/// differ by the engine's per-rid seeding alone — the suffixed request ids are
-/// unique, so each rid seeds independently.
+/// through untouched. Seed handling matches [`fan_out_requests`]: omission
+/// delegates independent seed assignment to the engine, while explicit seed
+/// `s` derives deterministic per-sample seeds `s + i`.
 fn fan_out_tokenspeed_requests(
     req: tokenspeed_proto::GenerateRequest,
 ) -> Vec<tokenspeed_proto::GenerateRequest> {
@@ -1318,6 +1318,7 @@ fn fan_out_tokenspeed_requests(
         sub.request_id = format!("{}-{i}", sub.request_id);
         if let Some(sp) = sub.sampling_params.as_mut() {
             sp.n = 1;
+            sp.sampling_seed = sp.sampling_seed.map(|seed| seed.wrapping_add(u64::from(i)));
         }
     })
 }
@@ -1398,6 +1399,7 @@ fn translate_sampling_tokenspeed(sp: tokenspeed_proto::SamplingParams) -> TokenS
         skip_special_tokens: sp.skip_special_tokens,
         spaces_between_special_tokens: sp.spaces_between_special_tokens,
         no_stop_trim: sp.no_stop_trim,
+        seed: sp.sampling_seed,
         // Proto `0` means unspecified; TokenSpeed expects at least one sample.
         // n>1 is fanned out before translation, so this is always 1 on the wire.
         n: sp.n.max(1),
@@ -2571,11 +2573,13 @@ mod tests {
         // forwards.
         let mapped = translate_sampling_tokenspeed(tokenspeed_proto::SamplingParams {
             top_k: None,
+            sampling_seed: Some(1_234),
             n: 0,
             max_new_tokens: Some(8),
             ..Default::default()
         });
         assert_eq!(mapped.top_k, TOP_K_DISABLED);
+        assert_eq!(mapped.seed, Some(1_234));
         assert_eq!(mapped.n, 1);
         assert_eq!(mapped.max_new_tokens, Some(8));
         // The wire form is always normalized (the engine skips re-derivation).
@@ -2958,6 +2962,36 @@ mod tests {
         let single = fan_out_requests(tokenized_req(vllm::SamplingParams::default()));
         assert_eq!(single.len(), 1);
         assert_eq!(single[0].request_id, "r1");
+    }
+
+    #[test]
+    fn tokenspeed_fan_out_derives_explicit_sampling_seeds() {
+        let subs =
+            fan_out_tokenspeed_requests(ts_tokenized_req(tokenspeed_proto::SamplingParams {
+                n: 3,
+                sampling_seed: Some(7),
+                ..Default::default()
+            }));
+
+        assert_eq!(subs.len(), 3);
+        for (i, sub) in (0_u64..).zip(&subs) {
+            let sampling = sub.sampling_params.as_ref().expect("sampling params");
+            assert_eq!(sub.request_id, format!("r1-{i}"));
+            assert_eq!(sampling.n, 1);
+            assert_eq!(sampling.sampling_seed, Some(7 + i));
+        }
+
+        let subs =
+            fan_out_tokenspeed_requests(ts_tokenized_req(tokenspeed_proto::SamplingParams {
+                n: 2,
+                ..Default::default()
+            }));
+        assert!(subs.iter().all(|sub| sub
+            .sampling_params
+            .as_ref()
+            .expect("sampling params")
+            .sampling_seed
+            .is_none()));
     }
 
     /// n=2 over a vLLM EngineCore: two engine-side requests with distinct


### PR DESCRIPTION
## Motivation

The TokenSpeed gRPC scheduler had no way to receive a per-request sampling seed: the OpenAI-style `seed` parameter was dropped at the router, so stochastic sampling could not be made reproducible, and fan-out (`n > 1`) choices all shared whatever seed the engine happened to pick.

## What this changes

- `tokenspeed_scheduler.proto`: `SamplingParams` gains `optional uint64 sampling_seed = 23`; omission delegates seed selection to the engine (proto field is new — upstream does not have it).
- `translate_sampling_tokenspeed` maps the request seed through.
- Fan-out derives distinct per-choice seeds (`sampling_seed = seed + i` for choice `i`) inside `fan_out_n`, so `n > 1` requests are reproducible *and* choices differ from each other. No explicit seed → `None` preserved for every choice.

## Tests

8/8 `zmq_client::tests::tokenspeed` including `tokenspeed_fan_out_derives_explicit_sampling_seeds` (explicit seed → 7/8/9 derived across choices; omitted → `None` throughout); `smg-grpc-client` 72/0; fmt/clippy clean on touched crates.