### PR TITLE
fix(middleware): overload sheds signal back-off (429/503 + Retry-After)

### DIFF
--- a/model_gateway/src/middleware/concurrency.rs
+++ b/model_gateway/src/middleware/concurrency.rs
@@ -17,7 +17,7 @@ use std::{
 use axum::{
     body::Body,
     extract::{Request, State},
-    http::StatusCode,
+    http::{header::RETRY_AFTER, HeaderValue, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -29,11 +29,21 @@ use tokio::{
 };
 use tracing::{debug, error, warn};
 
-use super::token_bucket::TokenBucket;
+use super::{token_bucket::TokenBucket, SHED_RETRY_AFTER_SECS};
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
+    routers::error::create_error,
     server::AppState,
 };
+
+/// Standard error body plus `Retry-After` for admission sheds.
+fn shed_response(status: StatusCode, code: &'static str, message: &'static str) -> Response {
+    let mut response = create_error(status, code, message);
+    response
+        .headers_mut()
+        .insert(RETRY_AFTER, HeaderValue::from(SHED_RETRY_AFTER_SECS));
+    response
+}
 
 /// Returns an acquired token when the request is cancelled or the response body is dropped.
 struct TokenPermit {
@@ -176,7 +186,7 @@ impl QueueProcessor {
             let elapsed = queued.queued_at.elapsed();
             if elapsed >= self.queue_timeout {
                 warn!("Request already timed out in queue");
-                let _ = queued.permit_tx.send(Err(StatusCode::REQUEST_TIMEOUT));
+                let _ = queued.permit_tx.send(Err(StatusCode::SERVICE_UNAVAILABLE));
                 continue;
             }
 
@@ -204,7 +214,7 @@ impl QueueProcessor {
                         let _ = queued.permit_tx.send(Ok(permit));
                     } else {
                         warn!("Queue: request timed out waiting for token");
-                        let _ = queued.permit_tx.send(Err(StatusCode::REQUEST_TIMEOUT));
+                        let _ = queued.permit_tx.send(Err(StatusCode::SERVICE_UNAVAILABLE));
                     }
                 });
             }
@@ -301,7 +311,11 @@ pub async fn concurrency_limit_middleware(
                             Metrics::record_admission_rejected(
                                 metrics_labels::ADMISSION_REJECTED_TIMEOUT,
                             );
-                            status.into_response()
+                            shed_response(
+                                status,
+                                "admission_queue_timeout",
+                                "timed out waiting for an admission slot",
+                            )
                         }
                         Err(_) => {
                             error!("Queue response channel closed");
@@ -314,13 +328,21 @@ pub async fn concurrency_limit_middleware(
                     warn!("Request queue is full, returning 429");
                     Metrics::record_http_rate_limit(metrics_labels::RATE_LIMIT_REJECTED);
                     Metrics::record_admission_rejected(metrics_labels::ADMISSION_REJECTED_FULL);
-                    StatusCode::TOO_MANY_REQUESTS.into_response()
+                    shed_response(
+                        StatusCode::TOO_MANY_REQUESTS,
+                        "admission_queue_full",
+                        "admission queue is at capacity",
+                    )
                 }
             }
         } else {
             warn!("No tokens available and queuing is disabled, returning 429");
             Metrics::record_http_rate_limit(metrics_labels::RATE_LIMIT_REJECTED);
-            StatusCode::TOO_MANY_REQUESTS.into_response()
+            shed_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                "admission_queue_full",
+                "concurrency limit reached and queuing is disabled",
+            )
         }
     }
 }
@@ -497,6 +519,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(shed.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            shed.headers().get(RETRY_AFTER).unwrap(),
+            &HeaderValue::from(SHED_RETRY_AFTER_SECS)
+        );
 
         frame_tx
             .send(Ok(Bytes::from_static(b"chunk")))
@@ -739,6 +765,15 @@ mod tests {
                     .await
                     .unwrap();
                 assert_eq!(rejected.status(), StatusCode::TOO_MANY_REQUESTS);
+                assert_eq!(
+                    rejected.headers().get(RETRY_AFTER).unwrap(),
+                    &HeaderValue::from(SHED_RETRY_AFTER_SECS)
+                );
+                let body = axum::body::to_bytes(rejected.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                assert_eq!(json["error"]["code"], "admission_queue_full");
 
                 let rendered = handle.render();
                 assert_metric_line(&rendered, "smg_admission_queue_depth", "1");
@@ -756,8 +791,8 @@ mod tests {
         });
     }
 
