### PR TITLE
fix(protocols): preserve custom sampling parameters

### DIFF
--- a/crates/protocols/src/sampling_params.rs
+++ b/crates/protocols/src/sampling_params.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use validator::Validate;
 
 use super::common::StringOrArray;
@@ -40,6 +41,8 @@ pub struct SamplingParams {
     pub no_stop_trim: Option<bool>,
     pub n: Option<u32>,
     pub sampling_seed: Option<u64>,
+    /// Custom parameters for engine-specific sampling behavior.
+    pub custom_params: Option<Map<String, Value>>,
 }
 
 // ============================================================================

--- a/crates/protocols/tests/sampling_params.rs
+++ b/crates/protocols/tests/sampling_params.rs
@@ -1,0 +1,62 @@
+use openai_protocol::{generate::GenerateRequest, sampling_params::SamplingParams};
+use serde_json::{json, Value};
+
+fn custom_params_payload() -> Value {
+    json!({
+        "nested": {
+            "list": [1, "two", true, null, {"leaf": null}],
+            "object": {"key": "value"}
+        },
+        "string": "custom",
+        "number": 42.5,
+        "bool": false,
+        "null": null
+    })
+}
+
+#[test]
+fn sampling_params_preserve_custom_params_round_trip() {
+    let input = json!({
+        "temperature": 0.5,
+        "custom_params": custom_params_payload()
+    });
+
+    let sampling_params: SamplingParams =
+        serde_json::from_value(input.clone()).expect("sampling params should deserialize");
+    let output = serde_json::to_value(sampling_params).expect("sampling params should serialize");
+
+    assert_eq!(
+        output, input,
+        "custom_params must survive the typed round-trip"
+    );
+}
+
+#[test]
+fn generate_request_preserves_nested_custom_params_round_trip() {
+    let custom_params = custom_params_payload();
+    let input = json!({
+        "text": "hello",
+        "sampling_params": {
+            "temperature": 0.5,
+            "custom_params": custom_params.clone()
+        }
+    });
+
+    let request: GenerateRequest =
+        serde_json::from_value(input).expect("generate request should deserialize");
+    assert!(
+        !request.other.contains_key("custom_params"),
+        "nested custom_params must not leak into the request catch-all"
+    );
+
+    let output = serde_json::to_value(request).expect("generate request should serialize");
+    assert_eq!(
+        output.pointer("/sampling_params/custom_params"),
+        Some(&custom_params),
+        "nested custom_params must survive the typed round-trip"
+    );
+    assert!(
+        output.get("custom_params").is_none(),
+        "nested custom_params must not be serialized at the request top level"
+    );
+}


### PR DESCRIPTION
Closes #2229

## Description

### Problem

`GenerateRequest` deserializes its nested `sampling_params` object into `SamplingParams`. Because that type does not currently define `custom_params`, Serde silently drops the nested object and it is absent when the typed request is serialized again.

The top-level catch-alls added by #1130 and #1503 do not cover this nested location. SGLang still pins `openai-protocol` 1.0.0, and the latest published 1.11.0 also lacks the nested field.

### Solution

Add `custom_params: Option<Map<String, Value>>` to `SamplingParams`. This is an explicit protocol field, not a general nested flatten. Its values retain arbitrary JSON structure, while the existing `skip_serializing_none` behavior keeps the property omitted when it is absent.

## Changes

- Add the optional `custom_params` field to `SamplingParams`.
- Add a direct semantic JSON round-trip regression test.
- Add a nested `GenerateRequest` regression test that verifies the field remains under `sampling_params` and does not leak into the request's top-level catch-all.

## Test Plan

- `cargo +nightly test -p openai-protocol` — passed (223 passed, 4 ignored), including the direct `SamplingParams` and nested `GenerateRequest` round-trip regressions.
- `cargo +stable clippy -p openai-protocol --all-targets --all-features -- -D warnings` — passed.
