### PR TITLE
fix(router): repair main build breaks and deflake client timeout test

### DIFF
--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1302,7 +1302,7 @@ impl PDRouter {
             client
                 .post(endpoint_url)
                 .header(CONTENT_TYPE, HeaderValue::from_static("application/json")),
-            bytes::Bytes::from(body),
+            body,
         );
         if connection_close {
             request = request.header("Connection", "close");
@@ -1910,7 +1910,7 @@ mod tests {
         assert!(result.is_err());
         // No workers at all is the pre-existing unavailable string, not a shed:
         // an empty pool has nothing to be overloaded.
-        match result.unwrap_err() {
+        match *result.unwrap_err() {
             PdSelectionFailure::Unavailable(error) => {
                 assert!(error.contains("No prefill workers available"));
             }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -1188,7 +1188,7 @@ impl Router {
             self.client
                 .post(&endpoint_url)
                 .header(CONTENT_TYPE, HeaderValue::from_static("application/json")),
-            bytes::Bytes::from(body),
+            body,
         );
 
         request_builder = header_utils::apply_forwarded_request_headers(

--- a/model_gateway/src/worker/http_client.rs
+++ b/model_gateway/src/worker/http_client.rs
@@ -166,7 +166,15 @@ mod tests {
     /// Loopback echo server; axum::serve accepts HTTP/1.1 and prior-knowledge
     /// h2c on the same listener, mirroring a dual-protocol engine.
     async fn spawn_echo_server() -> String {
-        let app = axum::Router::new().route("/probe", axum::routing::get(|| async { "ok" }));
+        let app = axum::Router::new()
+            .route("/probe", axum::routing::get(|| async { "ok" }))
+            .route(
+                "/hang",
+                axum::routing::get(|| async {
+                    tokio::time::sleep(Duration::from_secs(3600)).await;
+                    "late"
+                }),
+            );
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind echo server");
@@ -281,14 +289,20 @@ mod tests {
     async fn per_request_timeout_overrides_client_default() {
         let url = spawn_echo_server().await;
         // A zero client-level total timeout fails every request that relies
-        // on the client default...
+        // on the client default. Aim it at the hanging route: a fast local
+        // response can otherwise win the race against a zero-duration timer.
+        let hang_url = url.replace("/probe", "/hang");
         let client = cache(RouterConfig {
             request_timeout_secs: 0,
             ..RouterConfig::default()
         })
         .get(&HttpPoolConfig::default())
         .expect("client");
-        let err = client.get(&url).send().await.expect_err("default applies");
+        let err = client
+            .get(&hang_url)
+            .send()
+            .await
+            .expect_err("default applies");
         assert!(err.is_timeout());
         // ...while a per-request timeout replaces it entirely.
         let resp = client


### PR DESCRIPTION
## Description

### Problem

`main` currently fails `cargo test` compilation and `cargo clippy -D warnings`, which breaks the unit-tests lane on every PR merge build. Two concurrently merged changes raced: the owned-body dispatch refactor retyped the request body as `Bytes` and boxed `PdSelectionFailure`, while another branch merged code still wrapping the body in `Bytes::from(...)` and matching the selection failure unboxed. Each PR was green alone; their merge is not.

Separately, `worker::http_client::tests::per_request_timeout_overrides_client_default` is flaky: it races a zero-duration total timeout against a loopback echo response, and the fast local 200 wins often enough to fail roughly half of runs (reproduced locally at that rate; it also failed a PR lane today).

### Solution

- Pass the already-`Bytes` body through directly at both dispatch sites and deref the boxed failure in the empty-fleet test — restores compile and clippy cleanliness.
- Deflake the timeout test: the client-default leg now targets a route that sleeps far past any deadline, so the zero timeout always fires; the per-request-override leg keeps the instant route. Same contract, no race.

## Changes

- `model_gateway/src/routers/http/pd_router.rs`: drop redundant `Bytes::from`, deref boxed `PdSelectionFailure` in `test_empty_worker_lists`
- `model_gateway/src/routers/http/router.rs`: drop redundant `Bytes::from`
- `model_gateway/src/worker/http_client.rs`: add a hanging `/hang` route to the test echo server; aim the client-default timeout assertion at it

## Test Plan

- `cargo clippy -p smg --all-targets -- -D warnings` passes (was 4 errors)
- `cargo test -p smg --lib` passes: 1789 passed, 0 failed (compilation was broken before)
- `per_request_timeout_overrides_client_default` passes 10/10 consecutive runs (previously ~half failed)
- `cargo test -p smg --test inflight_tracker_test --test routing_tests` passes (132 tests, closest integration coverage to the dispatch sites)
- `cargo +nightly fmt` clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes for the touched crate
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