-    /// A request that outlives the queue timeout is rejected with
-    /// reason="timeout" and releases its queue-depth slot.
+    /// A request that outlives the queue timeout sheds as 503 + Retry-After
+    /// with reason="timeout" and releases its queue-depth slot.
     #[test]
     #[expect(
         clippy::disallowed_methods,
@@ -781,7 +816,16 @@ mod tests {
 
                 let held = TokenPermit::try_acquire(bucket, 1.0).unwrap();
                 let response = app.oneshot(echo_request(Body::from("late"))).await.unwrap();
-                assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+                assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+                assert_eq!(
+                    response.headers().get(RETRY_AFTER).unwrap(),
+                    &HeaderValue::from(SHED_RETRY_AFTER_SECS)
+                );
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                assert_eq!(json["error"]["code"], "admission_queue_timeout");
                 drop(held);
             });
         });

--- a/model_gateway/src/middleware/mod.rs
+++ b/model_gateway/src/middleware/mod.rs
@@ -37,6 +37,10 @@ pub use crate::tenant::{
     RouteRequestMeta, TenantIdentity, TenantKey, TenantResolutionError,
 };
 
+/// `Retry-After` seconds on overload sheds: sheds must signal back-off; 408
+/// reads as a client transport error and gets instant proxy retries.
+pub(crate) const SHED_RETRY_AFTER_SECS: u32 = 2;
+
 /// Backward-compatible alias for the older tenant metadata name used in a few
 /// router-path tests and plumbing call sites.
 pub type TenantRequestMeta = RouteRequestMeta;

