### PR TITLE
chore: fix import ordering in concurrency middleware tests

### DIFF
--- a/model_gateway/src/middleware/concurrency.rs
+++ b/model_gateway/src/middleware/concurrency.rs
@@ -336,11 +336,11 @@ mod tests {
     use http_body_util::BodyExt;
     use llm_tokenizer::registry::TokenizerRegistry;
     use metrics_exporter_prometheus::PrometheusBuilder;
-    use tokio_stream::wrappers::ReceiverStream;
     use smg_data_connector::{
         MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
     };
     use tokio::sync::Notify;
+    use tokio_stream::wrappers::ReceiverStream;
     use tower::ServiceExt;
 
     use super::*;


### PR DESCRIPTION
One misplaced test import landed on main with #2240, failing `cargo +nightly fmt --all --check` repo-wide — every subsequent PR's lint gate reddens on it. Mechanical `fmt` output, no code change.