### PR TITLE
fix(middleware): hold admission permits for the full response lifetime

### DIFF
--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -112,13 +112,13 @@ class RouterArgs:
     request_timeout_secs: int = 1800
     # Grace period in seconds to wait for in-flight requests during shutdown
     shutdown_grace_period_secs: int = 180
-    # Max concurrent requests for rate limiting (-1 to disable)
+    # Standing-concurrency cap (-1 to disable); permits span the full response
     max_concurrent_requests: int = -1
     # Queue size for pending requests when max concurrent limit reached
     queue_size: int = 100
     # Maximum time (in seconds) a request can wait in queue before timing out
     queue_timeout_secs: int = 60
-    # Token bucket refill rate (tokens per second). If not set, defaults to max_concurrent_requests
+    # Token bucket refill rate (tokens per second). Unset or 0 = no refill
     rate_limit_tokens_per_second: int | None = None
     # CORS allowed origins
     cors_allowed_origins: list[str] = dataclasses.field(default_factory=list)
@@ -1062,8 +1062,9 @@ class RouterArgs:
             type=int,
             default=RouterArgs.max_concurrent_requests,
             help=(
-                "Maximum number of concurrent requests allowed (for rate limiting)."
-                " Set to -1 to disable rate limiting."
+                "Maximum standing concurrent requests; each admission permit"
+                " is held for the full response, including streaming bodies."
+                " Set to -1 to disable."
             ),
         )
         rate_limit_group.add_argument(
@@ -1086,8 +1087,9 @@ class RouterArgs:
             type=int,
             default=RouterArgs.rate_limit_tokens_per_second,
             help=(
-                "Token bucket refill rate (tokens per second)."
-                " If not set, defaults to max_concurrent_requests"
+                "Token bucket refill rate (tokens per second). Unset or 0 ="
+                " no refill: --max-concurrent-requests bounds standing"
+                " concurrency alone."
             ),
         )
 

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -524,10 +524,12 @@ impl AppContextBuilder {
         self.rate_limiter = match config.max_concurrent_requests {
             n if n <= 0 => None,
             n => {
+                // No refill unless explicitly configured: the cap bounds
+                // standing concurrency, not admission rate.
                 let rate_limit_tokens = config
                     .rate_limit_tokens_per_second
-                    .filter(|&t| t >= 0)
-                    .unwrap_or(n);
+                    .filter(|&t| t > 0)
+                    .unwrap_or(0);
                 Some(Arc::new(TokenBucket::new(
                     n as usize,
                     rate_limit_tokens as usize,
@@ -831,6 +833,28 @@ mod tests {
             .expect("h1 request");
         assert_eq!(resp.version(), http::Version::HTTP_11);
         assert_eq!(resp.text().await.expect("body"), "ok");
+    }
+
+    #[tokio::test]
+    async fn unset_rate_limit_defaults_to_no_refill() {
+        let config = RouterConfig {
+            max_concurrent_requests: 10,
+            rate_limit_tokens_per_second: None,
+            ..RouterConfig::default()
+        };
+        let bucket = AppContextBuilder::new()
+            .maybe_rate_limiter(&config)
+            .rate_limiter
+            .expect("rate limiter should be enabled");
+
+        assert!(bucket.try_acquire(10.0).is_ok());
+        // The old fallback refilled at max_concurrent_requests per second,
+        // which would restore a token during this wait.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(bucket.try_acquire(1.0).is_err());
+
+        bucket.return_tokens_sync(1.0);
+        assert!(bucket.try_acquire(1.0).is_ok());
     }
 
     #[tokio::test]

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -167,11 +167,13 @@ pub struct RouterConfig {
     pub storage_context_headers: HashMap<String, String>,
     #[serde(default)]
     pub tenant_resolution: TenantResolutionConfig,
-    /// Set to -1 to disable rate limiting
+    /// Standing-concurrency cap; -1 disables. Each admission permit is
+    /// held for the full response, including streaming bodies.
     pub max_concurrent_requests: i32,
     pub queue_size: usize,
     pub queue_timeout_secs: u64,
-    /// If not set, defaults to max_concurrent_requests
+    /// Unset or 0 = no refill: `max_concurrent_requests` bounds standing
+    /// concurrency alone.
     pub rate_limit_tokens_per_second: Option<i32>,
     /// Enable the priority-aware admission scheduler. When false (default),
     /// the legacy concurrency-limit middleware stays wired — zero behavior

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -704,7 +704,8 @@ struct CliArgs {
     cors_allowed_origins: Vec<String>,
 
     // ==================== Rate Limiting ====================
-    /// Maximum concurrent requests (-1 to disable)
+    /// Maximum standing concurrent requests (-1 to disable). Each admission
+    /// permit is held for the full response, including streaming bodies.
     #[arg(long, default_value_t = -1, help_heading = "Rate Limiting")]
     max_concurrent_requests: i32,
 
@@ -746,7 +747,8 @@ struct CliArgs {
     #[arg(long, help_heading = "Tenant Rate Limit")]
     tenant_rate_limit_config: Option<String>,
 
-    /// Token bucket refill rate (tokens per second)
+    /// Token bucket refill rate (tokens per second). Unset or 0 = no refill:
+    /// --max-concurrent-requests bounds standing concurrency alone.
     #[arg(long, help_heading = "Rate Limiting")]
     rate_limit_tokens_per_second: Option<i32>,
 

--- a/model_gateway/src/middleware/concurrency.rs
+++ b/model_gateway/src/middleware/concurrency.rs
@@ -333,8 +333,10 @@ mod tests {
     };
 
     use axum::{routing::post, Router};
+    use http_body_util::BodyExt;
     use llm_tokenizer::registry::TokenizerRegistry;
     use metrics_exporter_prometheus::PrometheusBuilder;
+    use tokio_stream::wrappers::ReceiverStream;
     use smg_data_connector::{
         MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
     };
@@ -403,6 +405,42 @@ mod tests {
             .unwrap()
     }
 
+    /// App with a one-shot channel-fed streaming route plus `/echo`,
+    /// queueing disabled.
+    fn stream_app(
+        bucket: Arc<TokenBucket>,
+    ) -> (
+        Router,
+        mpsc::Sender<Result<Bytes, std::convert::Infallible>>,
+    ) {
+        let (frame_tx, frame_rx) = mpsc::channel(4);
+        let frame_rx = Arc::new(std::sync::Mutex::new(Some(frame_rx)));
+        let stream = move || {
+            let rx = frame_rx
+                .lock()
+                .unwrap()
+                .take()
+                .expect("stream route is one-shot");
+            async move { Body::from_stream(ReceiverStream::new(rx)) }
+        };
+        let app = Router::new()
+            .route("/stream", post(stream))
+            .route("/echo", post(|body: Bytes| async move { body }))
+            .layer(axum::middleware::from_fn_with_state(
+                test_app_state(bucket, None),
+                concurrency_limit_middleware,
+            ));
+        (app, frame_tx)
+    }
+
+    fn stream_request() -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/stream")
+            .body(Body::empty())
+            .unwrap()
+    }
+
     fn assert_metric_line(rendered: &str, series: &str, value: &str) {
         let expected = format!("{series} {value}");
         assert!(
@@ -441,6 +479,106 @@ mod tests {
         assert_eq!(bucket.available_tokens(), 0.0);
         drop(body);
         assert_eq!(bucket.available_tokens(), 1.0);
+    }
+
+    /// A streaming response keeps its token after the handler returns: a
+    /// request beyond the cap sheds until the stream is consumed and dropped.
+    #[tokio::test]
+    async fn streaming_response_holds_token_until_stream_consumed() {
+        let bucket = Arc::new(TokenBucket::new(1, 0));
+        let (app, frame_tx) = stream_app(bucket.clone());
+
+        let response = app.clone().oneshot(stream_request()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let shed = app
+            .clone()
+            .oneshot(echo_request(Body::from("x")))
+            .await
+            .unwrap();
+        assert_eq!(shed.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        frame_tx
+            .send(Ok(Bytes::from_static(b"chunk")))
+            .await
+            .unwrap();
+        let mut body = response.into_body();
+        let frame = body.frame().await.unwrap().unwrap();
+        assert_eq!(frame.into_data().unwrap(), Bytes::from_static(b"chunk"));
+
+        let shed = app
+            .clone()
+            .oneshot(echo_request(Body::from("x")))
+            .await
+            .unwrap();
+        assert_eq!(
+            shed.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "token must stay held mid-stream"
+        );
+
+        drop(frame_tx);
+        assert!(body.frame().await.is_none());
+        drop(body);
+        assert_eq!(bucket.available_tokens(), 1.0);
+
+        let admitted = app.oneshot(echo_request(Body::from("x"))).await.unwrap();
+        assert_eq!(admitted.status(), StatusCode::OK);
+    }
+
+    /// Dropping the response mid-stream (client disconnect) returns the token.
+    #[tokio::test]
+    async fn client_disconnect_mid_stream_returns_token() {
+        let bucket = Arc::new(TokenBucket::new(1, 0));
+        let (app, frame_tx) = stream_app(bucket.clone());
+
+        let response = app.clone().oneshot(stream_request()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        frame_tx
+            .send(Ok(Bytes::from_static(b"first")))
+            .await
+            .unwrap();
+        let mut body = response.into_body();
+        body.frame().await.unwrap().unwrap();
+
+        assert_eq!(bucket.available_tokens(), 0.0);
+        drop(body);
+        assert_eq!(bucket.available_tokens(), 1.0);
+
+        let admitted = app.oneshot(echo_request(Body::from("x"))).await.unwrap();
+        assert_eq!(admitted.status(), StatusCode::OK);
+    }
+
+    /// A buffered response also spans the write: the token frees only once
+    /// the body has been consumed.
+    #[tokio::test]
+    async fn buffered_response_holds_token_until_body_consumed() {
+        let bucket = Arc::new(TokenBucket::new(1, 0));
+        let app = echo_app(test_app_state(bucket.clone(), None));
+
+        let response = app
+            .clone()
+            .oneshot(echo_request(Body::from("payload")))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let shed = app
+            .clone()
+            .oneshot(echo_request(Body::from("x")))
+            .await
+            .unwrap();
+        assert_eq!(shed.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let echoed = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&echoed[..], b"payload");
+        assert_eq!(bucket.available_tokens(), 1.0);
+
+        let admitted = app.oneshot(echo_request(Body::from("x"))).await.unwrap();
+        assert_eq!(admitted.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -338,7 +338,7 @@ async fn build_test_app_context(
             let rate_limit_tokens = config
                 .rate_limit_tokens_per_second
                 .filter(|&t| t > 0)
-                .unwrap_or(n);
+                .unwrap_or(0);
             Some(Arc::new(TokenBucket::new(
                 n as usize,
                 rate_limit_tokens as usize,

--- a/model_gateway/tests/common/test_app.rs
+++ b/model_gateway/tests/common/test_app.rs
@@ -38,7 +38,7 @@ pub fn create_test_app(
             let rate_limit_tokens = router_config
                 .rate_limit_tokens_per_second
                 .filter(|&t| t > 0)
-                .unwrap_or(n);
+                .unwrap_or(0);
             Some(Arc::new(TokenBucket::new(
                 n as usize,
                 rate_limit_tokens as usize,


### PR DESCRIPTION
## Description

### Problem

`--max-concurrent-requests` does not actually bound standing concurrency. The cap is enforced by a token bucket, and when `--rate-limit-tokens-per-second` is unset the refill rate silently defaults to the cap value — so a `--max-concurrent-requests 8000` deployment gets a bucket that mints 8,000 fresh permits every second regardless of how many admitted requests are still running. For long-lived responses (SSE streams, large buffered generation reads) the flag degrades into an admission-rate knob and standing concurrency is unbounded.

Measured evidence, captured simultaneously on one production router: the token bucket logged `returned 1 tokens, 8000 available` (limiter believes it is idle) while the same router's smg_http_inflight_request_age_count summed to 48,331 standing requests — 6x the configured cap, with thousands aged 5-20 minutes; permits provably return at handler-response time, not response completion.

Two defects compound here:

1. Permits used to be released when the handler returned the `Response` object, not when the response body finished streaming. #2064 fixed this by moving the permit into `TokenGuardBody`, which releases on body completion, error, or client disconnect.
2. The implicit refill default neutralizes that fix: even with every permit correctly held by an open stream, the bucket refills to capacity within a second and admits the next wave. This is the remaining hole, and it feeds the overload loop (pile-up -> engine saturation -> multi-minute latencies -> more pile-up) that neither per-worker overload vetoes nor the cap could stop.

### Solution

Make `--max-concurrent-requests` a true standing-concurrency bound: the bucket no longer refills unless an explicit rate is configured. With refill at 0, tokens return only when `TokenGuardBody` drops — i.e. when the response body completes, errors, or the client disconnects — so the bucket's availability now equals `cap - standing requests`. Explicit `--rate-limit-tokens-per-second > 0` keeps refill-based rate limiting for operators who want it.

Queue semantics are unchanged: `queue_size` / `queue_timeout_secs` behave identically for waiting requests; only when a permit frees changed. Health/metrics endpoints remain outside the admission layer. The priority-scheduler path is unaffected (it only consults the bucket when an explicit per-second rate is set).

### Breaking change

> ⚠️ `--max-concurrent-requests N` alone is now a true standing-concurrency bound: the admission permit spans the entire response (including streaming bodies), and the bucket no longer refills at `N` tokens/second implicitly. Deployments that relied on the implicit refill — using the flag as a burst-rate knob — must set `--rate-limit-tokens-per-second N` explicitly to keep the old behavior.

## Changes

- `model_gateway/src/app_context.rs`: `maybe_rate_limiter` defaults the bucket refill to 0 when `rate_limit_tokens_per_second` is unset (previously defaulted to `max_concurrent_requests`); explicit positive rates unchanged. New `unset_rate_limit_defaults_to_no_refill` test.
- `model_gateway/src/main.rs`, `model_gateway/src/config/types.rs`, `bindings/python/src/smg/router_args.py`: flag help and field docs state that the permit spans the full response and that unset/0 means no refill.
- `model_gateway/src/middleware/concurrency.rs`: tests pinning the permit-lifetime invariant — token held while a streaming body is open (an excess request sheds with 429), released at stream completion, released on client disconnect mid-stream, and held across a buffered response until its body is consumed.
- `model_gateway/tests/common/{mod.rs,test_app.rs}`: test-app bucket construction mirrors the new refill default.

## Test Plan

Before: with `max_concurrent_requests = 1` and no explicit rate, a second request during an open response stream is admitted once the bucket refills (within a second). After: it sheds with 429 until the stream completes or the client disconnects.

```
cargo fmt --check                                                                    # clean
cargo test -p smg --lib -- middleware::concurrency middleware::token_bucket app_context  # 24 passed
cargo test -p smg --lib -- routers::http                                             # 56 passed
cargo test -p smg --test scheduler_admission_test                                    # 15 passed
```

New tests: `streaming_response_holds_token_until_stream_consumed` (excess request sheds with 429 while a stream is open, admitted after the stream drains), `client_disconnect_mid_stream_returns_token`, `buffered_response_holds_token_until_body_consumed`, `unset_rate_limit_defaults_to_no_refill`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
