### PR TITLE
feat(router): per-worker overload tuning with default-on load monitoring

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -32,7 +32,7 @@ use smg::{
         circuit_breaker::{CircuitBreaker, CircuitState},
         resilience::ResolvedResilience,
         worker::{RuntimeType, WorkerMetadata, WorkerRoutingKeyLoad},
-        ConnectionMode, Worker, WorkerResult, WorkerType,
+        ConnectionMode, OverloadThresholds, Worker, WorkerResult, WorkerType,
     },
 };
 use smg_grpc_client::sglang_scheduler::{SglangGenerateRequestOptions, SglangSchedulerClient};
@@ -74,6 +74,7 @@ impl GrpcWorker {
             spec: Arc::new(spec),
             health_config: HealthCheckConfig::default(),
             health_endpoint: "/health".to_string(),
+            overload: OverloadThresholds::default(),
         };
         Self {
             client,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -524,6 +524,8 @@ struct Router {
     job_queue_concurrency: usize,
     worker_overload_waiting_requests: Option<usize>,
     worker_overload_token_usage: Option<f64>,
+    worker_overload_protection: bool,
+    disable_load_monitoring: bool,
 }
 
 impl Router {
@@ -837,6 +839,8 @@ impl Router {
             .job_queue_concurrency(self.job_queue_concurrency)
             .worker_overload_waiting_requests(self.worker_overload_waiting_requests)
             .worker_overload_token_usage(self.worker_overload_token_usage)
+            .worker_overload_protection(self.worker_overload_protection)
+            .disable_load_monitoring(self.disable_load_monitoring)
             .load_monitor_interval_secs(self.load_monitor_interval)
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
@@ -1077,6 +1081,8 @@ impl Router {
         job_queue_concurrency = 200,
         worker_overload_waiting_requests = None,
         worker_overload_token_usage = None,
+        worker_overload_protection = false,
+        disable_load_monitoring = false,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1225,6 +1231,8 @@ impl Router {
         job_queue_concurrency: usize,
         worker_overload_waiting_requests: Option<usize>,
         worker_overload_token_usage: Option<f64>,
+        worker_overload_protection: bool,
+        disable_load_monitoring: bool,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1387,6 +1395,8 @@ impl Router {
             job_queue_concurrency,
             worker_overload_waiting_requests,
             worker_overload_token_usage,
+            worker_overload_protection,
+            disable_load_monitoring,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -238,6 +238,10 @@ class RouterArgs:
     # Absolute per-worker overload thresholds; both None disables the feature
     worker_overload_waiting_requests: int | None = None
     worker_overload_token_usage: float | None = None
+    # Enable overload protection with the gateway default token ceiling (0.9)
+    worker_overload_protection: bool = False
+    # Restore the conditional load-monitor poll gate (default: poll always)
+    disable_load_monitoring: bool = False
 
     @staticmethod
     def add_cli_args(
@@ -579,6 +583,21 @@ class RouterArgs:
             ),
         )
         routing_group.add_argument(
+            f"--{prefix}worker-overload-protection",
+            action="store_true",
+            help=(
+                "Enable worker overload protection with the gateway default"
+                " thresholds. This flag alone applies"
+                " --worker-overload-token-usage 0.9 and leaves"
+                " --worker-overload-waiting-requests unset: KV token usage means"
+                " the same thing on every engine, while a sensible"
+                " waiting-requests ceiling is workload-dependent, so it has no"
+                " universal default. Explicit thresholds override the default,"
+                " and either threshold set on its own enables protection without"
+                " this flag."
+            ),
+        )
+        routing_group.add_argument(
             f"--{prefix}overlap-decay",
             type=float,
             default=RouterArgs.overlap_decay,
@@ -825,6 +844,17 @@ class RouterArgs:
             type=int,
             default=RouterArgs.load_monitor_interval,
             help="Interval in seconds between load monitor checks for PowerOfTwo routing (default: 10)",
+        )
+        parser.add_argument(
+            f"--{prefix}disable-load-monitoring",
+            action="store_true",
+            help=(
+                "Only poll worker loads when a load-aware routing policy,"
+                " --engine-metrics, or worker overload protection needs the"
+                " data. By default every worker group is polled from"
+                " registration onward; this restores the old conditional gate"
+                " (a load-aware policy is always fed regardless)."
+            ),
         )
 
         # Multimodal tensor transport

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -611,6 +611,35 @@ class TestParseRouterArgs:
         assert router_args.worker_overload_waiting_requests == 8
         assert router_args.worker_overload_token_usage == pytest.approx(0.75)
 
+    def test_parse_overload_protection_and_monitoring_flags(self):
+        """The enable/opt-out flags round-trip, and both default to False.
+
+        Same failure mode as the threshold flags: a dest/field mismatch would
+        silently disable the feature from Python.
+        """
+        router_args = parse_router_args(
+            ["--worker-overload-protection", "--disable-load-monitoring"]
+        )
+        assert router_args.worker_overload_protection is True
+        assert router_args.disable_load_monitoring is True
+
+        defaults = parse_router_args([])
+        assert defaults.worker_overload_protection is False
+        assert defaults.disable_load_monitoring is False
+
+    def test_prefixed_overload_protection_and_monitoring_flags(self):
+        """The --router-prefixed aliases reach the same fields."""
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser, use_router_prefix=True)
+        namespace = parser.parse_args(
+            ["--router-worker-overload-protection", "--router-disable-load-monitoring"]
+        )
+
+        router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
+
+        assert router_args.worker_overload_protection is True
+        assert router_args.disable_load_monitoring is True
+
     def test_parse_pd_args(self):
         """Test parsing PD disaggregated mode arguments."""
         args = [
@@ -1370,6 +1399,8 @@ class TestRouterArgsFieldOrder:
         "job_queue_concurrency",
         "worker_overload_waiting_requests",
         "worker_overload_token_usage",
+        "worker_overload_protection",
+        "disable_load_monitoring",
     ]
 
     def test_complete_field_sequence_is_frozen(self):
@@ -1400,6 +1431,8 @@ class TestRouterArgsFieldOrder:
             "cache_ttl_secs",
             "worker_overload_waiting_requests",
             "worker_overload_token_usage",
+            "worker_overload_protection",
+            "disable_load_monitoring",
         ):
             assert names.index(appended) > marker, (
                 f"{appended} must be appended after worker_startup_delay to "

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -727,6 +727,12 @@ pub struct WorkerSpec {
     /// fixed, pre-agreed address rather than the derived one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub zmq_handshake_address: Option<String>,
+
+    /// Per-worker absolute overload threshold overrides (partial — only `Some`
+    /// fields override gateway defaults). Either field set enables overload
+    /// protection for this worker even when the gateway leaves it off.
+    #[serde(default, skip_serializing_if = "OverloadUpdate::is_empty")]
+    pub overload: OverloadUpdate,
 }
 
 impl WorkerSpec {
@@ -760,6 +766,7 @@ impl WorkerSpec {
             multimodal_tensor_transport: None,
             multimodal_shm_min_bytes: None,
             zmq_handshake_address: None,
+            overload: OverloadUpdate::default(),
         }
     }
 }
@@ -1026,6 +1033,28 @@ impl HttpPoolConfig {
             && self.pool_idle_timeout_secs.is_none()
             && self.timeout_secs.is_none()
             && self.connect_timeout_secs.is_none()
+    }
+}
+
+/// Per-worker absolute overload threshold overrides.
+/// All fields optional — `None` means "use gateway default". Either field set
+/// enables overload protection for this worker even when the gateway leaves
+/// it off. Mirrors `HealthCheckUpdate` pattern for PATCH-style config.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct OverloadUpdate {
+    /// Queued (waiting) requests summed across DP ranks at or above which this
+    /// worker is considered overloaded. Must be `>= 1`.
+    pub waiting_requests: Option<usize>,
+    /// Mean KV-cache token usage across DP ranks at or above which this worker
+    /// is considered overloaded. Must be in `(0.0, 1.0]`.
+    pub token_usage: Option<f64>,
+}
+
+impl OverloadUpdate {
+    /// Returns `true` if all fields are `None` (no overrides specified).
+    pub fn is_empty(&self) -> bool {
+        self.waiting_requests.is_none() && self.token_usage.is_none()
     }
 }
 
@@ -1585,5 +1614,61 @@ mod health_check_drain_settle_tests {
         }"#;
         let cfg: HealthCheckConfig = serde_json::from_str(json).unwrap();
         assert_eq!(cfg.drain_settle_secs, 5);
+    }
+}
+
+#[cfg(test)]
+mod overload_update_tests {
+    use serde_json::json;
+
+    use super::{OverloadUpdate, WorkerSpec};
+
+    #[test]
+    fn spec_without_block_deserializes_empty_and_is_not_serialized() {
+        // Existing serialized specs carry no `overload` key; they must keep
+        // deserializing, and an empty block must not appear on output.
+        let spec: WorkerSpec = serde_json::from_value(json!({"url": "http://w:1"})).unwrap();
+        assert!(spec.overload.is_empty());
+
+        let out = serde_json::to_value(&spec).unwrap();
+        assert!(out.get("overload").is_none());
+    }
+
+    #[test]
+    fn overload_block_round_trips_per_field() {
+        let spec: WorkerSpec = serde_json::from_value(json!({
+            "url": "http://w:1",
+            "overload": {"waiting_requests": 8, "token_usage": 0.85},
+        }))
+        .unwrap();
+        assert_eq!(spec.overload.waiting_requests, Some(8));
+        assert_eq!(spec.overload.token_usage, Some(0.85));
+
+        let out = serde_json::to_value(&spec).unwrap();
+        assert_eq!(out["overload"]["waiting_requests"], 8);
+        assert_eq!(out["overload"]["token_usage"], 0.85);
+
+        // A one-field block leaves the other signal unset, not defaulted.
+        let partial: WorkerSpec = serde_json::from_value(json!({
+            "url": "http://w:1",
+            "overload": {"token_usage": 0.9},
+        }))
+        .unwrap();
+        assert_eq!(partial.overload.waiting_requests, None);
+        assert_eq!(partial.overload.token_usage, Some(0.9));
+        assert!(!partial.overload.is_empty());
+    }
+
+    #[test]
+    fn is_empty_tracks_both_fields() {
+        let mut update = OverloadUpdate::default();
+        assert!(update.is_empty());
+        update.waiting_requests = Some(1);
+        assert!(!update.is_empty());
+        update = OverloadUpdate {
+            waiting_requests: None,
+            token_usage: Some(1.0),
+        };
+        assert!(!update.is_empty());
     }
 }

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -21,14 +21,14 @@ use crate::{
     policies::PolicyRegistry,
     rate_limit::RateLimitManager,
     routers::{
-        common::{openai_bridge::FormatRegistry, realtime::RealtimeRegistry},
+        common::{openai_bridge::FormatRegistry, overload, realtime::RealtimeRegistry},
         grpc::multimodal::MultimodalConfigRegistry,
         router_manager::RouterManager,
     },
     wasm::{config::WasmRuntimeConfig, module_manager::WasmModuleManager},
     worker::{
-        http_client::apply_upstream_http2, KvEventMonitor, OverloadThresholds,
-        WorkerHttpClientCache, WorkerMonitor, WorkerRegistry, WorkerService,
+        http_client::apply_upstream_http2, KvEventMonitor, WorkerHttpClientCache, WorkerMonitor,
+        WorkerRegistry, WorkerService,
     },
     workflow::{JobQueue, WorkflowEngines},
 };
