### PR TITLE
fix(grpc_servicer): survive load polls on encode workers; bump TokenSpeed pin

### DIFF
--- a/crates/engine_zmq_client/src/protocol/handshake.rs
+++ b/crates/engine_zmq_client/src/protocol/handshake.rs
@@ -54,7 +54,9 @@ pub struct EngineCoreReadyResponse {
     pub max_model_len: u64,
     /// Number of GPU blocks available for KV cache on this engine.
     pub num_gpu_blocks: u64,
-    /// KV cache block size (tokens per block).
+    /// KV cache block size (tokens per block). TokenSpeed renamed the wire
+    /// key to `prefix_granularity`; both spellings decode into this field.
+    #[serde(alias = "prefix_granularity")]
     pub block_size: u64,
     /// DP coordinator stats publish address, if applicable.
     pub dp_stats_address: Option<String>,
@@ -191,5 +193,25 @@ mod tests {
         let bytes = rmp_serde::to_vec_named(&json).unwrap();
         let resp: EngineCoreReadyResponse = decode_msgpack(&bytes).unwrap();
         assert_eq!(resp.max_num_batched_tokens, -1);
+    }
+
+    #[test]
+    fn ready_response_accepts_tokenspeed_prefix_granularity_rename() {
+        // TokenSpeed renamed the wire key `block_size` -> `prefix_granularity`;
+        // the decoder must accept either spelling.
+        let json = serde_json::json!({
+            "max_model_len": 131072u64,
+            "num_gpu_blocks": 6660u64,
+            "prefix_granularity": 64u64,
+            "dp_stats_address": serde_json::Value::Null,
+            "dtype": "bfloat16",
+            "vllm_version": "tokenspeed-0.1.0",
+            "world_size": 2u64,
+            "data_parallel_size": 2u64,
+            "kv_cache_size_tokens": 426176u64,
+        });
+        let bytes = rmp_serde::to_vec_named(&json).unwrap();
+        let resp: EngineCoreReadyResponse = decode_msgpack(&bytes).unwrap();
+        assert_eq!(resp.block_size, 64);
     }
 }

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -581,6 +581,26 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
         scheduler zmq channel; each reply carries ``num_reqs`` (running +
         waiting), ``num_waiting_reqs``, and ``num_pages`` (KV pages in use).
         """
+        # The EPD encode loop has no control-message dispatch: a GetLoadReqInput
+        # forwarded over the scheduler channel is submitted to the encode worker
+        # as if it were an encode request and kills the scheduler. Mirror the
+        # shallow health probe above — answer with an empty, well-formed
+        # response so a frontend polling loads on an encode worker reads "no
+        # scheduler load" instead of crashing the engine. Prefill/decode loops
+        # dispatch GetLoadReqInput correctly and keep reporting real loads.
+        if getattr(self.server_args, "disaggregation_mode", "null") == "encode":
+            return tokenspeed_scheduler_pb2.GetLoadsResponse(
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                version="tokenspeed",
+                dp_rank_count=0,
+                loads=[],
+                aggregate=tokenspeed_scheduler_pb2.AggregateMetrics(
+                    total_running_reqs=0,
+                    total_waiting_reqs=0,
+                    total_reqs=0,
+                    avg_token_usage=0.0,
+                ),
+            )
         try:
             load_outputs = await asyncio.wait_for(
                 self.async_llm.get_load(), timeout=HEALTH_CHECK_TIMEOUT

--- a/grpc_servicer/tests/test_tokenspeed_get_loads.py
+++ b/grpc_servicer/tests/test_tokenspeed_get_loads.py
@@ -1,0 +1,54 @@
+"""GetLoads must not round-trip to the scheduler on an encode worker.
+
+The EPD encode loop has no control-message dispatch: a GetLoadReqInput sent
+over the scheduler channel is submitted to the encode worker as an encode
+request and kills the scheduler. The servicer answers encode-mode load polls
+itself with an empty, well-formed response.
+
+Run with: pytest grpc_servicer/tests/test_tokenspeed_get_loads.py
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("smg_grpc_proto")
+servicer_mod = pytest.importorskip("smg_grpc_servicer.tokenspeed.servicer")
+
+
+def _bare_servicer(disaggregation_mode: str):
+    servicer = servicer_mod.TokenSpeedSchedulerServicer.__new__(
+        servicer_mod.TokenSpeedSchedulerServicer
+    )
+    servicer.server_args = SimpleNamespace(disaggregation_mode=disaggregation_mode)
+
+    async def _must_not_be_called():
+        raise AssertionError("encode-mode GetLoads must not reach the scheduler")
+
+    servicer.async_llm = SimpleNamespace(get_load=_must_not_be_called)
+    servicer.scheduler_info = {}
+    return servicer
+
+
+class TestEncodeModeGetLoads:
+    def test_encode_worker_answers_empty_without_touching_the_scheduler(self):
+        servicer = _bare_servicer("encode")
+        request = servicer_mod.tokenspeed_scheduler_pb2.GetLoadsRequest()
+
+        response = asyncio.run(servicer.GetLoads(request, context=None))
+
+        assert response.dp_rank_count == 0
+        assert len(response.loads) == 0
+        assert response.aggregate.total_reqs == 0
+        assert response.aggregate.avg_token_usage == 0.0
+        assert response.version == "tokenspeed"
+
+    def test_dp_rank_filter_is_irrelevant_on_the_empty_answer(self):
+        servicer = _bare_servicer("encode")
+        request = servicer_mod.tokenspeed_scheduler_pb2.GetLoadsRequest(dp_rank=1)
+
+        response = asyncio.run(servicer.GetLoads(request, context=None))
+
+        assert response.dp_rank_count == 0
+        assert len(response.loads) == 0