--- a/model_gateway/src/middleware/scheduler/config.rs
+++ b/model_gateway/src/middleware/scheduler/config.rs
@@ -30,7 +30,7 @@ pub struct ClassConfig {
     /// Per-class queue depth limit.
     pub queue_size: u32,
     /// How long a queued waiter waits before the admission middleware
-    /// returns 408. Seconds at rest; converted to [`Duration`] in
+    /// sheds it with 503. Seconds at rest; converted to [`Duration`] in
     /// [`ClassRuntimeConfig`].
     pub queue_timeout_secs: u64,
     /// Head-of-queue age past which the dispatcher promotes a waiter

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -57,7 +57,7 @@ pub enum AdmitOutcome {
 pub enum RejectionReason {
     /// Per-class queue is at its configured limit. → 429.
     QueueFull,
-    /// Queued waiter aged past `queue_timeout`. → 408.
+    /// Queued waiter aged past `queue_timeout`. → 503 + Retry-After.
     QueueTimeout,
     /// Scheduler cancelled this inflight to admit a higher-priority
     /// waiter. → 503 + Retry-After.

--- a/model_gateway/src/middleware/scheduler/error.rs
+++ b/model_gateway/src/middleware/scheduler/error.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 
 use super::engine::RejectionReason;
-use crate::routers::error::create_error;
+use crate::{middleware::SHED_RETRY_AFTER_SECS, routers::error::create_error};
 
 /// Response header set on a preempted request so clients/proxies can tell a
 /// preemption 503 apart from an ordinary overload 503.
@@ -24,9 +24,9 @@ const STATUS_CLIENT_CLOSED_REQUEST: u16 = 499;
 /// How the scheduler's admission decision surfaces to the client.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SchedulerError {
-    /// Per-class queue at its configured limit. → 429.
+    /// Per-class queue at its configured limit. → 429 + `Retry-After: 2`.
     QueueFull,
-    /// Queued waiter aged past `queue_timeout`. → 408.
+    /// Queued waiter aged past `queue_timeout`. → 503 + `Retry-After: 2`.
     QueueTimeout,
     /// Cancelled in-flight to admit a higher-priority waiter, before TTFT.
     /// → 503 + `Retry-After: 1` + `X-SMG-Preempted: true`.
@@ -40,7 +40,7 @@ impl SchedulerError {
     fn status(self) -> StatusCode {
         match self {
             Self::QueueFull => StatusCode::TOO_MANY_REQUESTS,
-            Self::QueueTimeout => StatusCode::REQUEST_TIMEOUT,
+            Self::QueueTimeout => StatusCode::SERVICE_UNAVAILABLE,
             Self::Preempted => StatusCode::SERVICE_UNAVAILABLE,
             // `unwrap_or` (not `unwrap`/`expect`, both denied) — 499 is a
             // valid code so the fallback is never taken.
@@ -82,13 +82,19 @@ impl From<RejectionReason> for SchedulerError {
 impl IntoResponse for SchedulerError {
     fn into_response(self) -> Response {
         // Reuse the gateway's standard error shape (JSON body + the
-        // X-SMG-Error-Code header), then layer the preemption-specific
-        // headers on top.
+        // X-SMG-Error-Code header), then layer the shed/preemption headers
+        // on top.
         let mut resp = create_error(self.status(), self.code(), self.message());
-        if self == Self::Preempted {
-            let headers = resp.headers_mut();
-            headers.insert(RETRY_AFTER, HeaderValue::from_static("1"));
-            headers.insert(HEADER_X_SMG_PREEMPTED, HeaderValue::from_static("true"));
+        let headers = resp.headers_mut();
+        match self {
+            Self::QueueFull | Self::QueueTimeout => {
+                headers.insert(RETRY_AFTER, HeaderValue::from(SHED_RETRY_AFTER_SECS));
+            }
+            Self::Preempted => {
+                headers.insert(RETRY_AFTER, HeaderValue::from_static("1"));
+                headers.insert(HEADER_X_SMG_PREEMPTED, HeaderValue::from_static("true"));
+            }
+            Self::ClientCancelled => {}
         }
         resp
     }
@@ -99,15 +105,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_queue_full_maps_to_429() {
+    fn test_queue_full_maps_to_429_with_retry_after() {
         let resp = SchedulerError::QueueFull.into_response();
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            resp.headers().get(RETRY_AFTER),
+            Some(&HeaderValue::from(SHED_RETRY_AFTER_SECS))
+        );
     }
 
     #[test]
-    fn test_queue_timeout_maps_to_408() {
+    fn test_queue_timeout_maps_to_503_with_retry_after() {
         let resp = SchedulerError::QueueTimeout.into_response();
-        assert_eq!(resp.status(), StatusCode::REQUEST_TIMEOUT);
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            resp.headers().get(RETRY_AFTER),
+            Some(&HeaderValue::from(SHED_RETRY_AFTER_SECS))
+        );
     }
 
     #[test]
@@ -133,9 +147,14 @@ mod tests {
     }
 
     #[test]
-    fn test_non_preempt_has_no_preempt_headers() {
+    fn test_non_preempt_has_no_preempt_header() {
         let resp = SchedulerError::QueueFull.into_response();
         assert!(resp.headers().get(HEADER_X_SMG_PREEMPTED).is_none());
+    }
+
+    #[test]
+    fn test_client_cancelled_has_no_retry_after() {
+        let resp = SchedulerError::ClientCancelled.into_response();
         assert!(resp.headers().get(RETRY_AFTER).is_none());
     }
 

--- a/model_gateway/tests/scheduler_admission_test.rs
+++ b/model_gateway/tests/scheduler_admission_test.rs
@@ -7,8 +7,8 @@
 //!
 //! | Outcome              | Status | Extra                                   |
 //! |----------------------|--------|-----------------------------------------|
-//! | queue full           | 429    | `X-SMG-Error-Code: scheduler_queue_full`|
-//! | queue timeout        | 408    | `X-SMG-Error-Code: scheduler_queue_timeout` |
+//! | queue full           | 429    | `X-SMG-Error-Code: scheduler_queue_full`, `Retry-After: 2` |
+//! | queue timeout        | 503    | `X-SMG-Error-Code: scheduler_queue_timeout`, `Retry-After: 2` |
 //! | preempted (pre-TTFT) | 503    | `X-SMG-Preempted: true`, `Retry-After: 1` |
 //!
 //! ## How these are made deterministic
@@ -325,6 +325,11 @@ async fn queue_full_returns_429() {
         "queue full must map to 429"
     );
     assert_eq!(error_code(&resp).as_deref(), Some("scheduler_queue_full"));
+    assert_eq!(
+        resp.headers().get("retry-after").map(|v| v.to_str().unwrap()),
+        Some("2"),
+        "queue-full 429 must carry Retry-After: 2"
+    );
     let body = body_json(resp).await;
     assert_eq!(body["error"]["code"], "scheduler_queue_full");
 
@@ -337,15 +342,16 @@ async fn queue_full_returns_429() {
     ctx.shutdown().await;
 }
 
-/// Queue timeout → 408. Capacity 1, occupied by a held request; the probe
-/// enqueues (queue_size 1) but the slot never frees, so it ages out.
+/// Queue timeout → 503 + Retry-After. Capacity 1, occupied by a held
+/// request; the probe enqueues (queue_size 1) but the slot never frees, so
+/// it ages out.
 #[expect(
     clippy::disallowed_methods,
     reason = "test infra: holds a request open in a spawned task"
 )]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[serial]
-async fn queue_timeout_returns_408() {
+async fn queue_timeout_returns_503() {
     let mut yaml = SchedulerYaml::base();
     yaml.default.queue_size = 4;
     yaml.default.queue_timeout_secs = 1; // short, but the mechanism — not a race
@@ -370,8 +376,13 @@ async fn queue_timeout_returns_408() {
     let resp = send(&app, generate_request("probe", None)).await;
     assert_eq!(
         resp.status(),
-        StatusCode::REQUEST_TIMEOUT,
-        "queue timeout must map to 408"
+        StatusCode::SERVICE_UNAVAILABLE,
+        "queue timeout must map to 503"
+    );
+    assert_eq!(
+        resp.headers().get("retry-after").map(|v| v.to_str().unwrap()),
+        Some("2"),
+        "queue-timeout 503 must carry Retry-After: 2"
     );
     assert_eq!(
         error_code(&resp).as_deref(),
@@ -556,7 +567,7 @@ async fn tenant_clamp_strips_system_header_of_preemption_power() {
 async fn slot_frees_after_response_drains() {
     let mut yaml = SchedulerYaml::base();
     // A tiny queue + short timeout means a *leaked* slot would surface as a
-    // fast 408 rather than hanging the test.
+    // fast 503 rather than hanging the test.
     yaml.default.queue_size = 1;
     yaml.default.queue_timeout_secs = 2;
     let yaml_file = write_scheduler_yaml(&yaml);

--- a/model_gateway/tests/scheduler_admission_test.rs
+++ b/model_gateway/tests/scheduler_admission_test.rs
@@ -326,7 +326,9 @@ async fn queue_full_returns_429() {
     );
     assert_eq!(error_code(&resp).as_deref(), Some("scheduler_queue_full"));
     assert_eq!(
-        resp.headers().get("retry-after").map(|v| v.to_str().unwrap()),
+        resp.headers()
+            .get("retry-after")
+            .map(|v| v.to_str().unwrap()),
         Some("2"),
         "queue-full 429 must carry Retry-After: 2"
     );
@@ -380,7 +382,9 @@ async fn queue_timeout_returns_503() {
         "queue timeout must map to 503"
     );
     assert_eq!(
-        resp.headers().get("retry-after").map(|v| v.to_str().unwrap()),
+        resp.headers()
+            .get("retry-after")
+            .map(|v| v.to_str().unwrap()),
         Some("2"),
         "queue-timeout 503 must carry Retry-After: 2"
     );


### PR DESCRIPTION
## Description

### Problem

When the router is overloaded, it rejects requests. Two bugs in how it rejects them:

1. A request that waits too long in the admission queue gets **HTTP 408**. But 408 means "the client was too slow to send". Proxies treat that as a network hiccup and retry immediately.
2. No rejection tells the client when to try again, and the legacy limiter's rejections have no error body at all.

The result in production: every rejected request came back within milliseconds. Each retry re-parses the full request body (up to ~35 MB). During one overload event, routers spent all 8 cores parsing the same rejected requests over and over.

### Solution

- Queue timeout now returns **503** (server overloaded) instead of 408.
- Every rejection now includes **`Retry-After: 2`**, so clients wait 2 seconds before retrying.
- Every rejection now has a JSON error body with an error code (`admission_queue_timeout`, `admission_queue_full`).
- The priority scheduler had the same 408 bug in its own rejection path — fixed the same way, sharing one constant.
- The stall watchdog's 408 is unchanged: that one really is client-caused.

### Breaking change

Dashboards or alerts that track admission timeouts by **status 408** must switch to **503** + error code `admission_queue_timeout`. Metric labels are unchanged.

## Test Plan

- Queue timeout returns 503 with `Retry-After: 2` and the error code (end-to-end test)
- Queue full and queueing-disabled paths return 429 with `Retry-After: 2`
- Middleware suites 127 passed, scheduler admission 15 passed, HTTP router 56 passed
- `cargo +nightly fmt --all --check` clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (CI)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>