@@ -636,14 +636,14 @@ impl AppContextBuilder {
             client.clone(),
             config.load_monitor_interval_secs,
             config.engine_metrics,
-            OverloadThresholds {
-                waiting_requests: config.worker_overload_waiting_requests,
-                token_usage: config.worker_overload_token_usage,
-            },
+            config.disable_load_monitoring,
         ));
+        // The overload shed advertises the poll interval as Retry-After — the
+        // veto cannot clear between polls.
+        overload::set_shed_retry_after_secs(config.load_monitor_interval_secs);
         // Wire the backend load-snapshot feed into every policy that consumes
-        // it; the monitor itself only polls while some policy reports needing
-        // the data.
+        // it; the monitor polls every group by default, conditionally under
+        // `--disable-load-monitoring`.
         policy_registry.set_load_receiver(Some(monitor.subscribe()));
         self.worker_monitor = Some(monitor);
         Ok(self)

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -263,6 +263,16 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn disable_load_monitoring(mut self, disabled: bool) -> Self {
+        self.config.disable_load_monitoring = disabled;
+        self
+    }
+
+    pub fn worker_overload_protection(mut self, enabled: bool) -> Self {
+        self.config.worker_overload_protection = enabled;
+        self
+    }
+
     pub fn worker_overload_waiting_requests(mut self, threshold: Option<usize>) -> Self {
         self.config.worker_overload_waiting_requests = threshold;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -93,6 +93,20 @@ pub struct RouterConfig {
     pub job_queue_concurrency: usize,
     #[serde(default = "default_load_monitor_interval_secs")]
     pub load_monitor_interval_secs: u64,
+    /// Restore the conditional load-monitor poll gate: only poll worker groups
+    /// when a load-aware routing policy, `engine_metrics`, or overload
+    /// protection needs the data. Default `false` — the monitor polls every
+    /// group unconditionally from registration onward. A load-aware policy is
+    /// always fed regardless of this flag.
+    #[serde(default)]
+    pub disable_load_monitoring: bool,
+    /// Enable absolute worker overload protection with the gateway default of
+    /// `worker_overload_token_usage = 0.9` (KV token usage is engine-universal;
+    /// a waiting-requests default would be workload-dependent, so that signal
+    /// stays unset). Redundant when either explicit threshold below is set —
+    /// those enable protection on their own, exactly as before this flag.
+    #[serde(default)]
+    pub worker_overload_protection: bool,
     /// Queued-request count at or above which a worker is considered
     /// overloaded and excluded from routing until the signal recovers; when all
     /// workers are overloaded, requests are shed immediately rather than
@@ -1040,6 +1054,8 @@ impl Default for RouterConfig {
             job_queue_capacity: default_job_queue_capacity(),
             job_queue_concurrency: default_job_queue_concurrency(),
             load_monitor_interval_secs: 10,
+            disable_load_monitoring: false,
+            worker_overload_protection: false,
             worker_overload_waiting_requests: None,
             worker_overload_token_usage: None,
             kv_indexer_ttl_secs: None,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -278,6 +278,24 @@ struct CliArgs {
     #[arg(long, default_value_t = 1.0, help_heading = "Routing Policy")]
     overload_token_usage_threshold: f32,
 
+    /// Enable worker overload protection with the gateway default thresholds.
+    ///
+    /// A worker whose load signal crosses a threshold is considered overloaded
+    /// and excluded from routing until the signal recovers; when every worker
+    /// is overloaded, requests are shed immediately rather than queued.
+    ///
+    /// This flag alone applies --worker-overload-token-usage 0.9 and leaves
+    /// --worker-overload-waiting-requests unset: KV token usage means the same
+    /// thing on every engine, while a sensible waiting-requests ceiling is
+    /// workload-dependent, so it has no universal default. Explicit thresholds
+    /// override the default, and either threshold set on its own enables
+    /// protection without this flag — exactly as before it existed. Per-worker
+    /// `overload` blocks on a WorkerSpec override the gateway values per
+    /// signal, and enable protection for that worker even with everything here
+    /// unset.
+    #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
+    worker_overload_protection: bool,
+
     /// Queued-request count at or above which a worker is considered
     /// overloaded and excluded from routing until the signal recovers; when
     /// every worker is overloaded, requests are shed immediately rather than
@@ -500,6 +518,14 @@ struct CliArgs {
     /// Interval in seconds between load monitor checks for PowerOfTwo routing
     #[arg(long, default_value_t = 10, help_heading = "Load Monitoring")]
     load_monitor_interval: u64,
+
+    /// Only poll worker loads when a load-aware routing policy,
+    /// --engine-metrics, or worker overload protection needs the data. By
+    /// default every worker group is polled from registration onward; this
+    /// restores the old conditional gate (a load-aware policy is always fed
+    /// regardless).
+    #[arg(long, default_value_t = false, help_heading = "Load Monitoring")]
+    disable_load_monitoring: bool,
 
     /// Re-export engine GetLoads signals (incl. PD) as smg_engine_* Prometheus
     /// gauges, polling even without a load-aware routing policy.
@@ -1756,6 +1782,8 @@ impl CliArgs {
             .job_queue_capacity(self.job_queue_capacity)
             .job_queue_concurrency(self.job_queue_concurrency)
             .load_monitor_interval_secs(self.load_monitor_interval)
+            .disable_load_monitoring(self.disable_load_monitoring)
+            .worker_overload_protection(self.worker_overload_protection)
             .worker_overload_waiting_requests(self.worker_overload_waiting_requests)
             .worker_overload_token_usage(self.worker_overload_token_usage)
             .kv_indexer_ttl_secs(self.kv_indexer_ttl_secs)
@@ -2423,6 +2451,53 @@ mod tests {
         // The inclusive ends of the accepted ranges must still parse.
         assert!(Cli::try_parse_from(["smg", "--worker-overload-waiting-requests", "1"]).is_ok());
         assert!(Cli::try_parse_from(["smg", "--worker-overload-token-usage", "1.0"]).is_ok());
+    }
+
+    /// `--worker-overload-protection` and `--disable-load-monitoring` must
+    /// reach `RouterConfig` and survive nesting into
+    /// `ServerConfig.router_config`. Two-path config-plumbing guard.
+    #[test]
+    fn overload_protection_and_monitoring_flags_flow_into_both_configs() {
+        let cli = cli_args_from(&["--worker-overload-protection", "--disable-load-monitoring"]);
+
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert!(
+            router_config.worker_overload_protection,
+            "worker_overload_protection must reach RouterConfig via to_router_config"
+        );
+        assert!(
+            router_config.disable_load_monitoring,
+            "disable_load_monitoring must reach RouterConfig via to_router_config"
+        );
+        // The flag alone carries no thresholds; the token default is applied
+        // at resolution, not stored in config.
+        assert_eq!(router_config.worker_overload_waiting_requests, None);
+        assert_eq!(router_config.worker_overload_token_usage, None);
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert!(
+            server_config.router_config.worker_overload_protection,
+            "worker_overload_protection must survive into ServerConfig"
+        );
+        assert!(
+            server_config.router_config.disable_load_monitoring,
+            "disable_load_monitoring must survive into ServerConfig"
+        );
+    }
+
+    /// Defaults: protection off, monitoring default-on (opt-out false) — the
+    /// behavior change is monitoring, and it is carried by the default here.
+    #[test]
+    fn overload_protection_and_monitoring_flags_default_off_in_both_configs() {
+        let cli = cli_args_from(&[]);
+
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert!(!router_config.worker_overload_protection);
+        assert!(!router_config.disable_load_monitoring);
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert!(!server_config.router_config.worker_overload_protection);
+        assert!(!server_config.router_config.disable_load_monitoring);
     }
 
     /// Cache-index flags must reach the cache_aware policy variant and the

--- a/model_gateway/src/routers/common/overload.rs
+++ b/model_gateway/src/routers/common/overload.rs
@@ -6,9 +6,15 @@
 //! and a whole-model predicate would miss a saturated PD leg, a mixed-transport
 //! model, or the model-less wildcard.
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 
-use axum::response::Response;
+use axum::{
+    http::{header::RETRY_AFTER, HeaderValue},
+    response::Response,
+};
 use tracing::debug;
 
 use crate::{
@@ -22,6 +28,18 @@ use crate::{
         Worker,
     },
 };
+
+/// Retry-After seconds advertised on every shed: the load-monitor poll
+/// interval, since the veto provably cannot clear faster. Process-wide because
+/// the shed helpers are free functions called from every router; the value is
+/// a client hint, not a correctness input. Default matches the config default.
+static SHED_RETRY_AFTER_SECS: AtomicU64 = AtomicU64::new(10);
+
+/// Latch the poll interval the shed responses advertise. Called once at
+/// startup when the load monitor is built.
+pub fn set_shed_retry_after_secs(secs: u64) {
+    SHED_RETRY_AFTER_SECS.store(secs.max(1), Ordering::Relaxed);
+}
 
 /// Whether every worker in a non-empty candidate pool is vetoed.
 ///
@@ -67,10 +85,16 @@ pub fn shed_if_worker_overloaded(worker: &dyn Worker, model_id: &str) -> Option<
 /// One decision line, one counter, one response — marked non-retryable: the
 /// veto clears at the poll interval, which no backoff window outlives, and a
 /// terminal shed is what keeps the counter per-request rather than per-attempt.
+/// Retry-After carries that interval so clients and proxies pace themselves;
+/// internal retries stay off regardless.
 fn shed(branch: &'static str, stage: &'static str, worker: &str, message: String) -> Response {
     Metrics::record_worker_overload_shed(stage);
     debug!(branch, stage, worker, "Overload shed");
     let mut response = error::service_unavailable("no_available_workers", message);
+    response.headers_mut().insert(
+        RETRY_AFTER,
+        HeaderValue::from(SHED_RETRY_AFTER_SECS.load(Ordering::Relaxed)),
+    );
     mark_non_retryable(&mut response);
     response
 }
@@ -145,6 +169,30 @@ mod tests {
 
         let dispatch = shed_if_worker_overloaded(a.as_ref(), "m").expect("shed");
         assert!(!is_retryable_response(&dispatch));
+    }
+
+    /// Both shed kinds advertise the poll interval as Retry-After — the veto
+    /// cannot clear faster — while staying terminal for the retry layer.
+    #[test]
+    fn shed_responses_carry_retry_after() {
+        let a = worker("http://127.0.0.1:9821", "m");
+        a.set_overloaded(true);
+
+        let selection = shed_if_all_overloaded(std::slice::from_ref(&a), "m").expect("shed");
+        let dispatch = shed_if_worker_overloaded(a.as_ref(), "m").expect("shed");
+        for response in [&selection, &dispatch] {
+            let value = response
+                .headers()
+                .get(RETRY_AFTER)
+                .expect("Retry-After present")
+                .to_str()
+                .expect("ascii");
+            assert!(
+                value.parse::<u64>().is_ok_and(|secs| secs >= 1),
+                "Retry-After must be whole seconds >= 1, got {value}"
+            );
+            assert!(!is_retryable_response(response));
+        }
     }
 
     /// An empty pool is a 404/unavailable question for the caller, not a shed.

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -3,13 +3,14 @@ use std::{collections::HashMap, sync::Arc};
 use arc_swap::{ArcSwap, ArcSwapOption};
 use openai_protocol::{
     model_card::ModelCard,
-    worker::{HealthCheckConfig, WorkerModels, WorkerSpec, WorkerStatus},
+    worker::{HealthCheckConfig, OverloadUpdate, WorkerModels, WorkerSpec, WorkerStatus},
 };
 use tokio::sync::mpsc;
 
 use super::{
     circuit_breaker::{CircuitBreaker, CircuitBreakerConfig},
     event::WorkerConnected,
+    overload::OverloadThresholds,
     resilience::ResolvedResilience,
     worker::{
         BasicWorker, ConnectionMode, LazyHttpClient, RuntimeType, WorkerMetadata, WorkerRuntime,
@@ -41,6 +42,10 @@ pub struct BasicWorkerBuilder {
     initial_status: Option<WorkerStatus>,
     /// Connect-readiness signal sender (ZMQ registration path only).
     connect_signal_tx: Option<mpsc::UnboundedSender<WorkerConnected>>,
+    /// Gateway-level overload thresholds the spec's `overload` block resolves
+    /// against. Default empty: a spec block alone still enables protection
+    /// for this worker.
+    overload_defaults: OverloadThresholds,
 }
 
 impl BasicWorkerBuilder {
@@ -56,6 +61,7 @@ impl BasicWorkerBuilder {
             resilience: None,
             initial_status: None,
             connect_signal_tx: None,
+            overload_defaults: OverloadThresholds::default(),
         }
     }
 
@@ -71,6 +77,7 @@ impl BasicWorkerBuilder {
             resilience: None,
             initial_status: None,
             connect_signal_tx: None,
+            overload_defaults: OverloadThresholds::default(),
         }
     }
 
@@ -88,6 +95,7 @@ impl BasicWorkerBuilder {
             resilience: None,
             initial_status: None,
             connect_signal_tx: None,
+            overload_defaults: OverloadThresholds::default(),
         }
     }
 
@@ -201,6 +209,20 @@ impl BasicWorkerBuilder {
         self
     }
 
+    /// Set per-worker overload threshold overrides (carried on the spec so
+    /// they survive replacement and show up in `GET /workers`).
+    pub fn overload(mut self, overrides: OverloadUpdate) -> Self {
+        self.spec.overload = overrides;
+        self
+    }
+
+    /// Set the gateway-level overload thresholds the spec overrides resolve
+    /// against (per signal: worker override, else this default).
+    pub fn overload_defaults(mut self, defaults: OverloadThresholds) -> Self {
+        self.overload_defaults = defaults;
+        self
+    }
+
     /// Set KV connector type (e.g., "MooncakeConnector", "NixlConnector")
     pub fn kv_connector(mut self, connector: impl Into<String>) -> Self {
         self.spec.kv_connector = Some(connector.into());
@@ -285,6 +307,7 @@ impl BasicWorkerBuilder {
             .unwrap_or_else(|| self.spec.health.apply_to(&HealthCheckConfig::default()));
 
         let metadata = WorkerMetadata {
+            overload: OverloadThresholds::resolve(&self.spec.overload, self.overload_defaults),
             spec: Arc::new(self.spec),
             health_config,
             health_endpoint: self.health_endpoint,
@@ -429,6 +452,44 @@ mod tests {
             .http_client(Arc::new(reqwest::Client::new()))
             .build();
         assert!(!worker.http_client.cell_is_empty());
+    }
+
+    #[test]
+    fn overload_overrides_resolve_per_signal_against_gateway_defaults() {
+        let worker = BasicWorkerBuilder::new("http://w:1")
+            .overload(OverloadUpdate {
+                waiting_requests: None,
+                token_usage: Some(0.5),
+            })
+            .overload_defaults(OverloadThresholds {
+                waiting_requests: Some(16),
+                token_usage: Some(0.9),
+            })
+            .build();
+        // Worker override wins its signal; the other keeps the gateway value.
+        assert_eq!(
+            worker.metadata().overload,
+            OverloadThresholds {
+                waiting_requests: Some(16),
+                token_usage: Some(0.5),
+            }
+        );
+        // The block itself rides the spec, so it survives spec-based rebuilds
+        // and appears in `GET /workers`.
+        assert_eq!(worker.metadata().spec.overload.token_usage, Some(0.5));
+    }
+
+    #[test]
+    fn spec_overload_block_alone_enables_protection() {
+        let mut spec = WorkerSpec::new("http://w:1");
+        spec.overload.waiting_requests = Some(4);
+        let worker = BasicWorkerBuilder::from_spec(spec).build();
+        assert!(worker.metadata().overload.is_enabled());
+        assert_eq!(worker.metadata().overload.waiting_requests, Some(4));
+
+        // No block, no defaults: protection stays off for this worker.
+        let plain = BasicWorkerBuilder::new("http://w:2").build();
+        assert!(!plain.metadata().overload.is_enabled());
     }
 
     #[test]

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -37,8 +37,11 @@
 //!
 //! Each group runs a single `tokio::time::interval` loop. Every tick:
 //!
-//! 1. Skip if no load-aware policy is currently active for this group
-//!    (matches the original `LoadMonitor` policy gate).
+//! 1. Fetch the group's `Ready` workers. Polling is unconditional by
+//!    default; with `--disable-load-monitoring` the tick is skipped
+//!    unless a load-aware policy, engine-metrics re-export, or overload
+//!    protection on a group member needs the data (the original
+//!    conditional gate — never "never poll").
 //! 2. Fetch loads concurrently from every `Ready` worker in the group.
 //! 3. Update load-aware policies and the DP cache.
 //! 4. Atomically clear stale entries for the group from the watch
@@ -67,9 +70,7 @@ use tracing::{debug, info, warn};
 use crate::{
     observability::metrics::Metrics,
     policies::PolicyRegistry,
-    worker::{
-        event::WorkerEvent, overload::OverloadThresholds, ConnectionMode, Worker, WorkerRegistry,
-    },
+    worker::{event::WorkerEvent, ConnectionMode, Worker, WorkerRegistry},
 };
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -226,10 +227,11 @@ pub struct WorkerMonitor {
     /// When set, poll loads and re-export `smg_engine_*` gauges even if no
     /// load-aware routing policy is active (`--engine-metrics`).
     engine_metrics: bool,
-    /// Absolute per-worker overload thresholds. When enabled, every ingested
-    /// load report is scored once here and the verdict latched onto the worker,
-    /// which is what keeps selection free of any per-request predicate.
-    overload: OverloadThresholds,
+    /// `--disable-load-monitoring`: restore the conditional poll gate (a
+    /// load-aware/dp-rank policy, engine metrics, or overload protection on a
+    /// group member still forces the poll) instead of polling every group
+    /// unconditionally from registration onward.
+    conditional_polling: bool,
     load_tx: watch::Sender<HashMap<String, WorkerLoadResponse>>,
     load_rx: watch::Receiver<HashMap<String, WorkerLoadResponse>>,
     /// Worker URLs that answered definitively that they do not serve
@@ -261,7 +263,7 @@ impl WorkerMonitor {
         client: reqwest::Client,
         default_interval_secs: u64,
         engine_metrics: bool,
-        overload: OverloadThresholds,
+        conditional_polling: bool,
     ) -> Self {
         let (load_tx, load_rx) = watch::channel(HashMap::new());
         Self {
@@ -271,7 +273,7 @@ impl WorkerMonitor {
             client,
             default_interval: Duration::from_secs(default_interval_secs.max(1)),
             engine_metrics,
-            overload,
+            conditional_polling,
             load_tx,
             load_rx,
             native_loads_absent: Arc::new(DashSet::new()),
@@ -367,16 +369,15 @@ impl WorkerMonitor {
         self.native_loads_absent.clear();
         // The feed that would clear the vetoes is being torn down: fail open,
         // but say so — a wiped gauge is otherwise indistinguishable from a
-        // genuine recovery.
-        if self.overload.is_enabled() {
-            let cleared = self.worker_registry.clear_all_overload_flags();
-            if cleared > 0 {
-                warn!(
-                    vetoes_cleared = cleared,
-                    "Overload vetoes cleared with the load feed; every worker is routable again \
-                     until its next poll"
-                );
-            }
+        // genuine recovery. With no thresholds anywhere no flag was ever
+        // written, so this clears nothing and stays silent.
+        let cleared = self.worker_registry.clear_all_overload_flags();
+        if cleared > 0 {
+            warn!(
+                vetoes_cleared = cleared,
+                "Overload vetoes cleared with the load feed; every worker is routable again \
+                 until its next poll"
+            );
         }
     }
 
@@ -895,20 +896,6 @@ async fn group_monitor_loop(
             return;
         };
 
-        // Poll when a load-aware policy needs the data, when engine-metrics
-        // re-export is on, or when overload protection is configured. The last
-        // two decouple the poll from routing policy: overload vetoes apply
-        // under every policy, including ones that never read loads.
-        let load_aware_policies = monitor.policy_registry.get_all_load_aware_policies();
-        let routing_needs_load = !load_aware_policies.is_empty()
-            || monitor.policy_registry.get_dp_rank_policy().is_some();
-        let overload = monitor.overload;
-        if !routing_needs_load && !monitor.engine_metrics && !overload.is_enabled() {
-            debug!("No load-aware policies and engine metrics off, skipping load fetch for group {group_key}");
-            drop(monitor);
-            continue;
-        }
-
         // Only poll Ready workers — Pending/NotReady/Failed do not
         // serve traffic and should not contribute load samples.
         let workers: Vec<Arc<dyn Worker>> = monitor
@@ -928,6 +915,23 @@ async fn group_monitor_loop(
             debug!("No Ready workers in group {group_key}, skipping");
             drop(monitor);
             continue;
+        }
+
+        // Polling is unconditional by default so registration alone gives a
+        // worker live load state. `--disable-load-monitoring` restores the
+        // conditional gate: a load-aware policy, engine-metrics re-export, or
+        // overload protection on any group member still forces the poll —
+        // never "never poll".
+        let load_aware_policies = monitor.policy_registry.get_all_load_aware_policies();
+        if monitor.conditional_polling {
+            let routing_needs_load = !load_aware_policies.is_empty()
+                || monitor.policy_registry.get_dp_rank_policy().is_some();
+            let overload_needs_load = workers.iter().any(|w| w.metadata().overload.is_enabled());
+            if !routing_needs_load && !monitor.engine_metrics && !overload_needs_load {
+                debug!("Load monitoring disabled and nothing needs the data, skipping load fetch for group {group_key}");
+                drop(monitor);
+                continue;
+            }
         }
 
         let futures: Vec<_> = workers
@@ -964,8 +968,10 @@ async fn group_monitor_loop(
         for (worker, response) in results {
             let url = worker.url().to_string();
             // The overload predicate runs exactly here, once per report, never
-            // on a request path. A failed fetch means no fresh signal, which
-            // clears the flag — absent means no opinion.
+            // on a request path, against the worker's effective thresholds
+            // (resolved at registration). A failed fetch means no fresh
+            // signal, which clears the flag — absent means no opinion.
+            let overload = worker.metadata().overload;
             if overload.is_enabled() {
                 let verdict = response
                     .as_ref()
@@ -1159,7 +1165,7 @@ mod worker_monitor_tests {
             reqwest::Client::new(),
             5,
             false,
-            OverloadThresholds::default(),
+            false,
         ));
         (registry, monitor)
     }
@@ -1516,7 +1522,10 @@ sglang:utilization{model="llama"} 0.9
 mod native_loads_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use openai_protocol::{model_card::ModelCard, worker::HealthCheckConfig};
+    use openai_protocol::{
+        model_card::ModelCard,
+        worker::{HealthCheckConfig, OverloadUpdate},
+    };
 
     use super::*;
     use crate::{
@@ -1575,12 +1584,19 @@ mod native_loads_tests {
     }
 
     fn vllm_worker(url: &str) -> Arc<dyn Worker> {
+        vllm_worker_with_overload(url, OverloadUpdate::default())
+    }
+
+    /// Worker carrying a per-worker overload block — protection for it is
+    /// enabled by the spec alone, with no gateway thresholds anywhere.
+    fn vllm_worker_with_overload(url: &str, overload: OverloadUpdate) -> Arc<dyn Worker> {
         Arc::new(
             BasicWorkerBuilder::new(url)
                 .worker_type(WorkerType::Regular)
                 .connection_mode(ConnectionMode::Http)
                 .runtime_type(RuntimeType::Vllm)
                 .model(ModelCard::new("a"))
+                .overload(overload)
                 .health_config(HealthCheckConfig {
                     disable_health_check: true,
                     ..Default::default()
@@ -1608,12 +1624,12 @@ mod native_loads_tests {
     }
 
     fn monitor_with_policy(config: PolicyConfig) -> (Arc<WorkerRegistry>, Arc<WorkerMonitor>) {
-        monitor_with(config, OverloadThresholds::default())
+        monitor_with(config, false)
     }
 
     fn monitor_with(
         config: PolicyConfig,
-        overload: OverloadThresholds,
+        conditional_polling: bool,
     ) -> (Arc<WorkerRegistry>, Arc<WorkerMonitor>) {
         let registry = Arc::new(WorkerRegistry::new());
         let policy_registry = Arc::new(PolicyRegistry::new(config));
@@ -1623,7 +1639,7 @@ mod native_loads_tests {
             reqwest::Client::new(),
             1,
             false,
-            overload,
+            conditional_polling,
         ));
         (registry, monitor)
     }
@@ -1643,18 +1659,19 @@ mod native_loads_tests {
     /// `NATIVE_BODY` reports 4 waiting requests, so a threshold of 4 vetoes and
     /// a threshold of 5 does not — the ingestion path must latch the verdict on
     /// the worker itself, under a policy (round-robin) that reads no loads at
-    /// all.
+    /// all. The threshold rides the worker's spec block, so this also proves a
+    /// spec block alone enables protection with no gateway flags anywhere.
     #[tokio::test]
     async fn load_ingestion_flags_worker_over_waiting_threshold() {
         let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
-        let (registry, monitor) = monitor_with(
-            PolicyConfig::RoundRobin,
-            OverloadThresholds {
+        let (registry, monitor) = monitor_with(PolicyConfig::RoundRobin, false);
+        let worker = vllm_worker_with_overload(
+            &stub.url,
+            OverloadUpdate {
                 waiting_requests: Some(4),
                 token_usage: None,
             },
         );
-        let worker = vllm_worker(&stub.url);
         worker.set_status(WorkerStatus::Ready);
         registry.register(Arc::clone(&worker)).unwrap();
         monitor.start_event_loop();
@@ -1672,14 +1689,14 @@ mod native_loads_tests {
     #[tokio::test]
     async fn busy_worker_under_threshold_stays_eligible() {
         let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
-        let (registry, monitor) = monitor_with(
-            PolicyConfig::RoundRobin,
-            OverloadThresholds {
+        let (registry, monitor) = monitor_with(PolicyConfig::RoundRobin, false);
+        let worker = vllm_worker_with_overload(
+            &stub.url,
+            OverloadUpdate {
                 waiting_requests: Some(5),
                 token_usage: None,
             },
         );
-        let worker = vllm_worker(&stub.url);
         worker.set_status(WorkerStatus::Ready);
         registry.register(Arc::clone(&worker)).unwrap();
         monitor.start_event_loop();
@@ -1699,19 +1716,20 @@ mod native_loads_tests {
         assert_eq!(registry.overloaded_worker_count("a"), 0);
     }
 
-    /// Overload protection alone must open the poll gate: without it the
-    /// feature would silently never engage under a load-blind policy.
+    /// Overload protection alone must open the poll gate even under
+    /// `--disable-load-monitoring`: without it the feature would silently
+    /// never engage under a load-blind policy.
     #[tokio::test]
     async fn overload_thresholds_alone_start_load_polling() {
         let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
-        let (registry, monitor) = monitor_with(
-            PolicyConfig::RoundRobin,
-            OverloadThresholds {
+        let (registry, monitor) = monitor_with(PolicyConfig::RoundRobin, true);
+        let worker = vllm_worker_with_overload(
+            &stub.url,
+            OverloadUpdate {
                 waiting_requests: None,
                 token_usage: Some(0.2),
             },
         );
-        let worker = vllm_worker(&stub.url);
         worker.set_status(WorkerStatus::Ready);
         registry.register(Arc::clone(&worker)).unwrap();
         monitor.start_event_loop();
@@ -1726,18 +1744,15 @@ mod native_loads_tests {
         .await;
     }
 
-    /// With both thresholds unset the feature is off: an engine reporting a
-    /// load that would trip either signal must still leave the flag, the
-    /// counters and every routing verdict exactly where they were.
+    /// With protection off and no spec block the feature is off: an engine
+    /// reporting a load that would trip either signal must still leave the
+    /// flag, the counters and every routing verdict exactly where they were.
     #[tokio::test]
     async fn unconfigured_thresholds_never_write_the_flag() {
         let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
         // cache_aware with overlap_decay on, so loads are polled and ingested
         // for reasons unrelated to overload protection.
-        let (registry, monitor) = monitor_with(
-            cache_aware_policy_config(1.0),
-            OverloadThresholds::default(),
-        );
+        let (registry, monitor) = monitor_with(cache_aware_policy_config(1.0), false);
         let worker = vllm_worker(&stub.url);
         worker.set_status(WorkerStatus::Ready);
         registry.register(Arc::clone(&worker)).unwrap();
@@ -1763,15 +1778,15 @@ mod native_loads_tests {
     /// re-admitted rather than stranded out of routing forever.
     #[tokio::test]
     async fn losing_the_load_feed_clears_the_veto() {
-        let (registry, monitor) = monitor_with(
-            PolicyConfig::RoundRobin,
-            OverloadThresholds {
+        let (registry, monitor) = monitor_with(PolicyConfig::RoundRobin, false);
+        // Never-registered address: every fetch fails, so the report is absent.
+        let worker = vllm_worker_with_overload(
+            "http://127.0.0.1:1",
+            OverloadUpdate {
                 waiting_requests: Some(1),
                 token_usage: None,
             },
         );
-        // Never-registered address: every fetch fails, so the report is absent.
-        let worker = vllm_worker("http://127.0.0.1:1");
         worker.set_status(WorkerStatus::Ready);
         registry.register(Arc::clone(&worker)).unwrap();
         registry.set_worker_overloaded(&worker, true);
@@ -1789,14 +1804,14 @@ mod native_loads_tests {
     /// so it must clear it itself — same rule the load snapshot follows.
     #[tokio::test]
     async fn stop_all_groups_clears_overload_flags() {
-        let (registry, monitor) = monitor_with(
-            PolicyConfig::RoundRobin,
-            OverloadThresholds {
+        let (registry, monitor) = monitor_with(PolicyConfig::RoundRobin, false);
+        let worker = vllm_worker_with_overload(
+            "http://127.0.0.1:1",
+            OverloadUpdate {
                 waiting_requests: Some(1),
                 token_usage: None,
             },
         );
-        let worker = vllm_worker("http://127.0.0.1:1");
         worker.set_status(WorkerStatus::Ready);
         registry.register(Arc::clone(&worker)).unwrap();
         registry.set_worker_overloaded(&worker, true);
@@ -1807,10 +1822,12 @@ mod native_loads_tests {
         assert_eq!(registry.overloaded_worker_count("a"), 0);
     }
 
+    /// A load-aware policy must still be fed with the opt-out set — the
+    /// conditional gate is "poll when needed", never "never poll".
     #[tokio::test]
     async fn pressure_configured_cache_aware_starts_load_polling() {
         let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
-        let (registry, monitor) = monitor_with_policy(cache_aware_policy_config(1.0));
+        let (registry, monitor) = monitor_with(cache_aware_policy_config(1.0), true);
         let worker = vllm_worker(&stub.url);
         worker.set_status(WorkerStatus::Ready);
         registry.register(worker).unwrap();
@@ -1834,10 +1851,31 @@ mod native_loads_tests {
         .expect("cache_aware with overlap_decay must trigger load polling");
     }
 
+    /// Load monitoring is on by default: a load-blind policy with no flags and
+    /// no spec blocks still gets its workers polled from registration onward.
     #[tokio::test]
-    async fn default_cache_aware_skips_load_polling() {
+    async fn load_blind_policy_polls_by_default() {
         let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
         let (registry, monitor) = monitor_with_policy(cache_aware_policy_config(0.0));
+        let worker = vllm_worker(&stub.url);
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(Arc::clone(&worker)).unwrap();
+        monitor.start_event_loop();
+
+        wait_until("default-on monitoring to poll the engine", || {
+            stub.probes.load(Ordering::SeqCst) > 0
+        })
+        .await;
+        // Polling alone must not write the overload flag.
+        assert!(!worker.is_overloaded());
+    }
+
+    /// `--disable-load-monitoring` restores the old conditional gate: a
+    /// load-blind policy with nothing needing the data is never polled.
+    #[tokio::test]
+    async fn disable_load_monitoring_restores_the_conditional_gate() {
+        let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
+        let (registry, monitor) = monitor_with(cache_aware_policy_config(0.0), true);
         let worker = vllm_worker(&stub.url);
         worker.set_status(WorkerStatus::Ready);
         registry.register(worker).unwrap();

--- a/model_gateway/src/worker/overload.rs
+++ b/model_gateway/src/worker/overload.rs
@@ -3,7 +3,15 @@
 //! The predicate is evaluated once per ingested load report, never per request;
 //! the verdict is latched into routing state, which selection already reads.
 
-use openai_protocol::worker::WorkerLoadResponse;
+use openai_protocol::worker::{OverloadUpdate, WorkerLoadResponse};
+
+use crate::config::types::RouterConfig;
+
+/// Token-usage ceiling applied when protection is enabled by
+/// `--worker-overload-protection` alone. KV token usage means the same thing
+/// on every engine; a waiting-requests default would be workload-dependent, so
+/// that signal stays unset unless configured.
+pub const DEFAULT_TOKEN_USAGE_CEILING: f64 = 0.9;
 
 /// Decision-log branch: every worker selection could have used is overloaded,
 /// so the request is shed immediately instead of queued.
@@ -39,6 +47,32 @@ impl OverloadThresholds {
     /// requirement and every write to the flag.
     pub const fn is_enabled(&self) -> bool {
         self.waiting_requests.is_some() || self.token_usage.is_some()
+    }
+
+    /// Gateway-level thresholds: the explicit `--worker-overload-*` values,
+    /// with the token ceiling defaulted to [`DEFAULT_TOKEN_USAGE_CEILING`]
+    /// when `--worker-overload-protection` enables the feature without one.
+    /// Everything unset with the flag off disables protection — exact #2220
+    /// behavior.
+    pub fn from_gateway_config(config: &RouterConfig) -> Self {
+        Self {
+            waiting_requests: config.worker_overload_waiting_requests,
+            token_usage: config.worker_overload_token_usage.or_else(|| {
+                config
+                    .worker_overload_protection
+                    .then_some(DEFAULT_TOKEN_USAGE_CEILING)
+            }),
+        }
+    }
+
+    /// Per-worker effective thresholds: each signal takes the worker's spec
+    /// override, else the gateway value. Resolved once at registration; the
+    /// monitor's ingestion predicate reads the result per report.
+    pub fn resolve(overrides: &OverloadUpdate, gateway: Self) -> Self {
+        Self {
+            waiting_requests: overrides.waiting_requests.or(gateway.waiting_requests),
+            token_usage: overrides.token_usage.or(gateway.token_usage),
+        }
     }
 
     /// Evaluate the veto for one load report. O(DP ranks), i.e. O(1) per report.
@@ -116,6 +150,100 @@ mod tests {
         assert!(!thresholds.is_overloaded(&response(3, 0.7)));
         assert!(thresholds.is_overloaded(&response(4, 0.1)));
         assert!(thresholds.is_overloaded(&response(0, 0.8)));
+    }
+
+    fn gateway_config(
+        protection: bool,
+        waiting: Option<usize>,
+        token: Option<f64>,
+    ) -> RouterConfig {
+        RouterConfig {
+            worker_overload_protection: protection,
+            worker_overload_waiting_requests: waiting,
+            worker_overload_token_usage: token,
+            ..RouterConfig::default()
+        }
+    }
+
+    /// The flag alone enables protection with the engine-universal token
+    /// ceiling and no waiting-requests threshold.
+    #[test]
+    fn protection_flag_alone_defaults_the_token_ceiling() {
+        let thresholds = OverloadThresholds::from_gateway_config(&gateway_config(true, None, None));
+        assert_eq!(
+            thresholds,
+            OverloadThresholds {
+                waiting_requests: None,
+                token_usage: Some(DEFAULT_TOKEN_USAGE_CEILING),
+            }
+        );
+        assert!(thresholds.is_enabled());
+    }
+
+    /// Explicit thresholds override the flag's default; without either, the
+    /// feature stays exactly off (#2220 back-compat).
+    #[test]
+    fn explicit_thresholds_override_the_flag_default() {
+        let explicit =
+            OverloadThresholds::from_gateway_config(&gateway_config(true, Some(8), Some(0.5)));
+        assert_eq!(explicit.token_usage, Some(0.5));
+        assert_eq!(explicit.waiting_requests, Some(8));
+
+        let no_flag =
+            OverloadThresholds::from_gateway_config(&gateway_config(false, Some(8), None));
+        assert_eq!(
+            no_flag,
+            OverloadThresholds {
+                waiting_requests: Some(8),
+                token_usage: None,
+            }
+        );
+
+        let off = OverloadThresholds::from_gateway_config(&gateway_config(false, None, None));
+        assert!(!off.is_enabled());
+    }
+
+    /// Per-signal resolution: a worker override beats the gateway default for
+    /// its signal only; the other signal keeps the gateway value.
+    #[test]
+    fn resolve_applies_worker_overrides_per_signal() {
+        let gateway = OverloadThresholds {
+            waiting_requests: Some(16),
+            token_usage: Some(DEFAULT_TOKEN_USAGE_CEILING),
+        };
+        let resolved = OverloadThresholds::resolve(
+            &OverloadUpdate {
+                waiting_requests: None,
+                token_usage: Some(0.5),
+            },
+            gateway,
+        );
+        assert_eq!(
+            resolved,
+            OverloadThresholds {
+                waiting_requests: Some(16),
+                token_usage: Some(0.5),
+            }
+        );
+
+        // A spec block alone enables the worker even with protection off.
+        let solo = OverloadThresholds::resolve(
+            &OverloadUpdate {
+                waiting_requests: Some(4),
+                token_usage: None,
+            },
+            OverloadThresholds::default(),
+        );
+        assert!(solo.is_enabled());
+        assert_eq!(solo.waiting_requests, Some(4));
+        assert_eq!(solo.token_usage, None);
+
+        // No block, protection off: resolution stays disabled.
+        assert!(!OverloadThresholds::resolve(
+            &OverloadUpdate::default(),
+            OverloadThresholds::default()
+        )
+        .is_enabled());
     }
 
     #[test]

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -26,8 +26,8 @@ use tokio::{
 };
 
 use super::{
-    event::WorkerConnected, CircuitBreaker, ResolvedResilience, WorkerError, WorkerResult,
-    UNKNOWN_MODEL_ID,
+    event::WorkerConnected, overload::OverloadThresholds, CircuitBreaker, ResolvedResilience,
+    WorkerError, WorkerResult, UNKNOWN_MODEL_ID,
 };
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
@@ -855,6 +855,11 @@ pub struct WorkerMetadata {
     pub health_config: HealthCheckConfig,
     /// Health check endpoint path (internal-only, from router config).
     pub health_endpoint: String,
+    /// Effective absolute overload thresholds (per signal: `spec.overload`
+    /// override, else gateway default). Resolved once at registration; the
+    /// load monitor's ingestion predicate scores every report against these,
+    /// so nothing on a request path re-resolves them.
+    pub overload: OverloadThresholds,
 }
 
 impl WorkerMetadata {
@@ -2693,6 +2698,7 @@ mod tests {
             spec: Arc::new(WorkerSpec::new("http://test:8080")),
             health_config: HealthCheckConfig::default(),
             health_endpoint: "/health".to_string(),
+            overload: OverloadThresholds::default(),
         };
 
         // Empty models list should accept any model
@@ -2716,6 +2722,7 @@ mod tests {
             spec: Arc::new(spec),
             health_config: HealthCheckConfig::default(),
             health_endpoint: "/health".to_string(),
+            overload: OverloadThresholds::default(),
         };
 
         // Find by primary ID

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -14,8 +14,9 @@ use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, Wo
 use crate::{
     routers::grpc::zmq_client::zmq_handshake_address,
     worker::{
-        circuit_breaker::CircuitBreakerConfig, resilience::resolve_resilience, worker::RuntimeType,
-        BasicWorkerBuilder, ConnectionMode, Worker, WorkerRegistry, UNKNOWN_MODEL_ID,
+        circuit_breaker::CircuitBreakerConfig, overload::OverloadThresholds,
+        resilience::resolve_resilience, worker::RuntimeType, BasicWorkerBuilder, ConnectionMode,
+        Worker, WorkerRegistry, UNKNOWN_MODEL_ID,
     },
     workflow::data::{WorkerKind, WorkerRegistrationMode, WorkerWorkflowData},
 };
@@ -138,6 +139,11 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
             RuntimeType::Sglang
         };
 
+        validate_overload_overrides(config).map_err(|message| WorkflowError::StepFailed {
+            step_id: StepId::new("create_worker"),
+            message,
+        })?;
+
         validate_zmq_handshake_override(config, *connection_mode).map_err(|message| {
             WorkflowError::StepFailed {
                 step_id: StepId::new("create_worker"),
@@ -211,6 +217,8 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
                 message: e,
             })?;
 
+        let overload_defaults = OverloadThresholds::from_gateway_config(&app_context.router_config);
+
         let health_base = app_context.router_config.health_check.to_protocol_config();
         let health_config =
             resolve_zmq_health_config(config.health.apply_to(&health_base), *connection_mode, &url);
@@ -245,7 +253,9 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
                     .health_endpoint(health_endpoint)
                     .bootstrap_port(config.bootstrap_port)
                     .priority(config.priority)
-                    .cost(config.cost);
+                    .cost(config.cost)
+                    .overload(config.overload)
+                    .overload_defaults(overload_defaults);
 
                 if let Some((rank, size)) = dp {
                     builder = builder.dp_config(rank, size);
@@ -520,6 +530,30 @@ fn infer_non_generation_type(labels: &HashMap<String, String>) -> ModelType {
     ModelType::EMBEDDINGS
 }
 
+/// Reject degenerate per-worker overload thresholds at registration — same
+/// rules and wording as `ConfigValidator` applies to the gateway-level
+/// `worker_overload_*` fields. Both comparisons are inclusive, so the excluded
+/// ends of these ranges would mark this worker overloaded unconditionally.
+fn validate_overload_overrides(config: &WorkerSpec) -> Result<(), String> {
+    if config.overload.waiting_requests == Some(0) {
+        return Err(format!(
+            "worker {} sets overload.waiting_requests to 0: Must be >= 1 \
+             (0 would mark every worker overloaded)",
+            config.url
+        ));
+    }
+    if let Some(threshold) = config.overload.token_usage {
+        if !threshold.is_finite() || threshold <= 0.0 || threshold > 1.0 {
+            return Err(format!(
+                "worker {} sets overload.token_usage to {threshold}: Must be a \
+                 fraction in (0.0, 1.0]",
+                config.url
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// `zmq_handshake_address` only steers the ZMQ handshake bind; on any other
 /// connection mode it would be silently ignored, so reject the registration
 /// loudly instead.
@@ -723,6 +757,33 @@ mod tests {
             normalize_url("localhost:30001", ConnectionMode::Grpc),
             "grpc://localhost:30001"
         );
+    }
+
+    #[test]
+    fn degenerate_overload_overrides_are_rejected_at_registration() {
+        // Silent acceptance would strand the worker permanently vetoed; the
+        // ConfigValidator rules apply to spec blocks too.
+        let mut spec = WorkerSpec::new("http://worker:8080");
+        spec.overload.waiting_requests = Some(0);
+        let err =
+            validate_overload_overrides(&spec).expect_err("waiting_requests = 0 must be rejected");
+        assert!(err.contains("overload.waiting_requests"), "{err}");
+        assert!(err.contains("http://worker:8080"), "{err}");
+
+        for bad in [0.0, -0.5, 1.5, f64::NAN] {
+            let mut spec = WorkerSpec::new("http://worker:8080");
+            spec.overload.token_usage = Some(bad);
+            let err = validate_overload_overrides(&spec)
+                .expect_err("degenerate token_usage must be rejected");
+            assert!(err.contains("(0.0, 1.0]"), "{err}");
+        }
+
+        // The excluded ends' valid neighbors and an empty block pass.
+        let mut spec = WorkerSpec::new("http://worker:8080");
+        spec.overload.waiting_requests = Some(1);
+        spec.overload.token_usage = Some(1.0);
+        assert!(validate_overload_overrides(&spec).is_ok());
+        assert!(validate_overload_overrides(&WorkerSpec::new("x")).is_ok());
     }
 
     #[test]

--- a/model_gateway/src/workflow/steps/local/update_worker_properties.rs
+++ b/model_gateway/src/workflow/steps/local/update_worker_properties.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info, warn};
 use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
 use crate::{
-    worker::{BasicWorkerBuilder, ConnectionMode, Worker},
+    worker::{overload::OverloadThresholds, BasicWorkerBuilder, ConnectionMode, Worker},
     workflow::data::WorkerUpdateWorkflowData,
 };
 
@@ -98,6 +98,13 @@ impl StepExecutor<WorkerUpdateWorkflowData> for UpdateWorkerPropertiesStep {
                 .resilience(worker.resilience().clone())
                 .priority(updated_priority)
                 .cost(updated_cost)
+                // The overload block is not updatable here, but it must survive
+                // the rebuild; effective thresholds re-resolve against the same
+                // gateway defaults registration used.
+                .overload(worker.metadata().spec.overload)
+                .overload_defaults(OverloadThresholds::from_gateway_config(
+                    &app_context.router_config,
+                ))
                 .status(next_status);
 
             // Adopt the old worker's client only if it was materialized: a
@@ -188,7 +195,7 @@ mod tests {
         mock_engine::{connect_to_frontend, default_ready_response},
         EngineId,
     };
-    use openai_protocol::worker::{HealthCheckConfig, WorkerUpdateRequest};
+    use openai_protocol::worker::{HealthCheckConfig, OverloadUpdate, WorkerUpdateRequest};
     use wfaas::WorkflowInstanceId;
 
     use super::*;
@@ -320,6 +327,10 @@ mod tests {
                 .zmq_handshake_address(handshake.clone())
                 .zmq_engine_group(2)
                 .health_config(HealthCheckConfig::default())
+                .overload(OverloadUpdate {
+                    waiting_requests: Some(8),
+                    token_usage: None,
+                })
                 .status(WorkerStatus::Ready)
                 .build(),
         );
@@ -359,6 +370,10 @@ mod tests {
             Some(handshake.as_str())
         );
         assert_eq!(new.metadata().zmq_engine_count(), 2);
+        // The overload block survives a metadata-only update, and so does the
+        // effective threshold resolved from it.
+        assert_eq!(new.metadata().spec.overload.waiting_requests, Some(8));
+        assert_eq!(new.metadata().overload.waiting_requests, Some(8));
         assert!(
             new.connect_signal_tx.is_some(),
             "ZMQ promotion stays event-driven after an update"

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -31,8 +31,8 @@ use smg::{
     policies::PolicyRegistry,
     routers::{router_manager::RouterManager, RouterFactory, RouterTrait},
     worker::{
-        BasicWorkerBuilder, ModelCard, OverloadThresholds, RuntimeType, Worker, WorkerMonitor,
-        WorkerRegistry, WorkerType,
+        BasicWorkerBuilder, ModelCard, RuntimeType, Worker, WorkerMonitor, WorkerRegistry,
+        WorkerType,
     },
     workflow::Job,
 };
@@ -362,7 +362,7 @@ async fn build_test_app_context(
         client.clone(),
         config.load_monitor_interval_secs,
         config.engine_metrics,
-        OverloadThresholds::default(),
+        config.disable_load_monitoring,
     )));
 
     // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator

--- a/model_gateway/tests/common/test_app.rs
+++ b/model_gateway/tests/common/test_app.rs
@@ -12,8 +12,8 @@ use smg::{
     routers::RouterTrait,
     server::{build_app, AppState},
     worker::{
-        BasicWorkerBuilder, ModelCard, OverloadThresholds, RuntimeType, Worker, WorkerMonitor,
-        WorkerRegistry, WorkerType,
+        BasicWorkerBuilder, ModelCard, RuntimeType, Worker, WorkerMonitor, WorkerRegistry,
+        WorkerType,
     },
 };
 use smg_data_connector::{
@@ -64,7 +64,7 @@ pub fn create_test_app(
         client.clone(),
         router_config.load_monitor_interval_secs,
         router_config.engine_metrics,
-        OverloadThresholds::default(),
+        router_config.disable_load_monitoring,
     )));
 
     // Create empty OnceLock for worker job queue and workflow engines

--- a/model_gateway/tests/routing/test_pd_routing.rs
+++ b/model_gateway/tests/routing/test_pd_routing.rs
@@ -221,7 +221,7 @@ mod pd_routing_unit_tests {
                 use smg::{
                     middleware::TokenBucket,
                     policies::PolicyRegistry,
-                    worker::{OverloadThresholds, WorkerMonitor, WorkerRegistry},
+                    worker::{WorkerMonitor, WorkerRegistry},
                 };
                 use smg_data_connector::{
                     MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
@@ -250,7 +250,7 @@ mod pd_routing_unit_tests {
                     client.clone(),
                     config.load_monitor_interval_secs,
                     config.engine_metrics,
-                    OverloadThresholds::default(),
+                    config.disable_load_monitoring,
                 )));
 
                 // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator

--- a/model_gateway/tests/wasm_test.rs
+++ b/model_gateway/tests/wasm_test.rs
@@ -31,7 +31,7 @@ use smg::{
         },
         module_manager::WasmModuleManager,
     },
-    worker::{OverloadThresholds, WorkerMonitor, WorkerRegistry},
+    worker::{WorkerMonitor, WorkerRegistry},
 };
 use smg_data_connector::{
     MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
@@ -70,7 +70,7 @@ async fn create_test_context_with_wasm() -> Arc<AppContext> {
         client.clone(),
         config.load_monitor_interval_secs,
         config.engine_metrics,
-        OverloadThresholds::default(),
+        config.disable_load_monitoring,
     )));
 
     // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator


### PR DESCRIPTION
## Description

### Problem

Follow-up to #2220. Enabling overload protection requires hand-picking two threshold values; load monitoring only runs when a load-aware policy happens to need it, so protection signals aren't fed by default; and thresholds are gateway-global, though saturation points differ per worker in heterogeneous fleets.

### Solution

- `--worker-overload-protection`: one flag enables protection with an engine-universal default (token usage ≥ 0.9; a waiting-requests default would be workload-dependent, so that signal stays unset unless configured). Explicit thresholds override. Thresholds-without-flag behaves exactly as #2220.
- **Load monitoring is now on by default** from registration onward, so every signal consumer is always fed. `--disable-load-monitoring` restores the old conditional gate — a load-aware policy, engine metrics, or a protected group member still forces the poll; never "never poll". *This is a behavior change: fleets that previously never polled loads now do, at `load_monitor_interval_secs` cadence.*
- Per-worker tuning: `WorkerSpec.overload { waiting_requests, token_usage }` (mirrors the `HealthCheckUpdate` pattern), resolved once at registration against gateway defaults — per signal, worker override wins. A spec block alone enables protection for that worker. Degenerate values are rejected at registration with `ConfigValidator` wording. The block survives worker updates/replacement. Zero per-request cost unchanged — the predicate still runs only at load-report ingestion, now against the worker's own thresholds.
- Shed responses carry `Retry-After: <load poll interval>` (the veto cannot clear faster); they stay internally non-retryable.

Notes: mesh-imported peers resolve from their spec block only (their home gateway applies its defaults — same trust model as other spec fields). External API workers have no load feed, so gateway defaults are not applied to them; protection there would never fire.

## Changes

- `crates/protocols`: `OverloadUpdate` spec block (serde-backward-compatible, shows in `GET /workers`).
- `worker/overload.rs`: `from_gateway_config` (flag default) + per-signal `resolve`; effective thresholds live on `WorkerMetadata`, resolved in `BasicWorkerBuilder::build`.
- `worker/monitor.rs`: poll gate default-on; opt-out restores conditional gating with per-worker consultation; ingestion scores each report against that worker's thresholds.
- `create_worker.rs`: `validate_overload_overrides` at registration; `update_worker_properties` carries the block and re-resolves.
- `routers/common/overload.rs`: `Retry-After` on both shed kinds (interval latched at startup).
- Config plumbing: both conversion paths, `ConfigValidator`, builder, Python bindings tail-appended with frozen sequences updated.

## Test Plan

- `cargo test -p smg --lib` — 1775 passed, 0 failed (flag defaults/overrides, per-signal resolution, spec-block-alone enablement, registration rejection, default-on polling + opt-out gating under load-blind and load-aware policies, update carry-over, Retry-After on both shed kinds, feature-off no-flag-writes).
- `cargo test -p openai-protocol` — 128 passed (spec serde round-trips, no-block back-compat).
- `cargo +nightly fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (local fallback without `--all-features`; no system OpenCV).
- `pytest tests/test_arg_parser.py` — 56 passed against a maturin build.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