--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -22,7 +22,7 @@ fi
 # engine-watch workflow files an issue when this drifts) rather than
 # floating against ``main`` — upstream has renamed APIs before and the
 # gRPC servicer broke until we caught up.
-TOKENSPEED_REF="${TOKENSPEED_REF:-04bc08649f3e53e19144ee86564be7c6121c99d2}"
+TOKENSPEED_REF="${TOKENSPEED_REF:-eaf9e503bbfda773a4749500e973c68538247ee2}"
 TOKENSPEED_REPO="${TOKENSPEED_REPO:-https://github.com/lightseekorg/tokenspeed.git}"
 TOKENSPEED_DIR="${TOKENSPEED_DIR:-/tmp/tokenspeed-src}"
 


### PR DESCRIPTION
## Description

### Problem

TokenSpeed's SMG-package bump (lightseekorg/tokenspeed#1181) cannot even bring the stack up: at gateway startup, the encode engine dies with `AttributeError: 'GetLoadReqInput' object has no attribute 'request_id'`, before any traffic flows.

Root cause chain (from their job log, timeline verified):
1. SMG #2233 made load monitoring default-on — the embedded frontend now polls `GetLoads` on every worker at registration, including the EPD **encode** server, which was never polled before.
2. Our `smg_grpc_servicer` forwards the poll as TokenSpeed's `AsyncLLM.get_load()`, which round-trips a `GetLoadReqInput` over the scheduler zmq channel.
3. TokenSpeed's `epd/encode_loop.py` has no control-message dispatch — it submits every received object to the encode worker (`encode_worker.py:98` reads `.request_id`) and the scheduler dies. Prefill/decode loops dispatch the message correctly (they were polled at the same moment and survived).

This is effectively a breaking change on our side for embedded deployments: the pairing dies at boot.

### Solution

Three commits:
- **Pin bump** (`TOKENSPEED_REF` `04bc0864` → `eaf9e503`, TokenSpeed current main) so the `e2e-4gpu-epd (tokenspeed)` lane exercises the exact combination their CI hit.
- **Servicer fix**: encode-mode `GetLoads` answers with an empty, well-formed response instead of round-tripping to a scheduler loop that cannot dispatch it — mirroring the existing shallow health probe for disaggregation workers in the same file. The router treats empty loads as "no opinion", so nothing downstream changes. Prefill/decode workers keep reporting real loads.
- **Handshake fix**: the first CI pass at the new pin surfaced a second, independent break — TokenSpeed renamed the ready-response wire key `block_size` → `prefix_granularity`, so our strict msgpack decoder failed the ZMQ handshake (`missing field block_size`), workers never left Pending, and every tokenspeed ZMQ lane timed out at 40 min. The decoder now accepts either spelling (`#[serde(alias)]`); the error's own value dump confirms no other field was renamed.

TokenSpeed's encode loop should still be hardened to ignore unknown control messages (defense in depth; a fix there is warranted regardless), but embedded deployments must not require a TokenSpeed-side change to boot.

Follow-up once green: remove the temporary gpt-oss/H100 skip in `e2e_test/fixtures/hooks.py` (tokenspeed#1036 is closed; this bump picks up its fix).

## Changes

- `scripts/ci_install_tokenspeed.sh`: `TOKENSPEED_REF` `04bc0864` → `eaf9e503` (sole pin site).
- `grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py`: encode-mode guard in `GetLoads`.
- `grpc_servicer/tests/test_tokenspeed_get_loads.py`: encode-mode answers empty without touching the scheduler (stub `get_load` raises if reached).
- `crates/engine_zmq_client/src/protocol/handshake.rs`: `prefix_granularity` alias on `block_size` + a wire test mirroring the exact map TokenSpeed now sends.

## Test Plan

- CI: `e2e-4gpu-epd (tokenspeed)` at the new pin is the validation target — it reproduces their startup kill without the servicer fix and must be green with it.
- `pytest grpc_servicer/tests/test_tokenspeed_get_loads.py` (runs in the CI env with tokenspeed installed; skips cleanly without it).
- `cargo test -p engine-zmq-client` — 90 passed incl. the new rename test; clippy clean.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
