### PR TITLE
ci: make the nightly build runner selectable at dispatch

### DIFF
--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -10,6 +10,10 @@ on:
         description: 'amd64-only fast build (skips the QEMU-emulated arm64 half and the floating :nightly tag)'
         type: boolean
         default: false
+      runner:
+        description: 'Runner label to build on (default self-hosted cpu-e5; any self-hosted label or a GitHub-hosted size works, x86_64 assumed)'
+        type: string
+        default: 'cpu-e5'
 
 concurrency:
   # Express builds run in their own lane so a fast one-off never cancels
@@ -29,7 +33,7 @@ jobs:
   build-and-push:
     name: Build nightly Docker image
     if: github.repository == 'smg-project/smg'
-    runs-on: ["cpu-e5"]
+    runs-on: ${{ inputs.runner || 'cpu-e5' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
The nightly Docker build pins `runs-on: [cpu-e5]` — a single self-hosted host. That host (moirai-e5-runner-0) is offline right now, queueing tonight's express indefinitely while other runners sit idle. This adds a `runner` workflow_dispatch input (default `cpu-e5`, scheduled runs unchanged) so one-off builds can retarget any online x86_64 runner — e.g. `b200` (self-hosted, Linux X64, currently idle) or a GitHub-hosted size label. Express builds are amd64-only so any x86_64 host builds natively.