### PR TITLE
fix(bench): match owned-body RouterTrait signature in wasm middleware bench

### DIFF
--- a/model_gateway/benches/wasm_middleware_latency.rs
+++ b/model_gateway/benches/wasm_middleware_latency.rs
@@ -33,7 +33,7 @@ impl RouterTrait for MockRouter {
         &self,
         _headers: Option<&HeaderMap>,
         _tenant_meta: &TenantRequestMeta,
-        _body: &ChatCompletionRequest,
+        _body: ChatCompletionRequest,
         _model_id: &str,
     ) -> Response<Body> {
         StatusCode::OK.into_response()


### PR DESCRIPTION
The RouterTrait typed-JSON methods take owned bodies since #2232; the wasm_middleware_latency bench's MockRouter still implemented `route_chat` with `&ChatCompletionRequest`, failing E0195 on any `--all-targets` build (benches were the one target family the targeted test gates never compiled — main's lint job caught it). One-line signature match.