### PR TITLE
fix(router): release request buffers after upstream dispatch

### DIFF
--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -265,6 +265,10 @@ pub(crate) fn init_metrics() {
         "smg_router_upstream_responses_total",
         "Upstream backend HTTP responses by router_type, status_code, error_code"
     );
+    describe_counter!(
+        "smg_router_request_buffers_released_early_bytes_total",
+        "Serialized size of request buffers freed at dispatch instead of response completion (retries disabled)"
+    );
 
     // Layer 2: Router inference metrics (gRPC only)
     describe_histogram!(
@@ -996,6 +1000,12 @@ impl Metrics {
             "router_type" => router_type
         )
         .increment(1);
+    }
+
+    /// Record request buffers freed at dispatch (retries disabled), sized by
+    /// the serialized upstream body.
+    pub fn record_request_buffers_released_early(bytes: usize) {
+        counter!("smg_router_request_buffers_released_early_bytes_total").increment(bytes as u64);
     }
 
     /// Record upstream backend response.

--- a/model_gateway/src/routers/anthropic/router.rs
+++ b/model_gateway/src/routers/anthropic/router.rs
@@ -93,10 +93,10 @@ impl RouterTrait for AnthropicRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &CreateMessageRequest,
+        body: CreateMessageRequest,
         model_id: &str,
     ) -> Response {
-        let request = body.clone();
+        let request = body;
         let headers_owned = headers.cloned();
 
         let mcp_servers = if header_utils::is_smg_mcp_enabled(headers) && request.has_mcp_toolset()

--- a/model_gateway/src/routers/gemini/router.rs
+++ b/model_gateway/src/routers/gemini/router.rs
@@ -76,10 +76,10 @@ impl RouterTrait for GeminiRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &InteractionsRequest,
+        body: InteractionsRequest,
         model_id: Option<&str>,
     ) -> Response {
-        let request = Arc::new(body.clone());
+        let request = Arc::new(body);
         let headers_cloned = headers.cloned();
         let model_id_cloned = model_id.map(String::from);
         let components = self.shared_components.clone();

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -536,10 +536,10 @@ impl GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ChatCompletionRequest,
+        body: ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
-        if let Err(response) = super::validate_text_only_output(body) {
+        if let Err(response) = super::validate_text_only_output(&body) {
             return *response;
         }
 
@@ -567,7 +567,7 @@ impl GrpcRouter {
         // would no-op and otherwise leave the alias sitting in the body for
         // response metadata and parser selection to read.
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
-        let mut canonical_body = body.clone();
+        let mut canonical_body = body;
         canonical_body.model = model_id_cloned.clone();
         let request = Arc::new(canonical_body);
         let headers_cloned = headers.cloned();
@@ -630,7 +630,7 @@ impl GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &GenerateRequest,
+        body: GenerateRequest,
         model_id: &str,
     ) -> Response {
         debug!("Processing generate request for model: {}", model_id);
@@ -639,7 +639,7 @@ impl GrpcRouter {
         // front -- see `resolve_canonical_model_id`'s doc comment. Rewrite
         // the body's `model` field to match; see `route_chat_impl`.
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
-        let mut canonical_body = body.clone();
+        let mut canonical_body = body;
         canonical_body.model = model_id_cloned.clone();
         let request = Arc::new(canonical_body);
         let headers_cloned = headers.cloned();
@@ -703,7 +703,7 @@ impl GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ResponsesRequest,
+        body: ResponsesRequest,
         model_id: &str,
     ) -> Response {
         let (Some(responses_context), Some(harmony_responses_context)) =
@@ -722,7 +722,7 @@ impl GrpcRouter {
         }
 
         let (body, canonical_model_id) =
-            canonicalize_responses_request(&self.worker_registry, body, model_id);
+            canonicalize_responses_request(&self.worker_registry, &body, model_id);
         let model_id = canonical_model_id.as_ref();
 
         // Choose implementation based on Harmony model detection (checks worker metadata)
@@ -774,7 +774,7 @@ impl GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &EmbeddingRequest,
+        body: EmbeddingRequest,
         model_id: &str,
     ) -> Response {
         let Some(embedding_pipeline) = self.embedding_pipeline.as_ref() else {
@@ -784,7 +784,7 @@ impl GrpcRouter {
 
         embedding_pipeline
             .execute_embeddings(
-                Arc::new(body.clone()),
+                Arc::new(body),
                 headers.cloned(),
                 model_id.to_string(),
                 self.shared_components.clone(),
@@ -798,7 +798,7 @@ impl GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &CreateMessageRequest,
+        body: CreateMessageRequest,
         model_id: &str,
     ) -> Response {
         debug!("Processing messages request for model: {}", model_id);
@@ -807,7 +807,7 @@ impl GrpcRouter {
         // front -- see `resolve_canonical_model_id`'s doc comment. Rewrite
         // the body's `model` field to match; see `route_chat_impl`.
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
-        let mut canonical_body = body.clone();
+        let mut canonical_body = body;
         canonical_body.model = model_id_cloned.clone();
         let request = Arc::new(canonical_body);
         let headers_cloned = headers.cloned();
@@ -866,7 +866,7 @@ impl GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &CompletionRequest,
+        body: CompletionRequest,
         model_id: &str,
     ) -> Response {
         debug!("Processing completion request for model: {}", model_id);
@@ -875,7 +875,7 @@ impl GrpcRouter {
         // doc comment. Rewrite the body's `model` field to match; see
         // `route_chat_impl`.
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
-        let mut canonical_body = body.clone();
+        let mut canonical_body = body;
         canonical_body.model = model_id_cloned.clone();
         let request = Arc::new(canonical_body);
         let headers_cloned = headers.cloned();
@@ -934,7 +934,7 @@ impl GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ClassifyRequest,
+        body: ClassifyRequest,
         model_id: &str,
     ) -> Response {
         let Some(classify_pipeline) = self.classify_pipeline.as_ref() else {
@@ -944,7 +944,7 @@ impl GrpcRouter {
 
         classify_pipeline
             .execute_classify(
-                Arc::new(body.clone()),
+                Arc::new(body),
                 headers.cloned(),
                 model_id.to_string(),
                 self.shared_components.clone(),
@@ -994,7 +994,7 @@ impl RouterTrait for GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &GenerateRequest,
+        body: GenerateRequest,
         model_id: &str,
     ) -> Response {
         self.route_generate_impl(headers, tenant_meta, body, model_id)
@@ -1005,7 +1005,7 @@ impl RouterTrait for GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ChatCompletionRequest,
+        body: ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
         self.route_chat_impl(headers, tenant_meta, body, model_id)
@@ -1016,7 +1016,7 @@ impl RouterTrait for GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ResponsesRequest,
+        body: ResponsesRequest,
         model_id: &str,
     ) -> Response {
         self.route_responses_impl(headers, tenant_meta, body, model_id)
@@ -1034,7 +1034,7 @@ impl RouterTrait for GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &EmbeddingRequest,
+        body: EmbeddingRequest,
         model_id: &str,
     ) -> Response {
         self.route_embeddings_impl(headers, tenant_meta, body, model_id)
@@ -1045,7 +1045,7 @@ impl RouterTrait for GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ClassifyRequest,
+        body: ClassifyRequest,
         model_id: &str,
     ) -> Response {
         self.route_classify_impl(headers, tenant_meta, body, model_id)
@@ -1134,7 +1134,7 @@ impl RouterTrait for GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &CompletionRequest,
+        body: CompletionRequest,
         model_id: &str,
     ) -> Response {
         self.route_completion_impl(headers, tenant_meta, body, model_id)
@@ -1145,7 +1145,7 @@ impl RouterTrait for GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &CreateMessageRequest,
+        body: CreateMessageRequest,
         model_id: &str,
     ) -> Response {
         self.route_messages_impl(headers, tenant_meta, body, model_id)
@@ -1545,7 +1545,7 @@ mod pd_tests {
 
         let request = responses_request("missing-model");
         let response = router
-            .route_responses(None, &tenant_meta, &request, "missing-model")
+            .route_responses(None, &tenant_meta, request.clone(), "missing-model")
             .await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
@@ -1562,7 +1562,7 @@ mod pd_tests {
 
         let request = responses_request("missing-model");
         let response = router
-            .route_responses(None, &tenant_meta, &request, "missing-model")
+            .route_responses(None, &tenant_meta, request.clone(), "missing-model")
             .await;
         assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
 

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -83,6 +83,23 @@ struct PDRequestContext<'a> {
     headers: Option<HeaderMap>,
 }
 
+/// Per-attempt view of the parsed request. `Shared` keeps it alive across
+/// retry attempts for replay; `Owned` (retries disabled) is dropped by the
+/// attempt as soon as its JSON tree exists.
+enum AttemptRequest<'a, T> {
+    Shared(&'a T),
+    Owned(T),
+}
+
+impl<T> AttemptRequest<'_, T> {
+    fn req(&self) -> &T {
+        match self {
+            Self::Shared(req) => req,
+            Self::Owned(req) => req,
+        }
+    }
+}
+
 impl PDRouter {
     async fn proxy_to_first_prefill_worker(
         &self,
@@ -322,10 +339,10 @@ impl PDRouter {
         }
     }
 
-    async fn execute_dual_dispatch<T: Serialize + Clone>(
+    async fn execute_dual_dispatch<T: Serialize>(
         &self,
         headers: Option<&HeaderMap>,
-        original_request: &T,
+        original_request: T,
         mut context: PDRequestContext<'_>,
     ) -> Response {
         let start_time = Instant::now();
@@ -348,9 +365,6 @@ impl PDRouter {
             endpoint,
             bool_to_static_str(context.is_stream),
         );
-        // Clone request once outside the retry loop, then use Arc to share across attempts
-        // This avoids O(retries) clones by sharing the same data
-        let shared_request = Arc::new(original_request.clone());
 
         // Use per-model retry config if set by a worker, otherwise fall back to router default.
         let per_model_retry_config = self.worker_registry.get_retry_config(model);
@@ -358,167 +372,66 @@ impl PDRouter {
             .as_ref()
             .unwrap_or(&self.retry_config);
 
-        let response = RetryExecutor::execute_response_with_retry(
-            retry_config,
-            {
-                move |attempt: u32| {
-                    // Clone Arc (cheap reference count increment) instead of cloning the entire request
-                    let shared_request = Arc::clone(&shared_request);
-                    let context = context.clone();
-                    async move {
-                        let (prefill, decode) = match self
-                            .select_pd_pair(
-                                context.request_text.as_deref(),
-                                context.routing_tokens.as_deref(),
-                                context.rid_key.as_deref(),
-                                context.model_id,
-                                context.headers.as_ref(),
-                            )
-                            .await
-                        {
-                            Ok(pair) => pair,
-                            Err(failure) => {
-                                return Self::handle_server_selection_error(failure);
-                            }
-                        };
-
-                        debug!(
-                            "PD retry attempt {} using prefill={} decode={}",
-                            attempt,
-                            prefill.url(),
-                            decode.url()
-                        );
-
-                        let mut json_request = match serde_json::to_value(shared_request.as_ref()) {
-                            Ok(v) => v,
-                            Err(e) => return Self::handle_serialization_error(e),
-                        };
-                        // The prefill and decode workers only know the
-                        // canonical name, so forward that, not the alias the
-                        // client sent.
-                        super::set_request_model(&mut json_request, model);
-
-                        json_request = match Self::inject_bootstrap_into_value(
-                            json_request,
-                            prefill.as_ref(),
-                            context.batch_size,
-                        ) {
-                            Ok(v) => v,
-                            Err(e) => {
-                                Metrics::record_pd_bootstrap_failure();
-                                return Self::handle_serialization_error(e);
-                            }
-                        };
-
-                        let mut prefill_json_request = json_request.clone();
-                        let mut decode_json_request = json_request;
-
-                        let mut prefill_rank = prefill.dp_rank().map(|rank| rank as isize);
-                        let mut decode_rank = decode.dp_rank().map(|rank| rank as isize);
-
-                        let dp_rank_policy_opt = self.policy_registry.get_dp_rank_policy();
-                        if let Some(dp_rank_policy) = dp_rank_policy_opt.as_ref() {
-                            let estimated_cost: isize = match (
-                                context.routing_tokens.as_deref(),
-                                context.request_text.as_ref(),
-                            ) {
-                                (Some(tokens), _) => (tokens.len() as isize).max(1),
-                                (None, Some(text)) => {
-                                    // Calculate token count using a simple heuristic
-                                    // In a real implementation, we would use the tokenizer
-                                    // For now, use a simple words-to-tokens ratio
-                                    let word_count = text.split_whitespace().count();
-                                    // Assume average 1.3 tokens per word
-                                    let token_count = (word_count as f64 * 1.3).ceil() as isize;
-                                    token_count.max(1)
-                                }
-                                (None, None) => 1, // Use at least 1 to avoid no-op
-                            };
-                            let policy_prefill_rank =
-                                dp_rank_policy.select_dp_rank(prefill.as_ref(), estimated_cost);
-                            let policy_decode_rank =
-                                dp_rank_policy.select_dp_rank(decode.as_ref(), estimated_cost);
-                            if let Some(rank) = policy_prefill_rank {
-                                prefill_rank = Some(rank);
-                            }
-                            if let Some(rank) = policy_decode_rank {
-                                decode_rank = Some(rank);
-                            }
-                        }
-
-                        if let Some(p_rank) = prefill_rank {
-                            Self::inject_dp_rank_to_json(
-                                &mut prefill_json_request,
-                                p_rank,
-                                "routed_dp_rank",
-                            );
-                            Self::inject_dp_rank_to_json(
-                                &mut decode_json_request,
-                                p_rank,
-                                "disagg_prefill_dp_rank",
-                            );
-                        }
-                        if let Some(d_rank) = decode_rank {
-                            Self::inject_dp_rank_to_json(
-                                &mut decode_json_request,
-                                d_rank,
-                                "routed_dp_rank",
-                            );
-                        }
-                        if prefill_rank.is_some() || decode_rank.is_some() {
-                            debug!(
-                                "PD selected DP ranks prefill={:?} decode={:?}",
-                                prefill_rank, decode_rank
-                            );
-                        }
-
-                        let response = self
-                            .execute_dual_dispatch_internal(
-                                headers,
-                                prefill_json_request,
-                                decode_json_request,
-                                context,
-                                Arc::clone(&prefill),
-                                Arc::clone(&decode),
-                            )
-                            .await;
-
-                        let status = response.status();
-                        prefill.record_outcome(status.as_u16());
-                        decode.record_outcome(status.as_u16());
-
-                        // Record worker errors for server errors (5xx)
-                        if status.is_server_error() {
-                            let error_type = error_type_from_status(status);
-                            Metrics::record_worker_error(
-                                metrics_labels::WORKER_PREFILL,
-                                metrics_labels::CONNECTION_HTTP,
-                                error_type,
-                            );
-                            Metrics::record_worker_error(
-                                metrics_labels::WORKER_DECODE,
-                                metrics_labels::CONNECTION_HTTP,
-                                error_type,
-                            );
-                        }
-
-                        response
-                    }
-                }
-            },
-            |res, _attempt| is_retryable_response(res),
-            |delay, attempt| {
-                // Layer 3 worker metrics (PD mode uses both prefill and decode workers)
-                Metrics::record_worker_retry(metrics_labels::WORKER_PREFILL, endpoint);
-                Metrics::record_worker_retry(metrics_labels::WORKER_DECODE, endpoint);
-                Metrics::record_worker_retry_backoff(attempt, delay);
-            },
-            || {
+        let response = if retry_config.max_retries.max(1) <= 1 {
+            // Retries disabled: one dispatch that owns the parsed request and
+            // releases it as soon as its JSON tree exists.
+            let res = self
+                .execute_dual_dispatch_attempt(
+                    0,
+                    headers,
+                    AttemptRequest::Owned(original_request),
+                    context,
+                )
+                .await;
+            // Mirror the retry executor's exhaustion accounting for a
+            // retryable status that gets no retry.
+            if is_retryable_response(&res) {
                 Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_PREFILL, endpoint);
                 Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_DECODE, endpoint);
-            },
-        )
-        .await;
+            }
+            res
+        } else {
+            // Arc-share the request across attempts; it stays alive for replay
+            // until the retry window closes (first non-retryable response).
+            let shared_request = Arc::new(original_request);
+            RetryExecutor::execute_response_with_retry(
+                retry_config,
+                {
+                    move |attempt: u32| {
+                        // Clone Arc (cheap reference count increment) instead of cloning the entire request
+                        let shared_request = Arc::clone(&shared_request);
+                        let context = context.clone();
+                        async move {
+                            self.execute_dual_dispatch_attempt(
+                                attempt,
+                                headers,
+                                AttemptRequest::Shared(&shared_request),
+                                context,
+                            )
+                            .await
+                        }
+                    }
+                },
+                |res, _attempt| is_retryable_response(res),
+                |delay, attempt| {
+                    // Layer 3 worker metrics (PD mode uses both prefill and decode workers)
+                    Metrics::record_worker_retry(metrics_labels::WORKER_PREFILL, endpoint);
+                    Metrics::record_worker_retry(metrics_labels::WORKER_DECODE, endpoint);
+                    Metrics::record_worker_retry_backoff(attempt, delay);
+                },
+                || {
+                    Metrics::record_worker_retries_exhausted(
+                        metrics_labels::WORKER_PREFILL,
+                        endpoint,
+                    );
+                    Metrics::record_worker_retries_exhausted(
+                        metrics_labels::WORKER_DECODE,
+                        endpoint,
+                    );
+                },
+            )
+            .await
+        };
 
         // Record Layer 2 metrics
         let duration = start_time.elapsed();
@@ -539,6 +452,153 @@ impl PDRouter {
                 model,
                 endpoint,
                 error_type_from_status(response.status()),
+            );
+        }
+
+        response
+    }
+
+    /// One PD dispatch attempt: select the pair, materialize the per-leg
+    /// JSON bodies, dispatch, and record per-attempt worker outcomes.
+    async fn execute_dual_dispatch_attempt<T: Serialize>(
+        &self,
+        attempt: u32,
+        headers: Option<&HeaderMap>,
+        request: AttemptRequest<'_, T>,
+        mut context: PDRequestContext<'_>,
+    ) -> Response {
+        let (prefill, decode) = match self
+            .select_pd_pair(
+                context.request_text.as_deref(),
+                context.routing_tokens.as_deref(),
+                context.rid_key.as_deref(),
+                context.model_id,
+                context.headers.as_ref(),
+            )
+            .await
+        {
+            Ok(pair) => pair,
+            Err(e) => {
+                return Self::handle_server_selection_error(e);
+            }
+        };
+
+        debug!(
+            "PD retry attempt {} using prefill={} decode={}",
+            attempt,
+            prefill.url(),
+            decode.url()
+        );
+
+        let mut json_request = match serde_json::to_value(request.req()) {
+            Ok(v) => v,
+            Err(e) => return Self::handle_serialization_error(e),
+        };
+        // The JSON tree is all dispatch needs from here on: an owned request
+        // (retries disabled) is freed now, before the upstream send.
+        drop(request);
+        // The prefill and decode workers only know the
+        // canonical name, so forward that, not the alias the
+        // client sent.
+        super::set_request_model(&mut json_request, context.model_id);
+
+        json_request = match Self::inject_bootstrap_into_value(
+            json_request,
+            prefill.as_ref(),
+            context.batch_size,
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                Metrics::record_pd_bootstrap_failure();
+                return Self::handle_serialization_error(e);
+            }
+        };
+
+        let mut prefill_json_request = json_request.clone();
+        let mut decode_json_request = json_request;
+
+        let mut prefill_rank = prefill.dp_rank().map(|rank| rank as isize);
+        let mut decode_rank = decode.dp_rank().map(|rank| rank as isize);
+
+        let dp_rank_policy_opt = self.policy_registry.get_dp_rank_policy();
+        if let Some(dp_rank_policy) = dp_rank_policy_opt.as_ref() {
+            let estimated_cost: isize = match (
+                context.routing_tokens.as_deref(),
+                context.request_text.as_ref(),
+            ) {
+                (Some(tokens), _) => (tokens.len() as isize).max(1),
+                (None, Some(text)) => {
+                    // Calculate token count using a simple heuristic
+                    // In a real implementation, we would use the tokenizer
+                    // For now, use a simple words-to-tokens ratio
+                    let word_count = text.split_whitespace().count();
+                    // Assume average 1.3 tokens per word
+                    let token_count = (word_count as f64 * 1.3).ceil() as isize;
+                    token_count.max(1)
+                }
+                (None, None) => 1, // Use at least 1 to avoid no-op
+            };
+            let policy_prefill_rank =
+                dp_rank_policy.select_dp_rank(prefill.as_ref(), estimated_cost);
+            let policy_decode_rank = dp_rank_policy.select_dp_rank(decode.as_ref(), estimated_cost);
+            if let Some(rank) = policy_prefill_rank {
+                prefill_rank = Some(rank);
+            }
+            if let Some(rank) = policy_decode_rank {
+                decode_rank = Some(rank);
+            }
+        }
+
+        if let Some(p_rank) = prefill_rank {
+            Self::inject_dp_rank_to_json(&mut prefill_json_request, p_rank, "routed_dp_rank");
+            Self::inject_dp_rank_to_json(
+                &mut decode_json_request,
+                p_rank,
+                "disagg_prefill_dp_rank",
+            );
+        }
+        if let Some(d_rank) = decode_rank {
+            Self::inject_dp_rank_to_json(&mut decode_json_request, d_rank, "routed_dp_rank");
+        }
+        if prefill_rank.is_some() || decode_rank.is_some() {
+            debug!(
+                "PD selected DP ranks prefill={:?} decode={:?}",
+                prefill_rank, decode_rank
+            );
+        }
+
+        // Selection and cost estimation are done with these; the dispatch and
+        // response relay must not pin the routing text or token vector.
+        context.request_text = None;
+        context.routing_tokens = None;
+
+        let response = self
+            .execute_dual_dispatch_internal(
+                headers,
+                prefill_json_request,
+                decode_json_request,
+                context,
+                Arc::clone(&prefill),
+                Arc::clone(&decode),
+            )
+            .await;
+
+        let status = response.status();
+        prefill.record_outcome(status.as_u16());
+        decode.record_outcome(status.as_u16());
+
+        // Record worker errors for server errors (5xx)
+        if status.is_server_error() {
+            let error_type = error_type_from_status(status);
+            Metrics::record_worker_error(
+                metrics_labels::WORKER_PREFILL,
+                metrics_labels::CONNECTION_HTTP,
+                error_type,
+            );
+            Metrics::record_worker_error(
+                metrics_labels::WORKER_DECODE,
+                metrics_labels::CONNECTION_HTTP,
+                error_type,
             );
         }
 
@@ -706,6 +766,10 @@ impl PDRouter {
             headers,
             false,
         );
+        // `.json()` already serialized both trees into the builders; free
+        // them before the sends instead of at scope end after the response.
+        drop(prefill_json_request);
+        drop(decode_json_request);
 
         // Send both requests concurrently and wait for both
         // Note: Using borrowed references avoids heap allocation
@@ -1498,7 +1562,7 @@ impl RouterTrait for PDRouter {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &GenerateRequest,
+        body: GenerateRequest,
         model_id: &str,
     ) -> Response {
         let is_stream = body.stream;
@@ -1513,7 +1577,7 @@ impl RouterTrait for PDRouter {
             (None, None)
         };
 
-        let batch_size = Self::get_generate_batch_size(body);
+        let batch_size = Self::get_generate_batch_size(&body);
 
         let context = PDRequestContext {
             route: "/generate",
@@ -1537,7 +1601,7 @@ impl RouterTrait for PDRouter {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &ChatCompletionRequest,
+        body: ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
         let is_stream = body.stream;
@@ -1550,7 +1614,7 @@ impl RouterTrait for PDRouter {
         };
 
         // Calculate batch size
-        let batch_size = Self::get_chat_batch_size(body);
+        let batch_size = Self::get_chat_batch_size(&body);
 
         let context = PDRequestContext {
             route: "/v1/chat/completions",
@@ -1574,7 +1638,7 @@ impl RouterTrait for PDRouter {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &CompletionRequest,
+        body: CompletionRequest,
         model_id: &str,
     ) -> Response {
         let is_stream = body.stream;
@@ -1590,7 +1654,7 @@ impl RouterTrait for PDRouter {
         };
 
         // Calculate batch size
-        let batch_size = Self::get_completion_batch_size(body);
+        let batch_size = Self::get_completion_batch_size(&body);
 
         let context = PDRequestContext {
             route: "/v1/completions",
@@ -1614,7 +1678,7 @@ impl RouterTrait for PDRouter {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &RerankRequest,
+        body: RerankRequest,
         model_id: &str,
     ) -> Response {
         // Extract text for cache-aware routing
@@ -1946,6 +2010,106 @@ mod tests {
         assert!(
             parsed.get("error").is_some(),
             "parsed SSE payload must contain an `error` field: {parsed}"
+        );
+    }
+
+    /// PD request with a drop probe (see the regular router's twin test):
+    /// with retries disabled the parsed request must be freed once its JSON
+    /// tree exists, before either upstream leg answers. The decode stub
+    /// refuses to respond until the probe's only remaining holder is the
+    /// test itself.
+    #[tokio::test]
+    async fn pd_disabled_retries_release_parsed_request_before_upstream_responds() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        #[derive(Serialize)]
+        struct DropProbeRequest {
+            text: String,
+            #[serde(skip)]
+            _probe: Arc<()>,
+        }
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test stub servers live for the duration of the test process"
+        )]
+        async fn spawn_stub(gate: Option<(std::sync::Weak<()>, Arc<AtomicBool>)>) -> String {
+            let app = axum::Router::new().route(
+                "/generate",
+                axum::routing::post(move || {
+                    let gate = gate.clone();
+                    async move {
+                        if let Some((probe, flag)) = gate {
+                            let deadline =
+                                tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+                            while probe.strong_count() > 1 && tokio::time::Instant::now() < deadline
+                            {
+                                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+                            }
+                            flag.store(probe.strong_count() <= 1, Ordering::SeqCst);
+                        }
+                        "{}"
+                    }
+                }),
+            );
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            format!("http://{addr}")
+        }
+
+        let probe = Arc::new(());
+        let released = Arc::new(AtomicBool::new(false));
+        let prefill_url = spawn_stub(None).await;
+        let decode_url = spawn_stub(Some((Arc::downgrade(&probe), Arc::clone(&released)))).await;
+
+        let router = create_test_pd_router();
+        let router = PDRouter {
+            retry_config: RetryConfig {
+                max_retries: 1,
+                ..Default::default()
+            },
+            ..router
+        };
+        router
+            .worker_registry
+            .register_or_replace(Arc::from(create_test_worker(
+                prefill_url,
+                WorkerType::Prefill,
+                true,
+            )));
+        router
+            .worker_registry
+            .register_or_replace(Arc::from(create_test_worker(
+                decode_url,
+                WorkerType::Decode,
+                true,
+            )));
+
+        let context = PDRequestContext {
+            route: "/generate",
+            batch_size: None,
+            is_stream: false,
+            return_logprob: false,
+            request_text: None,
+            routing_tokens: None,
+            rid_key: None,
+            model_id: UNKNOWN_MODEL_ID,
+            headers: None,
+        };
+        let request = DropProbeRequest {
+            text: "hello".to_string(),
+            _probe: Arc::clone(&probe),
+        };
+
+        let response = router.execute_dual_dispatch(None, request, context).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            released.load(Ordering::SeqCst),
+            "the parsed request must be freed before the decode leg answers"
         );
     }
 

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -84,6 +84,65 @@ const STREAMED_BODY_STALLED: &str = "request_body_stalled";
 const STREAMED_BODY_TOO_LARGE: &str = "request_body_too_large";
 const STREAMED_BODY_ABORTED: &str = "request_body_aborted";
 
+/// Per-attempt view of the parsed request and its routing derivatives.
+///
+/// `Borrowed` keeps them alive across retry attempts for replay; `Owned`
+/// (retries disabled) is released by the dispatch path as soon as the
+/// serialized upstream body exists, so neither the send wait nor the response
+/// relay pins the parsed request.
+enum AttemptPayload<'a, T> {
+    Borrowed {
+        req: &'a T,
+        text: Option<&'a str>,
+        tokens: Option<&'a [u32]>,
+        rid_key: Option<&'a str>,
+    },
+    Owned {
+        req: T,
+        text: Option<String>,
+        tokens: Option<Vec<u32>>,
+        rid_key: Option<String>,
+    },
+}
+
+impl<T> AttemptPayload<'_, T> {
+    fn req(&self) -> &T {
+        match self {
+            Self::Borrowed { req, .. } => req,
+            Self::Owned { req, .. } => req,
+        }
+    }
+
+    fn text(&self) -> Option<&str> {
+        match self {
+            Self::Borrowed { text, .. } => *text,
+            Self::Owned { text, .. } => text.as_deref(),
+        }
+    }
+
+    fn tokens(&self) -> Option<&[u32]> {
+        match self {
+            Self::Borrowed { tokens, .. } => *tokens,
+            Self::Owned { tokens, .. } => tokens.as_deref(),
+        }
+    }
+
+    fn rid_key(&self) -> Option<&str> {
+        match self {
+            Self::Borrowed { rid_key, .. } => *rid_key,
+            Self::Owned { rid_key, .. } => rid_key.as_deref(),
+        }
+    }
+
+    /// Consume the payload once the upstream body is serialized.
+    /// `upstream_bytes` sizes the early-release metric for `Owned`.
+    fn release(self, upstream_bytes: usize) {
+        if matches!(self, Self::Owned { .. }) {
+            Metrics::record_request_buffers_released_early(upstream_bytes);
+        }
+    }
+}
+
 /// Regular router that uses injected load balancing policies
 pub struct Router {
     worker_registry: Arc<WorkerRegistry>,
@@ -348,10 +407,10 @@ impl Router {
         }
     }
 
-    pub async fn route_typed_request<T: GenerationRequest + serde::Serialize + Clone>(
+    pub async fn route_typed_request<T: GenerationRequest + serde::Serialize>(
         &self,
         headers: Option<&HeaderMap>,
-        typed_req: &T,
+        typed_req: T,
         route: &'static str,
         model_id: &str,
     ) -> Response {
@@ -369,7 +428,6 @@ impl Router {
         let text = routing_tokens
             .is_none()
             .then(|| typed_req.extract_text_for_routing());
-        let rid_key = self.policy_registry.derive_rid_key(typed_req.rid());
         // Resolve once, here, so every registry, policy and metrics lookup
         // below is keyed by the canonical model ID. Only `get_by_model`
         // understands aliases; retry configs, hash rings and policies do not,
@@ -395,47 +453,91 @@ impl Router {
             .as_ref()
             .unwrap_or(&self.retry_config);
 
-        let response = RetryExecutor::execute_response_with_retry(
-            retry_config,
-            // operation per attempt
-            |_: u32| async {
-                let res = self
-                    .route_typed_request_once(
-                        headers,
-                        typed_req,
-                        route,
-                        model_id,
-                        canonical_model.as_deref(),
-                        is_stream,
-                        text.as_deref(),
-                        routing_tokens.as_deref(),
+        let response = if retry_config.max_retries.max(1) <= 1 {
+            // Retries disabled: one dispatch that owns the parsed request and
+            // its routing derivatives, releasing them the moment the upstream
+            // bytes are serialized instead of holding them for the response.
+            let rid_key = self
+                .policy_registry
+                .derive_rid_key(typed_req.rid())
+                .map(str::to_string);
+            let res = self
+                .route_typed_request_once(
+                    headers,
+                    AttemptPayload::Owned {
+                        req: typed_req,
+                        text,
+                        tokens: routing_tokens,
                         rid_key,
-                    )
-                    .await;
-
-                // Need to be outside `route_typed_request_once` because that function has multiple return paths
-                Metrics::record_router_upstream_response(
-                    metrics_labels::ROUTER_HTTP,
-                    res.status().as_u16(),
-                    extract_error_code_from_response(&res),
-                );
-
-                res
-            },
-            // should_retry predicate
-            |res, _attempt| is_retryable_response(res),
-            // on_backoff hook
-            |delay, attempt| {
-                // Layer 3 worker metrics
-                Metrics::record_worker_retry(metrics_labels::WORKER_REGULAR, endpoint);
-                Metrics::record_worker_retry_backoff(attempt, delay);
-            },
-            // on_exhausted hook
-            || {
+                    },
+                    route,
+                    model_id,
+                    canonical_model.as_deref(),
+                    is_stream,
+                )
+                .await;
+            Metrics::record_router_upstream_response(
+                metrics_labels::ROUTER_HTTP,
+                res.status().as_u16(),
+                extract_error_code_from_response(&res),
+            );
+            // Mirror the retry executor's exhaustion accounting for a
+            // retryable status that gets no retry.
+            if is_retryable_response(&res) {
                 Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_REGULAR, endpoint);
-            },
-        )
-        .await;
+            }
+            res
+        } else {
+            let rid_key = self.policy_registry.derive_rid_key(typed_req.rid());
+            RetryExecutor::execute_response_with_retry(
+                retry_config,
+                // operation per attempt; the parsed request stays alive for
+                // replay until the retry window closes (first non-retryable
+                // response).
+                |_: u32| async {
+                    let res = self
+                        .route_typed_request_once(
+                            headers,
+                            AttemptPayload::Borrowed {
+                                req: &typed_req,
+                                text: text.as_deref(),
+                                tokens: routing_tokens.as_deref(),
+                                rid_key,
+                            },
+                            route,
+                            model_id,
+                            canonical_model.as_deref(),
+                            is_stream,
+                        )
+                        .await;
+
+                    // Need to be outside `route_typed_request_once` because that function has multiple return paths
+                    Metrics::record_router_upstream_response(
+                        metrics_labels::ROUTER_HTTP,
+                        res.status().as_u16(),
+                        extract_error_code_from_response(&res),
+                    );
+
+                    res
+                },
+                // should_retry predicate
+                |res, _attempt| is_retryable_response(res),
+                // on_backoff hook
+                |delay, attempt| {
+                    // Layer 3 worker metrics
+                    Metrics::record_worker_retry(metrics_labels::WORKER_REGULAR, endpoint);
+                    Metrics::record_worker_retry_backoff(attempt, delay);
+                },
+                // on_exhausted hook
+                || {
+                    Metrics::record_worker_retries_exhausted(
+                        metrics_labels::WORKER_REGULAR,
+                        endpoint,
+                    );
+                },
+            )
+            .await
+        };
 
         if response.status().is_success() {
             let duration = start.elapsed();
@@ -461,23 +563,22 @@ impl Router {
         response
     }
 
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "per-attempt state threaded from route_typed_request; a struct would only move the arity"
-    )]
-    async fn route_typed_request_once<T: GenerationRequest + serde::Serialize + Clone>(
+    async fn route_typed_request_once<T: serde::Serialize>(
         &self,
         headers: Option<&HeaderMap>,
-        typed_req: &T,
+        payload: AttemptPayload<'_, T>,
         route: &'static str,
         model_id: &str,
         canonical_model: Option<&str>,
         is_stream: bool,
-        text: Option<&str>,
-        tokens: Option<&[u32]>,
-        rid_key: Option<&str>,
     ) -> Response {
-        let worker = match self.select_worker_for_model(model_id, text, tokens, headers, rid_key) {
+        let worker = match self.select_worker_for_model(
+            model_id,
+            payload.text(),
+            payload.tokens(),
+            headers,
+            payload.rid_key(),
+        ) {
             Some(w) => w,
             None => {
                 // Distinguish "no workers for this model" from "workers exist but unavailable"
@@ -521,7 +622,9 @@ impl Router {
         // rid-derived first, header fallback.
         let load_guard = WorkerLoadGuard::with_key(
             worker.clone(),
-            rid_key.or_else(|| self.policy_registry.sticky_header_key(headers)),
+            payload
+                .rid_key()
+                .or_else(|| self.policy_registry.sticky_header_key(headers)),
         );
 
         // Note: Using borrowed reference avoids heap allocation
@@ -530,17 +633,32 @@ impl Router {
         inject_trace_context_http(&mut headers_with_trace);
         let headers = Some(&headers_with_trace);
 
-        let response = self
-            .send_typed_request(
-                headers,
-                typed_req,
-                route,
-                canonical_model,
-                worker.as_ref(),
-                is_stream,
-                load_guard,
-            )
-            .await;
+        let response = match serialize_request_body(payload.req(), canonical_model, worker.as_ref())
+        {
+            Ok(body) => {
+                // Past this point dispatch needs only the serialized bytes: an
+                // owned payload (retries disabled) frees the parsed request and
+                // its routing token/text derivatives before the upstream send.
+                payload.release(body.len());
+                self.send_serialized_request(
+                    headers,
+                    body,
+                    route,
+                    worker.as_ref(),
+                    is_stream,
+                    load_guard,
+                )
+                .await
+            }
+            Err(RequestBodyError::Serialize(e)) => error::bad_request(
+                "serialization_failed",
+                format!("Failed to serialize request body: {e}"),
+            ),
+            Err(RequestBodyError::Prepare(e)) => error::bad_request(
+                "request_preparation_failed",
+                format!("Failed to prepare request: {e}"),
+            ),
+        };
 
         events::RequestReceivedEvent {}.emit();
 
@@ -1111,43 +1229,20 @@ impl Router {
         Ok(body.freeze())
     }
 
-    // Send typed request directly without conversion.
-    //
-    // `canonical_model` is set only when the client addressed the model by an
-    // alias. The worker was registered under the canonical ID and has never
-    // heard of the alias, so the body it receives carries the canonical name.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "per-request state threaded from route_typed_request_once; a struct would only move the arity"
-    )]
-    async fn send_typed_request<T: serde::Serialize>(
+    // Send an already-serialized request body. The stale-connection resend
+    // guard inside `send_with_stale_conn_retry` shares the body allocation by
+    // refcount, so the bytes live exactly until the response head arrives.
+    async fn send_serialized_request(
         &self,
         headers: Option<&HeaderMap>,
-        typed_req: &T,
+        body: Vec<u8>,
         route: &'static str,
-        canonical_model: Option<&str>,
         worker: &dyn Worker,
         is_stream: bool,
         load_guard: WorkerLoadGuard,
     ) -> Response {
         let api_key = worker.api_key().cloned();
         let endpoint_url = worker.endpoint_url(route);
-
-        let body = match serialize_request_body(typed_req, canonical_model, worker) {
-            Ok(body) => body,
-            Err(RequestBodyError::Serialize(e)) => {
-                return error::bad_request(
-                    "serialization_failed",
-                    format!("Failed to serialize request body: {e}"),
-                );
-            }
-            Err(RequestBodyError::Prepare(e)) => {
-                return error::bad_request(
-                    "request_preparation_failed",
-                    format!("Failed to prepare request: {e}"),
-                );
-            }
-        };
 
         let mut request_builder = self
             .client
@@ -1381,7 +1476,7 @@ impl Router {
     /// The worker body read is capped at `max_body_bytes`; a larger body is a
     /// misbehaving worker and yields a 502.
     async fn build_rerank_response(
-        req: &RerankRequest,
+        req: RerankResponseSpec,
         canonical_model: Option<&str>,
         response: Response,
         max_body_bytes: usize,
@@ -1420,8 +1515,8 @@ impl Router {
                 );
             }
         };
-        let model = canonical_model.map_or_else(|| req.model.clone(), ToOwned::to_owned);
-        let mut rerank_response = RerankResponse::new(rerank_results, model, req.rid.clone());
+        let model = canonical_model.map_or(req.model, ToOwned::to_owned);
+        let mut rerank_response = RerankResponse::new(rerank_results, model, req.rid);
         // Sorting is handled by Python worker (serving_rerank.py)
         if let Some(top_k) = req.top_k {
             rerank_response.apply_top_k(top_k);
@@ -1430,6 +1525,26 @@ impl Router {
             rerank_response.drop_documents();
         }
         Json(rerank_response).into_response()
+    }
+}
+
+/// Post-dispatch inputs for the rerank response builder; the request itself
+/// (documents included) is released at dispatch.
+struct RerankResponseSpec {
+    model: String,
+    rid: Option<openai_protocol::common::StringOrArray>,
+    top_k: Option<usize>,
+    return_documents: bool,
+}
+
+impl From<&RerankRequest> for RerankResponseSpec {
+    fn from(req: &RerankRequest) -> Self {
+        Self {
+            model: req.model.clone(),
+            rid: req.rid.clone(),
+            top_k: req.top_k,
+            return_documents: req.return_documents,
+        }
     }
 }
 
@@ -1806,7 +1921,7 @@ impl RouterTrait for Router {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &GenerateRequest,
+        body: GenerateRequest,
         model_id: &str,
     ) -> Response {
         self.route_typed_request(headers, body, "/generate", model_id)
@@ -1817,7 +1932,7 @@ impl RouterTrait for Router {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &ChatCompletionRequest,
+        body: ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/chat/completions", model_id)
@@ -1828,7 +1943,7 @@ impl RouterTrait for Router {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &CreateMessageRequest,
+        body: CreateMessageRequest,
         model_id: &str,
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/messages", model_id)
@@ -1839,7 +1954,7 @@ impl RouterTrait for Router {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &CompletionRequest,
+        body: CompletionRequest,
         model_id: &str,
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/completions", model_id)
@@ -1850,7 +1965,7 @@ impl RouterTrait for Router {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &ResponsesRequest,
+        body: ResponsesRequest,
         model_id: &str,
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/responses", model_id)
@@ -1866,7 +1981,7 @@ impl RouterTrait for Router {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &EmbeddingRequest,
+        body: EmbeddingRequest,
         model_id: &str,
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/embeddings", model_id)
@@ -1877,7 +1992,7 @@ impl RouterTrait for Router {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &ClassifyRequest,
+        body: ClassifyRequest,
         model_id: &str,
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/classify", model_id)
@@ -1906,16 +2021,17 @@ impl RouterTrait for Router {
         &self,
         headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        body: &RerankRequest,
+        body: RerankRequest,
         model_id: &str,
     ) -> Response {
         let canonical_model = self.worker_registry.resolve_model_alias(model_id);
+        let response_spec = RerankResponseSpec::from(&body);
         let response = self
             .route_typed_request(headers, body, "/v1/rerank", model_id)
             .await;
         if response.status().is_success() {
             Self::build_rerank_response(
-                body,
+                response_spec,
                 canonical_model.as_deref(),
                 response,
                 self.max_payload_size,
@@ -2057,7 +2173,7 @@ impl RouterTrait for Router {
 mod tests {
     use std::{
         net::SocketAddr,
-        sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
+        sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering},
     };
 
     use openai_protocol::worker::HealthCheckConfig;
@@ -2255,7 +2371,9 @@ mod tests {
         let limit = body.len();
         let upstream = Response::new(Body::from(body));
 
-        let response = Router::build_rerank_response(&req, None, upstream, limit).await;
+        let response =
+            Router::build_rerank_response(RerankResponseSpec::from(&req), None, upstream, limit)
+                .await;
 
         assert_eq!(response.status(), StatusCode::OK);
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
@@ -2272,7 +2390,9 @@ mod tests {
         let limit = body.len() - 1;
         let upstream = Response::new(Body::from(body));
 
-        let response = Router::build_rerank_response(&req, None, upstream, limit).await;
+        let response =
+            Router::build_rerank_response(RerankResponseSpec::from(&req), None, upstream, limit)
+                .await;
 
         assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
         assert_eq!(
@@ -2817,6 +2937,151 @@ mod tests {
             .route_streaming_request(req, "/generate")
             .await
             .is_err());
+    }
+
+    /// Typed request with a drop probe: the test watches the `Arc` count to
+    /// observe exactly when the router frees the parsed body.
+    #[derive(serde::Serialize)]
+    struct DropProbeRequest {
+        text: String,
+        #[serde(skip)]
+        _probe: Arc<()>,
+    }
+
+    impl GenerationRequest for DropProbeRequest {
+        fn is_stream(&self) -> bool {
+            false
+        }
+
+        fn get_model(&self) -> Option<&str> {
+            None
+        }
+
+        fn extract_text_for_routing(&self) -> String {
+            self.text.clone()
+        }
+    }
+
+    /// Upstream stub that answers only after every probe clone outside the
+    /// test is gone (or after a deadline, leaving `released` false).
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test stub server lives for the duration of the test process"
+    )]
+    async fn spawn_release_gated_stub(probe: std::sync::Weak<()>) -> (String, Arc<AtomicBool>) {
+        let released = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&released);
+        let app = axum::Router::new().route(
+            "/generate",
+            axum::routing::post(move || {
+                let probe = probe.clone();
+                let flag = Arc::clone(&flag);
+                async move {
+                    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+                    while probe.strong_count() > 1 && tokio::time::Instant::now() < deadline {
+                        tokio::time::sleep(Duration::from_millis(2)).await;
+                    }
+                    flag.store(probe.strong_count() <= 1, AtomicOrdering::SeqCst);
+                    ([(CONTENT_TYPE, "application/json")], "{}")
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}"), released)
+    }
+
+    /// With retries disabled the parsed request must be freed at dispatch:
+    /// the upstream stub refuses to answer until the probe's only remaining
+    /// holder is the test itself.
+    #[tokio::test]
+    async fn disabled_retries_release_parsed_request_before_upstream_responds() {
+        let probe = Arc::new(());
+        let (url, released) = spawn_release_gated_stub(Arc::downgrade(&probe)).await;
+        let mut router =
+            streaming_router(least_load_policy(), 1024 * 1024, vec![plain_worker(&url)]);
+        router.retry_config = RetryConfig {
+            max_retries: 1,
+            ..Default::default()
+        };
+
+        let req = DropProbeRequest {
+            text: "hello".to_string(),
+            _probe: Arc::clone(&probe),
+        };
+        let response = router
+            .route_typed_request(None, req, "/generate", crate::worker::UNKNOWN_MODEL_ID)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            released.load(AtomicOrdering::SeqCst),
+            "the parsed request must be freed before the upstream answers"
+        );
+    }
+
+    /// With retries enabled the request must survive for replay: a 503 on the
+    /// first attempt is retried with an identical body.
+    #[tokio::test]
+    async fn enabled_retries_replay_an_identical_body() {
+        use tokio::sync::Mutex;
+
+        let bodies: Arc<Mutex<Vec<Bytes>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&bodies);
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_clone = Arc::clone(&hits);
+        let app = axum::Router::new().route(
+            "/generate",
+            axum::routing::post(move |body: Bytes| {
+                let sink = Arc::clone(&sink);
+                let hits = Arc::clone(&hits_clone);
+                async move {
+                    sink.lock().await.push(body);
+                    if hits.fetch_add(1, AtomicOrdering::SeqCst) == 0 {
+                        (StatusCode::SERVICE_UNAVAILABLE, "busy").into_response()
+                    } else {
+                        (StatusCode::OK, "{}").into_response()
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test stub server lives for the duration of the test process"
+        )]
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let mut router = streaming_router(
+            least_load_policy(),
+            1024 * 1024,
+            vec![plain_worker(&format!("http://{addr}"))],
+        );
+        router.retry_config = RetryConfig {
+            max_retries: 2,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 2,
+            ..Default::default()
+        };
+
+        let req = DropProbeRequest {
+            text: "replay me".to_string(),
+            _probe: Arc::new(()),
+        };
+        let response = router
+            .route_typed_request(None, req, "/generate", crate::worker::UNKNOWN_MODEL_ID)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bodies = bodies.lock().await;
+        assert_eq!(bodies.len(), 2, "503 then 200 must mean two attempts");
+        assert_eq!(bodies[0], bodies[1], "the retry must replay the same body");
     }
 
     #[tokio::test]

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -84,11 +84,15 @@ pub trait RouterTrait: Send + Sync + Debug {
     }
 
     /// Route a generate request
+    ///
+    /// Typed-JSON route methods take the parsed body by value: the dispatching
+    /// router owns it and can free it as soon as the upstream bytes exist,
+    /// instead of the handler pinning a copy for the whole response.
     async fn route_generate(
         &self,
         _headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        _body: &GenerateRequest,
+        _body: GenerateRequest,
         _model_id: &str,
     ) -> Response {
         (
@@ -103,7 +107,7 @@ pub trait RouterTrait: Send + Sync + Debug {
         &self,
         _headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        _body: &ChatCompletionRequest,
+        _body: ChatCompletionRequest,
         _model_id: &str,
     ) -> Response {
         (
@@ -118,7 +122,7 @@ pub trait RouterTrait: Send + Sync + Debug {
         &self,
         _headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        _body: &CompletionRequest,
+        _body: CompletionRequest,
         _model_id: &str,
     ) -> Response {
         (
@@ -133,7 +137,7 @@ pub trait RouterTrait: Send + Sync + Debug {
         &self,
         _headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        _body: &ResponsesRequest,
+        _body: ResponsesRequest,
         _model_id: &str,
     ) -> Response {
         (
@@ -157,7 +161,7 @@ pub trait RouterTrait: Send + Sync + Debug {
         &self,
         _headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        _body: &EmbeddingRequest,
+        _body: EmbeddingRequest,
         _model_id: &str,
     ) -> Response {
         (StatusCode::NOT_IMPLEMENTED, "Embeddings not implemented").into_response()
@@ -168,7 +172,7 @@ pub trait RouterTrait: Send + Sync + Debug {
         &self,
         _headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        _body: &ClassifyRequest,
+        _body: ClassifyRequest,
         _model_id: &str,
     ) -> Response {
         (StatusCode::NOT_IMPLEMENTED, "Classify not implemented").into_response()
@@ -200,7 +204,7 @@ pub trait RouterTrait: Send + Sync + Debug {
         &self,
         _headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        _body: &RerankRequest,
+        _body: RerankRequest,
         _model_id: &str,
     ) -> Response {
         (StatusCode::NOT_IMPLEMENTED, "Rerank not implemented").into_response()
@@ -211,7 +215,7 @@ pub trait RouterTrait: Send + Sync + Debug {
         &self,
         _headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        _body: &CreateMessageRequest,
+        _body: CreateMessageRequest,
         _model_id: &str,
     ) -> Response {
         (
@@ -226,7 +230,7 @@ pub trait RouterTrait: Send + Sync + Debug {
         &self,
         _headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        _body: &InteractionsRequest,
+        _body: InteractionsRequest,
         _model_id: Option<&str>,
     ) -> Response {
         (

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -47,7 +47,7 @@ pub(super) async fn route_chat(
     deps: &ChatRouterContext<'_>,
     headers: Option<&HeaderMap>,
     tenant_meta: &TenantRequestMeta,
-    body: &ChatCompletionRequest,
+    body: ChatCompletionRequest,
     model_id: &str,
 ) -> Response {
     let start = Instant::now();
@@ -87,7 +87,7 @@ pub(super) async fn route_chat(
         }
     };
 
-    let mut payload = match to_value(body) {
+    let mut payload = match to_value(&body) {
         Ok(v) => v,
         Err(e) => {
             Metrics::record_router_error(
@@ -122,7 +122,7 @@ pub(super) async fn route_chat(
     }
 
     let mut ctx = RequestContext::for_chat(
-        Arc::new(body.clone()),
+        Arc::new(body),
         headers.cloned(),
         Some(model_id.to_string()),
         ComponentRefs::Shared(Arc::clone(deps.shared_components)),

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -158,7 +158,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ChatCompletionRequest,
+        body: ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
         // Use per-model retry config if set by a worker, otherwise fall back to router default.
@@ -180,7 +180,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ResponsesRequest,
+        body: ResponsesRequest,
         model_id: &str,
     ) -> Response {
         let deps = ResponsesRouterContext {
@@ -188,7 +188,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             provider_registry: &self.provider_registry,
             responses_components: &self.responses_components,
         };
-        responses_route::route_responses(&deps, headers, tenant_meta, body, model_id).await
+        responses_route::route_responses(&deps, headers, tenant_meta, &body, model_id).await
     }
 
     async fn route_realtime_session(

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -567,7 +567,7 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &GenerateRequest,
+        body: GenerateRequest,
         model_id: &str,
     ) -> Response {
         if self.requires_explicit_generate_model(model_id) {
@@ -596,7 +596,7 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ChatCompletionRequest,
+        body: ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(Some(model_id));
@@ -618,7 +618,7 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &CompletionRequest,
+        body: CompletionRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(Some(model_id));
@@ -640,7 +640,7 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &CreateMessageRequest,
+        body: CreateMessageRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(Some(model_id));
@@ -661,7 +661,7 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ResponsesRequest,
+        body: ResponsesRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(Some(model_id));
@@ -682,15 +682,19 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &InteractionsRequest,
+        body: InteractionsRequest,
         model_id: Option<&str>,
     ) -> Response {
-        let selected_model = model_id.or(body.model.as_deref()).or(body.agent.as_deref());
-        let router = self.select_router_for_request(selected_model);
+        // Owned so it can outlive `body`, which moves into the routed call.
+        let selected_model = model_id
+            .map(str::to_string)
+            .or_else(|| body.model.clone())
+            .or_else(|| body.agent.clone());
+        let router = self.select_router_for_request(selected_model.as_deref());
 
         if let Some(router) = router {
             router
-                .route_interactions(headers, tenant_meta, body, selected_model)
+                .route_interactions(headers, tenant_meta, body, selected_model.as_deref())
                 .await
         } else {
             (
@@ -718,7 +722,7 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &EmbeddingRequest,
+        body: EmbeddingRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(Some(model_id));
@@ -740,7 +744,7 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &ClassifyRequest,
+        body: ClassifyRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(Some(model_id));
@@ -785,7 +789,7 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         tenant_meta: &TenantRequestMeta,
-        body: &RerankRequest,
+        body: RerankRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(Some(model_id));
@@ -931,7 +935,7 @@ mod tests {
             &self,
             _headers: Option<&HeaderMap>,
             _tenant_meta: &TenantRequestMeta,
-            _body: &GenerateRequest,
+            _body: GenerateRequest,
             _model_id: &str,
         ) -> Response {
             (StatusCode::OK, "routed").into_response()
@@ -955,7 +959,7 @@ mod tests {
             &self,
             _headers: Option<&HeaderMap>,
             _tenant_meta: &TenantRequestMeta,
-            _body: &GenerateRequest,
+            _body: GenerateRequest,
             _model_id: &str,
         ) -> Response {
             (StatusCode::OK, "pd-routed").into_response()
@@ -979,7 +983,7 @@ mod tests {
             &self,
             _headers: Option<&HeaderMap>,
             _tenant_meta: &TenantRequestMeta,
-            _body: &GenerateRequest,
+            _body: GenerateRequest,
             _model_id: &str,
         ) -> Response {
             (StatusCode::OK, "epd-routed").into_response()
@@ -1110,7 +1114,7 @@ mod tests {
         assert_eq!(request.model, UNKNOWN_MODEL_ID);
 
         let response = manager
-            .route_generate(None, &test_tenant_meta(), &request, &request.model)
+            .route_generate(None, &test_tenant_meta(), request.clone(), &request.model)
             .await;
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -1128,7 +1132,7 @@ mod tests {
         assert_eq!(request.model, UNKNOWN_MODEL_ID);
 
         let response = manager
-            .route_generate(None, &test_tenant_meta(), &request, &request.model)
+            .route_generate(None, &test_tenant_meta(), request.clone(), &request.model)
             .await;
 
         assert_eq!(response.status(), StatusCode::OK);

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -151,11 +151,12 @@ async fn generate(
     cancel: middleware::scheduler::PreemptionGuard,
     Json(body): Json<GenerateRequest>,
 ) -> Response {
+    let model = body.model.clone();
     cancel
         .guard(
             state
                 .router
-                .route_generate(Some(&headers), &tenant_meta, &body, &body.model),
+                .route_generate(Some(&headers), &tenant_meta, body, &model),
         )
         .await
 }
@@ -167,11 +168,12 @@ async fn v1_chat_completions(
     cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
 ) -> Response {
+    let model = body.model.clone();
     cancel
         .guard(
             state
                 .router
-                .route_chat(Some(&headers), &tenant_meta, &body, &body.model),
+                .route_chat(Some(&headers), &tenant_meta, body, &model),
         )
         .await
 }
@@ -183,11 +185,12 @@ async fn v1_completions(
     cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<CompletionRequest>,
 ) -> Response {
+    let model = body.model.clone();
     cancel
         .guard(
             state
                 .router
-                .route_completion(Some(&headers), &tenant_meta, &body, &body.model),
+                .route_completion(Some(&headers), &tenant_meta, body, &model),
         )
         .await
 }
@@ -199,11 +202,12 @@ async fn rerank(
     cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<RerankRequest>,
 ) -> Response {
+    let model = body.model.clone();
     cancel
         .guard(
             state
                 .router
-                .route_rerank(Some(&headers), &tenant_meta, &body, &body.model),
+                .route_rerank(Some(&headers), &tenant_meta, body, &model),
         )
         .await
 }
@@ -216,13 +220,13 @@ async fn v1_rerank(
     Json(body): Json<V1RerankReqInput>,
 ) -> Response {
     let rerank_body: RerankRequest = body.into();
+    let model = rerank_body.model.clone();
     cancel
-        .guard(state.router.route_rerank(
-            Some(&headers),
-            &tenant_meta,
-            &rerank_body,
-            &rerank_body.model,
-        ))
+        .guard(
+            state
+                .router
+                .route_rerank(Some(&headers), &tenant_meta, rerank_body, &model),
+        )
         .await
 }
 
@@ -233,11 +237,12 @@ async fn v1_responses(
     cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<ResponsesRequest>,
 ) -> Response {
+    let model = body.model.clone();
     cancel
         .guard(
             state
                 .router
-                .route_responses(Some(&headers), &tenant_meta, &body, &body.model),
+                .route_responses(Some(&headers), &tenant_meta, body, &model),
         )
         .await
 }
@@ -249,13 +254,14 @@ async fn v1_interactions(
     cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<InteractionsRequest>,
 ) -> Response {
-    let model_id = body.model.as_deref().or(body.agent.as_deref());
+    let model_id = body.model.clone().or_else(|| body.agent.clone());
     cancel
-        .guard(
-            state
-                .router
-                .route_interactions(Some(&headers), &tenant_meta, &body, model_id),
-        )
+        .guard(state.router.route_interactions(
+            Some(&headers),
+            &tenant_meta,
+            body,
+            model_id.as_deref(),
+        ))
         .await
 }
 
@@ -266,11 +272,12 @@ async fn v1_embeddings(
     cancel: middleware::scheduler::PreemptionGuard,
     Json(body): Json<EmbeddingRequest>,
 ) -> Response {
+    let model = body.model.clone();
     cancel
         .guard(
             state
                 .router
-                .route_embeddings(Some(&headers), &tenant_meta, &body, &body.model),
+                .route_embeddings(Some(&headers), &tenant_meta, body, &model),
         )
         .await
 }
@@ -282,11 +289,12 @@ async fn v1_messages(
     cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<CreateMessageRequest>,
 ) -> Response {
+    let model = body.model.clone();
     cancel
         .guard(
             state
                 .router
-                .route_messages(Some(&headers), &tenant_meta, &body, &body.model),
+                .route_messages(Some(&headers), &tenant_meta, body, &model),
         )
         .await
 }
@@ -298,11 +306,12 @@ async fn v1_classify(
     cancel: middleware::scheduler::PreemptionGuard,
     Json(body): Json<ClassifyRequest>,
 ) -> Response {
+    let model = body.model.clone();
     cancel
         .guard(
             state
                 .router
-                .route_classify(Some(&headers), &tenant_meta, &body, &body.model),
+                .route_classify(Some(&headers), &tenant_meta, body, &model),
         )
         .await
 }

--- a/model_gateway/tests/api/request_formats_test.rs
+++ b/model_gateway/tests/api/request_formats_test.rs
@@ -37,7 +37,7 @@ mod request_format_tests {
             &self,
             _headers: Option<&HeaderMap>,
             _tenant_meta: &TenantRequestMeta,
-            body: &ChatCompletionRequest,
+            body: ChatCompletionRequest,
             _model_id: &str,
         ) -> Response {
             *self.request.lock().unwrap() = Some(body.reasoning_effort.clone());

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -124,7 +124,7 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
 
     let tenant_meta = test_tenant_meta();
     let resp = router
-        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .route_responses(None, &tenant_meta, req.clone(), req.model.as_str())
         .await;
 
     assert_eq!(resp.status(), StatusCode::OK);
@@ -345,7 +345,12 @@ async fn test_non_streaming_mcp_e2e_accepts_forwardable_request_headers() {
 
     let tenant_meta = test_tenant_meta();
     let resp = router
-        .route_responses(Some(&headers), &tenant_meta, &req, req.model.as_str())
+        .route_responses(
+            Some(&headers),
+            &tenant_meta,
+            req.clone(),
+            req.model.as_str(),
+        )
         .await;
 
     assert_eq!(resp.status(), StatusCode::OK);
@@ -469,7 +474,7 @@ async fn test_non_streaming_mcp_returns_approval_request_when_required() {
 
     let tenant_meta = test_tenant_meta();
     let resp = router
-        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .route_responses(None, &tenant_meta, req.clone(), req.model.as_str())
         .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
@@ -603,7 +608,7 @@ async fn test_final_response_hides_internal_mcp_trace_items() {
 
     let tenant_meta = test_tenant_meta();
     let resp = router
-        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .route_responses(None, &tenant_meta, req.clone(), req.model.as_str())
         .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
@@ -738,7 +743,7 @@ async fn test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_b
 
     let tenant_meta = test_tenant_meta();
     let resp1 = router
-        .route_responses(None, &tenant_meta, &req1, req1.model.as_str())
+        .route_responses(None, &tenant_meta, req1.clone(), req1.model.as_str())
         .await;
     assert_eq!(resp1.status(), StatusCode::OK);
 
@@ -793,7 +798,7 @@ async fn test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_b
 
     let tenant_meta = test_tenant_meta();
     let resp2 = router
-        .route_responses(None, &tenant_meta, &req2, req2.model.as_str())
+        .route_responses(None, &tenant_meta, req2.clone(), req2.model.as_str())
         .await;
     assert_eq!(resp2.status(), StatusCode::OK);
 
@@ -917,7 +922,7 @@ async fn test_final_response_hides_internal_mcp_error_details() {
 
     let tenant_meta = test_tenant_meta();
     let resp = router
-        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .route_responses(None, &tenant_meta, req.clone(), req.model.as_str())
         .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
@@ -1369,7 +1374,7 @@ async fn test_multi_turn_loop_with_mcp() {
     // Execute the request (this should trigger the multi-turn loop)
     let tenant_meta = test_tenant_meta();
     let response = router
-        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .route_responses(None, &tenant_meta, req.clone(), req.model.as_str())
         .await;
 
     // Check status
@@ -1531,7 +1536,7 @@ async fn test_max_tool_calls_limit() {
 
     let tenant_meta = test_tenant_meta();
     let response = router
-        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .route_responses(None, &tenant_meta, req.clone(), req.model.as_str())
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -1721,7 +1726,7 @@ async fn test_streaming_with_mcp_tool_calls() {
 
     let tenant_meta = test_tenant_meta();
     let response = router
-        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .route_responses(None, &tenant_meta, req.clone(), req.model.as_str())
         .await;
 
     // Verify streaming response
@@ -2009,7 +2014,7 @@ async fn test_streaming_multi_turn_with_mcp() {
 
     let tenant_meta = test_tenant_meta();
     let response = router
-        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .route_responses(None, &tenant_meta, req.clone(), req.model.as_str())
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 

--- a/model_gateway/tests/routing/grpc_completion_batch_test.rs
+++ b/model_gateway/tests/routing/grpc_completion_batch_test.rs
@@ -140,14 +140,14 @@ async fn grpc_completion_accepts_prompt_arrays_in_every_mode() {
 
         let scalar = completion_request(serde_json::json!("Hello world"));
         let scalar_response = router
-            .route_completion(None, &tenant_meta, &scalar, MODEL)
+            .route_completion(None, &tenant_meta, scalar, MODEL)
             .await;
         let scalar_status = scalar_response.status();
         let scalar_code = extract_error_code_from_response(&scalar_response).to_string();
 
         let array = completion_request(serde_json::json!(["Hello world", "Hello test"]));
         let array_response = router
-            .route_completion(None, &tenant_meta, &array, MODEL)
+            .route_completion(None, &tenant_meta, array, MODEL)
             .await;
 
         assert_ne!(

--- a/model_gateway/tests/routing/stream_relay_disconnect_test.rs
+++ b/model_gateway/tests/routing/stream_relay_disconnect_test.rs
@@ -133,12 +133,7 @@ async fn chat_relay_closes_upstream_when_client_disconnects_during_prefill() {
     let router = http_router_for(&upstream_url).await;
 
     let response = router
-        .route_chat(
-            None,
-            &tenant_meta(),
-            &streaming_chat_request(),
-            "mock-model",
-        )
+        .route_chat(None, &tenant_meta(), streaming_chat_request(), "mock-model")
         .await;
     assert_eq!(response.status(), 200);
 
@@ -160,12 +155,7 @@ async fn chat_relay_closes_upstream_when_client_disconnects_mid_stream() {
     let router = http_router_for(&upstream_url).await;
 
     let response = router
-        .route_chat(
-            None,
-            &tenant_meta(),
-            &streaming_chat_request(),
-            "mock-model",
-        )
+        .route_chat(None, &tenant_meta(), streaming_chat_request(), "mock-model")
         .await;
     assert_eq!(response.status(), 200);
 

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -242,7 +242,7 @@ async fn test_openai_router_responses_with_mock() {
 
     let tenant_meta = test_tenant_meta();
     let response1 = router
-        .route_responses(None, &tenant_meta, &request1, &request1.model)
+        .route_responses(None, &tenant_meta, request1.clone(), &request1.model)
         .await;
     assert_eq!(response1.status(), StatusCode::OK);
     let body1_bytes = axum::body::to_bytes(response1.into_body(), usize::MAX)
@@ -262,7 +262,7 @@ async fn test_openai_router_responses_with_mock() {
 
     let tenant_meta = test_tenant_meta();
     let response2 = router
-        .route_responses(None, &tenant_meta, &request2, &request2.model)
+        .route_responses(None, &tenant_meta, request2.clone(), &request2.model)
         .await;
     assert_eq!(response2.status(), StatusCode::OK);
     let body2_bytes = axum::body::to_bytes(response2.into_body(), usize::MAX)
@@ -511,7 +511,7 @@ async fn test_openai_router_responses_streaming_with_mock() {
 
     let tenant_meta = test_tenant_meta();
     let response = router
-        .route_responses(None, &tenant_meta, &request, &request.model)
+        .route_responses(None, &tenant_meta, request.clone(), &request.model)
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -656,7 +656,7 @@ async fn test_unsupported_endpoints() {
         .route_generate(
             None,
             &tenant_meta,
-            &generate_request,
+            generate_request.clone(),
             &generate_request.model,
         )
         .await;
@@ -668,7 +668,7 @@ async fn test_unsupported_endpoints() {
         .route_completion(
             None,
             &tenant_meta,
-            &completion_request,
+            completion_request.clone(),
             &completion_request.model,
         )
         .await;
@@ -698,7 +698,12 @@ async fn test_openai_router_chat_completion_with_mock() {
     // Route the request
     let tenant_meta = test_tenant_meta();
     let response = router
-        .route_chat(None, &tenant_meta, &chat_request, &chat_request.model)
+        .route_chat(
+            None,
+            &tenant_meta,
+            chat_request.clone(),
+            &chat_request.model,
+        )
         .await;
 
     // Should get a successful response from mock server
@@ -746,7 +751,7 @@ async fn test_openai_e2e_with_server() {
                         .route_chat(
                             Some(&parts.headers),
                             &tenant_meta,
-                            &chat_request,
+                            chat_request.clone(),
                             &chat_request.model,
                         )
                         .await
@@ -810,7 +815,12 @@ async fn test_openai_router_chat_streaming_with_mock() {
 
     let tenant_meta = test_tenant_meta();
     let response = router
-        .route_chat(None, &tenant_meta, &chat_request, &chat_request.model)
+        .route_chat(
+            None,
+            &tenant_meta,
+            chat_request.clone(),
+            &chat_request.model,
+        )
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -846,7 +856,12 @@ async fn test_openai_router_circuit_breaker() {
     for _ in 0..3 {
         let tenant_meta = test_tenant_meta();
         let response = router
-            .route_chat(None, &tenant_meta, &chat_request, &chat_request.model)
+            .route_chat(
+                None,
+                &tenant_meta,
+                chat_request.clone(),
+                &chat_request.model,
+            )
             .await;
         // Should get either an error or circuit breaker response
         assert!(

--- a/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
+++ b/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
@@ -217,7 +217,7 @@ async fn denial_returns_429_with_retry_after() {
     let request = generate_request();
 
     let first = router
-        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .route_generate(None, &fresh_tenant(), request.clone(), MODEL)
         .await;
     assert_eq!(first.status(), http::StatusCode::OK);
 
@@ -226,7 +226,7 @@ async fn denial_returns_429_with_retry_after() {
     // second 2-token reserve, but well within the 6-token capacity, so this
     // is a genuine "wait and retry" denial, not an impossible one.
     let second = router
-        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .route_generate(None, &fresh_tenant(), request, MODEL)
         .await;
     assert_eq!(second.status(), http::StatusCode::TOO_MANY_REQUESTS);
     assert!(
@@ -247,7 +247,7 @@ async fn impossible_request_denies_without_retry_after() {
 
     let request = generate_request();
     let response = router
-        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .route_generate(None, &fresh_tenant(), request, MODEL)
         .await;
 
     assert_eq!(response.status(), http::StatusCode::TOO_MANY_REQUESTS);
@@ -278,7 +278,7 @@ async fn non_streaming_settle_uses_real_usage_not_just_the_estimate() {
     let request = generate_request();
 
     let first = router
-        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .route_generate(None, &fresh_tenant(), request.clone(), MODEL)
         .await;
     assert_eq!(
         first.status(),
@@ -287,7 +287,7 @@ async fn non_streaming_settle_uses_real_usage_not_just_the_estimate() {
     );
 
     let second = router
-        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .route_generate(None, &fresh_tenant(), request, MODEL)
         .await;
     assert_eq!(
         second.status(),
@@ -307,7 +307,7 @@ async fn feature_disabled_is_a_no_op() {
 
     let request = generate_request();
     let response = router
-        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .route_generate(None, &fresh_tenant(), request, MODEL)
         .await;
 
     assert_eq!(response.status(), http::StatusCode::OK);
@@ -345,7 +345,7 @@ async fn completion_denial_reaches_the_client() {
 
     let request = completion_request();
     let response = router
-        .route_completion(None, &fresh_tenant(), &request, MODEL)
+        .route_completion(None, &fresh_tenant(), request, MODEL)
         .await;
 
     assert_eq!(

--- a/model_gateway/tests/zmq_backend_test.rs
+++ b/model_gateway/tests/zmq_backend_test.rs
@@ -200,7 +200,7 @@ async fn non_streaming_generate_over_zmq() {
     let router = build_router(&fixture, 1).await;
 
     let response = router
-        .route_generate(None, &test_meta(), &generate_request(false), MODEL)
+        .route_generate(None, &test_meta(), generate_request(false), MODEL)
         .await;
     assert_eq!(response.status(), http::StatusCode::OK);
 
@@ -231,7 +231,7 @@ async fn streaming_generate_over_zmq() {
     let router = build_router(&fixture, 1).await;
 
     let response = router
-        .route_generate(None, &test_meta(), &generate_request(true), MODEL)
+        .route_generate(None, &test_meta(), generate_request(true), MODEL)
         .await;
     assert_eq!(response.status(), http::StatusCode::OK);
 
@@ -267,8 +267,8 @@ async fn concurrent_requests_share_one_zmq_transport() {
     let (first_meta, second_meta) = (test_meta(), test_meta());
     let (first_request, second_request) = (generate_request(false), generate_request(false));
     let (first, second) = tokio::join!(
-        router.route_generate(None, &first_meta, &first_request, MODEL),
-        router.route_generate(None, &second_meta, &second_request, MODEL),
+        router.route_generate(None, &first_meta, first_request, MODEL),
+        router.route_generate(None, &second_meta, second_request, MODEL),
     );
     assert_eq!(first.status(), http::StatusCode::OK);
     assert_eq!(second.status(), http::StatusCode::OK);
@@ -285,7 +285,7 @@ async fn grouped_zmq_worker_serves_requests_from_either_rank() {
 
     for _ in 0..4 {
         let response = router
-            .route_generate(None, &test_meta(), &generate_request(false), MODEL)
+            .route_generate(None, &test_meta(), generate_request(false), MODEL)
             .await;
         assert_eq!(response.status(), http::StatusCode::OK);
     }


### PR DESCRIPTION
## Description

### Problem

Routers proxying large multimodal payloads at high stream concurrency hold every buffered request body for the full response lifetime. The handler owns the parsed struct and the retry loop borrows it until the response completes — for buffered (non-streaming) responses, until the entire body is read, i.e. the whole generation — so live memory scales as concurrency × body size and overload spikes can OOM the router. This retention buys nothing under `--disable-retries`, where the only post-dispatch use of the body (retry replay) never happens. Measured on a production-shaped workload: ~70 MB live per in-flight request, 425 GB allocated at ~6k concurrent streams. The PD router additionally materializes up to five copies per dispatch (parsed struct, a whole-request clone ahead of the retry loop, a JSON tree per leg, and two serialized bodies).

### Solution

Typed-JSON route methods take the parsed body by value so the dispatching router owns its lifetime. With retries disabled (`max_retries <= 1`) a single-dispatch path frees the parsed request and its routing text/token derivatives the moment the upstream body is serialized — before the send — so neither the send wait nor the response read/relay pins request memory. With retries enabled the request lives exactly until the retry window closes (first non-retryable response), matching existing semantics.

## Changes

- `RouterTrait` generate/chat/completion/responses/embeddings/classify/rerank/messages/interactions take owned bodies; handlers pass ownership through.
- HTTP regular router: `AttemptPayload::{Borrowed,Owned}` per attempt; retries-disabled bypass with retry-executor metric parity; serialization hoisted out of the send (`send_serialized_request`); rerank keeps only the small post-dispatch fields.
- HTTP PD router: whole-request clone removed (Arc wraps the owned request); per-leg JSON trees freed once the builders serialize them; selection-only routing text/tokens cleared before dispatch; retries-disabled requests freed at `to_value`.
- gRPC/OpenAI-compat/Anthropic/Gemini routers each drop one ingress clone.
- New counter `smg_router_request_buffers_released_early_bytes_total`.

## Test Plan

- New drop-probe tests prove the parsed request is freed before the upstream answers when retries are disabled (regular + PD): a stub upstream refuses to respond until the probe's only holder is the test.
- New replay test proves enabled retries resend an identical body after a 503.
- Existing retry (`reliability_tests`, incl. `test_retries_disabled`), streaming relay/disconnect (`routing_tests`), api, spec, zmq, tenant-rate-limit, messages suites all green; `cargo test -p smg --lib` 1734 passed.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
