### PR TITLE
fix(router): drop external-provider request copies before dispatch

### DIFF
--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -145,12 +145,14 @@ pub(super) async fn route_chat(
         clippy::expect_used,
         reason = "payload is set earlier in this function; absence is a logic error"
     )]
-    let payload_ref = ctx.payload().expect("Payload not prepared");
-    let payload_json = Arc::new(payload_ref.json.clone());
+    let payload_json = Arc::new(ctx.take_payload().expect("Payload not prepared").json);
     let client = ctx.components.client().clone();
     let headers_cloned = Arc::new(ctx.headers().cloned());
     let worker_api_key = Arc::new(worker.api_key().cloned());
     let is_streaming = ctx.is_streaming();
+    // The retry loop replays from the serialized payload alone; the parsed
+    // request and its context must not outlive dispatch.
+    drop(ctx);
 
     let response = RetryExecutor::execute_response_with_retry(
         deps.retry_config,


### PR DESCRIPTION
## Description

### Problem

The external-provider chat route holds three request-sized allocations across its upstream retry loop: the parsed body in the request context, the serialized payload `Value` in the context, and a deep-cloned `Arc` of that payload for the attempts.

### Solution

Move the payload out of the context into the retry loop's `Arc` (no clone) and drop the context — and with it the parsed body — before dispatch. Retries replay from the single serialized payload, so replay semantics are unchanged.

## Changes

- `routers/openai/chat.rs`: `take_payload()` instead of clone; explicit `drop(ctx)` ahead of the retry loop

## Test Plan

`routing_tests` openai suite (16) green; behavior is unchanged — same payload bytes on every attempt.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
