### PR TITLE
refactor(grpc): end request ownership at request building, by construction

### DIFF
--- a/model_gateway/src/routers/grpc/common/stages/client_acquisition.rs
+++ b/model_gateway/src/routers/grpc/common/stages/client_acquisition.rs
@@ -1,92 +1,69 @@
-//! Client acquisition stage: Get gRPC clients from selected workers
+//! Client acquisition: get gRPC clients from selected workers.
+//!
+//! Called once at ingress and again per retry attempt after worker
+//! re-selection.
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use axum::response::Response;
 use tracing::error;
 
-use super::PipelineStage;
 use crate::{
     routers::{
         common::overload,
         error,
         grpc::{
             backend_client::BackendClient,
-            context::{ClientSelection, RequestContext, WorkerSelection},
+            context::{ClientSelection, WorkerSelection},
         },
     },
     worker::Worker,
 };
 
-/// Client acquisition stage: Get gRPC clients from selected workers
-pub(crate) struct ClientAcquisitionStage;
-
-#[async_trait]
-impl PipelineStage for ClientAcquisitionStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        let workers = ctx.state.workers.as_ref().ok_or_else(|| {
-            error!(
-                function = "ClientAcquisitionStage::execute",
-                "Worker selection stage not completed"
-            );
-            error::internal_error(
-                "worker_selection_not_completed",
-                "Worker selection not completed",
-            )
-        })?;
-
-        // Dispatch-time re-check: one relaxed atomic read per already-chosen
-        // worker, closing the window between selection and dispatch in which a
-        // load report can flip the veto.
-        let model_id = ctx.input.model_id.as_str();
-        let clients = match workers {
-            WorkerSelection::Single { worker } => {
-                if let Some(shed) = overload::shed_if_worker_overloaded(worker.as_ref(), model_id) {
-                    return Err(shed);
-                }
-                let client = get_backend_client_from_worker(worker).await?;
-                ClientSelection::Single { client }
+/// Acquire backend clients for the selected workers, with a dispatch-time
+/// overload re-check: one relaxed atomic read per already-chosen worker,
+/// closing the window between selection and dispatch in which a load report
+/// can flip the veto.
+pub(crate) async fn acquire_clients(
+    workers: &WorkerSelection,
+    model_id: &str,
+) -> Result<ClientSelection, Response> {
+    match workers {
+        WorkerSelection::Single { worker } => {
+            if let Some(shed) = overload::shed_if_worker_overloaded(worker.as_ref(), model_id) {
+                return Err(shed);
             }
-            WorkerSelection::Disaggregated {
-                encode_assignments,
-                prefill,
-                decode,
-                ..
-            } => {
-                // Every assigned leg, encode included: an encode worker is
-                // vetoed at selection through the same filter, so leaving it out
-                // of the re-check would be the one dispatch path that can send
-                // to a worker known to be over the ceiling.
-                if let Some(shed) = overload::shed_if_worker_overloaded(prefill.as_ref(), model_id)
-                    .or_else(|| overload::shed_if_worker_overloaded(decode.as_ref(), model_id))
-                    .or_else(|| {
-                        encode_assignments.iter().flatten().find_map(|assignment| {
-                            overload::shed_if_worker_overloaded(
-                                assignment.worker.as_ref(),
-                                model_id,
-                            )
-                        })
+            let client = get_backend_client_from_worker(worker).await?;
+            Ok(ClientSelection::Single { client })
+        }
+        WorkerSelection::Disaggregated {
+            encode_assignments,
+            prefill,
+            decode,
+            ..
+        } => {
+            // Every assigned leg, encode included: an encode worker is
+            // vetoed at selection through the same filter, so leaving it out
+            // of the re-check would be the one dispatch path that can send
+            // to a worker known to be over the ceiling.
+            if let Some(shed) = overload::shed_if_worker_overloaded(prefill.as_ref(), model_id)
+                .or_else(|| overload::shed_if_worker_overloaded(decode.as_ref(), model_id))
+                .or_else(|| {
+                    encode_assignments.iter().flatten().find_map(|assignment| {
+                        overload::shed_if_worker_overloaded(assignment.worker.as_ref(), model_id)
                     })
-                {
-                    return Err(shed);
-                }
-                let prefill_client = get_backend_client_from_worker(prefill).await?;
-                let decode_client = get_backend_client_from_worker(decode).await?;
-
-                ClientSelection::Disaggregated {
-                    prefill: prefill_client,
-                    decode: decode_client,
-                }
+                })
+            {
+                return Err(shed);
             }
-        };
+            let prefill_client = get_backend_client_from_worker(prefill).await?;
+            let decode_client = get_backend_client_from_worker(decode).await?;
 
-        ctx.state.clients = Some(clients);
-        Ok(None)
-    }
-
-    fn name(&self) -> &'static str {
-        "ClientAcquisition"
+            Ok(ClientSelection::Disaggregated {
+                prefill: prefill_client,
+                decode: decode_client,
+            })
+        }
     }
 }
 

--- a/model_gateway/src/routers/grpc/common/stages/dispatch_metadata.rs
+++ b/model_gateway/src/routers/grpc/common/stages/dispatch_metadata.rs
@@ -1,75 +1,35 @@
-//! Dispatch metadata stage: Prepare metadata for dispatch
+//! Dispatch metadata: per-attempt response metadata derived from the stamped
+//! plan and the attempt's worker selection.
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use async_trait::async_trait;
-use axum::response::Response;
-use tracing::error;
+use crate::routers::grpc::context::{DispatchMetadata, ExecutionPlan, WorkerSelection};
 
-use super::PipelineStage;
-use crate::routers::{
-    error,
-    grpc::context::{DispatchMetadata, RequestContext, RequestType, WorkerSelection},
-};
+/// Metadata for one dispatch attempt. `dispatch_model` was captured from the
+/// request at the build boundary (already canonical); the weight version
+/// comes from the attempt's selected worker.
+pub(crate) fn prepare_dispatch_metadata(
+    plan: &ExecutionPlan,
+    dispatch_model: &str,
+    workers: Option<&WorkerSelection>,
+) -> DispatchMetadata {
+    let weight_version = workers
+        .map(|w| match w {
+            WorkerSelection::Single { worker } => worker,
+            WorkerSelection::Disaggregated { decode, .. } => decode,
+        })
+        .and_then(|w| w.metadata().spec.labels.get("weight_version").cloned())
+        .unwrap_or_else(|| "default".to_string());
 
-/// Dispatch metadata stage: Prepare metadata for dispatch
-pub(crate) struct DispatchMetadataStage;
+    let created = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
 
-#[async_trait]
-impl PipelineStage for DispatchMetadataStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        let execution_plan = ctx.state.execution_plan.as_ref().ok_or_else(|| {
-            error!(
-                function = "DispatchMetadataStage::execute",
-                "Execution plan not built"
-            );
-            error::internal_error("execution_plan_not_built", "Execution plan not built")
-        })?;
-
-        let request_id = execution_plan.request_id().to_string();
-        // The model the response reports. `RequestContext::new` already
-        // rewrote every one of these to the canonical model ID, so a request
-        // that arrived under an alias is answered under the canonical name.
-        let model = match &ctx.input.request_type {
-            RequestType::Chat(req) => req.model.clone(),
-            RequestType::Completion(req) => req.model.clone(),
-            // `GenerateRequest` carries a model field too, but callers of the
-            // native `/generate` route may leave it empty, so prefer the
-            // model the router resolved.
-            RequestType::Generate(_req) => ctx.input.model_id.clone(),
-            RequestType::Responses(req) => req.model.clone(),
-            RequestType::Embedding(req) => req.model.clone(),
-            RequestType::Classify(req) => req.model.clone(),
-            RequestType::Messages(req) => req.model.clone(),
-        };
-
-        let weight_version = ctx
-            .state
-            .workers
-            .as_ref()
-            .map(|w| match w {
-                WorkerSelection::Single { worker } => worker,
-                WorkerSelection::Disaggregated { decode, .. } => decode,
-            })
-            .and_then(|w| w.metadata().spec.labels.get("weight_version").cloned())
-            .unwrap_or_else(|| "default".to_string());
-
-        let created = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-
-        ctx.state.dispatch = Some(DispatchMetadata {
-            request_id,
-            model,
-            created,
-            weight_version: Some(weight_version),
-        });
-
-        Ok(None)
-    }
-
-    fn name(&self) -> &'static str {
-        "DispatchMetadata"
+    DispatchMetadata {
+        request_id: plan.request_id().to_string(),
+        model: dispatch_model.to_string(),
+        created,
+        weight_version: Some(weight_version),
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/encode.rs
+++ b/model_gateway/src/routers/grpc/common/stages/encode.rs
@@ -58,7 +58,7 @@ impl EncodeStage {
 
 #[async_trait]
 impl PipelineStage for EncodeStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response> {
         if ctx
             .state
             .workers
@@ -66,11 +66,11 @@ impl PipelineStage for EncodeStage {
             .and_then(WorkerSelection::encode_assignments)
             .is_none_or(|assignments| assignments.is_empty())
         {
-            return Ok(None);
+            return Ok(());
         }
 
         let Some(intermediate) = ctx.state.multimodal_intermediate.as_ref() else {
-            return Ok(None);
+            return Ok(());
         };
 
         let plan = build_plan(
@@ -87,7 +87,7 @@ impl PipelineStage for EncodeStage {
         // request building takes the plain prefill path (with pixels) rather
         // than the pixel-drop encode path.
         if plan.is_empty() {
-            return Ok(None);
+            return Ok(());
         }
 
         let (bootstrap_info, dispatch) = plan.into_parts();
@@ -95,16 +95,11 @@ impl PipelineStage for EncodeStage {
             bootstrap_info,
             dispatch,
         });
-        Ok(None)
+        Ok(())
     }
 
     fn name(&self) -> &'static str {
         "Encode"
-    }
-
-    #[cfg(test)]
-    fn signature(&self) -> String {
-        "EncodeStage".to_string()
     }
 }
 

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use axum::response::Response;
 use llm_tokenizer::traits::Tokenizer;
 use rand::RngExt;
 use smg_grpc_client::{
@@ -9,15 +10,18 @@ use smg_grpc_client::{
     sglang_proto::{self, DisaggregatedParams},
     tokenspeed_proto, vllm_proto,
 };
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use super::pd_protocol::{DpPlacement, PdProtocol, PdRendezvous};
 use crate::{
     middleware::{RequestId, TenantRequestMeta},
     rate_limit::{ReservationAttachment, SharedReservationHandle},
-    routers::grpc::{
-        context::{LoadGuards, RequestType, WorkerSelection},
-        proto_wrapper::ProtoGenerateRequest,
+    routers::{
+        error,
+        grpc::{
+            context::{AttemptStamp, ExecutionPlan, LoadGuards, RequestType, WorkerSelection},
+            proto_wrapper::ProtoGenerateRequest,
+        },
     },
     worker::{
         sampling_defaults::SamplingDefaults, AttachedBody, Worker, DEFAULT_BOOTSTRAP_PORT,
@@ -26,7 +30,7 @@ use crate::{
 };
 
 #[derive(Clone, Copy, Debug, Default)]
-struct SamplingDefaultsMask {
+pub(crate) struct SamplingDefaultsMask {
     temperature: bool,
     top_p: bool,
     top_k: bool,
@@ -35,7 +39,7 @@ struct SamplingDefaultsMask {
 }
 
 impl SamplingDefaultsMask {
-    fn from_request_type(request_type: &RequestType) -> Option<Self> {
+    pub(crate) fn from_request_type(request_type: &RequestType) -> Option<Self> {
         match request_type {
             RequestType::Chat(request) => Some(Self {
                 temperature: request.temperature.is_none(),
@@ -89,10 +93,10 @@ impl SamplingDefaultsMask {
 /// regardless of how the client disconnects. A no-op returning `response`
 /// unchanged when both are `None`.
 pub(crate) fn attach_response_guards(
-    response: axum::response::Response,
+    response: Response,
     guards: Option<LoadGuards>,
     reservation: Option<Arc<SharedReservationHandle>>,
-) -> axum::response::Response {
+) -> Response {
     match (guards, reservation) {
         (Some(guards), Some(handle)) => {
             AttachedBody::wrap_response(response, (guards, ReservationAttachment::new(handle)))
@@ -114,34 +118,281 @@ pub(crate) fn middleware_request_id(tenant_meta: Option<&TenantRequestMeta>) -> 
         .map(|request_id| request_id.0.as_str())
 }
 
-/// Backend request id for any endpoint.
+/// How each retry attempt re-mints the engine request id, captured at build
+/// so replays reproduce exactly what a fresh build would have minted.
+///
+/// Engine ids must be unique per dispatch — a NIXL-tagged prefill keeps the
+/// id alive until the KV lease expires, and responses tool loops re-execute
+/// the pipeline per iteration — so every derived id gets a fresh
+/// per-execution component. A bare `rid` outside PD is the one exception:
+/// its value is the caller's contract (matching /generate's long-standing
+/// behavior) and stays stable across attempts.
+pub(crate) enum IdStamp {
+    /// Bare client `rid` outside PD: stable across attempts.
+    Exact,
+    /// `{base}-{uuid}` minted fresh per attempt (rid under PD,
+    /// middleware-derived ids).
+    Suffixed { base: String },
+    /// `{prefix}{uuid}` minted fresh per attempt.
+    Minted { prefix: &'static str },
+    /// Batched completion fan-out: shared id plus per-sub engine ids.
+    Batch(BatchIdStamp),
+}
+
+pub(crate) struct BatchIdStamp {
+    /// `None`: the shared id is minted fresh per attempt as `{prefix}{uuid}`.
+    pub stable_shared: Option<String>,
+    pub prefix: &'static str,
+    /// Sub ids carry a per-execution uuid (PD, or a shared id that is stable
+    /// across executions).
+    pub unique_subs: bool,
+}
+
+/// Backend request id for any single-request endpoint, plus the stamp retry
+/// attempts re-mint it with.
 ///
 /// Priority: the protocol `rid`, else the middleware request id, else a fresh
-/// `{prefix}{uuid}`.
-///
-/// Engine ids must be unique per dispatch — PD retries re-run request
-/// building while a NIXL-tagged prefill keeps the id alive until the KV lease
-/// expires, and responses tool loops re-execute the pipeline per iteration —
-/// so middleware-derived ids always get a per-execution suffix. A bare `rid`
-/// outside PD is used exactly: its value is the caller's contract (matching
-/// /generate's long-standing behavior).
-pub(crate) fn resolve_request_id(
+/// `{prefix}{uuid}` (see [`IdStamp`] for the uniqueness rules).
+pub(crate) fn resolve_request_id_stamp(
     request_type: &RequestType,
     tenant_meta: Option<&TenantRequestMeta>,
-    prefix: &str,
+    prefix: &'static str,
     disaggregated: bool,
-) -> String {
+) -> (String, IdStamp) {
     if let Some(rid) = request_type.rid() {
         return if disaggregated {
-            format!("{rid}-{}", uuid::Uuid::now_v7())
+            let stamp = IdStamp::Suffixed {
+                base: rid.to_string(),
+            };
+            (format!("{rid}-{}", uuid::Uuid::now_v7()), stamp)
         } else {
-            rid.to_string()
+            (rid.to_string(), IdStamp::Exact)
         };
     }
     match middleware_request_id(tenant_meta) {
-        Some(request_id) => format!("{request_id}-{}", uuid::Uuid::now_v7()),
-        None => format!("{prefix}{}", uuid::Uuid::now_v7()),
+        Some(request_id) => (
+            format!("{request_id}-{}", uuid::Uuid::now_v7()),
+            IdStamp::Suffixed {
+                base: request_id.to_string(),
+            },
+        ),
+        None => (
+            format!("{prefix}{}", uuid::Uuid::now_v7()),
+            IdStamp::Minted { prefix },
+        ),
     }
+}
+
+/// Shared id + stamp for the batched completion fan-out. The shared id
+/// (client rid or middleware request id) stays clean for the response;
+/// per-sub engine ids get a uniqueness suffix in PD mode and whenever the
+/// shared id is stable across executions (rid- or middleware-derived).
+pub(crate) fn resolve_batch_id_stamp(
+    request_type: &RequestType,
+    tenant_meta: Option<&TenantRequestMeta>,
+    prefix: &'static str,
+    disaggregated: bool,
+) -> (String, BatchIdStamp) {
+    let (shared, stable_shared, unique_subs) = match request_type.rid() {
+        Some(rid) => (rid.to_string(), Some(rid.to_string()), disaggregated),
+        None => match middleware_request_id(tenant_meta) {
+            Some(request_id) => (request_id.to_string(), Some(request_id.to_string()), true),
+            None => (
+                format!("{prefix}{}", uuid::Uuid::now_v7()),
+                None,
+                disaggregated,
+            ),
+        },
+    };
+    (
+        shared,
+        BatchIdStamp {
+            stable_shared,
+            prefix,
+            unique_subs,
+        },
+    )
+}
+
+/// One batched sub-request's engine id.
+pub(crate) fn batch_sub_id(shared: &str, index: usize, unique: bool) -> String {
+    if unique {
+        format!("{shared}-p{index}-{}", uuid::Uuid::now_v7())
+    } else {
+        format!("{shared}-p{index}")
+    }
+}
+
+impl IdStamp {
+    /// Re-mint the retained plan's engine id(s) for a retry attempt. A plan
+    /// shape that doesn't match the stamp is a build-stage wiring bug: fail
+    /// rather than re-dispatch the previous attempt's engine ids.
+    #[expect(
+        clippy::result_large_err,
+        reason = "Response is the standard error type in the pipeline stage pattern"
+    )]
+    pub(crate) fn restamp(&self, plan: &mut ExecutionPlan) -> Result<(), Response> {
+        match self {
+            Self::Exact => Ok(()),
+            Self::Suffixed { base } => {
+                plan.set_request_id(format!("{base}-{}", uuid::Uuid::now_v7()))
+            }
+            Self::Minted { prefix } => {
+                plan.set_request_id(format!("{prefix}{}", uuid::Uuid::now_v7()))
+            }
+            Self::Batch(batch) => {
+                let ExecutionPlan::Batch {
+                    shared_request_id,
+                    requests,
+                    ..
+                } = plan
+                else {
+                    error!(
+                        function = "IdStamp::restamp",
+                        "Batch id stamp on a non-batch plan"
+                    );
+                    return Err(error::internal_error(
+                        "id_stamp_plan_mismatch",
+                        "Id stamp does not match the plan shape",
+                    ));
+                };
+                let shared = batch
+                    .stable_shared
+                    .clone()
+                    .unwrap_or_else(|| format!("{}{}", batch.prefix, uuid::Uuid::now_v7()));
+                for (i, request) in requests.iter_mut().enumerate() {
+                    request.set_request_id(batch_sub_id(&shared, i, batch.unique_subs));
+                }
+                *shared_request_id = shared;
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Pre-worker-default values of a plan's sampling params, captured at build
+/// before the first worker's defaults are applied. Retry re-application
+/// restores the masked fields from this baseline first, so attempt N's
+/// effective params are exactly (request values) + (worker N's defaults) —
+/// never contaminated by a previous attempt's worker.
+#[derive(Clone)]
+pub(crate) enum SamplingBaseline {
+    Sglang(sglang_proto::SamplingParams),
+    Vllm(vllm_proto::SamplingParams),
+    Mlx(mlx_proto::SamplingParams),
+    TokenSpeed(tokenspeed_proto::SamplingParams),
+}
+
+impl SamplingBaseline {
+    fn capture(request: &ProtoGenerateRequest) -> Option<Self> {
+        match request {
+            ProtoGenerateRequest::Sglang(req) => req.sampling_params.clone().map(Self::Sglang),
+            ProtoGenerateRequest::Vllm(req) => req.sampling_params.clone().map(Self::Vllm),
+            ProtoGenerateRequest::Mlx(req) => req.sampling_params.clone().map(Self::Mlx),
+            ProtoGenerateRequest::TokenSpeed(req) => {
+                req.sampling_params.clone().map(Self::TokenSpeed)
+            }
+            ProtoGenerateRequest::Trtllm(_) => None,
+        }
+    }
+
+    /// Reset the masked fields to their pre-default values.
+    #[expect(
+        clippy::result_large_err,
+        reason = "Response is the standard error type in the pipeline stage pattern"
+    )]
+    fn restore_masked(
+        &self,
+        request: &mut ProtoGenerateRequest,
+        mask: SamplingDefaultsMask,
+    ) -> Result<(), Response> {
+        macro_rules! restore {
+            ($params:expr, $baseline:expr) => {{
+                let params = $params;
+                let baseline = $baseline;
+                if mask.temperature {
+                    params.temperature = baseline.temperature;
+                }
+                if mask.top_p {
+                    params.top_p = baseline.top_p;
+                }
+                if mask.top_k {
+                    params.top_k = baseline.top_k;
+                }
+                if mask.min_p {
+                    params.min_p = baseline.min_p;
+                }
+                if mask.repetition_penalty {
+                    params.repetition_penalty = baseline.repetition_penalty;
+                }
+            }};
+        }
+        match (request, self) {
+            (ProtoGenerateRequest::Sglang(req), Self::Sglang(baseline)) => {
+                if let Some(params) = req.sampling_params.as_mut() {
+                    restore!(params, baseline);
+                }
+                Ok(())
+            }
+            (ProtoGenerateRequest::Vllm(req), Self::Vllm(baseline)) => {
+                if let Some(params) = req.sampling_params.as_mut() {
+                    restore!(params, baseline);
+                }
+                Ok(())
+            }
+            (ProtoGenerateRequest::Mlx(req), Self::Mlx(baseline)) => {
+                if let Some(params) = req.sampling_params.as_mut() {
+                    restore!(params, baseline);
+                }
+                Ok(())
+            }
+            (ProtoGenerateRequest::TokenSpeed(req), Self::TokenSpeed(baseline)) => {
+                if let Some(params) = req.sampling_params.as_mut() {
+                    restore!(params, baseline);
+                }
+                Ok(())
+            }
+            _ => {
+                error!(
+                    function = "SamplingBaseline::restore_masked",
+                    "Sampling baseline does not match the plan's backend"
+                );
+                Err(error::internal_error(
+                    "sampling_baseline_plan_mismatch",
+                    "Sampling baseline does not match the plan shape",
+                ))
+            }
+        }
+    }
+}
+
+/// Re-stamp the retained plan for a retry attempt's newly selected workers:
+/// fresh engine ids per [`IdStamp`], the new worker's sampling defaults
+/// (re-applied over the build-time baseline), and fresh PD
+/// bootstrap/rendezvous rooms. EPD encode bootstrap info is deliberately
+/// untouched — those rooms are the rendezvous with encode jobs the first
+/// dispatch already launched.
+#[expect(
+    clippy::result_large_err,
+    reason = "Response is the standard error type in the pipeline stage pattern"
+)]
+pub(crate) fn restamp_plan_for_attempt(
+    plan: &mut ExecutionPlan,
+    stamp: &AttemptStamp,
+    workers: &WorkerSelection,
+) -> Result<(), Response> {
+    stamp.id.restamp(plan)?;
+    for request in plan.generate_requests_mut() {
+        if let (Some(mask), Some(baseline)) = (stamp.sampling_mask, &stamp.sampling_baseline) {
+            baseline.restore_masked(request, mask)?;
+            apply_sampling_defaults_with_mask(request, mask, Some(workers));
+        }
+        if stamp.inject_pd_metadata {
+            maybe_inject_pd_metadata(request, workers);
+        }
+        maybe_inject_pd_rendezvous(request, workers);
+    }
+    Ok(())
 }
 
 /// Decode selected-worker sampling defaults from labels.
@@ -175,22 +426,37 @@ pub(crate) fn sampling_defaults_for_request(
     }
 }
 
+/// Apply the selected worker's sampling defaults at build, capturing the
+/// masked fields' pre-default baseline first: retry attempts re-apply the
+/// new worker's defaults over this baseline, not over the previous worker's.
+pub(crate) fn apply_sampling_defaults(
+    request: &mut ProtoGenerateRequest,
+    mask: Option<SamplingDefaultsMask>,
+    workers: Option<&WorkerSelection>,
+) -> Option<SamplingBaseline> {
+    let mask = mask?;
+    if !mask.any() || matches!(request, ProtoGenerateRequest::Trtllm(_)) {
+        return None;
+    }
+    let baseline = SamplingBaseline::capture(request);
+    apply_sampling_defaults_with_mask(request, mask, workers);
+    baseline
+}
+
 /// Apply model sampling defaults to a built proto request.
 ///
-/// The proto already contains backend fallback values, so `request_type` is
-/// used only as an omission mask: defaults fill fields the user did not set.
-pub(crate) fn apply_sampling_defaults_to_generate_request(
+/// The proto already contains backend fallback values, so `mask` (derived
+/// from the request at build) selects only fields the user did not set.
+/// Retry attempts reuse the same mask against the newly selected worker.
+fn apply_sampling_defaults_with_mask(
     request: &mut ProtoGenerateRequest,
-    request_type: &RequestType,
+    mask: SamplingDefaultsMask,
     workers: Option<&WorkerSelection>,
 ) {
     if matches!(request, ProtoGenerateRequest::Trtllm(_)) {
         return;
     }
 
-    let Some(mask) = SamplingDefaultsMask::from_request_type(request_type) else {
-        return;
-    };
     if !mask.any() {
         return;
     }
@@ -578,21 +844,82 @@ mod request_id_tests {
             .with_extension(RequestId(id.to_string()))
     }
 
+    fn single_plan(request_id: &str) -> ExecutionPlan {
+        use smg_grpc_client::sglang_proto;
+
+        use crate::routers::grpc::proto_wrapper::ProtoRequest;
+        let request = ProtoGenerateRequest::Sglang(Box::new(sglang_proto::GenerateRequest {
+            request_id: request_id.to_string(),
+            ..Default::default()
+        }));
+        ExecutionPlan::Single(ProtoRequest::Generate(request))
+    }
+
+    fn batch_plan(shared: &str, sub_ids: &[String]) -> ExecutionPlan {
+        use smg_grpc_client::sglang_proto;
+
+        use crate::routers::grpc::context::ExecutionPlanKind;
+        ExecutionPlan::Batch {
+            kind: ExecutionPlanKind::Single,
+            shared_request_id: shared.to_string(),
+            requests: sub_ids
+                .iter()
+                .map(|id| {
+                    ProtoGenerateRequest::Sglang(Box::new(sglang_proto::GenerateRequest {
+                        request_id: id.clone(),
+                        ..Default::default()
+                    }))
+                })
+                .collect(),
+        }
+    }
+
+    fn plan_ids(plan: &ExecutionPlan) -> (String, Vec<String>) {
+        match plan {
+            ExecutionPlan::Batch {
+                shared_request_id,
+                requests,
+                ..
+            } => (
+                shared_request_id.clone(),
+                requests
+                    .iter()
+                    .map(|r| r.request_id().to_string())
+                    .collect(),
+            ),
+            other => (other.request_id().to_string(), Vec::new()),
+        }
+    }
+
     #[test]
-    fn rid_is_used_exactly_outside_pd() {
+    fn rid_is_used_exactly_outside_pd_and_stays_stable_on_restamp() {
         let request_type = chat_request_type(Some("client-rid"));
         let meta = meta_with_request_id("chatcmpl-mw");
 
-        let id = resolve_request_id(&request_type, Some(&meta), "chatcmpl-", false);
+        let (id, stamp) = resolve_request_id_stamp(&request_type, Some(&meta), "chatcmpl-", false);
         assert_eq!(id, "client-rid");
+
+        let mut plan = single_plan(&id);
+        stamp.restamp(&mut plan).unwrap();
+        assert_eq!(
+            plan.request_id(),
+            "client-rid",
+            "rid is the caller's contract"
+        );
     }
 
     #[test]
     fn rid_gets_per_attempt_suffix_in_pd() {
         let request_type = chat_request_type(Some("client-rid"));
 
-        let id = resolve_request_id(&request_type, None, "chatcmpl-", true);
+        let (id, stamp) = resolve_request_id_stamp(&request_type, None, "chatcmpl-", true);
         assert!(id.starts_with("client-rid-") && id != "client-rid");
+
+        let mut plan = single_plan(&id);
+        stamp.restamp(&mut plan).unwrap();
+        let restamped = plan.request_id().to_string();
+        assert!(restamped.starts_with("client-rid-"));
+        assert_ne!(restamped, id, "each attempt gets a fresh engine id");
     }
 
     #[test]
@@ -600,9 +927,13 @@ mod request_id_tests {
         let request_type = chat_request_type(None);
         let meta = meta_with_request_id("chatcmpl-mw");
 
-        let first = resolve_request_id(&request_type, Some(&meta), "chatcmpl-", false);
-        let second = resolve_request_id(&request_type, Some(&meta), "chatcmpl-", false);
+        let (first, stamp) =
+            resolve_request_id_stamp(&request_type, Some(&meta), "chatcmpl-", false);
         assert!(first.starts_with("chatcmpl-mw-"));
+
+        let mut plan = single_plan(&first);
+        stamp.restamp(&mut plan).unwrap();
+        let second = plan.request_id().to_string();
         assert!(second.starts_with("chatcmpl-mw-"));
         assert_ne!(first, second);
     }
@@ -612,8 +943,71 @@ mod request_id_tests {
         let request_type = chat_request_type(None);
         let meta = TenantRequestMeta::new(TenantKey::new("test-tenant"));
 
-        let id = resolve_request_id(&request_type, Some(&meta), "chatcmpl-", false);
+        let (id, stamp) = resolve_request_id_stamp(&request_type, Some(&meta), "chatcmpl-", false);
         assert!(id.starts_with("chatcmpl-"));
+
+        let mut plan = single_plan(&id);
+        stamp.restamp(&mut plan).unwrap();
+        assert!(plan.request_id().starts_with("chatcmpl-"));
+        assert_ne!(plan.request_id(), id, "minted ids are fresh per attempt");
+    }
+
+    #[test]
+    fn batch_rid_subs_stay_stable_outside_pd() {
+        let request_type = chat_request_type(Some("client-rid"));
+        let (shared, stamp) = resolve_batch_id_stamp(&request_type, None, "cmpl_", false);
+        assert_eq!(shared, "client-rid");
+        assert!(!stamp.unique_subs);
+
+        let subs: Vec<String> = (0..2).map(|i| batch_sub_id(&shared, i, false)).collect();
+        assert_eq!(subs, ["client-rid-p0", "client-rid-p1"]);
+
+        let mut plan = batch_plan(&shared, &subs);
+        IdStamp::Batch(stamp).restamp(&mut plan).unwrap();
+        assert_eq!(plan_ids(&plan), (shared, subs), "rid batch ids are stable");
+    }
+
+    #[test]
+    fn batch_middleware_subs_are_unique_per_attempt_under_stable_shared() {
+        let request_type = chat_request_type(None);
+        let meta = meta_with_request_id("mw-id");
+        let (shared, stamp) = resolve_batch_id_stamp(&request_type, Some(&meta), "cmpl_", false);
+        assert_eq!(shared, "mw-id");
+        assert!(stamp.unique_subs);
+
+        let subs: Vec<String> = (0..2)
+            .map(|i| batch_sub_id(&shared, i, stamp.unique_subs))
+            .collect();
+        let mut plan = batch_plan(&shared, &subs);
+        IdStamp::Batch(stamp).restamp(&mut plan).unwrap();
+        let (restamped_shared, restamped_subs) = plan_ids(&plan);
+        assert_eq!(restamped_shared, "mw-id");
+        for (i, (before, after)) in subs.iter().zip(&restamped_subs).enumerate() {
+            assert!(after.starts_with(&format!("mw-id-p{i}-")));
+            assert_ne!(before, after, "sub engine ids must be fresh per attempt");
+        }
+    }
+
+    #[test]
+    fn batch_minted_shared_is_fresh_per_attempt() {
+        let request_type = chat_request_type(None);
+        let (shared, stamp) = resolve_batch_id_stamp(&request_type, None, "cmpl_", false);
+        assert!(shared.starts_with("cmpl_"));
+        assert!(stamp.stable_shared.is_none());
+
+        let subs: Vec<String> = (0..2).map(|i| batch_sub_id(&shared, i, false)).collect();
+        let mut plan = batch_plan(&shared, &subs);
+        IdStamp::Batch(stamp).restamp(&mut plan).unwrap();
+        let (restamped_shared, restamped_subs) = plan_ids(&plan);
+        assert!(restamped_shared.starts_with("cmpl_"));
+        assert_ne!(restamped_shared, shared);
+        assert_eq!(
+            restamped_subs,
+            [
+                format!("{restamped_shared}-p0"),
+                format!("{restamped_shared}-p1")
+            ]
+        );
     }
 }
 
@@ -856,5 +1250,177 @@ mod stop_resolution_tests {
         let params = tokenspeed_params(&req);
         assert!(params.stop.is_empty());
         assert_eq!(params.stop_token_ids, vec![42], "existing ids kept");
+    }
+}
+
+#[cfg(test)]
+mod restamp_shape_mismatch_tests {
+    use std::sync::Arc;
+
+    use openai_protocol::chat::ChatCompletionRequest;
+    use smg_grpc_client::sglang_proto;
+
+    use super::*;
+    use crate::routers::{
+        error::extract_error_code_from_response,
+        grpc::{context::ExecutionPlanKind, proto_wrapper::ProtoRequest},
+    };
+
+    fn single_plan() -> ExecutionPlan {
+        ExecutionPlan::Single(ProtoRequest::Generate(ProtoGenerateRequest::Sglang(
+            Box::default(),
+        )))
+    }
+
+    fn batch_plan() -> ExecutionPlan {
+        ExecutionPlan::Batch {
+            kind: ExecutionPlanKind::Single,
+            shared_request_id: "cmpl_shared".to_string(),
+            requests: vec![ProtoGenerateRequest::Sglang(Box::default())],
+        }
+    }
+
+    /// A stamp/plan shape mismatch is a build-stage wiring bug; a warn-and-
+    /// continue would re-dispatch the previous attempt's engine ids.
+    #[test]
+    fn id_stamp_shape_mismatch_is_an_error() {
+        let batch_stamp = IdStamp::Batch(BatchIdStamp {
+            stable_shared: None,
+            prefix: "cmpl_",
+            unique_subs: false,
+        });
+        let response = batch_stamp
+            .restamp(&mut single_plan())
+            .expect_err("batch stamp on a single plan must fail");
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "id_stamp_plan_mismatch"
+        );
+
+        let minted_stamp = IdStamp::Minted { prefix: "cmpl_" };
+        let response = minted_stamp
+            .restamp(&mut batch_plan())
+            .expect_err("single stamp on a batch plan must fail");
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "id_stamp_plan_mismatch"
+        );
+    }
+
+    /// A baseline captured from one backend flavor cannot restore another.
+    #[test]
+    fn sampling_baseline_backend_mismatch_is_an_error() {
+        let baseline = SamplingBaseline::Vllm(vllm_proto::SamplingParams::default());
+        let mut request = ProtoGenerateRequest::Sglang(Box::new(sglang_proto::GenerateRequest {
+            sampling_params: Some(sglang_proto::SamplingParams::default()),
+            ..Default::default()
+        }));
+        let mask = SamplingDefaultsMask::from_request_type(&RequestType::Chat(Arc::new(
+            ChatCompletionRequest::default(),
+        )))
+        .expect("chat requests always carry a mask");
+        let response = baseline
+            .restore_masked(&mut request, mask)
+            .expect_err("cross-backend baseline must fail");
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "sampling_baseline_plan_mismatch"
+        );
+    }
+}
+
+#[cfg(test)]
+mod sampling_restamp_tests {
+    use std::sync::Arc;
+
+    use openai_protocol::chat::ChatCompletionRequest;
+    use smg_grpc_client::sglang_proto;
+
+    use super::*;
+    use crate::{
+        routers::grpc::{context::ExecutionPlanKind, proto_wrapper::ProtoRequest},
+        worker::{BasicWorkerBuilder, WorkerType},
+    };
+
+    fn worker_with_defaults(url: &str, defaults_json: Option<&str>) -> WorkerSelection {
+        let mut builder = BasicWorkerBuilder::new(url).worker_type(WorkerType::Regular);
+        if let Some(json) = defaults_json {
+            builder = builder.label(DEFAULT_SAMPLING_PARAMS_LABEL, json);
+        }
+        WorkerSelection::Single {
+            worker: Arc::new(builder.build()),
+        }
+    }
+
+    fn sglang_request() -> ProtoGenerateRequest {
+        ProtoGenerateRequest::Sglang(Box::new(sglang_proto::GenerateRequest {
+            request_id: "sampling-restamp".to_string(),
+            sampling_params: Some(sglang_proto::SamplingParams {
+                temperature: 1.0,
+                top_k: 3,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+    }
+
+    fn sglang_params(plan: &ExecutionPlan) -> &sglang_proto::SamplingParams {
+        match plan {
+            ExecutionPlan::Single(ProtoRequest::Generate(ProtoGenerateRequest::Sglang(req))) => {
+                req.sampling_params.as_ref().unwrap()
+            }
+            _ => panic!("expected single SGLang plan"),
+        }
+    }
+
+    /// Attempt N's effective sampling params must be exactly (request values)
+    /// + (worker N's defaults). A retry worker that omits a field the first
+    /// worker defaulted must fall back to the build-time baseline, never to
+    /// the first worker's value.
+    #[test]
+    fn retry_reapplies_defaults_from_the_baseline_not_the_previous_worker() {
+        let mask = SamplingDefaultsMask::from_request_type(&RequestType::Chat(Arc::new(
+            ChatCompletionRequest::default(),
+        )))
+        .expect("chat requests always carry a mask");
+
+        let worker_a = worker_with_defaults(
+            "grpc://worker-a:30000",
+            Some(r#"{"temperature":0.5,"top_k":7}"#),
+        );
+        let mut request = sglang_request();
+        let baseline = apply_sampling_defaults(&mut request, Some(mask), Some(&worker_a));
+        let stamp = AttemptStamp {
+            id: IdStamp::Exact,
+            sampling_mask: Some(mask),
+            sampling_baseline: baseline,
+            inject_pd_metadata: false,
+        };
+        let mut plan = ExecutionPlan::generate(ExecutionPlanKind::Single, request);
+        {
+            let params = sglang_params(&plan);
+            assert_eq!(params.temperature, 0.5, "worker A's default applied");
+            assert_eq!(params.top_k, 7);
+        }
+
+        // Worker B omits temperature: it must return to the baseline (1.0),
+        // not keep worker A's 0.5.
+        let worker_b = worker_with_defaults("grpc://worker-b:30000", Some(r#"{"top_k":9}"#));
+        restamp_plan_for_attempt(&mut plan, &stamp, &worker_b).unwrap();
+        {
+            let params = sglang_params(&plan);
+            assert_eq!(params.temperature, 1.0, "baseline restored, not worker A's");
+            assert_eq!(params.top_k, 9, "worker B's default applied");
+        }
+
+        // Worker C has no defaults label at all: everything returns to the
+        // baseline.
+        let worker_c = worker_with_defaults("grpc://worker-c:30000", None);
+        restamp_plan_for_attempt(&mut plan, &stamp, &worker_c).unwrap();
+        {
+            let params = sglang_params(&plan);
+            assert_eq!(params.temperature, 1.0);
+            assert_eq!(params.top_k, 3);
+        }
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -227,10 +227,6 @@ impl IdStamp {
     /// Re-mint the retained plan's engine id(s) for a retry attempt. A plan
     /// shape that doesn't match the stamp is a build-stage wiring bug: fail
     /// rather than re-dispatch the previous attempt's engine ids.
-    #[expect(
-        clippy::result_large_err,
-        reason = "Response is the standard error type in the pipeline stage pattern"
-    )]
     pub(crate) fn restamp(&self, plan: &mut ExecutionPlan) -> Result<(), Response> {
         match self {
             Self::Exact => Ok(()),
@@ -297,10 +293,6 @@ impl SamplingBaseline {
     }
 
     /// Reset the masked fields to their pre-default values.
-    #[expect(
-        clippy::result_large_err,
-        reason = "Response is the standard error type in the pipeline stage pattern"
-    )]
     fn restore_masked(
         &self,
         request: &mut ProtoGenerateRequest,
@@ -372,10 +364,6 @@ impl SamplingBaseline {
 /// bootstrap/rendezvous rooms. EPD encode bootstrap info is deliberately
 /// untouched — those rooms are the rendezvous with encode jobs the first
 /// dispatch already launched.
-#[expect(
-    clippy::result_large_err,
-    reason = "Response is the standard error type in the pipeline stage pattern"
-)]
 pub(crate) fn restamp_plan_for_attempt(
     plan: &mut ExecutionPlan,
     stamp: &AttemptStamp,
@@ -1422,5 +1410,104 @@ mod sampling_restamp_tests {
             assert_eq!(params.temperature, 1.0);
             assert_eq!(params.top_k, 3);
         }
+    }
+}
+
+#[cfg(test)]
+mod epd_restamp_tests {
+    use std::sync::Arc;
+
+    use smg_grpc_client::tokenspeed_proto;
+
+    use super::*;
+    use crate::{
+        routers::grpc::{context::ExecutionPlanKind, proto_wrapper::EncodeItemBootstrapInfo},
+        worker::{BasicWorkerBuilder, RuntimeType, Worker, WorkerType},
+    };
+
+    fn tokenspeed_pd_pair(prefill_url: &str, decode_url: &str) -> WorkerSelection {
+        let prefill: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new(prefill_url)
+                .worker_type(WorkerType::Prefill)
+                .build(),
+        );
+        let decode: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new(decode_url)
+                .worker_type(WorkerType::Decode)
+                .build(),
+        );
+        WorkerSelection::Disaggregated {
+            encode_assignments: None,
+            prefill,
+            decode,
+            runtime_type: RuntimeType::TokenSpeed,
+        }
+    }
+
+    fn tokenspeed_rendezvous(
+        plan: &ExecutionPlan,
+    ) -> (
+        &tokenspeed_proto::EncodeBootstrapInfo,
+        &tokenspeed_proto::KvBootstrapInfo,
+    ) {
+        match plan {
+            ExecutionPlan::EncodePrefillDecode {
+                request: ProtoGenerateRequest::TokenSpeed(req),
+            } => (
+                req.encode_bootstrap_info.as_ref().unwrap(),
+                req.kv_bootstrap_info.as_ref().unwrap(),
+            ),
+            _ => panic!("expected a TokenSpeed EPD plan"),
+        }
+    }
+
+    /// An EPD retry re-selects only the prefill/decode pair. The PD KV room
+    /// must be re-minted for the new prefill, while the encode rooms must
+    /// survive untouched — the first attempt's encode jobs are already
+    /// parked at those rendezvous points, so re-minting them would strand
+    /// the embeddings.
+    #[test]
+    fn epd_restamp_remints_pd_room_and_keeps_encode_rooms() {
+        let mut request = ProtoGenerateRequest::TokenSpeed(Box::default());
+        request.set_encode_bootstrap_info(vec![EncodeItemBootstrapInfo {
+            item_index: 0,
+            bootstrap_host: "encode-worker".to_string(),
+            bootstrap_port: 9000,
+            bootstrap_room: 41,
+        }]);
+        request.set_kv_bootstrap_info("attempt1-prefill".to_string(), 8998, 42);
+        let mut plan = ExecutionPlan::generate(ExecutionPlanKind::EncodePrefillDecode, request);
+
+        let stamp = AttemptStamp {
+            id: IdStamp::Exact,
+            sampling_mask: None,
+            sampling_baseline: None,
+            inject_pd_metadata: false,
+        };
+        let retry_pair = tokenspeed_pd_pair("grpc://retry-prefill:30000", "grpc://decode:30000");
+        restamp_plan_for_attempt(&mut plan, &stamp, &retry_pair).unwrap();
+
+        let (encode, kv) = tokenspeed_rendezvous(&plan);
+        assert_eq!(
+            (
+                encode.items[0].bootstrap_host.as_str(),
+                encode.items[0].bootstrap_room
+            ),
+            ("encode-worker", 41),
+            "encode rendezvous must survive the retry"
+        );
+        assert_ne!(kv.bootstrap_room, 42, "PD KV room is re-minted per attempt");
+        let new_prefill_host = match &retry_pair {
+            WorkerSelection::Disaggregated { prefill, .. } => {
+                prefill.metadata().bootstrap_host().to_string()
+            }
+            WorkerSelection::Single { .. } => {
+                panic!("tokenspeed_pd_pair builds a disaggregated selection")
+            }
+        };
+        assert_eq!(
+            kv.bootstrap_host, new_prefill_host,
+            "KV rendezvous names the newly selected prefill"
+        );
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/mod.rs
+++ b/model_gateway/src/routers/grpc/common/stages/mod.rs
@@ -21,7 +21,7 @@ pub trait PipelineStage: Send + Sync {
     fn name(&self) -> &'static str;
 }
 
-/// Terminal ingress stage: the last reader of the parsed request. Produces
+/// Final ingress stage: the last reader of the parsed request. Produces
 /// the retained execution plan, the response spec, and the per-attempt stamp.
 #[async_trait]
 pub trait BuildStage: Send + Sync {

--- a/model_gateway/src/routers/grpc/common/stages/mod.rs
+++ b/model_gateway/src/routers/grpc/common/stages/mod.rs
@@ -1,42 +1,56 @@
-//! Common pipeline stages shared across all endpoints and model types
+//! Common pipeline stages shared across all endpoints and model types.
 //!
-//! These stages are endpoint-agnostic and model-agnostic:
-//! - Worker selection
-//! - Client acquisition
-//! - Dispatch metadata generation
-//! - Request execution
+//! The pipeline is two-phase: ingress stages run on [`RequestContext`] (which
+//! owns the parsed request) through request building; the dispatch phase runs
+//! on [`DispatchContext`], which has no request field.
 
 use async_trait::async_trait;
 use axum::response::Response;
 
-use crate::routers::grpc::context::RequestContext;
+use crate::routers::grpc::{
+    context::{BuildOutput, DispatchContext, RequestContext},
+    spec::ResponseSpec,
+};
 
-/// Trait for pipeline stages that process requests
+/// Ingress-phase stage: full access to the parsed request.
 #[async_trait]
 pub trait PipelineStage: Send + Sync {
-    /// Execute this stage, mutating the context
-    ///
-    /// Returns:
-    /// - `Ok(None)` - Continue to next stage
-    /// - `Ok(Some(response))` - Pipeline complete, return this response (e.g., streaming)
-    /// - `Err(response)` - Error occurred, return this error response
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response>;
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response>;
 
     /// Stage name for logging
     fn name(&self) -> &'static str;
+}
+
+/// Terminal ingress stage: the last reader of the parsed request. Produces
+/// the retained execution plan, the response spec, and the per-attempt stamp.
+#[async_trait]
+pub trait BuildStage: Send + Sync {
+    async fn build(&self, ctx: &mut RequestContext) -> Result<BuildOutput, Response>;
+
+    fn name(&self) -> &'static str;
 
     /// Stable descriptor of the stage plus its mode-bearing args, compared
-    /// against golden literals in the pipeline parity test. Stages whose
-    /// construction args vary by mode override this to include them; the default
-    /// emits the short type name (last `::` segment).
+    /// against golden literals in the pipeline parity test.
     #[cfg(test)]
-    fn signature(&self) -> String {
-        std::any::type_name::<Self>()
-            .rsplit("::")
-            .next()
-            .unwrap_or_default()
-            .to_string()
-    }
+    fn signature(&self) -> String;
+}
+
+/// Dispatch-phase stage: consumes one attempt's execution result. The spec is
+/// its only request-derived input.
+///
+/// Returns:
+/// - `Ok(Some(response))` — early response (streaming SSE), return as-is
+/// - `Ok(None)` — final response stored in `ctx.response`
+/// - `Err(response)` — error
+#[async_trait]
+pub trait ProcessStage: Send + Sync {
+    async fn process(
+        &self,
+        ctx: &mut DispatchContext,
+        spec: ResponseSpec,
+    ) -> Result<Option<Response>, Response>;
+
+    fn name(&self) -> &'static str;
 }
 
 mod client_acquisition;
@@ -49,9 +63,9 @@ mod request_execution;
 mod worker_selection;
 
 // Export stage implementations
-pub(crate) use client_acquisition::ClientAcquisitionStage;
-pub(crate) use dispatch_metadata::DispatchMetadataStage;
+pub(crate) use client_acquisition::acquire_clients;
+pub(crate) use dispatch_metadata::prepare_dispatch_metadata;
 pub(crate) use encode::EncodeStage;
 pub(crate) use rate_limit::{RateLimitCell, RateLimitOutcome, RateLimitReserveStage};
-pub(crate) use request_execution::RequestExecutionStage;
+pub(crate) use request_execution::execute_plan;
 pub(crate) use worker_selection::{WorkerSelectionMode, WorkerSelectionStage};

--- a/model_gateway/src/routers/grpc/common/stages/rate_limit.rs
+++ b/model_gateway/src/routers/grpc/common/stages/rate_limit.rs
@@ -1,12 +1,11 @@
 //! Tenant rate-limit reserve stage: admit or reject a logical request once,
-//! before dispatch, reusing the exact input-token count preparation just
-//! produced.
+//! at ingress, reusing the exact input-token count preparation just produced.
 //!
-//! `RetryExecutor` reruns the whole pipeline (this stage included) fresh on
-//! every retry attempt, so [`RateLimitCell`] is threaded in from the router
-//! and shared across attempts of one logical request: the first attempt to
-//! reach this stage reserves (or is denied) and caches the outcome; every
-//! later attempt sees the cached outcome and skips straight through.
+//! Ingress runs once per logical request (retries re-dispatch the retained
+//! plan without re-running this stage), so the reservation is naturally
+//! single-shot. [`RateLimitCell`] is threaded in from the router and holds
+//! the outcome for the paths that resolve it later: non-streaming settle,
+//! the streaming handoff, and the router's close-if-unsettled.
 
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -35,10 +34,10 @@ pub(crate) enum RateLimitOutcome {
     Denied,
 }
 
-/// Shared across every retry attempt of one logical request. `parking_lot::Mutex`
-/// (not `tokio::sync::Mutex`) is fine: `peek`/`set` never hold the lock
-/// across an `.await`, and `RetryExecutor` runs attempts strictly
-/// sequentially, so there's no real contention -- this is just correct
+/// One cell per logical request, holding the reservation outcome for every
+/// later resolver (settle, streaming handoff, close-if-unsettled).
+/// `parking_lot::Mutex` (not `tokio::sync::Mutex`) is fine: `peek`/`set`
+/// never hold the lock across an `.await` -- this is just correct
 /// check-then-act bookkeeping, not a concurrency primitive.
 ///
 /// `Drop` is the safety net for a reservation that never gets the chance to
@@ -124,22 +123,19 @@ impl RateLimitReserveStage {
 
 #[async_trait]
 impl PipelineStage for RateLimitReserveStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response> {
         let Some(manager) = &self.manager else {
-            return Ok(None);
+            return Ok(());
         };
         let Some(cell) = ctx.input.rate_limit_cell.as_ref() else {
-            return Ok(None);
+            return Ok(());
         };
 
         match cell.peek() {
-            Some(RateLimitOutcome::Admitted(_)) => Ok(None),
-            Some(RateLimitOutcome::Denied) => {
-                // Defensive: `should_retry` in router.rs stops the retry loop
-                // as soon as a Denied outcome is cached, so a second attempt
-                // should never actually reach this stage.
-                Err(rejection_response(0))
-            }
+            Some(RateLimitOutcome::Admitted(_)) => Ok(()),
+            // Defensive: ingress runs once per logical request, so a cached
+            // Denied outcome should never be seen here again.
+            Some(RateLimitOutcome::Denied) => Err(rejection_response(0)),
             None => {
                 let Some(tenant_meta) = ctx.input.tenant_request_meta.as_ref() else {
                     // No tenant identity resolved (shouldn't happen once
@@ -149,7 +145,7 @@ impl PipelineStage for RateLimitReserveStage {
                         function = "RateLimitReserveStage::execute",
                         "tenant_request_meta missing; skipping rate-limit reservation"
                     );
-                    return Ok(None);
+                    return Ok(());
                 };
                 let prep = ctx.state.preparation.as_ref().ok_or_else(|| {
                     error!(
@@ -172,7 +168,7 @@ impl PipelineStage for RateLimitReserveStage {
                 match manager.reserve(request).await {
                     Reservation::Admitted(handle) => {
                         cell.set(RateLimitOutcome::Admitted(handle));
-                        Ok(None)
+                        Ok(())
                     }
                     Reservation::Denied { retry_after_secs } => {
                         cell.set(RateLimitOutcome::Denied);

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -1,16 +1,12 @@
-//! Request execution stage: execute gRPC requests from an execution plan.
+//! Request execution: dispatch one attempt of the retained execution plan.
 
 use std::time::Instant;
 
-use async_trait::async_trait;
 use axum::response::Response;
 use futures::future::{join_all, try_join_all};
 use tracing::{debug, error, info_span, Instrument};
 
-use super::{
-    pd_protocol::{DpPlacement, PdDispatch, PdProtocol},
-    PipelineStage,
-};
+use super::pd_protocol::{DpPlacement, PdDispatch, PdProtocol};
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
@@ -22,8 +18,8 @@ use crate::{
         grpc::{
             common::stages::encode::EncodeDispatchPlan,
             context::{
-                ClientSelection, ExecutionPlan, ExecutionPlanKind, ExecutionResult, LoadGuards,
-                PdTiming, RequestContext, WorkerSelection,
+                ClientSelection, DispatchContext, ExecutionPlan, ExecutionPlanKind,
+                ExecutionResult, LoadGuards, PdTiming, WorkerSelection,
             },
             proto_wrapper::{
                 ProtoEmbedRequest, ProtoGenerateRequest, ProtoRequest, ProtoResponseVariant,
@@ -53,467 +49,433 @@ fn pd_leg_labels(workers: &WorkerSelection) -> (&'static str, &'static str) {
     }
 }
 
-/// Request execution stage: execute the plan produced by request building.
-pub(crate) struct RequestExecutionStage;
+/// Dispatch one attempt of the retained plan: create the attempt's load
+/// guards, fan out encode jobs on the first EPD dispatch, and store the
+/// execution result on the context for response processing.
+pub(crate) async fn execute_plan(
+    ctx: &mut DispatchContext,
+    execution_plan: ExecutionPlan,
+) -> Result<(), Response> {
+    // `None` for non-EPD, text-only EPD, or an EPD retry (the first dispatch
+    // consumed it). Taking it transfers the encode jobs' SHM Drop guards
+    // here: dispatch consumes them, while an early error before dispatch
+    // drops them and reclaims the SHM.
+    let encode_dispatch = ctx.encode_outputs.take().map(|o| o.dispatch);
 
-impl RequestExecutionStage {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-#[async_trait]
-impl PipelineStage for RequestExecutionStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        let execution_plan = ctx.state.execution_plan.take().ok_or_else(|| {
-            error!(
-                function = "RequestExecutionStage::execute",
-                "Execution plan not built"
-            );
-            error::internal_error("execution_plan_not_built", "Execution plan not built")
-        })?;
-
-        // `None` for non-EPD or text-only EPD. Taking it transfers the encode
-        // jobs' SHM Drop guards here: dispatch consumes them, while an early
-        // error before dispatch drops them and reclaims the SHM.
-        let encode_dispatch = ctx.state.encode_outputs.take().map(|o| o.dispatch);
-
-        let clients = ctx.state.clients.as_mut().ok_or_else(|| {
-            error!(
-                function = "RequestExecutionStage::execute",
-                "Client acquisition not completed"
-            );
-            error::internal_error(
-                "client_acquisition_not_completed",
-                "Client acquisition not completed",
-            )
-        })?;
-
-        // Create load guards for worker load tracking (increment load when created)
-        // They will be automatically dropped (and decrement load) when RequestContext is dropped
-        let workers = ctx.state.workers.as_ref().ok_or_else(|| {
-            error!(
-                function = "RequestExecutionStage::execute",
-                "Worker selection not completed"
-            );
-            error::internal_error(
-                "worker_selection_not_completed",
-                "Worker selection not completed",
-            )
-        })?;
-
-        let sub_requests = match &execution_plan {
-            ExecutionPlan::Batch { requests, .. } => requests.len(),
-            _ => 1,
-        };
-        ctx.state.load_guards = Some(LoadGuards::scaled(
-            workers,
-            ctx.state.sticky_key.as_deref(),
-            sub_requests,
-        ));
-
-        // Extract dispatch metadata for tracing span
-        let dispatch = ctx.state.dispatch.as_ref();
-        let request_id = dispatch.map(|d| d.request_id.as_str()).unwrap_or("unknown");
-        let model = dispatch.map(|d| d.model.as_str()).unwrap_or("unknown");
-        let request_type = execution_plan.request_type();
-        let mode = execution_plan.mode_label();
-
-        // Create OTEL span for gRPC request execution
-        let span = info_span!(
-            target: "smg::otel-trace",
-            "grpc_execute",
-            request_type,
-            request_id = %request_id,
-            model = %model,
-            mode = %mode,
+    let clients = ctx.clients.as_mut().ok_or_else(|| {
+        error!(
+            function = "execute_plan",
+            "Client acquisition not completed"
         );
+        error::internal_error(
+            "client_acquisition_not_completed",
+            "Client acquisition not completed",
+        )
+    })?;
 
-        let result = async {
-            match execution_plan {
-                ExecutionPlan::Single(request) => match request {
-                    ProtoRequest::Generate(req) => self.execute_single(req, clients, workers).await,
-                    ProtoRequest::Embed(req) => {
-                        self.execute_single_embed(req, clients, workers).await
-                    }
-                },
-                ExecutionPlan::PrefillDecode(req) => {
-                    self.execute_pd_dispatch(req, clients, workers, model).await
-                }
-                ExecutionPlan::EncodePrefillDecode { request } => {
-                    // Bootstrap info was injected into the prefill request during
-                    // request building; dispatch the encode jobs with the
-                    // prefill+decode leg.
-                    self.execute_epd_dispatch(request, clients, workers, model, encode_dispatch)
-                        .await
-                }
-                ExecutionPlan::Batch { kind, requests, .. } => {
-                    self.execute_batch_dispatch(kind, requests, clients, workers, model)
-                        .await
-                }
-            }
-        }
-        .instrument(span)
-        .await?;
+    // Create load guards for worker load tracking (increment load when created)
+    // They will be automatically dropped (and decrement load) when the
+    // dispatch context (or the streaming body they are attached to) drops.
+    let workers = ctx.workers.as_ref().ok_or_else(|| {
+        error!(function = "execute_plan", "Worker selection not completed");
+        error::internal_error(
+            "worker_selection_not_completed",
+            "Worker selection not completed",
+        )
+    })?;
 
-        // Store result in context for ResponseProcessingStage
-        ctx.state.response.execution_result = Some(result);
-        Ok(None)
-    }
+    let sub_requests = match &execution_plan {
+        ExecutionPlan::Batch { requests, .. } => requests.len(),
+        _ => 1,
+    };
+    ctx.load_guards = Some(LoadGuards::scaled(
+        workers,
+        ctx.sticky_key.as_deref(),
+        sub_requests,
+    ));
 
-    fn name(&self) -> &'static str {
-        "RequestExecution"
-    }
-}
+    // Extract dispatch metadata for the tracing span and PD metric labels.
+    let dispatch = ctx.dispatch.as_ref().ok_or_else(|| {
+        error!(function = "execute_plan", "Dispatch metadata not set");
+        error::internal_error("dispatch_metadata_not_set", "Dispatch metadata not set")
+    })?;
+    let request_id = dispatch.request_id.as_str();
+    let model = dispatch.model.as_str();
+    let request_type = execution_plan.request_type();
+    let mode = execution_plan.mode_label();
 
-impl RequestExecutionStage {
-    async fn execute_pd_dispatch(
-        &self,
-        proto_request: ProtoGenerateRequest,
-        clients: &mut ClientSelection,
-        workers: &WorkerSelection,
-        model: &str,
-    ) -> Result<ExecutionResult, Response> {
-        let Some(runtime_type) = workers.disaggregated_runtime_type() else {
-            error!(
-                function = "RequestExecutionStage::execute",
-                "PD mode requires disaggregated worker selection"
-            );
-            return Err(error::internal_error(
-                "pd_mode_requires_disaggregated_workers",
-                "PD mode requires disaggregated worker selection",
-            ));
-        };
-        let Some(protocol) = PdProtocol::for_runtime(*runtime_type) else {
-            error!(
-                function = "RequestExecutionStage::execute",
-                runtime_type = ?runtime_type,
-                "Runtime does not support PD disaggregated mode"
-            );
-            return Err(error::bad_request(
-                "runtime_pd_not_supported",
-                "This runtime does not support PD disaggregated mode",
-            ));
-        };
-        // Dispatch shape comes from the per-runtime PD protocol table (see
-        // `PdProtocol::for_runtime`): sequential legs relay the KV handoff
-        // through the router, parallel legs rendezvous on bootstrap info
-        // carried in the request.
-        match protocol.dispatch {
-            PdDispatch::Sequential => {
-                self.execute_sequential_pd(proto_request, clients, workers, model)
-                    .await
-            }
-            PdDispatch::Parallel => {
-                self.execute_parallel_pd(proto_request, clients, workers, protocol)
-                    .await
-            }
-        }
-    }
+    // Create OTEL span for gRPC request execution
+    let span = info_span!(
+        target: "smg::otel-trace",
+        "grpc_execute",
+        request_type,
+        request_id = %request_id,
+        model = %model,
+        mode = %mode,
+    );
 
-    async fn execute_epd_dispatch(
-        &self,
-        mut proto_request: ProtoGenerateRequest,
-        clients: &mut ClientSelection,
-        workers: &WorkerSelection,
-        model: &str,
-        encode_dispatch: Option<EncodeDispatchPlan>,
-    ) -> Result<ExecutionResult, Response> {
-        if let Some(encode_dispatch) = encode_dispatch {
-            Self::spawn_encode_dispatch(encode_dispatch);
-        }
-        proto_request.clear_mm_pixel_values();
-        self.execute_pd_dispatch(proto_request, clients, workers, model)
-            .await
-    }
-
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "EPD encode dispatch is intentionally supervised in the background while the prefill leg blocks on embedding receive."
-    )]
-    fn spawn_encode_dispatch(encode_dispatch: EncodeDispatchPlan) {
-        if encode_dispatch.is_empty() {
-            return;
-        }
-
-        let num_encode_items = encode_dispatch.len();
-        let sends: Vec<_> = encode_dispatch
-            .into_jobs()
-            .into_iter()
-            .map(|job| tokio::spawn(async move { job.dispatch().await }))
-            .collect();
-
-        debug!(
-            num_encode_items,
-            "EPD encode dispatch issued with prefill/decode"
-        );
-
-        tokio::spawn(async move {
-            for join_res in join_all(sends).await {
-                match join_res {
-                    Ok(Ok(())) => {}
-                    Ok(Err(message)) => {
-                        error!(
-                            function = "RequestExecutionStage::execute_epd_dispatch",
-                            error = %message,
-                            "Backend encode dispatch failed after EPD dispatch; embedding-receive timeout will abort the request"
-                        );
-                    }
-                    Err(join_err) => {
-                        error!(
-                            function = "RequestExecutionStage::execute_epd_dispatch",
-                            error = %join_err,
-                            "Encode dispatch task panicked after EPD dispatch"
-                        );
-                    }
-                }
-            }
-        });
-    }
-
-    /// Dispatch one backend request per batched prompt concurrently, preserving
-    /// prompt order. Fail-fast: the first failed dispatch fails the batch and
-    /// drops the remaining streams (abort-on-drop reclaims them backend-side).
-    async fn execute_batch_dispatch(
-        &self,
-        kind: ExecutionPlanKind,
-        requests: Vec<ProtoGenerateRequest>,
-        clients: &ClientSelection,
-        workers: &WorkerSelection,
-        model: &str,
-    ) -> Result<ExecutionResult, Response> {
-        let dispatches = requests.into_iter().map(|request| {
-            let mut clients = clients.clone();
-            async move {
-                match kind {
-                    ExecutionPlanKind::Single => {
-                        self.execute_single(request, &mut clients, workers).await
-                    }
-                    // Completion EPD carries no encode jobs; sub-requests dispatch as PD.
-                    ExecutionPlanKind::PrefillDecode | ExecutionPlanKind::EncodePrefillDecode => {
-                        self.execute_pd_dispatch(request, &mut clients, workers, model)
-                            .await
-                    }
-                }
-            }
-        });
-
-        let results = try_join_all(dispatches).await?;
-        Ok(ExecutionResult::Batch { results })
-    }
-
-    async fn execute_single(
-        &self,
-        mut proto_request: ProtoGenerateRequest,
-        clients: &mut ClientSelection,
-        workers: &WorkerSelection,
-    ) -> Result<ExecutionResult, Response> {
-        let client = clients.single_mut().ok_or_else(|| {
-            error!(
-                function = "execute_single",
-                "Expected single client but got disaggregated"
-            );
-            error::internal_error(
-                "expected_single_client_got_disaggregated",
-                "Expected single client but got disaggregated",
-            )
-        })?;
-
-        if let Some(rank) = workers.single().and_then(|w| w.dp_rank()) {
-            proto_request.set_data_parallel_rank(rank as i32);
-        }
-
-        let result = client.generate(proto_request).await;
-        workers.record_outcome(result.cb_status_code());
-
-        let stream = result.map_err(|e| {
-            error!(function = "execute_single", error = %e, "Failed to start generation");
-            e.to_http_error(
-                "start_generation_failed",
-                format!("Failed to start generation: {}", e.message()),
-            )
-        })?;
-
-        Ok(ExecutionResult::Single { stream })
-    }
-
-    async fn execute_single_embed(
-        &self,
-        proto_request: ProtoEmbedRequest,
-        clients: &mut ClientSelection,
-        workers: &WorkerSelection,
-    ) -> Result<ExecutionResult, Response> {
-        let client = clients.single_mut().ok_or_else(|| {
-            error!(
-                function = "execute_single_embed",
-                "Expected single client but got disaggregated"
-            );
-            error::internal_error(
-                "expected_single_client_got_disaggregated",
-                "Expected single client but got disaggregated",
-            )
-        })?;
-
-        let result = client.embed(proto_request).await;
-        workers.record_outcome(result.cb_status_code());
-
-        let complete = result.map_err(|e| {
-            error!(function = "execute_single_embed", error = %e, "Failed to start embedding");
-            e.to_http_error(
-                "start_embedding_failed",
-                format!("Failed to start embedding: {}", e.message()),
-            )
-        })?;
-
-        Ok(ExecutionResult::Embedding { response: complete })
-    }
-
-    async fn execute_parallel_pd(
-        &self,
-        proto_request: ProtoGenerateRequest,
-        clients: &mut ClientSelection,
-        workers: &WorkerSelection,
-        protocol: PdProtocol,
-    ) -> Result<ExecutionResult, Response> {
-        let runtime = workers
-            .disaggregated_runtime_type()
-            .map(|r| r.as_str())
-            .unwrap_or("");
-        let (prefill_client, decode_client) = clients.disaggregated_mut().ok_or_else(|| {
-            error!(
-                function = "execute_parallel_pd",
-                "Expected disaggregated clients but got single"
-            );
-            error::internal_error(
-                "expected_disaggregated_clients_got_single",
-                "Expected disaggregated clients but got single",
-            )
-        })?;
-
-        // Decode consumes the KV handoff from prefill, but TokenSpeed still
-        // needs multimodal metadata to pad placeholders and compute MRoPE in
-        // the same way as prefill. Drop raw pixels and prefill-only encode
-        // rooms, but keep the per-item metadata. The pixel-free leg is the
-        // clone, so pixel tensors are never duplicated.
-        let mut prefill_request = proto_request;
-        let mut decode_request = prefill_request.clone_without_mm_pixels();
-        decode_request.clear_encode_bootstrap_info();
-        // Pin each leg's DP rank only when the engine reads placement from
-        // the request field; `RoomResidue` engines take it from the bootstrap
-        // room minted in maybe_inject_pd_rendezvous, ignore the pin, and spam
-        // conflict warnings on a mismatched decode-leg pin.
-        if protocol.dp_placement == DpPlacement::PinField {
-            if let Some(rank) = workers.prefill_worker().and_then(|w| w.dp_rank()) {
-                prefill_request.set_data_parallel_rank(rank as i32);
-            }
-            if let Some(rank) = workers.decode_worker().and_then(|w| w.dp_rank()) {
-                decode_request.set_data_parallel_rank(rank as i32);
-            }
-        }
-
-        // `generate` only establishes the prefill stream here (SMG does not drain
-        // it on this path), so prefill duration cannot be measured — only TTFT,
-        // recorded at the first decode token in streaming. prefill_start anchors it.
-        let prefill_start = Instant::now();
-        let (prefill_result, decode_result): (StreamResult, StreamResult) = tokio::join!(
-            prefill_client.generate(prefill_request),
-            decode_client.generate(decode_request)
-        );
-
-        // Record circuit breaker outcomes (client errors don't count as failures)
-        workers.record_prefill_decode_outcomes(
-            prefill_result.cb_status_code(),
-            decode_result.cb_status_code(),
-        );
-
-        let (prefill_label, decode_label) = pd_leg_labels(workers);
-
-        // Handle prefill result
-        let prefill_stream = prefill_result.map_err(|e| {
-            Metrics::record_worker_error(
-                metrics_labels::WORKER_PREFILL,
-                prefill_label,
-                metrics_labels::ERROR_BACKEND,
-            );
-            error!(function = "execute_parallel_pd", error = %e, "Prefill worker failed to start");
-            e.to_http_error(
-                "prefill_worker_failed_to_start",
-                format!("Prefill worker failed to start: {}", e.message()),
-            )
-        })?;
-
-        // Handle decode result
-        let decode_stream = decode_result.map_err(|e| {
-            Metrics::record_worker_error(
-                metrics_labels::WORKER_DECODE,
-                decode_label,
-                metrics_labels::ERROR_BACKEND,
-            );
-            error!(function = "execute_parallel_pd", error = %e, "Decode worker failed to start");
-            e.to_http_error(
-                "decode_worker_failed_to_start",
-                format!("Decode worker failed to start: {}", e.message()),
-            )
-        })?;
-
-        // A client disconnect drops both leg streams, which normally fires an
-        // immediate abort to each worker. The decode leg must not be aborted
-        // while it is still receiving the KV handoff from prefill — tearing
-        // the request down mid-transfer can crash or leak on the engine — so
-        // its abort is deferred until the first decode response (the proof
-        // the handoff completed). The prefill leg keeps the immediate abort:
-        // if prefill is still running there is nothing to hand off yet, and
-        // stopping it promptly frees capacity.
-        let decode_stream = decode_stream.defer_abort_until_first_item();
-
-        Ok(ExecutionResult::PrefillDecode {
-            prefill: prefill_stream,
-            decode: Box::new(decode_stream),
-            pd_timing: PdTiming {
-                prefill_start,
-                runtime,
+    let result = async {
+        match execution_plan {
+            ExecutionPlan::Single(request) => match request {
+                ProtoRequest::Generate(req) => execute_single(req, clients, workers).await,
+                ProtoRequest::Embed(req) => execute_single_embed(req, clients, workers).await,
             },
-        })
+            ExecutionPlan::PrefillDecode(req) => {
+                execute_pd_dispatch(req, clients, workers, model).await
+            }
+            ExecutionPlan::EncodePrefillDecode { request } => {
+                // Bootstrap info was injected into the prefill request during
+                // request building; dispatch the encode jobs with the
+                // prefill+decode leg.
+                execute_epd_dispatch(request, clients, workers, model, encode_dispatch).await
+            }
+            ExecutionPlan::Batch { kind, requests, .. } => {
+                execute_batch_dispatch(kind, requests, clients, workers, model).await
+            }
+        }
+    }
+    .instrument(span)
+    .await?;
+
+    // Store result in context for response processing
+    ctx.response.execution_result = Some(result);
+    Ok(())
+}
+
+async fn execute_pd_dispatch(
+    proto_request: ProtoGenerateRequest,
+    clients: &mut ClientSelection,
+    workers: &WorkerSelection,
+    model: &str,
+) -> Result<ExecutionResult, Response> {
+    let Some(runtime_type) = workers.disaggregated_runtime_type() else {
+        error!(
+            function = "execute_pd_dispatch",
+            "PD mode requires disaggregated worker selection"
+        );
+        return Err(error::internal_error(
+            "pd_mode_requires_disaggregated_workers",
+            "PD mode requires disaggregated worker selection",
+        ));
+    };
+    let Some(protocol) = PdProtocol::for_runtime(*runtime_type) else {
+        error!(
+            function = "execute_pd_dispatch",
+            runtime_type = ?runtime_type,
+            "Runtime does not support PD disaggregated mode"
+        );
+        return Err(error::bad_request(
+            "runtime_pd_not_supported",
+            "This runtime does not support PD disaggregated mode",
+        ));
+    };
+    // Dispatch shape comes from the per-runtime PD protocol table (see
+    // `PdProtocol::for_runtime`): sequential legs relay the KV handoff
+    // through the router, parallel legs rendezvous on bootstrap info
+    // carried in the request.
+    match protocol.dispatch {
+        PdDispatch::Sequential => {
+            execute_sequential_pd(proto_request, clients, workers, model).await
+        }
+        PdDispatch::Parallel => {
+            execute_parallel_pd(proto_request, clients, workers, protocol).await
+        }
+    }
+}
+
+async fn execute_epd_dispatch(
+    mut proto_request: ProtoGenerateRequest,
+    clients: &mut ClientSelection,
+    workers: &WorkerSelection,
+    model: &str,
+    encode_dispatch: Option<EncodeDispatchPlan>,
+) -> Result<ExecutionResult, Response> {
+    if let Some(encode_dispatch) = encode_dispatch {
+        spawn_encode_dispatch(encode_dispatch);
+    }
+    proto_request.clear_mm_pixel_values();
+    execute_pd_dispatch(proto_request, clients, workers, model).await
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "EPD encode dispatch is intentionally supervised in the background while the prefill leg blocks on embedding receive."
+)]
+fn spawn_encode_dispatch(encode_dispatch: EncodeDispatchPlan) {
+    if encode_dispatch.is_empty() {
+        return;
     }
 
-    /// Execute vLLM PD: send to prefill with max_tokens=1 first, wait for completion,
-    /// then send original request to decode.
-    ///
-    /// For Mooncake: injects bootstrap_host/port from prefill worker metadata into
-    /// the decode request. For NIXL: tags the prefill request with do_remote_decode,
-    /// then relays the kv_transfer_params returned by the prefill engine to decode.
-    async fn execute_sequential_pd(
-        &self,
-        mut proto_request: ProtoGenerateRequest,
-        clients: &mut ClientSelection,
-        workers: &WorkerSelection,
-        model: &str,
-    ) -> Result<ExecutionResult, Response> {
-        let runtime = workers
-            .disaggregated_runtime_type()
-            .map(|r| r.as_str())
-            .unwrap_or("");
-        let (prefill_client, decode_client) = clients.disaggregated_mut().ok_or_else(|| {
-            error!(
-                function = "execute_sequential_pd",
-                "Expected disaggregated clients but got single"
-            );
-            error::internal_error(
-                "expected_disaggregated_clients_got_single",
-                "Expected disaggregated clients but got single",
-            )
-        })?;
+    let num_encode_items = encode_dispatch.len();
+    let sends: Vec<_> = encode_dispatch
+        .into_jobs()
+        .into_iter()
+        .map(|job| tokio::spawn(async move { job.dispatch().await }))
+        .collect();
 
-        let mode = workers
-            .prefill_worker()
-            .map(|w| connector_mode_for_worker(w.as_ref()))
-            .unwrap_or(KvConnectorMode::Passthrough);
+    debug!(
+        num_encode_items,
+        "EPD encode dispatch issued with prefill/decode"
+    );
 
-        // Recorded on the success path (after decode established) so failed
-        // requests don't pollute success metrics; captured here before use of mode.
-        let kv_connector_label = mode.metrics_label();
+    tokio::spawn(async move {
+        for join_res in join_all(sends).await {
+            match join_res {
+                Ok(Ok(())) => {}
+                Ok(Err(message)) => {
+                    error!(
+                        function = "execute_epd_dispatch",
+                        error = %message,
+                        "Backend encode dispatch failed after EPD dispatch; embedding-receive timeout will abort the request"
+                    );
+                }
+                Err(join_err) => {
+                    error!(
+                        function = "execute_epd_dispatch",
+                        error = %join_err,
+                        "Encode dispatch task panicked after EPD dispatch"
+                    );
+                }
+            }
+        }
+    });
+}
 
-        match &mode {
+/// Dispatch one backend request per batched prompt concurrently, preserving
+/// prompt order. Fail-fast: the first failed dispatch fails the batch and
+/// drops the remaining streams (abort-on-drop reclaims them backend-side).
+async fn execute_batch_dispatch(
+    kind: ExecutionPlanKind,
+    requests: Vec<ProtoGenerateRequest>,
+    clients: &ClientSelection,
+    workers: &WorkerSelection,
+    model: &str,
+) -> Result<ExecutionResult, Response> {
+    let dispatches = requests.into_iter().map(|request| {
+        let mut clients = clients.clone();
+        async move {
+            match kind {
+                ExecutionPlanKind::Single => execute_single(request, &mut clients, workers).await,
+                // Completion EPD carries no encode jobs; sub-requests dispatch as PD.
+                ExecutionPlanKind::PrefillDecode | ExecutionPlanKind::EncodePrefillDecode => {
+                    execute_pd_dispatch(request, &mut clients, workers, model).await
+                }
+            }
+        }
+    });
+
+    let results = try_join_all(dispatches).await?;
+    Ok(ExecutionResult::Batch { results })
+}
+
+async fn execute_single(
+    mut proto_request: ProtoGenerateRequest,
+    clients: &mut ClientSelection,
+    workers: &WorkerSelection,
+) -> Result<ExecutionResult, Response> {
+    let client = clients.single_mut().ok_or_else(|| {
+        error!(
+            function = "execute_single",
+            "Expected single client but got disaggregated"
+        );
+        error::internal_error(
+            "expected_single_client_got_disaggregated",
+            "Expected single client but got disaggregated",
+        )
+    })?;
+
+    if let Some(rank) = workers.single().and_then(|w| w.dp_rank()) {
+        proto_request.set_data_parallel_rank(rank as i32);
+    }
+
+    let result = client.generate(proto_request).await;
+    workers.record_outcome(result.cb_status_code());
+
+    let stream = result.map_err(|e| {
+        error!(function = "execute_single", error = %e, "Failed to start generation");
+        e.to_http_error(
+            "start_generation_failed",
+            format!("Failed to start generation: {}", e.message()),
+        )
+    })?;
+
+    Ok(ExecutionResult::Single { stream })
+}
+
+async fn execute_single_embed(
+    proto_request: ProtoEmbedRequest,
+    clients: &mut ClientSelection,
+    workers: &WorkerSelection,
+) -> Result<ExecutionResult, Response> {
+    let client = clients.single_mut().ok_or_else(|| {
+        error!(
+            function = "execute_single_embed",
+            "Expected single client but got disaggregated"
+        );
+        error::internal_error(
+            "expected_single_client_got_disaggregated",
+            "Expected single client but got disaggregated",
+        )
+    })?;
+
+    let result = client.embed(proto_request).await;
+    workers.record_outcome(result.cb_status_code());
+
+    let complete = result.map_err(|e| {
+        error!(function = "execute_single_embed", error = %e, "Failed to start embedding");
+        e.to_http_error(
+            "start_embedding_failed",
+            format!("Failed to start embedding: {}", e.message()),
+        )
+    })?;
+
+    Ok(ExecutionResult::Embedding { response: complete })
+}
+
+async fn execute_parallel_pd(
+    proto_request: ProtoGenerateRequest,
+    clients: &mut ClientSelection,
+    workers: &WorkerSelection,
+    protocol: PdProtocol,
+) -> Result<ExecutionResult, Response> {
+    let runtime = workers
+        .disaggregated_runtime_type()
+        .map(|r| r.as_str())
+        .unwrap_or("");
+    let (prefill_client, decode_client) = clients.disaggregated_mut().ok_or_else(|| {
+        error!(
+            function = "execute_parallel_pd",
+            "Expected disaggregated clients but got single"
+        );
+        error::internal_error(
+            "expected_disaggregated_clients_got_single",
+            "Expected disaggregated clients but got single",
+        )
+    })?;
+
+    // Decode consumes the KV handoff from prefill, but TokenSpeed still
+    // needs multimodal metadata to pad placeholders and compute MRoPE in
+    // the same way as prefill. Drop raw pixels and prefill-only encode
+    // rooms, but keep the per-item metadata. The pixel-free leg is the
+    // clone, so pixel tensors are never duplicated.
+    let mut prefill_request = proto_request;
+    let mut decode_request = prefill_request.clone_without_mm_pixels();
+    decode_request.clear_encode_bootstrap_info();
+    // Pin each leg's DP rank only when the engine reads placement from
+    // the request field; `RoomResidue` engines take it from the bootstrap
+    // room minted in maybe_inject_pd_rendezvous, ignore the pin, and spam
+    // conflict warnings on a mismatched decode-leg pin.
+    if protocol.dp_placement == DpPlacement::PinField {
+        if let Some(rank) = workers.prefill_worker().and_then(|w| w.dp_rank()) {
+            prefill_request.set_data_parallel_rank(rank as i32);
+        }
+        if let Some(rank) = workers.decode_worker().and_then(|w| w.dp_rank()) {
+            decode_request.set_data_parallel_rank(rank as i32);
+        }
+    }
+
+    // `generate` only establishes the prefill stream here (SMG does not drain
+    // it on this path), so prefill duration cannot be measured — only TTFT,
+    // recorded at the first decode token in streaming. prefill_start anchors it.
+    let prefill_start = Instant::now();
+    let (prefill_result, decode_result): (StreamResult, StreamResult) = tokio::join!(
+        prefill_client.generate(prefill_request),
+        decode_client.generate(decode_request)
+    );
+
+    // Record circuit breaker outcomes (client errors don't count as failures)
+    workers.record_prefill_decode_outcomes(
+        prefill_result.cb_status_code(),
+        decode_result.cb_status_code(),
+    );
+
+    let (prefill_label, decode_label) = pd_leg_labels(workers);
+
+    // Handle prefill result
+    let prefill_stream = prefill_result.map_err(|e| {
+        Metrics::record_worker_error(
+            metrics_labels::WORKER_PREFILL,
+            prefill_label,
+            metrics_labels::ERROR_BACKEND,
+        );
+        error!(function = "execute_parallel_pd", error = %e, "Prefill worker failed to start");
+        e.to_http_error(
+            "prefill_worker_failed_to_start",
+            format!("Prefill worker failed to start: {}", e.message()),
+        )
+    })?;
+
+    // Handle decode result
+    let decode_stream = decode_result.map_err(|e| {
+        Metrics::record_worker_error(
+            metrics_labels::WORKER_DECODE,
+            decode_label,
+            metrics_labels::ERROR_BACKEND,
+        );
+        error!(function = "execute_parallel_pd", error = %e, "Decode worker failed to start");
+        e.to_http_error(
+            "decode_worker_failed_to_start",
+            format!("Decode worker failed to start: {}", e.message()),
+        )
+    })?;
+
+    // A client disconnect drops both leg streams, which normally fires an
+    // immediate abort to each worker. The decode leg must not be aborted
+    // while it is still receiving the KV handoff from prefill — tearing
+    // the request down mid-transfer can crash or leak on the engine — so
+    // its abort is deferred until the first decode response (the proof
+    // the handoff completed). The prefill leg keeps the immediate abort:
+    // if prefill is still running there is nothing to hand off yet, and
+    // stopping it promptly frees capacity.
+    let decode_stream = decode_stream.defer_abort_until_first_item();
+
+    Ok(ExecutionResult::PrefillDecode {
+        prefill: prefill_stream,
+        decode: Box::new(decode_stream),
+        pd_timing: PdTiming {
+            prefill_start,
+            runtime,
+        },
+    })
+}
+
+/// Execute vLLM PD: send to prefill with max_tokens=1 first, wait for completion,
+/// then send original request to decode.
+///
+/// For Mooncake: injects bootstrap_host/port from prefill worker metadata into
+/// the decode request. For NIXL: tags the prefill request with do_remote_decode,
+/// then relays the kv_transfer_params returned by the prefill engine to decode.
+async fn execute_sequential_pd(
+    mut proto_request: ProtoGenerateRequest,
+    clients: &mut ClientSelection,
+    workers: &WorkerSelection,
+    model: &str,
+) -> Result<ExecutionResult, Response> {
+    let runtime = workers
+        .disaggregated_runtime_type()
+        .map(|r| r.as_str())
+        .unwrap_or("");
+    let (prefill_client, decode_client) = clients.disaggregated_mut().ok_or_else(|| {
+        error!(
+            function = "execute_sequential_pd",
+            "Expected disaggregated clients but got single"
+        );
+        error::internal_error(
+            "expected_disaggregated_clients_got_single",
+            "Expected disaggregated clients but got single",
+        )
+    })?;
+
+    let mode = workers
+        .prefill_worker()
+        .map(|w| connector_mode_for_worker(w.as_ref()))
+        .unwrap_or(KvConnectorMode::Passthrough);
+
+    // Recorded on the success path (after decode established) so failed
+    // requests don't pollute success metrics; captured here before use of mode.
+    let kv_connector_label = mode.metrics_label();
+
+    match &mode {
             KvConnectorMode::Mooncake {
                 host,
                 port,
@@ -540,67 +502,67 @@ impl RequestExecutionStage {
             }
         }
 
-        // The KV handoff is single-consumer: with n>1 each fan-out child on decode
-        // would pull, and the first completion frees the prefill blocks under its
-        // siblings (same hazard for NIXL and Mooncake)
-        let relay_kv_params = proto_request.sampling_n() <= 1;
+    // The KV handoff is single-consumer: with n>1 each fan-out child on decode
+    // would pull, and the first completion frees the prefill blocks under its
+    // siblings (same hazard for NIXL and Mooncake)
+    let relay_kv_params = proto_request.sampling_n() <= 1;
 
-        // Mooncake is push-based: the engine returns nothing, so the router mints
-        // the transfer correlation id and synthesizes decode params from metadata
-        let mooncake_transfer_id = match &mode {
-            KvConnectorMode::Mooncake {
-                engine_id: Some(_), ..
-            } if relay_kv_params => Some(format!("xfer-{}", uuid::Uuid::now_v7())),
-            _ => None,
-        };
+    // Mooncake is push-based: the engine returns nothing, so the router mints
+    // the transfer correlation id and synthesizes decode params from metadata
+    let mooncake_transfer_id = match &mode {
+        KvConnectorMode::Mooncake {
+            engine_id: Some(_), ..
+        } if relay_kv_params => Some(format!("xfer-{}", uuid::Uuid::now_v7())),
+        _ => None,
+    };
 
-        // Decode normally reuses the request minus pixels: it receives KV via
-        // the P/D transfer, and prefill reads and unlinks any /dev/shm
-        // segments, so a reused ShmHandle would be unreadable. Same request_id
-        // on both legs is load-bearing for NIXL P/D correlation on vLLM <
-        // 0.13. The pixel-free leg is the clone, so pixel tensors are never
-        // duplicated and die with the prefill send; the per-image mm identity
-        // and grid tensors survive for decode-side hashing and positions.
-        // Without a KV handoff (n>1) decode recomputes the prompt locally and
-        // must run the vision encoder, so that leg keeps the full multimodal
-        // payload (SHM-backed tensors cannot serve both legs and fail loudly
-        // on the decode read).
-        let mut decode_request = if relay_kv_params {
-            proto_request.clone_without_mm_pixels()
+    // Decode normally reuses the request minus pixels: it receives KV via
+    // the P/D transfer, and prefill reads and unlinks any /dev/shm
+    // segments, so a reused ShmHandle would be unreadable. Same request_id
+    // on both legs is load-bearing for NIXL P/D correlation on vLLM <
+    // 0.13. The pixel-free leg is the clone, so pixel tensors are never
+    // duplicated and die with the prefill send; the per-image mm identity
+    // and grid tensors survive for decode-side hashing and positions.
+    // Without a KV handoff (n>1) decode recomputes the prompt locally and
+    // must run the vision encoder, so that leg keeps the full multimodal
+    // payload (SHM-backed tensors cannot serve both legs and fail loudly
+    // on the decode read).
+    let mut decode_request = if relay_kv_params {
+        proto_request.clone_without_mm_pixels()
+    } else {
+        proto_request.clone()
+    };
+    // Sanitize prefill sampling (max_tokens=1, n=1), stream=false.
+    let mut prefill_request = proto_request;
+    prefill_request.sanitize_sampling_for_prefill(1);
+    prefill_request.set_stream(false);
+    if let Some(rank) = workers.prefill_worker().and_then(|w| w.dp_rank()) {
+        prefill_request.set_data_parallel_rank(rank as i32);
+    }
+    if mode == KvConnectorMode::Nixl {
+        if relay_kv_params {
+            prefill_request.set_kv_transfer_params_json(NIXL_PREFILL_KV_PARAMS.to_string());
         } else {
-            proto_request.clone()
-        };
-        // Sanitize prefill sampling (max_tokens=1, n=1), stream=false.
-        let mut prefill_request = proto_request;
-        prefill_request.sanitize_sampling_for_prefill(1);
-        prefill_request.set_stream(false);
-        if let Some(rank) = workers.prefill_worker().and_then(|w| w.dp_rank()) {
-            prefill_request.set_data_parallel_rank(rank as i32);
+            debug!(
+                request_id = %prefill_request.request_id(),
+                "vLLM PD (NIXL): n>1 request, skipping kv_transfer_params relay \
+                 (decode recomputes the prompt locally)"
+            );
         }
-        if mode == KvConnectorMode::Nixl {
-            if relay_kv_params {
-                prefill_request.set_kv_transfer_params_json(NIXL_PREFILL_KV_PARAMS.to_string());
-            } else {
-                debug!(
-                    request_id = %prefill_request.request_id(),
-                    "vLLM PD (NIXL): n>1 request, skipping kv_transfer_params relay \
-                     (decode recomputes the prompt locally)"
-                );
-            }
-        }
-        if let Some(ref transfer_id) = mooncake_transfer_id {
-            prefill_request.set_kv_transfer_params_json(mooncake_prefill_params(transfer_id));
-        }
+    }
+    if let Some(ref transfer_id) = mooncake_transfer_id {
+        prefill_request.set_kv_transfer_params_json(mooncake_prefill_params(transfer_id));
+    }
 
-        debug!(
-            request_id = %prefill_request.request_id(),
-            "vLLM PD: sending prefill request (max_tokens=1)"
-        );
+    debug!(
+        request_id = %prefill_request.request_id(),
+        "vLLM PD: sending prefill request (max_tokens=1)"
+    );
 
-        // Send to prefill, wait for completion
-        let (prefill_label, decode_label) = pd_leg_labels(workers);
-        let prefill_start = Instant::now();
-        let mut prefill_stream = prefill_client
+    // Send to prefill, wait for completion
+    let (prefill_label, decode_label) = pd_leg_labels(workers);
+    let prefill_start = Instant::now();
+    let mut prefill_stream = prefill_client
             .generate(prefill_request)
             .await
             .map_err(|e| {
@@ -614,141 +576,138 @@ impl RequestExecutionStage {
                 e.to_http_error("prefill_worker_failed_to_start", format!("Prefill worker failed to start: {}", e.message()))
             })?;
 
-        // Drain prefill response, harvesting connector params from the Complete frame
-        let mut prefill_kv_params: Option<String> = None;
-        while let Some(result) = prefill_stream.next().await {
-            match result {
-                Ok(response) => {
-                    if let ProtoResponseVariant::Complete(complete) = response.into_response() {
-                        if let Some(json) = complete.kv_transfer_params_json() {
-                            prefill_kv_params = Some(json.to_owned());
-                        }
+    // Drain prefill response, harvesting connector params from the Complete frame
+    let mut prefill_kv_params: Option<String> = None;
+    while let Some(result) = prefill_stream.next().await {
+        match result {
+            Ok(response) => {
+                if let ProtoResponseVariant::Complete(complete) = response.into_response() {
+                    if let Some(json) = complete.kv_transfer_params_json() {
+                        prefill_kv_params = Some(json.to_owned());
                     }
                 }
-                Err(e) => {
-                    workers.record_outcome_prefill(e.http_status().as_u16());
-                    Metrics::record_worker_error(
-                        metrics_labels::WORKER_PREFILL,
-                        prefill_label,
-                        metrics_labels::ERROR_BACKEND,
-                    );
-                    error!(function = "execute_sequential_pd", error = %e, "Prefill stream error");
-                    return Err(e.to_http_error(
-                        "prefill_stream_error",
-                        format!("Prefill stream error: {}", e.message()),
-                    ));
-                }
             }
-        }
-        prefill_stream.mark_completed();
-        workers.record_outcome_prefill(200);
-        // Captured at drain; recorded below only once decode is established.
-        let prefill_duration = prefill_start.elapsed();
-
-        // KV-transfer window: prefill drain complete to decode send complete.
-        let kv_window_start = Instant::now();
-
-        debug!("vLLM PD: prefill completed, sending decode request");
-
-        if let Some(rank) = workers.decode_worker().and_then(|w| w.dp_rank()) {
-            decode_request.set_data_parallel_rank(rank as i32);
-        }
-        match (&mode, prefill_kv_params) {
-            // Modern Mooncake: synthesized params under the minted transfer_id
-            (
-                KvConnectorMode::Mooncake {
-                    host,
-                    port,
-                    engine_id: Some(engine_id),
-                },
-                _,
-            ) if mooncake_transfer_id.is_some() => {
-                let transfer_id = mooncake_transfer_id.as_deref().unwrap_or_default();
-                debug!(
-                    request_id = %decode_request.request_id(),
-                    transfer_id = %transfer_id,
-                    "vLLM PD (Mooncake): injecting minted kv_transfer_params into decode request"
+            Err(e) => {
+                workers.record_outcome_prefill(e.http_status().as_u16());
+                Metrics::record_worker_error(
+                    metrics_labels::WORKER_PREFILL,
+                    prefill_label,
+                    metrics_labels::ERROR_BACKEND,
                 );
-                decode_request.set_kv_transfer_params_json(mooncake_decode_params(
-                    transfer_id,
-                    engine_id,
-                    host,
-                    *port,
+                error!(function = "execute_sequential_pd", error = %e, "Prefill stream error");
+                return Err(e.to_http_error(
+                    "prefill_stream_error",
+                    format!("Prefill stream error: {}", e.message()),
                 ));
             }
-            // Legacy Mooncake (no engine_id discovered, or n>1): typed host/port injection
-            (KvConnectorMode::Mooncake { host, port, .. }, _) => {
-                debug!(
-                    remote_host = %host,
-                    remote_port = port,
-                    "vLLM PD: injecting kv_transfer_params into decode request"
-                );
-                decode_request.set_kv_transfer_params(host.clone(), *port);
-            }
-            (KvConnectorMode::Nixl | KvConnectorMode::Passthrough, Some(json))
-                if relay_kv_params =>
-            {
-                debug!(
-                    request_id = %decode_request.request_id(),
-                    params_len = json.len(),
-                    "vLLM PD: relaying prefill kv_transfer_params to decode request"
-                );
-                decode_request.set_kv_transfer_params_json(json);
-            }
-            (KvConnectorMode::Nixl, None) if relay_kv_params => {
-                Metrics::record_pd_kv_transfer_failure();
-                tracing::warn!(
-                    request_id = %decode_request.request_id(),
-                    "vLLM PD (NIXL): prefill returned no kv_transfer_params; decode will \
-                     recompute the prompt locally (outdated smg-grpc-servicer or missing \
-                     kv-transfer-config?)"
-                );
-            }
-            _ => {}
         }
-
-        // Send request to decode
-        let decode_stream = decode_client.generate(decode_request).await.map_err(|e| {
-            workers.record_outcome_decode(e.http_status().as_u16());
-            Metrics::record_worker_error(
-                metrics_labels::WORKER_DECODE,
-                decode_label,
-                metrics_labels::ERROR_BACKEND,
-            );
-            error!(function = "execute_sequential_pd", error = %e, "Decode worker failed to start");
-            e.to_http_error(
-                "decode_worker_failed_to_start",
-                format!("Decode worker failed to start: {}", e.message()),
-            )
-        })?;
-
-        workers.record_outcome_decode(200);
-        // Decode established: record the success-only PD metrics here.
-        Metrics::record_pd_kv_connector_mode(kv_connector_label);
-        Metrics::record_pd_prefill_duration(
-            metrics_labels::BACKEND_PD,
-            model,
-            runtime,
-            prefill_duration,
-        );
-        Metrics::record_pd_kv_transfer_duration(
-            metrics_labels::BACKEND_PD,
-            model,
-            runtime,
-            kv_window_start.elapsed(),
-        );
-
-        // Prefill has completed and its KV blocks are held pending decode's
-        // transfer; aborting decode mid-transfer on a client disconnect can
-        // crash or leak on the engine side. Defer the abort until the first
-        // decode response proves the handoff finished (see the parallel PD
-        // path for the same invariant).
-        let decode_stream = decode_stream.defer_abort_until_first_item();
-
-        Ok(ExecutionResult::Single {
-            stream: decode_stream,
-        })
     }
+    prefill_stream.mark_completed();
+    workers.record_outcome_prefill(200);
+    // Captured at drain; recorded below only once decode is established.
+    let prefill_duration = prefill_start.elapsed();
+
+    // KV-transfer window: prefill drain complete to decode send complete.
+    let kv_window_start = Instant::now();
+
+    debug!("vLLM PD: prefill completed, sending decode request");
+
+    if let Some(rank) = workers.decode_worker().and_then(|w| w.dp_rank()) {
+        decode_request.set_data_parallel_rank(rank as i32);
+    }
+    match (&mode, prefill_kv_params) {
+        // Modern Mooncake: synthesized params under the minted transfer_id
+        (
+            KvConnectorMode::Mooncake {
+                host,
+                port,
+                engine_id: Some(engine_id),
+            },
+            _,
+        ) if mooncake_transfer_id.is_some() => {
+            let transfer_id = mooncake_transfer_id.as_deref().unwrap_or_default();
+            debug!(
+                request_id = %decode_request.request_id(),
+                transfer_id = %transfer_id,
+                "vLLM PD (Mooncake): injecting minted kv_transfer_params into decode request"
+            );
+            decode_request.set_kv_transfer_params_json(mooncake_decode_params(
+                transfer_id,
+                engine_id,
+                host,
+                *port,
+            ));
+        }
+        // Legacy Mooncake (no engine_id discovered, or n>1): typed host/port injection
+        (KvConnectorMode::Mooncake { host, port, .. }, _) => {
+            debug!(
+                remote_host = %host,
+                remote_port = port,
+                "vLLM PD: injecting kv_transfer_params into decode request"
+            );
+            decode_request.set_kv_transfer_params(host.clone(), *port);
+        }
+        (KvConnectorMode::Nixl | KvConnectorMode::Passthrough, Some(json)) if relay_kv_params => {
+            debug!(
+                request_id = %decode_request.request_id(),
+                params_len = json.len(),
+                "vLLM PD: relaying prefill kv_transfer_params to decode request"
+            );
+            decode_request.set_kv_transfer_params_json(json);
+        }
+        (KvConnectorMode::Nixl, None) if relay_kv_params => {
+            Metrics::record_pd_kv_transfer_failure();
+            tracing::warn!(
+                request_id = %decode_request.request_id(),
+                "vLLM PD (NIXL): prefill returned no kv_transfer_params; decode will \
+                 recompute the prompt locally (outdated smg-grpc-servicer or missing \
+                 kv-transfer-config?)"
+            );
+        }
+        _ => {}
+    }
+
+    // Send request to decode
+    let decode_stream = decode_client.generate(decode_request).await.map_err(|e| {
+        workers.record_outcome_decode(e.http_status().as_u16());
+        Metrics::record_worker_error(
+            metrics_labels::WORKER_DECODE,
+            decode_label,
+            metrics_labels::ERROR_BACKEND,
+        );
+        error!(function = "execute_sequential_pd", error = %e, "Decode worker failed to start");
+        e.to_http_error(
+            "decode_worker_failed_to_start",
+            format!("Decode worker failed to start: {}", e.message()),
+        )
+    })?;
+
+    workers.record_outcome_decode(200);
+    // Decode established: record the success-only PD metrics here.
+    Metrics::record_pd_kv_connector_mode(kv_connector_label);
+    Metrics::record_pd_prefill_duration(
+        metrics_labels::BACKEND_PD,
+        model,
+        runtime,
+        prefill_duration,
+    );
+    Metrics::record_pd_kv_transfer_duration(
+        metrics_labels::BACKEND_PD,
+        model,
+        runtime,
+        kv_window_start.elapsed(),
+    );
+
+    // Prefill has completed and its KV blocks are held pending decode's
+    // transfer; aborting decode mid-transfer on a client disconnect can
+    // crash or leak on the engine side. Defer the abort until the first
+    // decode response proves the handoff finished (see the parallel PD
+    // path for the same invariant).
+    let decode_stream = decode_stream.defer_abort_until_first_item();
+
+    Ok(ExecutionResult::Single {
+        stream: decode_stream,
+    })
 }
 
 #[cfg(test)]

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -235,10 +235,6 @@ impl WorkerSelectionStage {
     /// EPD re-selects only the prefill/decode pair — the first dispatch
     /// already launched the encode jobs, and the plan carries their
     /// bootstrap rooms.
-    #[expect(
-        clippy::result_large_err,
-        reason = "Response is the standard error type in the pipeline stage pattern"
-    )]
     pub(crate) fn reselect(&self, ctx: &mut DispatchContext) -> Result<(), Response> {
         let text = ctx.routing.routing_text.as_deref();
         let tokens = if ctx.routing.token_ids.is_empty() {
@@ -399,7 +395,7 @@ impl WorkerSelectionStage {
 
         let filtered;
         let available: &[Arc<dyn Worker>] = if policy_filters_unavailable_workers(policy.as_ref()) {
-            &candidates
+            candidates
         } else {
             filtered = candidates
                 .iter()

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -20,7 +20,10 @@ use crate::{
         common::overload,
         error,
         grpc::{
-            context::{EncodeWorkerAssignment, RequestContext, WorkerSelection},
+            context::{
+                DispatchContext, EncodeWorkerAssignment, RequestContext, RoutingSnapshot,
+                WireConstraint, WorkerSelection,
+            },
             multimodal,
         },
     },
@@ -74,7 +77,7 @@ impl WorkerSelectionStage {
 
 #[async_trait]
 impl PipelineStage for WorkerSelectionStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response> {
         let prep = ctx.state.preparation.as_ref().ok_or_else(|| {
             error!(
                 function = "WorkerSelectionStage::execute",
@@ -104,18 +107,31 @@ impl PipelineStage for WorkerSelectionStage {
                 .sticky_header_key(headers)
                 .map(str::to_string)
         });
+
+        // Selection inputs that survive the request drop: retry attempts
+        // re-select from these. Text is copied only when a configured policy
+        // would actually read it (tokens win otherwise).
+        let keep_text =
+            tokens.is_none() || self.policy_registry.any_policy_needs_request_text(headers);
+        ctx.state.routing_snapshot = Some(RoutingSnapshot {
+            routing_text: keep_text.then(|| text.map(str::to_string)).flatten(),
+            token_ids: ids.to_vec(),
+            rid_key: rid_key.clone(),
+        });
         let rid_key = rid_key.as_deref();
 
         let model_id = ctx.input.model_id.as_str();
         let workers = match self.mode {
             WorkerSelectionMode::Regular => {
-                match self.select_single_worker(model_id, text, tokens, headers, rid_key) {
+                match self.select_single_worker(model_id, text, tokens, headers, rid_key, None) {
                     Some(w) => WorkerSelection::Single { worker: w },
-                    None => return Err(self.selection_failure(model_id, &[WorkerType::Regular])),
+                    None => {
+                        return Err(self.selection_failure(model_id, &[WorkerType::Regular], None))
+                    }
                 }
             }
             WorkerSelectionMode::PrefillDecode => {
-                match self.select_pd_pair(model_id, text, tokens, headers, rid_key) {
+                match self.select_pd_pair(model_id, text, tokens, headers, rid_key, None) {
                     Some((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
                         encode_assignments: None,
                         prefill,
@@ -126,6 +142,7 @@ impl PipelineStage for WorkerSelectionStage {
                         return Err(self.selection_failure(
                             model_id,
                             &[WorkerType::Prefill, WorkerType::Decode],
+                            None,
                         ))
                     }
                 }
@@ -174,7 +191,7 @@ impl PipelineStage for WorkerSelectionStage {
                         } else {
                             &[WorkerType::Prefill, WorkerType::Decode, WorkerType::Encode]
                         };
-                        return Err(self.selection_failure(model_id, legs));
+                        return Err(self.selection_failure(model_id, legs, None));
                     }
                 }
             }
@@ -198,16 +215,72 @@ impl PipelineStage for WorkerSelectionStage {
         }
 
         ctx.state.workers = Some(workers);
-        Ok(None)
+        Ok(())
     }
 
     fn name(&self) -> &'static str {
         "WorkerSelection"
     }
+}
 
+impl WorkerSelectionStage {
     #[cfg(test)]
-    fn signature(&self) -> String {
+    pub(crate) fn signature(&self) -> String {
         format!("WorkerSelectionStage({:?})", self.mode)
+    }
+
+    /// Per-attempt re-selection from the routing snapshot, after the request
+    /// dropped at build. Candidates are pinned to the retained plan's wire
+    /// (runtime + transport): the plan cannot be rebuilt for another flavor.
+    /// EPD re-selects only the prefill/decode pair — the first dispatch
+    /// already launched the encode jobs, and the plan carries their
+    /// bootstrap rooms.
+    #[expect(
+        clippy::result_large_err,
+        reason = "Response is the standard error type in the pipeline stage pattern"
+    )]
+    pub(crate) fn reselect(&self, ctx: &mut DispatchContext) -> Result<(), Response> {
+        let text = ctx.routing.routing_text.as_deref();
+        let tokens = if ctx.routing.token_ids.is_empty() {
+            None
+        } else {
+            Some(ctx.routing.token_ids.as_slice())
+        };
+        let rid_key = ctx.routing.rid_key.as_deref();
+        let headers = ctx.headers.as_ref();
+        let model_id = ctx.model_id.as_str();
+        let wire = Some(ctx.wire);
+
+        let workers = match self.mode {
+            WorkerSelectionMode::Regular => {
+                match self.select_single_worker(model_id, text, tokens, headers, rid_key, wire) {
+                    Some(w) => WorkerSelection::Single { worker: w },
+                    None => {
+                        return Err(self.selection_failure(model_id, &[WorkerType::Regular], wire))
+                    }
+                }
+            }
+            WorkerSelectionMode::PrefillDecode | WorkerSelectionMode::EncodePrefillDecode => {
+                match self.select_pd_pair(model_id, text, tokens, headers, rid_key, wire) {
+                    Some((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
+                        encode_assignments: None,
+                        prefill,
+                        decode,
+                        runtime_type,
+                    },
+                    None => {
+                        return Err(self.selection_failure(
+                            model_id,
+                            &[WorkerType::Prefill, WorkerType::Decode],
+                            wire,
+                        ))
+                    }
+                }
+            }
+        };
+
+        ctx.workers = Some(workers);
+        Ok(())
     }
 }
 
@@ -229,9 +302,17 @@ impl WorkerSelectionStage {
     /// saturated leg made the set unselectable, and an undemanded leg (EPD
     /// without encode items) must not be able to shed a request that never
     /// needed it.
-    fn selection_failure(&self, model_id: &str, legs: &[WorkerType]) -> Response {
+    /// `wire` narrows the verdict to the retained plan's runtime/transport on
+    /// the retry path: a drained pinned pool must not answer 404 just because
+    /// other runtimes still serve the model.
+    fn selection_failure(
+        &self,
+        model_id: &str,
+        legs: &[WorkerType],
+        wire: Option<WireConstraint>,
+    ) -> Response {
         for leg in legs {
-            let candidates = self.leg_candidates(model_id, *leg);
+            let candidates = self.leg_candidates(model_id, *leg, wire);
             if let Some(shed) = overload::shed_if_all_overloaded(&candidates, model_id) {
                 return shed;
             }
@@ -248,7 +329,12 @@ impl WorkerSelectionStage {
     /// The pool one leg selected over, *before* the `is_available()` filter,
     /// under the same worker-type and transport rules selection applied.
     /// Failure path only.
-    fn leg_candidates(&self, model_id: &str, worker_type: WorkerType) -> Vec<Arc<dyn Worker>> {
+    fn leg_candidates(
+        &self,
+        model_id: &str,
+        worker_type: WorkerType,
+        wire: Option<WireConstraint>,
+    ) -> Vec<Arc<dyn Worker>> {
         // One definition shared with selection: the same routing-pool
         // projection, before the `is_available()` filter. Regular selection
         // takes either gRPC-pipeline transport; the disaggregated legs are
@@ -262,7 +348,19 @@ impl WorkerSelectionStage {
         };
         self.worker_registry
             .get_routing_pool(model_id, pool)
-            .to_vec()
+            .iter()
+            .filter(|w| {
+                wire.is_none_or(|c| {
+                    w.metadata().spec.runtime_type == c.runtime
+                        && match worker_type {
+                            WorkerType::Regular => *w.connection_mode() == c.connection,
+                            // Disaggregated legs are gRPC-only regardless of pin.
+                            _ => true,
+                        }
+                })
+            })
+            .cloned()
+            .collect()
     }
 
     fn select_single_worker(
@@ -272,12 +370,29 @@ impl WorkerSelectionStage {
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
+        wire: Option<WireConstraint>,
     ) -> Option<Arc<dyn Worker>> {
         // Get workers for the specified model. The gRPC router serves both gRPC
         // and direct-ZMQ workers, so accept either transport (not HTTP).
-        let candidates = self
+        let pool = self
             .worker_registry
             .get_routing_pool(model_id, RoutingPool::GrpcPipelineRegular);
+        // A retry pins the retained plan's runtime/transport.
+        let wire_pinned;
+        let candidates: &[Arc<dyn Worker>] = match wire {
+            None => &pool,
+            Some(c) => {
+                wire_pinned = pool
+                    .iter()
+                    .filter(|w| {
+                        w.metadata().spec.runtime_type == c.runtime
+                            && *w.connection_mode() == c.connection
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                &wire_pinned
+            }
+        };
 
         // Get the appropriate policy for this model
         let policy = self.policy_registry.get_policy_or_default(model_id);
@@ -349,6 +464,7 @@ impl WorkerSelectionStage {
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
+        wire: Option<WireConstraint>,
     ) -> Option<PdWorkerPair> {
         // Both legs derive from ONE membership snapshot: separate pool
         // lookups could straddle a concurrent replacement and pair workers
@@ -359,6 +475,21 @@ impl WorkerSelectionStage {
         let snapshot = self.worker_registry.get_routing_snapshot(model_id);
         let all_prefill = Self::available_workers(&snapshot, RoutingPool::GrpcPrefill);
         let all_decode = Self::available_workers(&snapshot, RoutingPool::GrpcDecode);
+
+        // Retry re-selection pins both legs to the retained plan's runtime.
+        let (all_prefill, all_decode) = match wire {
+            Some(constraint) => (
+                all_prefill
+                    .into_iter()
+                    .filter(|w| w.metadata().spec.runtime_type == constraint.runtime)
+                    .collect::<Vec<_>>(),
+                all_decode
+                    .into_iter()
+                    .filter(|w| w.metadata().spec.runtime_type == constraint.runtime)
+                    .collect::<Vec<_>>(),
+            ),
+            None => (all_prefill, all_decode),
+        };
 
         if all_prefill.is_empty() {
             warn!("No available prefill workers");
@@ -798,7 +929,7 @@ mod tests {
         let mut decode_hits = HashMap::new();
         for _ in 0..iterations {
             let (prefill, decode, _) = stage
-                .select_pd_pair(model_id, None, None, None, None)
+                .select_pd_pair(model_id, None, None, None, None, None)
                 .expect("select_pd_pair should return a pair");
             *prefill_hits.entry(prefill.url().to_string()).or_default() += 1;
             *decode_hits.entry(decode.url().to_string()).or_default() += 1;
@@ -824,7 +955,7 @@ mod tests {
             WorkerSelectionMode::PrefillDecode,
         );
         assert!(stage
-            .select_pd_pair(model_id, None, None, None, None)
+            .select_pd_pair(model_id, None, None, None, None, None)
             .is_some());
 
         for url in &prefill_urls {
@@ -834,12 +965,12 @@ mod tests {
 
         assert!(
             stage
-                .select_pd_pair(model_id, None, None, None, None)
+                .select_pd_pair(model_id, None, None, None, None, None)
                 .is_none(),
             "the veto empties the prefill pool"
         );
         let response =
-            stage.selection_failure(model_id, &[WorkerType::Prefill, WorkerType::Decode]);
+            stage.selection_failure(model_id, &[WorkerType::Prefill, WorkerType::Decode], None);
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             error::extract_error_code_from_response(&response),
@@ -878,13 +1009,14 @@ mod tests {
         // No prefill/decode workers registered: with encode undemanded this is
         // model absence (404), not pressure.
         let text_only =
-            stage.selection_failure(model_id, &[WorkerType::Prefill, WorkerType::Decode]);
+            stage.selection_failure(model_id, &[WorkerType::Prefill, WorkerType::Decode], None);
         assert_eq!(text_only.status(), StatusCode::NOT_FOUND);
 
         // With encode demanded, the saturated encode pool is a shed.
         let with_encode = stage.selection_failure(
             model_id,
             &[WorkerType::Prefill, WorkerType::Decode, WorkerType::Encode],
+            None,
         );
         assert_eq!(with_encode.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
@@ -900,7 +1032,7 @@ mod tests {
         );
         assert_eq!(
             stage
-                .selection_failure("nobody", &[WorkerType::Prefill, WorkerType::Decode])
+                .selection_failure("nobody", &[WorkerType::Prefill, WorkerType::Decode], None)
                 .status(),
             StatusCode::NOT_FOUND
         );
@@ -1003,7 +1135,7 @@ mod tests {
 
         assert!(
             stage
-                .select_pd_pair(model_id, None, None, None, None)
+                .select_pd_pair(model_id, None, None, None, None, None)
                 .is_none(),
             "ZMQ-only PD pools must not yield a pair"
         );
@@ -1011,7 +1143,7 @@ mod tests {
         // Adding gRPC legs makes selection succeed, and it never picks the ZMQ ones.
         let (prefill_urls, decode_urls) = register_pd_workers(&worker_registry, model_id, 4);
         let (prefill, decode, _) = stage
-            .select_pd_pair(model_id, None, None, None, None)
+            .select_pd_pair(model_id, None, None, None, None, None)
             .expect("gRPC PD pair should be selected");
         assert!(prefill_urls.contains(&prefill.url().to_string()));
         assert!(decode_urls.contains(&decode.url().to_string()));
@@ -1058,7 +1190,7 @@ mod tests {
         let mut poison = HeaderMap::new();
         poison.insert("x-smg-routing-key", "req-unique-1".parse().unwrap());
         let first = stage
-            .select_single_worker(model_id, None, None, Some(&poison), rid_key)
+            .select_single_worker(model_id, None, None, Some(&poison), rid_key, None)
             .unwrap();
         for (i, rid) in ["conv7_t2", "conv7_t2_r1", "conv7_t3"].iter().enumerate() {
             let mut rotated = HeaderMap::new();
@@ -1073,6 +1205,7 @@ mod tests {
                     None,
                     Some(&rotated),
                     policy_registry.derive_rid_key(Some(rid)),
+                    None,
                 )
                 .unwrap();
             assert_eq!(again.url(), first.url(), "follow-up must pin by rid key");
@@ -1110,13 +1243,13 @@ mod tests {
         );
 
         assert!(stage
-            .select_single_worker(model_id, None, None, None, None)
+            .select_single_worker(model_id, None, None, None, None, None)
             .is_some());
 
         worker_registry.set_worker_overloaded(&workers[0], true);
         assert!(
             stage
-                .select_single_worker(model_id, None, None, None, None)
+                .select_single_worker(model_id, None, None, None, None, None)
                 .is_some(),
             "one eligible worker left still serves"
         );
@@ -1124,12 +1257,12 @@ mod tests {
         worker_registry.set_worker_overloaded(&workers[1], true);
         assert!(
             stage
-                .select_single_worker(model_id, None, None, None, None)
+                .select_single_worker(model_id, None, None, None, None, None)
                 .is_none(),
             "the veto empties the candidate pool"
         );
 
-        let response = stage.selection_failure(model_id, &[WorkerType::Regular]);
+        let response = stage.selection_failure(model_id, &[WorkerType::Regular], None);
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             extract_error_code_from_response(&response),
@@ -1140,13 +1273,221 @@ mod tests {
         // genuinely absent model.
         worker_registry.set_worker_overloaded(&workers[0], false);
         assert!(stage
-            .select_single_worker(model_id, None, None, None, None)
+            .select_single_worker(model_id, None, None, None, None, None)
             .is_some());
         assert_eq!(
             stage
-                .selection_failure("no-such-model", &[WorkerType::Regular])
+                .selection_failure("no-such-model", &[WorkerType::Regular], None)
                 .status(),
             StatusCode::NOT_FOUND
+        );
+    }
+
+    fn dispatch_ctx(model_id: &str, wire: WireConstraint) -> DispatchContext {
+        DispatchContext {
+            model_id: model_id.to_string(),
+            dispatch_model: model_id.to_string(),
+            streaming: false,
+            headers: None,
+            rate_limit_cell: None,
+            routing: RoutingSnapshot {
+                routing_text: None,
+                token_ids: vec![1, 2, 3],
+                rid_key: None,
+            },
+            wire,
+            tokenizer: None,
+            workers: None,
+            sticky_key: None,
+            clients: None,
+            encode_outputs: None,
+            dispatch: None,
+            load_guards: None,
+            response: Default::default(),
+        }
+    }
+
+    /// Retry re-selection must never leave the retained plan's wire: the
+    /// runtime AND transport filters both apply, or a retry could pick a
+    /// worker the plan's proto flavor cannot be dispatched to.
+    #[test]
+    fn reselect_pins_regular_candidates_to_the_retained_wire() {
+        let model_id = "wire-pin-model";
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        for (url, runtime, connection) in [
+            (
+                "grpc://127.0.0.1:9300",
+                RuntimeType::Sglang,
+                ConnectionMode::Grpc,
+            ),
+            (
+                "grpc://127.0.0.1:9301",
+                RuntimeType::Vllm,
+                ConnectionMode::Grpc,
+            ),
+            (
+                "ipc:///tmp/smg-wire-pin",
+                RuntimeType::Vllm,
+                ConnectionMode::Zmq,
+            ),
+        ] {
+            worker_registry
+                .register(Arc::new(
+                    BasicWorkerBuilder::new(url)
+                        .model(ModelCard::new(model_id))
+                        .worker_type(WorkerType::Regular)
+                        .connection_mode(connection)
+                        .runtime_type(runtime)
+                        .health_config(no_health_check())
+                        .build(),
+                ))
+                .unwrap();
+        }
+        let stage = WorkerSelectionStage::new(
+            worker_registry,
+            Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
+            WorkerSelectionMode::Regular,
+        );
+
+        let mut ctx = dispatch_ctx(
+            model_id,
+            WireConstraint {
+                runtime: RuntimeType::Vllm,
+                connection: ConnectionMode::Grpc,
+            },
+        );
+        for _ in 0..8 {
+            stage.reselect(&mut ctx).unwrap();
+            match ctx.workers.as_ref().unwrap() {
+                WorkerSelection::Single { worker } => {
+                    assert_eq!(
+                        worker.url(),
+                        "grpc://127.0.0.1:9301",
+                        "reselect must stay on the retained runtime and transport"
+                    );
+                }
+                WorkerSelection::Disaggregated { .. } => panic!("expected single selection"),
+            }
+        }
+    }
+
+    #[test]
+    fn reselect_pins_pd_pair_to_the_retained_runtime() {
+        let model_id = "wire-pin-pd-model";
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        for (url, worker_type, runtime) in [
+            (
+                "grpc://127.0.0.1:9310",
+                WorkerType::Prefill,
+                RuntimeType::Sglang,
+            ),
+            (
+                "grpc://127.0.0.1:9311",
+                WorkerType::Decode,
+                RuntimeType::Sglang,
+            ),
+            (
+                "grpc://127.0.0.1:9312",
+                WorkerType::Prefill,
+                RuntimeType::Vllm,
+            ),
+            (
+                "grpc://127.0.0.1:9313",
+                WorkerType::Decode,
+                RuntimeType::Vllm,
+            ),
+        ] {
+            worker_registry
+                .register(Arc::new(
+                    BasicWorkerBuilder::new(url)
+                        .model(ModelCard::new(model_id))
+                        .worker_type(worker_type)
+                        .connection_mode(ConnectionMode::Grpc)
+                        .runtime_type(runtime)
+                        .health_config(no_health_check())
+                        .build(),
+                ))
+                .unwrap();
+        }
+        let stage = WorkerSelectionStage::new(
+            worker_registry,
+            Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
+            WorkerSelectionMode::PrefillDecode,
+        );
+
+        let mut ctx = dispatch_ctx(
+            model_id,
+            WireConstraint {
+                runtime: RuntimeType::Vllm,
+                connection: ConnectionMode::Grpc,
+            },
+        );
+        for _ in 0..8 {
+            stage.reselect(&mut ctx).unwrap();
+            match ctx.workers.as_ref().unwrap() {
+                WorkerSelection::Disaggregated {
+                    prefill,
+                    decode,
+                    runtime_type,
+                    ..
+                } => {
+                    assert_eq!(*runtime_type, RuntimeType::Vllm);
+                    assert_eq!(prefill.url(), "grpc://127.0.0.1:9312");
+                    assert_eq!(decode.url(), "grpc://127.0.0.1:9313");
+                }
+                WorkerSelection::Single { .. } => panic!("expected PD selection"),
+            }
+        }
+    }
+
+    /// A drained pinned pool must shed (503), not answer 404 just because
+    /// another runtime still serves the model: 404 is non-retryable and would
+    /// end the retry loop on a lie.
+    #[test]
+    fn reselect_verdict_reflects_the_pinned_pool() {
+        let model_id = "wire-verdict-model";
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let mut pinned = None;
+        for (url, runtime) in [
+            ("grpc://127.0.0.1:9320", RuntimeType::Sglang),
+            ("grpc://127.0.0.1:9321", RuntimeType::Vllm),
+        ] {
+            let worker: Arc<dyn Worker> = Arc::new(
+                BasicWorkerBuilder::new(url)
+                    .model(ModelCard::new(model_id))
+                    .worker_type(WorkerType::Regular)
+                    .connection_mode(ConnectionMode::Grpc)
+                    .runtime_type(runtime)
+                    .health_config(no_health_check())
+                    .build(),
+            );
+            worker_registry.register(worker.clone()).unwrap();
+            if runtime == RuntimeType::Vllm {
+                pinned = Some(worker);
+            }
+        }
+        worker_registry.set_worker_overloaded(&pinned.expect("vllm worker registered"), true);
+
+        let stage = WorkerSelectionStage::new(
+            worker_registry,
+            Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
+            WorkerSelectionMode::Regular,
+        );
+        let mut ctx = dispatch_ctx(
+            model_id,
+            WireConstraint {
+                runtime: RuntimeType::Vllm,
+                connection: ConnectionMode::Grpc,
+            },
+        );
+
+        let response = stage
+            .reselect(&mut ctx)
+            .expect_err("the pinned pool is fully vetoed");
+        assert_eq!(
+            response.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "verdict must reflect the pinned pool, not every runtime"
         );
     }
 }

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -1,7 +1,7 @@
 //! Request context types for the two-phase gRPC router pipeline.
 //!
 //! [`RequestContext`] owns the parsed request through the ingress phase;
-//! request building is its terminal consumer and [`RequestContext::into_dispatch`]
+//! request building is its last reader and [`RequestContext::into_dispatch`]
 //! yields the request-free [`DispatchContext`] the dispatch phase runs on.
 
 use std::sync::Arc;
@@ -238,11 +238,11 @@ impl WireConstraint {
 
 /// Post-build request context.
 ///
-/// Invariant, by type structure: there is no request field here, so the
+/// Invariant, by construction: there is no request field here, so the
 /// dispatch phase (worker re-selection, dispatch, response processing,
 /// streaming) cannot reach the parsed request — it dropped in
 /// [`RequestContext::into_dispatch`]. `ResponseSpec` is the only
-/// request-derived channel past this point.
+/// request-derived input past this point.
 pub(crate) struct DispatchContext {
     /// Canonical model ID (routing, registries).
     pub model_id: String,
@@ -399,10 +399,6 @@ impl ExecutionPlan {
     /// Set the engine request id on a non-batch plan. A batch plan here is a
     /// build-stage wiring bug (its sub ids are stamped individually): fail
     /// rather than let a retry re-dispatch the previous attempt's ids.
-    #[expect(
-        clippy::result_large_err,
-        reason = "Response is the standard error type in the pipeline stage pattern"
-    )]
     pub(crate) fn set_request_id(
         &mut self,
         request_id: String,
@@ -716,10 +712,6 @@ impl RequestContext {
     /// Fails loudly when worker selection's outputs (routing snapshot, wire)
     /// are absent: a retry context with defaulted routing inputs could
     /// re-select a worker the retained plan cannot be dispatched to.
-    #[expect(
-        clippy::result_large_err,
-        reason = "Response is the standard error type in the pipeline stage pattern"
-    )]
     pub fn into_dispatch(self) -> Result<DispatchContext, axum::response::Response> {
         let RequestContext {
             input,

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -1,8 +1,8 @@
-//! Request context types for gRPC router pipeline
+//! Request context types for the two-phase gRPC router pipeline.
 //!
-//! This module provides the core context types that flow through the router pipeline,
-//! eliminating deep parameter passing chains and providing a single source of truth
-//! for request state.
+//! [`RequestContext`] owns the parsed request through the ingress phase;
+//! request building is its terminal consumer and [`RequestContext::into_dispatch`]
+//! yields the request-free [`DispatchContext`] the dispatch phase runs on.
 
 use std::sync::Arc;
 
@@ -19,28 +19,34 @@ use openai_protocol::{
 };
 use reasoning_parser::ParserFactory as ReasoningParserFactory;
 use tool_parser::ParserFactory as ToolParserFactory;
-use tracing::debug;
+use tracing::{debug, error};
 
 use super::{
     backend_client::BackendClient,
-    common::stages::{encode::EncodeDispatchPlan, RateLimitCell},
+    common::stages::{
+        encode::EncodeDispatchPlan,
+        helpers::{IdStamp, SamplingBaseline, SamplingDefaultsMask},
+        RateLimitCell,
+    },
     multimodal::{MultimodalComponents, MultimodalIntermediate},
     proto_wrapper::{
         EncodeItemBootstrapInfo, ProtoEmbedComplete, ProtoEmbedRequest, ProtoGenerateRequest,
         ProtoRequest, ProtoStream,
     },
+    spec::ResponseSpec,
     utils::ParserResolver,
 };
 use crate::{
     middleware::TenantRequestMeta,
-    worker::{RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry},
+    routers::error::internal_error,
+    worker::{ConnectionMode, RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry},
 };
 
-/// Main request processing context
+/// Ingress-phase request context: owns the parsed request.
 ///
-/// This is the single source of truth for all request state as it flows
-/// through the pipeline stages. Uses Rust's type system to enforce proper
-/// stage ordering at compile time.
+/// Lives from request entry through request building, which is the terminal
+/// consumer — [`RequestContext::into_dispatch`] drops the request and yields
+/// the [`DispatchContext`] the post-build phase runs on.
 pub(crate) struct RequestContext {
     pub input: RequestInput,
     pub components: Arc<SharedComponents>,
@@ -53,11 +59,13 @@ pub(crate) struct RequestInput {
     pub headers: Option<HeaderMap>,
     /// Canonical model ID used after aliases are resolved at request entry.
     pub model_id: String,
+    /// Captured at construction so it survives the request drop at build.
+    pub streaming: bool,
     pub tenant_request_meta: Option<TenantRequestMeta>,
-    /// Shared across every retry attempt of one logical request so
-    /// `RateLimitReserveStage` reserves at most once. `None` for endpoints
-    /// that haven't opted into tenant rate limiting yet (Responses,
-    /// embeddings, classify).
+    /// Holds the reservation outcome for the whole request (settle on
+    /// success, denial check, streaming handoff). `None` for endpoints that
+    /// haven't opted into tenant rate limiting yet (Responses, embeddings,
+    /// classify).
     pub rate_limit_cell: Option<Arc<RateLimitCell>>,
 }
 
@@ -76,10 +84,10 @@ pub(crate) enum RequestType {
 impl RequestType {
     /// Overwrite the request's own `model` field.
     ///
-    /// Callers hold the request behind an `Arc` that the retry loop also
-    /// holds, so `Arc::make_mut` copies the request here. That cost is paid
-    /// only on the alias path — [`RequestContext::new`] skips this call
-    /// entirely when the client already used the canonical model ID.
+    /// `Arc::make_mut` copies the request when another handle is still
+    /// alive. That cost is paid only on the alias path —
+    /// [`RequestContext::new`] skips this call entirely when the client
+    /// already used the canonical model ID.
     fn set_model(&mut self, model_id: &str) {
         fn replace(model: &mut String, model_id: &str) {
             model.clear();
@@ -152,7 +160,8 @@ pub(crate) struct SharedComponents {
     pub multimodal: Option<Arc<MultimodalComponents>>,
 }
 
-/// Mutable processing state (evolves through pipeline stages)
+/// Ingress-phase state (evolves through preparation, worker selection,
+/// client acquisition, encode, and request building).
 #[derive(Default)]
 pub(crate) struct ProcessingState {
     // Stage 1: Preparation outputs
@@ -179,20 +188,110 @@ pub(crate) struct ProcessingState {
     /// worker selection so load guards account keyed load identically.
     pub sticky_key: Option<String>,
 
+    /// Selection inputs that survive the request drop, captured by worker
+    /// selection for per-attempt re-selection in the dispatch phase.
+    pub routing_snapshot: Option<RoutingSnapshot>,
+
     // Stage 3: Client acquisition outputs
     pub clients: Option<ClientSelection>,
 
-    // Stage 4: Request building outputs
-    pub execution_plan: Option<ExecutionPlan>,
-
-    // Stage 5: Dispatch metadata
-    pub dispatch: Option<DispatchMetadata>,
-
-    // Load guard for worker load tracking (created at execution stage)
-    pub load_guards: Option<LoadGuards>,
-
-    // Stage 6: Response processing state
+    // Response processing state seeded during ingress (stop decoder, router
+    // stop obligations, derived skip_special_tokens).
     pub response: ResponseState,
+}
+
+/// Worker-selection inputs that outlive the parsed request.
+#[derive(Default)]
+pub(crate) struct RoutingSnapshot {
+    /// Captured only when a configured policy actually consumes request text.
+    pub routing_text: Option<String>,
+    /// Routing-affinity token proxy (first prompt for batched completions).
+    pub token_ids: Vec<u32>,
+    /// rid-derived sticky key, derived once at first selection.
+    pub rid_key: Option<String>,
+}
+
+/// The wire the retained plan was built for. Retry re-selection filters
+/// candidates to this (runtime, transport): the plan's proto flavor and its
+/// stop-resolution are wire-specific and cannot be rebuilt post-drop.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct WireConstraint {
+    pub runtime: RuntimeType,
+    pub connection: ConnectionMode,
+}
+
+impl WireConstraint {
+    fn of(workers: &WorkerSelection) -> Self {
+        match workers {
+            WorkerSelection::Single { worker } => Self {
+                runtime: worker.metadata().spec.runtime_type,
+                connection: *worker.connection_mode(),
+            },
+            // Disaggregated legs are gRPC-only.
+            WorkerSelection::Disaggregated { runtime_type, .. } => Self {
+                runtime: *runtime_type,
+                connection: ConnectionMode::Grpc,
+            },
+        }
+    }
+}
+
+/// Post-build request context.
+///
+/// Invariant, by type structure: there is no request field here, so the
+/// dispatch phase (worker re-selection, dispatch, response processing,
+/// streaming) cannot reach the parsed request — it dropped in
+/// [`RequestContext::into_dispatch`]. `ResponseSpec` is the only
+/// request-derived channel past this point.
+pub(crate) struct DispatchContext {
+    /// Canonical model ID (routing, registries).
+    pub model_id: String,
+    /// Model the response reports, captured from the request at the build
+    /// boundary.
+    pub dispatch_model: String,
+    pub streaming: bool,
+    pub headers: Option<HeaderMap>,
+    pub rate_limit_cell: Option<Arc<RateLimitCell>>,
+    pub routing: RoutingSnapshot,
+    pub wire: WireConstraint,
+    pub tokenizer: Option<Arc<dyn Tokenizer>>,
+    pub workers: Option<WorkerSelection>,
+    pub sticky_key: Option<String>,
+    pub clients: Option<ClientSelection>,
+    /// Consumed by the first dispatch; retries re-dispatch only the
+    /// prefill/decode legs against the already-running encode jobs.
+    pub encode_outputs: Option<EncodeOutputs>,
+    pub dispatch: Option<DispatchMetadata>,
+    pub load_guards: Option<LoadGuards>,
+    pub response: ResponseState,
+}
+
+impl DispatchContext {
+    /// Cached tokenizer (cheap Arc clone).
+    pub fn tokenizer_arc(&self) -> Option<Arc<dyn Tokenizer>> {
+        self.tokenizer.clone()
+    }
+}
+
+/// Everything request building hands the dispatch phase.
+pub(crate) struct BuildOutput {
+    pub plan: ExecutionPlan,
+    pub spec: ResponseSpec,
+    pub stamp: AttemptStamp,
+}
+
+/// Per-attempt plan stamping inputs, captured at build so retries reproduce
+/// exactly what a fresh build would have minted for the new attempt.
+pub(crate) struct AttemptStamp {
+    pub id: IdStamp,
+    /// Which sampling fields the client left unset; retry attempts re-apply
+    /// the newly selected worker's defaults through this mask.
+    pub sampling_mask: Option<SamplingDefaultsMask>,
+    /// Pre-default values of the masked fields, so re-application never
+    /// carries a previous attempt's worker defaults forward.
+    pub sampling_baseline: Option<SamplingBaseline>,
+    /// Mode::PrefillDecode only (mirrors the build stage's flag).
+    pub inject_pd_metadata: bool,
 }
 
 /// Per-item bootstrap rendezvous info for prefill, plus the dispatch plan that
@@ -209,7 +308,9 @@ pub(crate) struct EncodeOutputs {
     pub dispatch: EncodeDispatchPlan,
 }
 
-/// Execution shape produced by request building and consumed by request execution.
+/// Execution shape produced by request building. Retained until the retry
+/// window closes; each attempt dispatches a clone (the last moves it).
+#[derive(Clone)]
 pub(crate) enum ExecutionPlan {
     Single(ProtoRequest),
     PrefillDecode(ProtoGenerateRequest),
@@ -279,6 +380,67 @@ impl ExecutionPlan {
                 ExecutionPlanKind::PrefillDecode => "prefill_decode",
                 ExecutionPlanKind::EncodePrefillDecode => "encode_prefill_decode",
             },
+        }
+    }
+
+    /// Serialized wire size of the built request(s), for the release metric.
+    pub(crate) fn wire_len(&self) -> usize {
+        match self {
+            Self::Single(request) => request.wire_len(),
+            Self::PrefillDecode(request) | Self::EncodePrefillDecode { request } => {
+                request.wire_len()
+            }
+            Self::Batch { requests, .. } => {
+                requests.iter().map(ProtoGenerateRequest::wire_len).sum()
+            }
+        }
+    }
+
+    /// Set the engine request id on a non-batch plan. A batch plan here is a
+    /// build-stage wiring bug (its sub ids are stamped individually): fail
+    /// rather than let a retry re-dispatch the previous attempt's ids.
+    #[expect(
+        clippy::result_large_err,
+        reason = "Response is the standard error type in the pipeline stage pattern"
+    )]
+    pub(crate) fn set_request_id(
+        &mut self,
+        request_id: String,
+    ) -> Result<(), axum::response::Response> {
+        match self {
+            Self::Single(ProtoRequest::Generate(request))
+            | Self::PrefillDecode(request)
+            | Self::EncodePrefillDecode { request } => {
+                request.set_request_id(request_id);
+                Ok(())
+            }
+            Self::Single(ProtoRequest::Embed(request)) => {
+                request.set_request_id(request_id);
+                Ok(())
+            }
+            Self::Batch { .. } => {
+                error!(
+                    function = "ExecutionPlan::set_request_id",
+                    "Single id stamp on a batch plan"
+                );
+                Err(internal_error(
+                    "id_stamp_plan_mismatch",
+                    "Id stamp does not match the plan shape",
+                ))
+            }
+        }
+    }
+
+    /// Every generate request in the plan, for per-attempt re-stamping.
+    pub(crate) fn generate_requests_mut(
+        &mut self,
+    ) -> impl Iterator<Item = &mut ProtoGenerateRequest> {
+        match self {
+            Self::Single(ProtoRequest::Generate(request))
+            | Self::PrefillDecode(request)
+            | Self::EncodePrefillDecode { request } => std::slice::from_mut(request).iter_mut(),
+            Self::Single(ProtoRequest::Embed(_)) => [].iter_mut(),
+            Self::Batch { requests, .. } => requests.iter_mut(),
         }
     }
 }
@@ -524,17 +686,111 @@ impl RequestContext {
             model_id.push_str(&canonical_model_id);
             request_type.set_model(&model_id);
         }
+        let streaming = match &request_type {
+            RequestType::Chat(req) => req.stream,
+            RequestType::Generate(req) => req.stream,
+            RequestType::Completion(req) => req.stream,
+            RequestType::Responses(req) => req.stream.unwrap_or(false),
+            RequestType::Messages(req) => req.stream.unwrap_or(false),
+            // Embeddings and classification never stream.
+            RequestType::Embedding(_) | RequestType::Classify(_) => false,
+        };
         Self {
             input: RequestInput {
                 request_type,
                 headers,
                 model_id,
+                streaming,
                 tenant_request_meta: None,
                 rate_limit_cell: None,
             },
             components,
             state: ProcessingState::default(),
         }
+    }
+
+    /// Build-boundary conversion. The parsed request is dropped inside this
+    /// function — `DispatchContext` has no field to carry it, so post-build
+    /// stages cannot read it even by mistake.
+    ///
+    /// Fails loudly when worker selection's outputs (routing snapshot, wire)
+    /// are absent: a retry context with defaulted routing inputs could
+    /// re-select a worker the retained plan cannot be dispatched to.
+    #[expect(
+        clippy::result_large_err,
+        reason = "Response is the standard error type in the pipeline stage pattern"
+    )]
+    pub fn into_dispatch(self) -> Result<DispatchContext, axum::response::Response> {
+        let RequestContext {
+            input,
+            components,
+            state,
+        } = self;
+        let RequestInput {
+            request_type,
+            headers,
+            model_id,
+            streaming,
+            tenant_request_meta: _,
+            rate_limit_cell,
+        } = input;
+        // The model the response reports. `RequestContext::new` already
+        // canonicalized both the request's `model` field and `model_id`, so a
+        // request that arrived under an alias is answered under the canonical
+        // name. Native `/generate` callers may leave the field empty, so
+        // prefer the resolved id there.
+        let dispatch_model = match &request_type {
+            RequestType::Chat(req) => req.model.clone(),
+            RequestType::Completion(req) => req.model.clone(),
+            RequestType::Generate(_) => model_id.clone(),
+            RequestType::Responses(req) => req.model.clone(),
+            RequestType::Embedding(req) => req.model.clone(),
+            RequestType::Classify(req) => req.model.clone(),
+            RequestType::Messages(req) => req.model.clone(),
+        };
+        drop(request_type);
+        drop(components);
+        let routing = state.routing_snapshot.ok_or_else(|| {
+            error!(
+                function = "RequestContext::into_dispatch",
+                "Routing snapshot not captured by worker selection"
+            );
+            internal_error(
+                "routing_snapshot_not_captured",
+                "Routing snapshot not captured",
+            )
+        })?;
+        let wire = state
+            .workers
+            .as_ref()
+            .map(WireConstraint::of)
+            .ok_or_else(|| {
+                error!(
+                    function = "RequestContext::into_dispatch",
+                    "Worker selection not completed"
+                );
+                internal_error(
+                    "worker_selection_not_completed",
+                    "Worker selection not completed",
+                )
+            })?;
+        Ok(DispatchContext {
+            model_id,
+            dispatch_model,
+            streaming,
+            headers,
+            rate_limit_cell,
+            routing,
+            wire,
+            tokenizer: state.tokenizer,
+            workers: state.workers,
+            sticky_key: state.sticky_key,
+            clients: state.clients,
+            encode_outputs: state.encode_outputs,
+            dispatch: None,
+            load_guards: None,
+            response: state.response,
+        })
     }
 
     /// Create context for chat completion request
@@ -637,18 +893,6 @@ impl RequestContext {
         )
     }
 
-    /// Get chat request (panics if not chat)
-    #[expect(
-        clippy::panic,
-        reason = "typed accessor: caller guarantees variant via RequestType construction"
-    )]
-    pub fn chat_request(&self) -> &ChatCompletionRequest {
-        match &self.input.request_type {
-            RequestType::Chat(req) => req.as_ref(),
-            _ => panic!("Expected chat request"),
-        }
-    }
-
     /// Get Arc clone of chat request (panics if not chat)
     #[expect(
         clippy::panic,
@@ -661,18 +905,6 @@ impl RequestContext {
         }
     }
 
-    /// Get generate request (panics if not generate)
-    #[expect(
-        clippy::panic,
-        reason = "typed accessor: caller guarantees variant via RequestType construction"
-    )]
-    pub fn generate_request(&self) -> &GenerateRequest {
-        match &self.input.request_type {
-            RequestType::Generate(req) => req.as_ref(),
-            _ => panic!("Expected generate request"),
-        }
-    }
-
     /// Get Arc clone of generate request (panics if not generate)
     #[expect(
         clippy::panic,
@@ -682,22 +914,6 @@ impl RequestContext {
         match &self.input.request_type {
             RequestType::Generate(req) => Arc::clone(req),
             _ => panic!("Expected generate request"),
-        }
-    }
-
-    /// Get completion request (panics if not completion)
-    #[expect(
-        dead_code,
-        reason = "ref accessor provided for API completeness alongside Arc accessor"
-    )]
-    #[expect(
-        clippy::panic,
-        reason = "typed accessor: caller guarantees variant via RequestType construction"
-    )]
-    pub fn completion_request(&self) -> &CompletionRequest {
-        match &self.input.request_type {
-            RequestType::Completion(req) => req.as_ref(),
-            _ => panic!("Expected completion request"),
         }
     }
 
@@ -725,22 +941,6 @@ impl RequestContext {
         }
     }
 
-    /// Get messages request (panics if not messages)
-    #[expect(
-        dead_code,
-        reason = "scaffolding for Messages API pipeline, wired in follow-up PR"
-    )]
-    #[expect(
-        clippy::panic,
-        reason = "typed accessor: caller guarantees variant via RequestType construction"
-    )]
-    pub fn messages_request(&self) -> &CreateMessageRequest {
-        match &self.input.request_type {
-            RequestType::Messages(req) => req.as_ref(),
-            _ => panic!("Expected messages request"),
-        }
-    }
-
     /// Get Arc clone of messages request (panics if not messages)
     #[expect(
         clippy::panic,
@@ -753,17 +953,9 @@ impl RequestContext {
         }
     }
 
-    /// Check if request is streaming
+    /// Check if request is streaming (captured at construction).
     pub fn is_streaming(&self) -> bool {
-        match &self.input.request_type {
-            RequestType::Chat(req) => req.stream,
-            RequestType::Generate(req) => req.stream,
-            RequestType::Completion(req) => req.stream,
-            RequestType::Responses(req) => req.stream.unwrap_or(false),
-            RequestType::Messages(req) => req.stream.unwrap_or(false),
-            RequestType::Embedding(_) => false, // Embeddings are never streaming
-            RequestType::Classify(_) => false,  // Classification is never streaming
-        }
+        self.input.streaming
     }
 
     /// Get the cached tokenizer, cloning the Arc (cheap 8-byte clone)

--- a/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -47,7 +47,7 @@ impl Default for HarmonyPreparationStage {
 
 #[async_trait]
 impl PipelineStage for HarmonyPreparationStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response> {
         // Clone Arc before match to avoid borrow checker issues
         // Arc clone is cheap (8 bytes) - avoids full request clone (15KB-200KB)
         let is_chat = matches!(&ctx.input.request_type, RequestType::Chat(_));
@@ -79,7 +79,7 @@ impl PipelineStage for HarmonyPreparationStage {
             ));
         }
 
-        Ok(None)
+        Ok(())
     }
 
     fn name(&self) -> &'static str {
@@ -93,7 +93,7 @@ impl HarmonyPreparationStage {
         &self,
         ctx: &mut RequestContext,
         request: &ChatCompletionRequest,
-    ) -> Result<Option<Response>, Response> {
+    ) -> Result<(), Response> {
         // Step 1: Filter tools if needed
         let mut body_ref = utils::filter_chat_request_by_tool_choice(request);
 
@@ -151,7 +151,7 @@ impl HarmonyPreparationStage {
             harmony_stop_ids: build_output.stop_token_ids,
         });
 
-        Ok(None)
+        Ok(())
     }
 
     /// Prepare a responses API request using Harmony encoding
@@ -162,7 +162,7 @@ impl HarmonyPreparationStage {
         &self,
         ctx: &mut RequestContext,
         request: &ResponsesRequest,
-    ) -> Result<Option<Response>, Response> {
+    ) -> Result<(), Response> {
         // Step 1: Extract function tools with schemas from ResponseTools
         let mut function_tools = extract_tools_from_response_tools(request.tools.as_deref());
 
@@ -226,7 +226,7 @@ impl HarmonyPreparationStage {
             harmony_stop_ids: build_output.stop_token_ids,
         });
 
-        Ok(None)
+        Ok(())
     }
 
     /// Generate Harmony structural tag for structured output (text field)

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -84,7 +84,7 @@ impl BuildStage for HarmonyRequestBuildingStage {
 
         // Generate request_id based on request type. The Harmony spec owns a
         // handle to the request: the tool loop legitimately re-reads it
-        // across iterations (the one sanctioned post-build request holder).
+        // across iterations (the one deliberate post-build request holder).
         let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
         let (request_id, id_stamp, harmony_spec) = match &ctx.input.request_type {
             RequestType::Chat(request) => {

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -10,12 +10,13 @@ use crate::routers::{
     grpc::{
         backend_client::BackendClient,
         client::GrpcClient,
-        common::stages::{helpers, PipelineStage},
+        common::stages::{helpers, BuildStage},
         context::{
-            ClientSelection, ExecutionPlan, ExecutionPlanKind, PreparationOutput, RequestContext,
-            RequestType,
+            AttemptStamp, BuildOutput, ClientSelection, ExecutionPlan, ExecutionPlanKind,
+            PreparationOutput, RequestContext, RequestType,
         },
         proto_wrapper::ProtoGenerateRequest,
+        spec::{HarmonyResponseSpec, ResponseSpec},
         zmq_client::ZmqDialect,
     },
 };
@@ -40,12 +41,12 @@ impl HarmonyRequestBuildingStage {
 }
 
 #[async_trait]
-impl PipelineStage for HarmonyRequestBuildingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+impl BuildStage for HarmonyRequestBuildingStage {
+    async fn build(&self, ctx: &mut RequestContext) -> Result<BuildOutput, Response> {
         // Take preparation output (last consumer — worker_selection already ran)
         let prep = ctx.state.preparation.take().ok_or_else(|| {
             error!(
-                function = "HarmonyRequestBuildingStage::execute",
+                function = "HarmonyRequestBuildingStage::build",
                 "Preparation stage not completed"
             );
             error::internal_error("preparation_not_completed", "Preparation not completed")
@@ -68,7 +69,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
         // Get clients
         let clients = ctx.state.clients.as_ref().ok_or_else(|| {
             error!(
-                function = "HarmonyRequestBuildingStage::execute",
+                function = "HarmonyRequestBuildingStage::build",
                 "Client acquisition stage not completed"
             );
             error::internal_error(
@@ -81,28 +82,36 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             ClientSelection::Disaggregated { prefill, .. } => prefill,
         };
 
-        // Generate request_id based on request type
+        // Generate request_id based on request type. The Harmony spec owns a
+        // handle to the request: the tool loop legitimately re-reads it
+        // across iterations (the one sanctioned post-build request holder).
         let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
-        let request_id = match &ctx.input.request_type {
-            RequestType::Chat(_) => helpers::resolve_request_id(
-                &ctx.input.request_type,
-                ctx.input.tenant_request_meta.as_ref(),
-                "chatcmpl-",
-                disaggregated,
-            ),
-            RequestType::Responses(_) => helpers::resolve_request_id(
-                &ctx.input.request_type,
-                ctx.input.tenant_request_meta.as_ref(),
-                "responses-",
-                disaggregated,
-            ),
+        let (request_id, id_stamp, harmony_spec) = match &ctx.input.request_type {
+            RequestType::Chat(request) => {
+                let (id, stamp) = helpers::resolve_request_id_stamp(
+                    &ctx.input.request_type,
+                    ctx.input.tenant_request_meta.as_ref(),
+                    "chatcmpl-",
+                    disaggregated,
+                );
+                (id, stamp, HarmonyResponseSpec::Chat(request.clone()))
+            }
+            RequestType::Responses(request) => {
+                let (id, stamp) = helpers::resolve_request_id_stamp(
+                    &ctx.input.request_type,
+                    ctx.input.tenant_request_meta.as_ref(),
+                    "responses-",
+                    disaggregated,
+                );
+                (id, stamp, HarmonyResponseSpec::Responses(request.clone()))
+            }
             request_type @ (RequestType::Generate(_)
             | RequestType::Completion(_)
             | RequestType::Embedding(_)
             | RequestType::Classify(_)
             | RequestType::Messages(_)) => {
                 error!(
-                    function = "HarmonyRequestBuildingStage::execute",
+                    function = "HarmonyRequestBuildingStage::build",
                     request_type = %request_type,
                     "{request_type} request type not supported for Harmony models"
                 );
@@ -150,7 +159,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             tool_constraints,
         )
         .map_err(|e| {
-            error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build Harmony generate request");
+            error!(function = "HarmonyRequestBuildingStage::build", error = %e, "Failed to build Harmony generate request");
             error::bad_request(
                 "invalid_request_parameters",
                 format!("Invalid request parameters: {e}"),
@@ -185,8 +194,18 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             }
         }
 
-        ctx.state.execution_plan = Some(ExecutionPlan::generate(self.plan_kind, proto_request));
-        Ok(None)
+        Ok(BuildOutput {
+            plan: ExecutionPlan::generate(self.plan_kind, proto_request),
+            spec: ResponseSpec::Harmony(harmony_spec),
+            stamp: AttemptStamp {
+                id: id_stamp,
+                // Harmony builds never applied worker sampling defaults;
+                // retries must not start applying them.
+                sampling_mask: None,
+                sampling_baseline: None,
+                inject_pd_metadata: self.inject_pd_metadata,
+            },
+        })
     }
 
     fn name(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
@@ -10,23 +10,17 @@ use super::super::{HarmonyResponseProcessor, HarmonyStreamingProcessor};
 use crate::routers::{
     error,
     grpc::{
-        common::stages::{helpers, PipelineStage, RateLimitCell},
-        context::{FinalResponse, RequestContext, RequestType},
+        common::stages::{helpers, ProcessStage, RateLimitCell},
+        context::{DispatchContext, FinalResponse},
+        spec::{HarmonyResponseSpec, ResponseSpec},
     },
 };
-
-/// String `stop` sequences the ROUTER must enforce, as reported by the
-/// backend client during request building (its residual obligation: strings
-/// the engine will never match). Empty for engines that match server-side —
-/// no transport inspection here.
-fn router_stop_strings(ctx: &RequestContext) -> Vec<String> {
-    ctx.state.response.router_stop_obligations.clone()
-}
 
 /// Harmony Response Processing stage: Parse and format Harmony responses
 ///
 /// Takes output tokens from execution and parses them using HarmonyParserAdapter
 /// to extract analysis, tool calls, and final response text from Harmony channels.
+/// The Harmony spec owns its request handle — the sanctioned post-build reader.
 pub(crate) struct HarmonyResponseProcessingStage {
     processor: HarmonyResponseProcessor,
     streaming_processor: Arc<HarmonyStreamingProcessor>,
@@ -49,27 +43,46 @@ impl Default for HarmonyResponseProcessingStage {
 }
 
 #[async_trait]
-impl PipelineStage for HarmonyResponseProcessingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        let is_streaming = ctx.is_streaming();
+impl ProcessStage for HarmonyResponseProcessingStage {
+    async fn process(
+        &self,
+        ctx: &mut DispatchContext,
+        spec: ResponseSpec,
+    ) -> Result<Option<Response>, Response> {
+        let ResponseSpec::Harmony(harmony_spec) = spec else {
+            error!(
+                function = "HarmonyResponseProcessingStage::process",
+                "Wrong response spec"
+            );
+            return Err(error::internal_error(
+                "wrong_response_spec",
+                "Wrong response spec",
+            ));
+        };
 
-        // Check request type to determine which processor method to call
-        match &ctx.input.request_type {
-            RequestType::Chat(_) => {
+        let is_streaming = ctx.streaming;
+
+        // String `stop` sequences the ROUTER must enforce, as reported by the
+        // backend client during request building (its residual obligation:
+        // strings the engine will never match). Empty for engines that match
+        // server-side.
+        let router_stops = ctx.response.router_stop_obligations.clone();
+
+        match harmony_spec {
+            HarmonyResponseSpec::Chat(chat_request) => {
                 // Get execution result (output tokens from model)
-                let execution_result =
-                    ctx.state.response.execution_result.take().ok_or_else(|| {
-                        error!(
-                            function = "HarmonyResponseProcessingStage::execute",
-                            request_type = "Chat",
-                            "No execution result available"
-                        );
-                        error::internal_error("no_execution_result", "No execution result")
-                    })?;
-
-                let dispatch = ctx.state.dispatch.as_ref().cloned().ok_or_else(|| {
+                let execution_result = ctx.response.execution_result.take().ok_or_else(|| {
                     error!(
-                        function = "HarmonyResponseProcessingStage::execute",
+                        function = "HarmonyResponseProcessingStage::process",
+                        request_type = "Chat",
+                        "No execution result available"
+                    );
+                    error::internal_error("no_execution_result", "No execution result")
+                })?;
+
+                let dispatch = ctx.dispatch.as_ref().cloned().ok_or_else(|| {
+                    error!(
+                        function = "HarmonyResponseProcessingStage::process",
                         request_type = "Chat",
                         "Dispatch metadata not set"
                     );
@@ -84,7 +97,6 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                     // ReservationAttachment's Drop below on early
                     // disconnect/error.
                     let reservation = ctx
-                        .input
                         .rate_limit_cell
                         .as_deref()
                         .and_then(RateLimitCell::take_for_streaming_handoff);
@@ -94,9 +106,9 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                         .clone()
                         .process_streaming_chat_response(
                             execution_result,
-                            ctx.chat_request_arc(),
+                            chat_request,
                             dispatch,
-                            router_stop_strings(ctx),
+                            router_stops,
                             reservation.clone(),
                         )
                         .await;
@@ -106,7 +118,7 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                     // proper RAII lifecycle.
                     let response = helpers::attach_response_guards(
                         response,
-                        ctx.state.load_guards.take(),
+                        ctx.load_guards.take(),
                         reservation,
                     );
 
@@ -114,22 +126,20 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                 }
 
                 // For non-streaming, delegate to Harmony response processor to build ChatCompletionResponse
-                let chat_request = ctx.chat_request_arc();
-                let stops = router_stop_strings(ctx);
                 let response = self
                     .processor
                     .process_non_streaming_chat_response(
                         execution_result,
                         chat_request,
                         dispatch,
-                        &stops,
+                        &router_stops,
                     )
                     .await?;
 
-                ctx.state.response.final_response = Some(FinalResponse::Chat(response));
+                ctx.response.final_response = Some(FinalResponse::Chat(response));
                 Ok(None)
             }
-            RequestType::Responses(_) => {
+            HarmonyResponseSpec::Responses(responses_request) => {
                 // For streaming Responses API, leave execution_result in context
                 // for external streaming processor (serve_harmony_responses_stream)
                 if is_streaming {
@@ -138,48 +148,31 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                 }
 
                 // For non-streaming, process normally
-                let execution_result =
-                    ctx.state.response.execution_result.take().ok_or_else(|| {
-                        error!(
-                            function = "HarmonyResponseProcessingStage::execute",
-                            request_type = "Responses",
-                            "No execution result available"
-                        );
-                        error::internal_error("no_execution_result", "No execution result")
-                    })?;
-
-                let dispatch = ctx.state.dispatch.as_ref().cloned().ok_or_else(|| {
+                let execution_result = ctx.response.execution_result.take().ok_or_else(|| {
                     error!(
-                        function = "HarmonyResponseProcessingStage::execute",
+                        function = "HarmonyResponseProcessingStage::process",
+                        request_type = "Responses",
+                        "No execution result available"
+                    );
+                    error::internal_error("no_execution_result", "No execution result")
+                })?;
+
+                let dispatch = ctx.dispatch.as_ref().cloned().ok_or_else(|| {
+                    error!(
+                        function = "HarmonyResponseProcessingStage::process",
                         request_type = "Responses",
                         "Dispatch metadata not set"
                     );
                     error::internal_error("dispatch_metadata_not_set", "Dispatch metadata not set")
                 })?;
 
-                let responses_request = ctx.responses_request_arc();
                 let iteration_result = self
                     .processor
                     .process_responses_iteration(execution_result, responses_request, dispatch)
                     .await?;
 
-                ctx.state.response.responses_iteration_result = Some(iteration_result);
+                ctx.response.responses_iteration_result = Some(iteration_result);
                 Ok(None)
-            }
-            request_type @ (RequestType::Generate(_)
-            | RequestType::Completion(_)
-            | RequestType::Embedding(_)
-            | RequestType::Classify(_)
-            | RequestType::Messages(_)) => {
-                error!(
-                    function = "HarmonyResponseProcessingStage::execute",
-                    request_type = %request_type,
-                    "{request_type} request type not supported in Harmony pipeline"
-                );
-                Err(error::internal_error(
-                    "not_supported_in_harmony",
-                    format!("{request_type} requests not supported in Harmony pipeline"),
-                ))
             }
         }
     }

--- a/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
@@ -20,7 +20,7 @@ use crate::routers::{
 ///
 /// Takes output tokens from execution and parses them using HarmonyParserAdapter
 /// to extract analysis, tool calls, and final response text from Harmony channels.
-/// The Harmony spec owns its request handle — the sanctioned post-build reader.
+/// The Harmony spec owns its request handle — the one deliberate post-build reader.
 pub(crate) struct HarmonyResponseProcessingStage {
     processor: HarmonyResponseProcessor,
     streaming_processor: Arc<HarmonyStreamingProcessor>,

--- a/model_gateway/src/routers/grpc/mod.rs
+++ b/model_gateway/src/routers/grpc/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod pipeline;
 pub(crate) mod proto_wrapper;
 pub(crate) mod regular;
 pub(crate) mod router; // Used by routers/factory
+pub(crate) mod spec;
 pub mod utils; // Used by routers/http and bindings/golang
 pub mod zmq_client; // ZMQ backend adapter behind the vLLM client surface
 pub(crate) mod zmq_multimodal; // Proto mm inputs → EngineCore mm_features

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -1,7 +1,14 @@
-//! Pipeline orchestrator for gRPC router request processing
+//! Two-phase pipeline orchestrator for gRPC router request processing.
 //!
-//! This module defines the RequestPipeline orchestrator that coordinates
-//! the execution of pipeline stages from request preparation to response delivery.
+//! Ingress phase (owns the parsed request): preparation → rate-limit reserve
+//! → worker selection → client acquisition → encode (EPD) → request building.
+//! Request building is the terminal consumer: it yields `(ExecutionPlan,
+//! ResponseSpec)` and the request drops at [`RequestContext::into_dispatch`].
+//!
+//! Dispatch phase (no request, by type structure): per-attempt worker
+//! re-selection + dispatch of the retained plan, then response processing.
+//! The plan is held until the retry window closes (first non-retryable
+//! response).
 
 use std::{sync::Arc, time::Instant};
 
@@ -16,10 +23,8 @@ use openai_protocol::{
 };
 use reasoning_parser::ParserFactory as ReasoningParserFactory;
 use tool_parser::ParserFactory as ToolParserFactory;
-use tracing::{debug, error};
+use tracing::error;
 
-// Import embedding-specific, classify-specific, messages-specific, and completion-specific stages
-use super::regular::stages::classify::ClassifyResponseProcessingStage;
 use super::{
     common::{responses::ResponsesContext, stages::*},
     context::*,
@@ -28,6 +33,7 @@ use super::{
     regular::{
         processor,
         stages::{
+            classify::ClassifyResponseProcessingStage,
             completion::{
                 CompletionPreparationStage, CompletionRequestBuildingStage,
                 CompletionResponseProcessingStage,
@@ -46,21 +52,26 @@ use super::{
         },
         streaming,
     },
+    spec::ResponseSpec,
     utils,
     utils::error_type_from_status,
 };
 use crate::{
+    config::types::RetryConfig,
     middleware::TenantRequestMeta,
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     policies::PolicyRegistry,
     rate_limit::{RateLimitManager, UsageSettlement},
-    routers::error,
+    routers::{
+        common::retry::{is_retryable_response, BackoffCalculator},
+        error,
+    },
     worker::WorkerRegistry,
 };
 
-/// Which endpoint a pipeline serves. Selects the endpoint-specific stage list
+/// Which endpoint a pipeline serves. Selects the endpoint-specific stage set
 /// (preparation / request-building / response-processing); `Mode` then selects
-/// the disaggregation params within that list.
+/// the disaggregation params within that set.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Endpoint {
     Chat,
@@ -195,18 +206,455 @@ impl PipelineDeps {
     }
 }
 
-/// Generic request pipeline for all request types
-///
-/// Orchestrates all stages from request preparation to response delivery.
-/// Configured differently for regular vs PD mode.
+/// The two-phase stage set. Phase ordering is encoded by the struct itself:
+/// ingress stages operate on the request-owning [`RequestContext`], the
+/// process stage on the request-free [`DispatchContext`].
+struct PipelineStages {
+    preparation: Box<dyn PipelineStage>,
+    /// `None` for endpoints that haven't opted into tenant rate limiting
+    /// (embeddings/classify).
+    rate_limit: Option<RateLimitReserveStage>,
+    worker_selection: WorkerSelectionStage,
+    /// EPD-only encode planning/staging.
+    encode: Option<EncodeStage>,
+    request_building: Box<dyn BuildStage>,
+    response_processing: Box<dyn ProcessStage>,
+}
+
+/// Generic request pipeline for all request types.
 #[derive(Clone)]
 pub(crate) struct RequestPipeline {
-    stages: Arc<Vec<Box<dyn PipelineStage>>>,
+    stages: Arc<PipelineStages>,
     /// Backend type for metrics labeling
     backend_type: &'static str,
+    /// Disaggregation mode, for per-leg retry metric labels.
+    mode: Mode,
+}
+
+/// Outcome of one full pipeline run.
+enum RunOutcome {
+    /// Early response (streaming SSE) already produced by response processing.
+    Early(Response),
+    /// Buffered completion: the final response (or responses-iteration state)
+    /// sits on the dispatch context; the Instant is the successful attempt's
+    /// start, for duration metrics.
+    Final(Box<DispatchContext>, Instant),
 }
 
 impl RequestPipeline {
+    /// Build the pipeline for `endpoint` in the given disaggregation `mode`,
+    /// mapping `mode` to the per-stage worker-selection, execution-plan, and
+    /// PD-injection params. `None` for endpoint/mode combinations that have no
+    /// pipeline: Harmony has no EPD variant, and embeddings/classify are
+    /// single-worker only.
+    pub(crate) fn build(endpoint: Endpoint, mode: Mode, deps: &PipelineDeps) -> Option<Self> {
+        // PD and EPD are both served by the "pd" backend metrics bucket; only
+        // plain Regular reports as "regular".
+        let backend = match mode {
+            Mode::Regular => metrics_labels::BACKEND_REGULAR,
+            Mode::PrefillDecode | Mode::EncodePrefillDecode => metrics_labels::BACKEND_PD,
+        };
+        let worker_selection = WorkerSelectionStage::new(
+            deps.worker_registry.clone(),
+            deps.policy_registry.clone(),
+            mode.worker_selection(),
+        );
+        let plan_kind = mode.plan_kind();
+        let inject_pd_metadata = mode.inject_pd_metadata();
+        let encode = matches!(mode, Mode::EncodePrefillDecode).then(EncodeStage::new);
+        let rate_limit = || RateLimitReserveStage::new(deps.rate_limit_manager.clone());
+
+        let stages = match endpoint {
+            Endpoint::Chat => {
+                let (processor, streaming_processor) = deps.configured_processors(backend);
+                PipelineStages {
+                    preparation: Box::new(ChatGeneratePreparationStage::new()),
+                    rate_limit: Some(rate_limit()),
+                    worker_selection,
+                    encode,
+                    request_building: Box::new(ChatGenerateRequestBuildingStage::new(
+                        inject_pd_metadata,
+                        plan_kind,
+                    )),
+                    response_processing: Box::new(ChatGenerateResponseProcessingStage::new(
+                        processor,
+                        streaming_processor,
+                    )),
+                }
+            }
+            Endpoint::Messages => {
+                let (processor, streaming_processor) = deps.configured_processors(backend);
+                PipelineStages {
+                    preparation: Box::new(MessagePreparationStage),
+                    rate_limit: Some(rate_limit()),
+                    worker_selection,
+                    encode,
+                    request_building: Box::new(MessageRequestBuildingStage::new(
+                        inject_pd_metadata,
+                        plan_kind,
+                    )),
+                    response_processing: Box::new(MessageResponseProcessingStage::new(
+                        processor,
+                        streaming_processor,
+                    )),
+                }
+            }
+            Endpoint::Completion => {
+                // Completion uses default parser factories, not the configured ones.
+                let (processor, streaming_processor) = PipelineDeps::default_processors(backend);
+                PipelineStages {
+                    preparation: Box::new(CompletionPreparationStage),
+                    rate_limit: Some(rate_limit()),
+                    worker_selection,
+                    encode,
+                    request_building: Box::new(CompletionRequestBuildingStage::new(
+                        inject_pd_metadata,
+                        plan_kind,
+                    )),
+                    response_processing: Box::new(CompletionResponseProcessingStage::new(
+                        processor,
+                        streaming_processor,
+                    )),
+                }
+            }
+            Endpoint::Harmony => {
+                // Harmony has no EPD variant.
+                if matches!(mode, Mode::EncodePrefillDecode) {
+                    return None;
+                }
+                PipelineStages {
+                    preparation: Box::new(harmony::stages::HarmonyPreparationStage::new()),
+                    rate_limit: Some(rate_limit()),
+                    worker_selection,
+                    encode: None,
+                    request_building: Box::new(harmony::stages::HarmonyRequestBuildingStage::new(
+                        inject_pd_metadata,
+                        plan_kind,
+                    )),
+                    response_processing: Box::new(
+                        harmony::stages::HarmonyResponseProcessingStage::new(),
+                    ),
+                }
+            }
+            Endpoint::Embeddings => {
+                // Embeddings are single-worker only.
+                if !matches!(mode, Mode::Regular) {
+                    return None;
+                }
+                PipelineStages {
+                    preparation: Box::new(EmbeddingPreparationStage::new()),
+                    rate_limit: None,
+                    worker_selection,
+                    encode: None,
+                    request_building: Box::new(EmbeddingRequestBuildingStage::new()),
+                    response_processing: Box::new(EmbeddingResponseProcessingStage::new()),
+                }
+            }
+            Endpoint::Classify => {
+                // Classify is single-worker only.
+                if !matches!(mode, Mode::Regular) {
+                    return None;
+                }
+                PipelineStages {
+                    preparation: Box::new(EmbeddingPreparationStage::new()),
+                    rate_limit: None,
+                    worker_selection,
+                    encode: None,
+                    request_building: Box::new(EmbeddingRequestBuildingStage::new()),
+                    response_processing: Box::new(ClassifyResponseProcessingStage::new()),
+                }
+            }
+        };
+
+        Some(Self {
+            stages: Arc::new(stages),
+            backend_type: backend,
+            mode,
+        })
+    }
+
+    /// Ingress phase: run the request-owning stages through request building.
+    async fn run_ingress(&self, ctx: &mut RequestContext) -> Result<BuildOutput, Response> {
+        macro_rules! step {
+            ($stage:expr, $result:expr) => {
+                $result.inspect_err(|response: &Response| {
+                    error!("Stage {} failed with status {}", $stage, response.status());
+                })
+            };
+        }
+
+        let stages = &self.stages;
+        step!(
+            stages.preparation.name(),
+            stages.preparation.execute(ctx).await
+        )?;
+        if let Some(rate_limit) = &stages.rate_limit {
+            step!(rate_limit.name(), rate_limit.execute(ctx).await)?;
+        }
+        step!(
+            stages.worker_selection.name(),
+            stages.worker_selection.execute(ctx).await
+        )?;
+        let workers = ctx.state.workers.as_ref().ok_or_else(|| {
+            error!(function = "run_ingress", "Worker selection not completed");
+            error::internal_error(
+                "worker_selection_not_completed",
+                "Worker selection not completed",
+            )
+        })?;
+        ctx.state.clients = Some(step!(
+            "ClientAcquisition",
+            acquire_clients(workers, &ctx.input.model_id).await
+        )?);
+        if let Some(encode) = &stages.encode {
+            step!(encode.name(), encode.execute(ctx).await)?;
+        }
+        step!(
+            stages.request_building.name(),
+            stages.request_building.build(ctx).await
+        )
+    }
+
+    /// One dispatch attempt: (re-)selection for retries, plan stamping,
+    /// dispatch metadata, execution, response processing.
+    async fn run_attempt(
+        &self,
+        dctx: &mut DispatchContext,
+        plan: &mut Option<ExecutionPlan>,
+        spec: &ResponseSpec,
+        stamp: &AttemptStamp,
+        attempt: u32,
+        last_attempt: bool,
+    ) -> Result<Option<Response>, Response> {
+        if attempt > 0 {
+            // Fresh worker selection per attempt; the retained plan is
+            // re-stamped (engine ids, sampling defaults, PD rooms) for the
+            // new workers. Buffered decode state from the failed attempt is
+            // reset.
+            self.stages.worker_selection.reselect(dctx)?;
+            let workers = dctx.workers.as_ref().ok_or_else(|| {
+                error!(
+                    function = "run_attempt",
+                    "Worker re-selection not completed"
+                );
+                error::internal_error(
+                    "worker_selection_not_completed",
+                    "Worker selection not completed",
+                )
+            })?;
+            dctx.clients = Some(acquire_clients(workers, &dctx.model_id).await?);
+            if let Some(plan) = plan.as_mut() {
+                helpers::restamp_plan_for_attempt(plan, stamp, workers)?;
+            }
+            if let Some(decoder) = dctx.response.stop_decoder.as_mut() {
+                decoder.reset();
+            }
+            dctx.response.execution_result = None;
+        }
+
+        // The last allowed attempt moves the plan (no clone); earlier
+        // attempts dispatch a clone and retain the original for replay.
+        let attempt_plan = if last_attempt {
+            plan.take()
+        } else {
+            plan.clone()
+        }
+        .ok_or_else(|| {
+            error!(function = "run_attempt", "Execution plan already consumed");
+            error::internal_error("execution_plan_consumed", "Execution plan already consumed")
+        })?;
+
+        dctx.dispatch = Some(prepare_dispatch_metadata(
+            &attempt_plan,
+            &dctx.dispatch_model,
+            dctx.workers.as_ref(),
+        ));
+
+        execute_plan(dctx, attempt_plan).await?;
+        self.stages
+            .response_processing
+            .process(dctx, spec.clone())
+            .await
+            .inspect_err(|response| {
+                error!(
+                    "Stage {} failed with status {}",
+                    self.stages.response_processing.name(),
+                    response.status()
+                );
+            })
+    }
+
+    /// Full two-phase run. `metrics_endpoint` enables per-attempt
+    /// router-request/error/duration recording (the responses-internal entry
+    /// points pass `None`, matching their historical behavior); `retry_config`
+    /// enables the dispatch-phase retry loop. Callers `Box::pin` this future:
+    /// it holds ingress + per-attempt state across awaits.
+    async fn run(
+        &self,
+        mut ctx: RequestContext,
+        metrics_endpoint: Option<&'static str>,
+        retry_config: Option<&RetryConfig>,
+    ) -> Result<RunOutcome, Response> {
+        let mut attempt_start = Instant::now();
+        if let Some(endpoint) = metrics_endpoint {
+            Metrics::record_router_request(
+                metrics_labels::ROUTER_GRPC,
+                self.backend_type,
+                metrics_labels::CONNECTION_GRPC,
+                &ctx.input.model_id,
+                endpoint,
+                bool_to_static_str(ctx.is_streaming()),
+            );
+        }
+
+        let build = match self.run_ingress(&mut ctx).await {
+            Ok(build) => build,
+            Err(response) => {
+                self.record_error(metrics_endpoint, &ctx.input.model_id, &response);
+                return Err(response);
+            }
+        };
+        let BuildOutput { plan, spec, stamp } = build;
+
+        // Build boundary: the parsed request drops inside into_dispatch —
+        // the dispatch phase has no field that could carry it. The built
+        // plan's wire size stands in for the released buffers.
+        let model_id = ctx.input.model_id.clone();
+        let mut dctx = match ctx.into_dispatch() {
+            Ok(dctx) => Box::new(dctx),
+            Err(response) => {
+                self.record_error(metrics_endpoint, &model_id, &response);
+                return Err(response);
+            }
+        };
+        Metrics::record_request_buffers_released_early(plan.wire_len());
+
+        let max_attempts = retry_config.map_or(1, |config| config.max_retries.max(1));
+        let mut plan = Some(plan);
+        let mut attempt: u32 = 0;
+        loop {
+            if attempt > 0 {
+                attempt_start = Instant::now();
+                if let Some(endpoint) = metrics_endpoint {
+                    Metrics::record_router_request(
+                        metrics_labels::ROUTER_GRPC,
+                        self.backend_type,
+                        metrics_labels::CONNECTION_GRPC,
+                        &dctx.model_id,
+                        endpoint,
+                        bool_to_static_str(dctx.streaming),
+                    );
+                }
+            }
+
+            let last_attempt = attempt + 1 >= max_attempts;
+            let failure = match self
+                .run_attempt(&mut dctx, &mut plan, &spec, &stamp, attempt, last_attempt)
+                .await
+            {
+                Ok(Some(response)) => {
+                    if let Some(endpoint) = metrics_endpoint {
+                        Metrics::record_router_duration(
+                            metrics_labels::ROUTER_GRPC,
+                            self.backend_type,
+                            metrics_labels::CONNECTION_GRPC,
+                            &dctx.model_id,
+                            endpoint,
+                            attempt_start.elapsed(),
+                        );
+                    }
+                    return Ok(RunOutcome::Early(response));
+                }
+                Ok(None) => return Ok(RunOutcome::Final(dctx, attempt_start)),
+                Err(response) => response,
+            };
+
+            self.record_error(metrics_endpoint, &dctx.model_id, &failure);
+            error!(
+                attempt,
+                status = %failure.status(),
+                "pipeline attempt failed"
+            );
+            // The failed attempt's worker load must not stay elevated through
+            // the backoff window (a fresh context dropped them here before).
+            dctx.load_guards = None;
+
+            let Some(config) = retry_config else {
+                return Err(failure);
+            };
+            if !is_retryable_response(&failure) {
+                return Err(failure);
+            }
+            if last_attempt {
+                if let Some(endpoint) = metrics_endpoint {
+                    self.record_retries_exhausted(endpoint);
+                }
+                return Err(failure);
+            }
+
+            let next_attempt = attempt + 1;
+            let delay = BackoffCalculator::calculate_delay(config, attempt);
+            if let Some(endpoint) = metrics_endpoint {
+                self.record_retry(endpoint);
+                Metrics::record_worker_retry_backoff(next_attempt, delay);
+            }
+            tokio::time::sleep(delay).await;
+            attempt = next_attempt;
+        }
+    }
+
+    fn record_error(&self, endpoint: Option<&'static str>, model: &str, response: &Response) {
+        if let Some(endpoint) = endpoint {
+            Metrics::record_router_error(
+                metrics_labels::ROUTER_GRPC,
+                self.backend_type,
+                metrics_labels::CONNECTION_GRPC,
+                model,
+                endpoint,
+                error_type_from_status(response.status()),
+            );
+        }
+    }
+
+    /// Retry metrics for one backoff, labeled per mode: Regular emits a single
+    /// `regular` worker label; PD/EPD emit `prefill` and `decode` (never
+    /// `encode`).
+    fn record_retry(&self, endpoint: &'static str) {
+        match self.mode {
+            Mode::Regular => {
+                Metrics::record_worker_retry(metrics_labels::WORKER_REGULAR, endpoint);
+            }
+            Mode::PrefillDecode | Mode::EncodePrefillDecode => {
+                Metrics::record_worker_retry(metrics_labels::WORKER_PREFILL, endpoint);
+                Metrics::record_worker_retry(metrics_labels::WORKER_DECODE, endpoint);
+            }
+        }
+    }
+
+    /// Record retry-exhaustion metrics, labeled per mode (see [`Self::record_retry`]).
+    fn record_retries_exhausted(&self, endpoint: &'static str) {
+        match self.mode {
+            Mode::Regular => {
+                Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_REGULAR, endpoint);
+            }
+            Mode::PrefillDecode | Mode::EncodePrefillDecode => {
+                Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_PREFILL, endpoint);
+                Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_DECODE, endpoint);
+            }
+        }
+    }
+
+    fn record_duration(&self, endpoint: &'static str, model: &str, start: Instant) {
+        Metrics::record_router_duration(
+            metrics_labels::ROUTER_GRPC,
+            self.backend_type,
+            metrics_labels::CONNECTION_GRPC,
+            model,
+            endpoint,
+            start.elapsed(),
+        );
+    }
+
     fn wrong_response_type(
         &self,
         function: &'static str,
@@ -231,6 +679,24 @@ impl RequestPipeline {
         error::internal_error("wrong_response_type", "Internal error: wrong response type")
     }
 
+    fn no_response_produced(
+        &self,
+        function: &'static str,
+        model: &str,
+        endpoint: &'static str,
+    ) -> Response {
+        error!(function = function, "No response produced by pipeline");
+        Metrics::record_router_error(
+            metrics_labels::ROUTER_GRPC,
+            self.backend_type,
+            metrics_labels::CONNECTION_GRPC,
+            model,
+            endpoint,
+            metrics_labels::ERROR_INTERNAL,
+        );
+        error::internal_error("no_response_produced", "No response produced")
+    }
+
     /// Settle a non-streaming success's reservation with real usage, if this
     /// logical request reserved one. No-op if the cell is unset (feature
     /// disabled or endpoint opted out) or was never admitted (e.g. prep
@@ -252,199 +718,8 @@ impl RequestPipeline {
             .await;
     }
 
-    fn no_response_produced(
-        &self,
-        function: &'static str,
-        model: &str,
-        endpoint: &'static str,
-    ) -> Response {
-        error!(function = function, "No response produced by pipeline");
-        Metrics::record_router_error(
-            metrics_labels::ROUTER_GRPC,
-            self.backend_type,
-            metrics_labels::CONNECTION_GRPC,
-            model,
-            endpoint,
-            metrics_labels::ERROR_INTERNAL,
-        );
-        error::internal_error("no_response_produced", "No response produced")
-    }
-
-    /// Build the pipeline for `endpoint` in the given disaggregation `mode`,
-    /// mapping `mode` to the per-stage worker-selection, execution-plan, and
-    /// PD-injection params. `None` for endpoint/mode combinations that have no
-    /// pipeline: Harmony has no EPD variant, and embeddings/classify are
-    /// single-worker only.
-    pub(crate) fn build(endpoint: Endpoint, mode: Mode, deps: &PipelineDeps) -> Option<Self> {
-        // PD and EPD are both served by the "pd" backend metrics bucket; only
-        // plain Regular reports as "regular".
-        let backend = match mode {
-            Mode::Regular => metrics_labels::BACKEND_REGULAR,
-            Mode::PrefillDecode | Mode::EncodePrefillDecode => metrics_labels::BACKEND_PD,
-        };
-        let worker_selection = mode.worker_selection();
-        let plan_kind = mode.plan_kind();
-        let inject_pd_metadata = mode.inject_pd_metadata();
-
-        let stages: Vec<Box<dyn PipelineStage>> = match endpoint {
-            Endpoint::Chat => {
-                let (processor, streaming_processor) = deps.configured_processors(backend);
-                let mut stages: Vec<Box<dyn PipelineStage>> = vec![
-                    Box::new(ChatGeneratePreparationStage::new()),
-                    Box::new(RateLimitReserveStage::new(deps.rate_limit_manager.clone())),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
-                    Box::new(ClientAcquisitionStage),
-                ];
-                if matches!(mode, Mode::EncodePrefillDecode) {
-                    stages.push(Box::new(EncodeStage::new()));
-                }
-                stages.extend([
-                    Box::new(ChatGenerateRequestBuildingStage::new(
-                        inject_pd_metadata,
-                        plan_kind,
-                    )) as Box<dyn PipelineStage>,
-                    Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
-                    Box::new(ChatGenerateResponseProcessingStage::new(
-                        processor,
-                        streaming_processor,
-                    )),
-                ]);
-                stages
-            }
-            Endpoint::Messages => {
-                let (processor, streaming_processor) = deps.configured_processors(backend);
-                let mut stages: Vec<Box<dyn PipelineStage>> = vec![
-                    Box::new(MessagePreparationStage),
-                    Box::new(RateLimitReserveStage::new(deps.rate_limit_manager.clone())),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
-                    Box::new(ClientAcquisitionStage),
-                ];
-                if matches!(mode, Mode::EncodePrefillDecode) {
-                    stages.push(Box::new(EncodeStage::new()));
-                }
-                stages.extend([
-                    Box::new(MessageRequestBuildingStage::new(
-                        inject_pd_metadata,
-                        plan_kind,
-                    )) as Box<dyn PipelineStage>,
-                    Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
-                    Box::new(MessageResponseProcessingStage::new(
-                        processor,
-                        streaming_processor,
-                    )),
-                ]);
-                stages
-            }
-            Endpoint::Completion => {
-                // Completion uses default parser factories, not the configured ones.
-                let (processor, streaming_processor) = PipelineDeps::default_processors(backend);
-                let mut stages: Vec<Box<dyn PipelineStage>> = vec![
-                    Box::new(CompletionPreparationStage),
-                    Box::new(RateLimitReserveStage::new(deps.rate_limit_manager.clone())),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
-                    Box::new(ClientAcquisitionStage),
-                ];
-                if matches!(mode, Mode::EncodePrefillDecode) {
-                    stages.push(Box::new(EncodeStage::new()));
-                }
-                stages.extend([
-                    Box::new(CompletionRequestBuildingStage::new(
-                        inject_pd_metadata,
-                        plan_kind,
-                    )) as Box<dyn PipelineStage>,
-                    Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
-                    Box::new(CompletionResponseProcessingStage::new(
-                        processor,
-                        streaming_processor,
-                    )),
-                ]);
-                stages
-            }
-            Endpoint::Harmony => {
-                // Harmony has no EPD variant.
-                if matches!(mode, Mode::EncodePrefillDecode) {
-                    return None;
-                }
-                vec![
-                    Box::new(harmony::stages::HarmonyPreparationStage::new()),
-                    Box::new(RateLimitReserveStage::new(deps.rate_limit_manager.clone())),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
-                    Box::new(ClientAcquisitionStage),
-                    Box::new(harmony::stages::HarmonyRequestBuildingStage::new(
-                        inject_pd_metadata,
-                        plan_kind,
-                    )),
-                    Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
-                    Box::new(harmony::stages::HarmonyResponseProcessingStage::new()),
-                ]
-            }
-            Endpoint::Embeddings => {
-                // Embeddings are single-worker only.
-                if !matches!(mode, Mode::Regular) {
-                    return None;
-                }
-                vec![
-                    Box::new(EmbeddingPreparationStage::new()),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
-                    Box::new(ClientAcquisitionStage),
-                    Box::new(EmbeddingRequestBuildingStage::new()),
-                    Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
-                    Box::new(EmbeddingResponseProcessingStage::new()),
-                ]
-            }
-            Endpoint::Classify => {
-                // Classify is single-worker only.
-                if !matches!(mode, Mode::Regular) {
-                    return None;
-                }
-                vec![
-                    Box::new(EmbeddingPreparationStage::new()),
-                    Box::new(WorkerSelectionStage::new(
-                        deps.worker_registry.clone(),
-                        deps.policy_registry.clone(),
-                        worker_selection,
-                    )),
-                    Box::new(ClientAcquisitionStage),
-                    Box::new(EmbeddingRequestBuildingStage::new()),
-                    Box::new(DispatchMetadataStage),
-                    Box::new(RequestExecutionStage::new()),
-                    Box::new(ClassifyResponseProcessingStage::new()),
-                ]
-            }
-        };
-
-        Some(Self {
-            stages: Arc::new(stages),
-            backend_type: backend,
-        })
-    }
-
     /// Execute the complete pipeline for a chat request
+    #[expect(clippy::too_many_arguments)]
     pub async fn execute_chat(
         &self,
         request: Arc<ChatCompletionRequest>,
@@ -453,97 +728,42 @@ impl RequestPipeline {
         components: Arc<SharedComponents>,
         tenant_request_meta: Option<TenantRequestMeta>,
         rate_limit_cell: Option<Arc<RateLimitCell>>,
+        retry_config: Option<&RetryConfig>,
     ) -> Response {
-        let start = Instant::now();
-        let streaming = request.stream;
         let mut ctx = RequestContext::for_chat(request, headers, model_id, components);
         ctx.input.tenant_request_meta = tenant_request_meta;
         ctx.input.rate_limit_cell = rate_limit_cell;
-        let model = ctx.input.model_id.clone();
 
-        // Record request start
-        Metrics::record_router_request(
-            metrics_labels::ROUTER_GRPC,
-            self.backend_type,
-            metrics_labels::CONNECTION_GRPC,
-            &model,
-            metrics_labels::ENDPOINT_CHAT,
-            bool_to_static_str(streaming),
-        );
-
-        for stage in self.stages.iter() {
-            match stage.execute(&mut ctx).await {
-                Ok(Some(response)) => {
-                    // Stage completed with streaming response - record success and return
-                    Metrics::record_router_duration(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model,
-                        metrics_labels::ENDPOINT_CHAT,
-                        start.elapsed(),
-                    );
-                    return response;
+        const ENDPOINT: &str = metrics_labels::ENDPOINT_CHAT;
+        match Box::pin(self.run(ctx, Some(ENDPOINT), retry_config)).await {
+            Ok(RunOutcome::Early(response)) => response,
+            Ok(RunOutcome::Final(mut dctx, start)) => match dctx.response.final_response.take() {
+                Some(FinalResponse::Chat(response)) => {
+                    let usage = response.usage.as_ref();
+                    Self::settle_reservation(
+                        dctx.rate_limit_cell.as_deref(),
+                        usage.map_or(0, |u| u.prompt_tokens),
+                        usage.map_or(0, |u| u.completion_tokens),
+                    )
+                    .await;
+                    self.record_duration(ENDPOINT, &dctx.model_id, start);
+                    axum::Json(response).into_response()
                 }
-                Ok(None) => continue,
-                Err(response) => {
-                    Metrics::record_router_error(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model,
-                        metrics_labels::ENDPOINT_CHAT,
-                        error_type_from_status(response.status()),
-                    );
-                    error!(
-                        "Stage {} failed with status {}",
-                        stage.name(),
-                        response.status()
-                    );
-                    return response;
-                }
-            }
-        }
-
-        match ctx.state.response.final_response {
-            Some(FinalResponse::Chat(response)) => {
-                let usage = response.usage.as_ref();
-                Self::settle_reservation(
-                    ctx.input.rate_limit_cell.as_deref(),
-                    usage.map_or(0, |u| u.prompt_tokens),
-                    usage.map_or(0, |u| u.completion_tokens),
-                )
-                .await;
-                Metrics::record_router_duration(
-                    metrics_labels::ROUTER_GRPC,
-                    self.backend_type,
-                    metrics_labels::CONNECTION_GRPC,
-                    &model,
-                    metrics_labels::ENDPOINT_CHAT,
-                    start.elapsed(),
-                );
-                axum::Json(response).into_response()
-            }
-            Some(
-                response_type @ (FinalResponse::Generate(_)
-                | FinalResponse::Completion(_)
-                | FinalResponse::Embedding(_)
-                | FinalResponse::Classify(_)
-                | FinalResponse::Messages(_)),
-            ) => self.wrong_response_type(
-                "execute_chat",
-                "Chat",
-                &response_type,
-                &model,
-                metrics_labels::ENDPOINT_CHAT,
-            ),
-            None => {
-                self.no_response_produced("execute_chat", &model, metrics_labels::ENDPOINT_CHAT)
-            }
+                Some(other) => self.wrong_response_type(
+                    "execute_chat",
+                    "Chat",
+                    &other,
+                    &dctx.model_id,
+                    ENDPOINT,
+                ),
+                None => self.no_response_produced("execute_chat", &dctx.model_id, ENDPOINT),
+            },
+            Err(response) => response,
         }
     }
 
     /// Execute the complete pipeline for a generate request
+    #[expect(clippy::too_many_arguments)]
     pub async fn execute_generate(
         &self,
         request: Arc<GenerateRequest>,
@@ -552,100 +772,45 @@ impl RequestPipeline {
         components: Arc<SharedComponents>,
         tenant_request_meta: Option<TenantRequestMeta>,
         rate_limit_cell: Option<Arc<RateLimitCell>>,
+        retry_config: Option<&RetryConfig>,
     ) -> Response {
-        let start = Instant::now();
-        let streaming = request.stream;
         let mut ctx = RequestContext::for_generate(request, headers, model_id, components);
         ctx.input.tenant_request_meta = tenant_request_meta;
         ctx.input.rate_limit_cell = rate_limit_cell;
-        let model_id = ctx.input.model_id.clone();
 
-        // Record request start
-        Metrics::record_router_request(
-            metrics_labels::ROUTER_GRPC,
-            self.backend_type,
-            metrics_labels::CONNECTION_GRPC,
-            &model_id,
-            metrics_labels::ENDPOINT_GENERATE,
-            bool_to_static_str(streaming),
-        );
-
-        for stage in self.stages.iter() {
-            match stage.execute(&mut ctx).await {
-                Ok(Some(response)) => {
-                    Metrics::record_router_duration(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model_id,
-                        metrics_labels::ENDPOINT_GENERATE,
-                        start.elapsed(),
-                    );
-                    return response;
+        const ENDPOINT: &str = metrics_labels::ENDPOINT_GENERATE;
+        match Box::pin(self.run(ctx, Some(ENDPOINT), retry_config)).await {
+            Ok(RunOutcome::Early(response)) => response,
+            Ok(RunOutcome::Final(mut dctx, start)) => match dctx.response.final_response.take() {
+                Some(FinalResponse::Generate(response)) => {
+                    let actual_input_tokens =
+                        response.first().map_or(0, |r| r.meta_info.prompt_tokens);
+                    let completion_tokens =
+                        response.iter().map(|r| r.meta_info.completion_tokens).sum();
+                    Self::settle_reservation(
+                        dctx.rate_limit_cell.as_deref(),
+                        actual_input_tokens,
+                        completion_tokens,
+                    )
+                    .await;
+                    self.record_duration(ENDPOINT, &dctx.model_id, start);
+                    axum::Json(response).into_response()
                 }
-                Ok(None) => continue,
-                Err(response) => {
-                    Metrics::record_router_error(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model_id,
-                        metrics_labels::ENDPOINT_GENERATE,
-                        error_type_from_status(response.status()),
-                    );
-                    error!(
-                        "Stage {} failed with status {}",
-                        stage.name(),
-                        response.status()
-                    );
-                    return response;
-                }
-            }
-        }
-
-        match ctx.state.response.final_response {
-            Some(FinalResponse::Generate(response)) => {
-                let actual_input_tokens = response.first().map_or(0, |r| r.meta_info.prompt_tokens);
-                let completion_tokens =
-                    response.iter().map(|r| r.meta_info.completion_tokens).sum();
-                Self::settle_reservation(
-                    ctx.input.rate_limit_cell.as_deref(),
-                    actual_input_tokens,
-                    completion_tokens,
-                )
-                .await;
-                Metrics::record_router_duration(
-                    metrics_labels::ROUTER_GRPC,
-                    self.backend_type,
-                    metrics_labels::CONNECTION_GRPC,
-                    &model_id,
-                    metrics_labels::ENDPOINT_GENERATE,
-                    start.elapsed(),
-                );
-                axum::Json(response).into_response()
-            }
-            Some(
-                response_type @ (FinalResponse::Chat(_)
-                | FinalResponse::Completion(_)
-                | FinalResponse::Embedding(_)
-                | FinalResponse::Classify(_)
-                | FinalResponse::Messages(_)),
-            ) => self.wrong_response_type(
-                "execute_generate",
-                "Generate",
-                &response_type,
-                &model_id,
-                metrics_labels::ENDPOINT_GENERATE,
-            ),
-            None => self.no_response_produced(
-                "execute_generate",
-                &model_id,
-                metrics_labels::ENDPOINT_GENERATE,
-            ),
+                Some(other) => self.wrong_response_type(
+                    "execute_generate",
+                    "Generate",
+                    &other,
+                    &dctx.model_id,
+                    ENDPOINT,
+                ),
+                None => self.no_response_produced("execute_generate", &dctx.model_id, ENDPOINT),
+            },
+            Err(response) => response,
         }
     }
 
     /// Execute the complete pipeline for a completion request
+    #[expect(clippy::too_many_arguments)]
     pub async fn execute_completion(
         &self,
         request: Arc<CompletionRequest>,
@@ -654,93 +819,80 @@ impl RequestPipeline {
         components: Arc<SharedComponents>,
         tenant_request_meta: Option<TenantRequestMeta>,
         rate_limit_cell: Option<Arc<RateLimitCell>>,
+        retry_config: Option<&RetryConfig>,
     ) -> Response {
-        let start = Instant::now();
-        let streaming = request.stream;
         let mut ctx = RequestContext::for_completion(request, headers, model_id, components);
         ctx.input.tenant_request_meta = tenant_request_meta;
         ctx.input.rate_limit_cell = rate_limit_cell;
-        let model = ctx.input.model_id.clone();
 
-        Metrics::record_router_request(
-            metrics_labels::ROUTER_GRPC,
-            self.backend_type,
-            metrics_labels::CONNECTION_GRPC,
-            &model,
-            metrics_labels::ENDPOINT_COMPLETIONS,
-            bool_to_static_str(streaming),
-        );
-
-        for stage in self.stages.iter() {
-            match stage.execute(&mut ctx).await {
-                Ok(Some(response)) => {
-                    Metrics::record_router_duration(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model,
-                        metrics_labels::ENDPOINT_COMPLETIONS,
-                        start.elapsed(),
-                    );
-                    return response;
+        const ENDPOINT: &str = metrics_labels::ENDPOINT_COMPLETIONS;
+        match Box::pin(self.run(ctx, Some(ENDPOINT), retry_config)).await {
+            Ok(RunOutcome::Early(response)) => response,
+            Ok(RunOutcome::Final(mut dctx, start)) => match dctx.response.final_response.take() {
+                Some(FinalResponse::Completion(response)) => {
+                    let usage = response.usage.as_ref();
+                    Self::settle_reservation(
+                        dctx.rate_limit_cell.as_deref(),
+                        usage.map_or(0, |u| u.prompt_tokens),
+                        usage.map_or(0, |u| u.completion_tokens),
+                    )
+                    .await;
+                    self.record_duration(ENDPOINT, &dctx.model_id, start);
+                    axum::Json(response).into_response()
                 }
-                Ok(None) => continue,
-                Err(response) => {
-                    Metrics::record_router_error(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model,
-                        metrics_labels::ENDPOINT_COMPLETIONS,
-                        error_type_from_status(response.status()),
-                    );
-                    error!(
-                        "Stage {} failed with status {}",
-                        stage.name(),
-                        response.status()
-                    );
-                    return response;
-                }
-            }
+                Some(other) => self.wrong_response_type(
+                    "execute_completion",
+                    "Completion",
+                    &other,
+                    &dctx.model_id,
+                    ENDPOINT,
+                ),
+                None => self.no_response_produced("execute_completion", &dctx.model_id, ENDPOINT),
+            },
+            Err(response) => response,
         }
+    }
 
-        match ctx.state.response.final_response {
-            Some(FinalResponse::Completion(response)) => {
-                let usage = response.usage.as_ref();
-                Self::settle_reservation(
-                    ctx.input.rate_limit_cell.as_deref(),
-                    usage.map_or(0, |u| u.prompt_tokens),
-                    usage.map_or(0, |u| u.completion_tokens),
-                )
-                .await;
-                Metrics::record_router_duration(
-                    metrics_labels::ROUTER_GRPC,
-                    self.backend_type,
-                    metrics_labels::CONNECTION_GRPC,
-                    &model,
-                    metrics_labels::ENDPOINT_COMPLETIONS,
-                    start.elapsed(),
-                );
-                axum::Json(response).into_response()
-            }
-            Some(
-                response_type @ (FinalResponse::Chat(_)
-                | FinalResponse::Generate(_)
-                | FinalResponse::Embedding(_)
-                | FinalResponse::Classify(_)
-                | FinalResponse::Messages(_)),
-            ) => self.wrong_response_type(
-                "execute_completion",
-                "Completion",
-                &response_type,
-                &model,
-                metrics_labels::ENDPOINT_COMPLETIONS,
-            ),
-            None => self.no_response_produced(
-                "execute_completion",
-                &model,
-                metrics_labels::ENDPOINT_COMPLETIONS,
-            ),
+    /// Execute the complete pipeline for a Messages API request
+    #[expect(clippy::too_many_arguments)]
+    pub async fn execute_messages(
+        &self,
+        request: Arc<CreateMessageRequest>,
+        headers: Option<http::HeaderMap>,
+        model_id: String,
+        components: Arc<SharedComponents>,
+        tenant_request_meta: Option<TenantRequestMeta>,
+        rate_limit_cell: Option<Arc<RateLimitCell>>,
+        retry_config: Option<&RetryConfig>,
+    ) -> Response {
+        let mut ctx = RequestContext::for_messages(request, headers, model_id, components);
+        ctx.input.tenant_request_meta = tenant_request_meta;
+        ctx.input.rate_limit_cell = rate_limit_cell;
+
+        const ENDPOINT: &str = metrics_labels::ENDPOINT_MESSAGES;
+        match Box::pin(self.run(ctx, Some(ENDPOINT), retry_config)).await {
+            Ok(RunOutcome::Early(response)) => response,
+            Ok(RunOutcome::Final(mut dctx, start)) => match dctx.response.final_response.take() {
+                Some(FinalResponse::Messages(response)) => {
+                    Self::settle_reservation(
+                        dctx.rate_limit_cell.as_deref(),
+                        response.usage.input_tokens,
+                        response.usage.output_tokens,
+                    )
+                    .await;
+                    self.record_duration(ENDPOINT, &dctx.model_id, start);
+                    axum::Json(response).into_response()
+                }
+                Some(other) => self.wrong_response_type(
+                    "execute_messages",
+                    "Messages",
+                    &other,
+                    &dctx.model_id,
+                    ENDPOINT,
+                ),
+                None => self.no_response_produced("execute_messages", &dctx.model_id, ENDPOINT),
+            },
+            Err(response) => response,
         }
     }
 
@@ -755,94 +907,25 @@ impl RequestPipeline {
     ) -> Response {
         let mut ctx = RequestContext::for_embedding(request, headers, model_id, components);
         ctx.input.tenant_request_meta = tenant_request_meta;
-        let model_id = ctx.input.model_id.clone();
-        debug!(
-            "execute_embeddings: Starting execution for model: {}",
-            &model_id
-        );
-        let start = Instant::now();
 
-        // Record request start
-        Metrics::record_router_request(
-            metrics_labels::ROUTER_GRPC,
-            self.backend_type,
-            metrics_labels::CONNECTION_GRPC,
-            &model_id,
-            metrics_labels::ENDPOINT_EMBEDDINGS,
-            bool_to_static_str(false),
-        );
-
-        for stage in self.stages.iter() {
-            debug!("execute_embeddings: Executing stage: {}", stage.name());
-            match stage.execute(&mut ctx).await {
-                Ok(Some(response)) => {
-                    debug!(
-                        "execute_embeddings: Stage {} returned final response.",
-                        stage.name()
-                    );
-                    Metrics::record_router_duration(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model_id,
-                        metrics_labels::ENDPOINT_EMBEDDINGS,
-                        start.elapsed(),
-                    );
-                    return response;
+        const ENDPOINT: &str = metrics_labels::ENDPOINT_EMBEDDINGS;
+        match Box::pin(self.run(ctx, Some(ENDPOINT), None)).await {
+            Ok(RunOutcome::Early(response)) => response,
+            Ok(RunOutcome::Final(mut dctx, start)) => match dctx.response.final_response.take() {
+                Some(FinalResponse::Embedding(response)) => {
+                    self.record_duration(ENDPOINT, &dctx.model_id, start);
+                    axum::Json(response).into_response()
                 }
-                Ok(None) => {
-                    debug!(
-                        "execute_embeddings: Stage {} completed, continuing to next stage.",
-                        stage.name()
-                    );
-                    continue;
-                }
-                Err(response) => {
-                    error!(
-                        "execute_embeddings: Stage {} failed with status {:?}, returning error response.",
-                        stage.name(),
-                        response.status()
-                    );
-                    Metrics::record_router_error(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model_id,
-                        metrics_labels::ENDPOINT_EMBEDDINGS,
-                        error_type_from_status(response.status()),
-                    );
-                    return response;
-                }
-            }
-        }
-
-        debug!(
-            "execute_embeddings: Pipeline finished, processing final_response. Current state: {:?}",
-            ctx.state.response.final_response
-        );
-        match ctx.state.response.final_response {
-            Some(FinalResponse::Embedding(response)) => {
-                Metrics::record_router_duration(
-                    metrics_labels::ROUTER_GRPC,
-                    self.backend_type,
-                    metrics_labels::CONNECTION_GRPC,
-                    &model_id,
-                    metrics_labels::ENDPOINT_EMBEDDINGS,
-                    start.elapsed(),
-                );
-                axum::Json(response).into_response()
-            }
-            Some(_) => {
-                error!(function = "execute_embeddings", "Wrong response type");
-                error::internal_error("wrong_response_type", "Internal error: wrong response type")
-            }
-            None => {
-                error!(
-                    function = "execute_embeddings",
-                    "No final response produced by pipeline."
-                );
-                error::internal_error("no_response_produced", "No response produced")
-            }
+                Some(other) => self.wrong_response_type(
+                    "execute_embeddings",
+                    "Embedding",
+                    &other,
+                    &dctx.model_id,
+                    ENDPOINT,
+                ),
+                None => self.no_response_produced("execute_embeddings", &dctx.model_id, ENDPOINT),
+            },
+            Err(response) => response,
         }
     }
 
@@ -857,201 +940,32 @@ impl RequestPipeline {
     ) -> Response {
         let mut ctx = RequestContext::for_classify(request, headers, model_id, components);
         ctx.input.tenant_request_meta = tenant_request_meta;
-        let model_id = ctx.input.model_id.clone();
-        debug!(
-            "execute_classify: Starting execution for model: {}",
-            &model_id
-        );
-        let start = Instant::now();
 
-        // Record request start
-        Metrics::record_router_request(
-            metrics_labels::ROUTER_GRPC,
-            self.backend_type,
-            metrics_labels::CONNECTION_GRPC,
-            &model_id,
-            metrics_labels::ENDPOINT_CLASSIFY,
-            bool_to_static_str(false), // Classify is never streaming
-        );
-
-        for stage in self.stages.iter() {
-            debug!("execute_classify: Executing stage: {}", stage.name());
-            match stage.execute(&mut ctx).await {
-                Ok(Some(response)) => {
-                    debug!(
-                        "execute_classify: Stage {} returned final response.",
-                        stage.name()
-                    );
-                    Metrics::record_router_duration(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model_id,
-                        metrics_labels::ENDPOINT_CLASSIFY,
-                        start.elapsed(),
-                    );
-                    return response;
+        const ENDPOINT: &str = metrics_labels::ENDPOINT_CLASSIFY;
+        match Box::pin(self.run(ctx, Some(ENDPOINT), None)).await {
+            Ok(RunOutcome::Early(response)) => response,
+            Ok(RunOutcome::Final(mut dctx, start)) => match dctx.response.final_response.take() {
+                Some(FinalResponse::Classify(response)) => {
+                    self.record_duration(ENDPOINT, &dctx.model_id, start);
+                    axum::Json(response).into_response()
                 }
-                Ok(None) => {
-                    debug!(
-                        "execute_classify: Stage {} completed, continuing to next stage.",
-                        stage.name()
-                    );
-                    continue;
-                }
-                Err(response) => {
-                    error!(
-                        "execute_classify: Stage {} failed with status {:?}, returning error response.",
-                        stage.name(),
-                        response.status()
-                    );
-                    Metrics::record_router_error(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model_id,
-                        metrics_labels::ENDPOINT_CLASSIFY,
-                        error_type_from_status(response.status()),
-                    );
-                    return response;
-                }
-            }
-        }
-
-        debug!(
-            "execute_classify: Pipeline finished, processing final_response. Current state: {:?}",
-            ctx.state.response.final_response
-        );
-        match ctx.state.response.final_response {
-            Some(FinalResponse::Classify(response)) => {
-                Metrics::record_router_duration(
-                    metrics_labels::ROUTER_GRPC,
-                    self.backend_type,
-                    metrics_labels::CONNECTION_GRPC,
-                    &model_id,
-                    metrics_labels::ENDPOINT_CLASSIFY,
-                    start.elapsed(),
-                );
-                axum::Json(response).into_response()
-            }
-            Some(_) => {
-                error!(function = "execute_classify", "Wrong response type");
-                error::internal_error("wrong_response_type", "Internal error: wrong response type")
-            }
-            None => {
-                error!(
-                    function = "execute_classify",
-                    "No final response produced by pipeline."
-                );
-                error::internal_error("no_response_produced", "No response produced")
-            }
-        }
-    }
-
-    /// Execute the complete pipeline for a Messages API request
-    pub async fn execute_messages(
-        &self,
-        request: Arc<CreateMessageRequest>,
-        headers: Option<http::HeaderMap>,
-        model_id: String,
-        components: Arc<SharedComponents>,
-        tenant_request_meta: Option<TenantRequestMeta>,
-        rate_limit_cell: Option<Arc<RateLimitCell>>,
-    ) -> Response {
-        let start = Instant::now();
-        let streaming = request.stream.unwrap_or(false);
-        let mut ctx = RequestContext::for_messages(request, headers, model_id, components);
-        ctx.input.tenant_request_meta = tenant_request_meta;
-        ctx.input.rate_limit_cell = rate_limit_cell;
-        let model = ctx.input.model_id.clone();
-
-        // Record request start
-        Metrics::record_router_request(
-            metrics_labels::ROUTER_GRPC,
-            self.backend_type,
-            metrics_labels::CONNECTION_GRPC,
-            &model,
-            metrics_labels::ENDPOINT_MESSAGES,
-            bool_to_static_str(streaming),
-        );
-
-        for stage in self.stages.iter() {
-            match stage.execute(&mut ctx).await {
-                Ok(Some(response)) => {
-                    // Stage completed with streaming response
-                    Metrics::record_router_duration(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model,
-                        metrics_labels::ENDPOINT_MESSAGES,
-                        start.elapsed(),
-                    );
-                    return response;
-                }
-                Ok(None) => continue,
-                Err(response) => {
-                    Metrics::record_router_error(
-                        metrics_labels::ROUTER_GRPC,
-                        self.backend_type,
-                        metrics_labels::CONNECTION_GRPC,
-                        &model,
-                        metrics_labels::ENDPOINT_MESSAGES,
-                        error_type_from_status(response.status()),
-                    );
-                    error!(
-                        "Stage {} failed with status {}",
-                        stage.name(),
-                        response.status()
-                    );
-                    return response;
-                }
-            }
-        }
-
-        match ctx.state.response.final_response {
-            Some(FinalResponse::Messages(response)) => {
-                Self::settle_reservation(
-                    ctx.input.rate_limit_cell.as_deref(),
-                    response.usage.input_tokens,
-                    response.usage.output_tokens,
-                )
-                .await;
-                Metrics::record_router_duration(
-                    metrics_labels::ROUTER_GRPC,
-                    self.backend_type,
-                    metrics_labels::CONNECTION_GRPC,
-                    &model,
-                    metrics_labels::ENDPOINT_MESSAGES,
-                    start.elapsed(),
-                );
-                axum::Json(response).into_response()
-            }
-            Some(
-                response_type @ (FinalResponse::Chat(_)
-                | FinalResponse::Generate(_)
-                | FinalResponse::Completion(_)
-                | FinalResponse::Embedding(_)
-                | FinalResponse::Classify(_)),
-            ) => self.wrong_response_type(
-                "execute_messages",
-                "Messages",
-                &response_type,
-                &model,
-                metrics_labels::ENDPOINT_MESSAGES,
-            ),
-            None => self.no_response_produced(
-                "execute_messages",
-                &model,
-                metrics_labels::ENDPOINT_MESSAGES,
-            ),
+                Some(other) => self.wrong_response_type(
+                    "execute_classify",
+                    "Classify",
+                    &other,
+                    &dctx.model_id,
+                    ENDPOINT,
+                ),
+                None => self.no_response_produced("execute_classify", &dctx.model_id, ENDPOINT),
+            },
+            Err(response) => response,
         }
     }
 
     /// Execute chat pipeline for responses endpoint
     ///
     /// Used by ALL non-streaming /v1/responses requests.
-    /// Uses the same 7 pipeline stages as execute_chat(), with two differences:
+    /// Same stages as execute_chat(), with two differences:
     /// 1. Returns Result<ChatCompletionResponse, Response> for tool_loop composition
     /// 2. Disallows streaming (responses endpoint uses different SSE format)
     pub async fn execute_chat_for_responses(
@@ -1065,86 +979,56 @@ impl RequestPipeline {
         let mut ctx = RequestContext::for_chat(request, headers, model_id, components);
         ctx.input.tenant_request_meta = tenant_request_meta;
 
-        for (idx, stage) in self.stages.iter().enumerate() {
-            match stage.execute(&mut ctx).await {
-                Ok(Some(_response)) => {
-                    // Streaming not supported for responses sync mode
+        match Box::pin(self.run(ctx, None, None)).await {
+            Ok(RunOutcome::Early(_)) => {
+                // Streaming not supported for responses sync mode
+                error!(
+                    function = "execute_chat_for_responses",
+                    "Streaming attempted in responses context"
+                );
+                Err(error::bad_request(
+                    "streaming_not_supported",
+                    "Streaming is not supported in this context".to_string(),
+                ))
+            }
+            Ok(RunOutcome::Final(mut dctx, _)) => match dctx.response.final_response.take() {
+                Some(FinalResponse::Chat(response)) => Ok(response),
+                Some(_) => {
                     error!(
                         function = "execute_chat_for_responses",
-                        "Streaming attempted in responses context"
+                        "Wrong response type: expected Chat"
                     );
-                    return Err(error::bad_request(
-                        "streaming_not_supported",
-                        "Streaming is not supported in this context".to_string(),
-                    ));
+                    Err(error::internal_error(
+                        "wrong_response_type",
+                        "Internal error: wrong response type",
+                    ))
                 }
-                Ok(None) => {
-                    continue;
-                }
-                Err(response) => {
-                    // Error occurred - return the response as-is to preserve HTTP status codes
+                None => {
                     error!(
-                        "Stage {} ({}) failed with status {}",
-                        idx + 1,
-                        stage.name(),
-                        response.status()
+                        function = "execute_chat_for_responses",
+                        "No response produced by pipeline"
                     );
-                    return Err(response);
+                    Err(error::internal_error(
+                        "no_response_produced",
+                        "No response produced",
+                    ))
                 }
-            }
-        }
-
-        match ctx.state.response.final_response {
-            Some(FinalResponse::Chat(response)) => Ok(response),
-            Some(FinalResponse::Generate(_))
-            | Some(FinalResponse::Completion(_))
-            | Some(FinalResponse::Embedding(_))
-            | Some(FinalResponse::Classify(_))
-            | Some(FinalResponse::Messages(_)) => {
-                error!(
-                    function = "execute_chat_for_responses",
-                    "Wrong response type: expected Chat, got Generate/Embedding/Classify/Messages"
-                );
-                Err(error::internal_error(
-                    "wrong_response_type",
-                    "Internal error: wrong response type",
-                ))
-            }
-            None => {
-                error!(
-                    function = "execute_chat_for_responses",
-                    "No response produced by pipeline"
-                );
-                Err(error::internal_error(
-                    "no_response_produced",
-                    "No response produced",
-                ))
-            }
+            },
+            Err(response) => Err(response),
         }
     }
 
-    /// Execute Harmony Responses API request through all pipeline stages
+    /// Execute one Harmony Responses API iteration through the pipeline.
     ///
-    /// This method runs a single iteration of the Responses API request,
-    /// returning either ToolCallsFound (continue serving) or Completed (final response).
-    ///
-    /// Called by harmony::responses::serve_harmony_responses() for each iteration.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - Responses API request
-    /// * `ctx` - Harmony Responses context with MCP manager and components
-    ///
-    /// # Returns
-    ///
-    /// ResponsesIterationResult indicating whether to continue iteration or return
+    /// Returns ToolCallsFound (continue serving) or Completed (final
+    /// response); called by harmony::responses::serve_harmony_responses()
+    /// per iteration.
     pub async fn execute_harmony_responses(
         &self,
         request: &openai_protocol::responses::ResponsesRequest,
         harmony_ctx: &ResponsesContext,
         tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Result<harmony::ResponsesIterationResult, Response> {
-        // Create RequestContext for this Responses request
         let mut ctx = RequestContext::for_responses(
             Arc::new(request.clone()),
             None,                  // No headers needed for internal pipeline execution
@@ -1153,37 +1037,19 @@ impl RequestPipeline {
         );
         ctx.input.tenant_request_meta = tenant_request_meta;
 
-        for (idx, stage) in self.stages.iter().enumerate() {
-            match stage.execute(&mut ctx).await {
-                Ok(Some(response)) => {
-                    // Stage returned early response (e.g., streaming) - not expected for Responses iteration
-                    error!(
-                        "Stage {} ({}) returned unexpected response during Responses iteration",
-                        idx + 1,
-                        stage.name()
-                    );
-                    return Err(response);
-                }
-                Ok(None) => {
-                    continue;
-                }
-                Err(response) => {
-                    // Stage failed
-                    error!(
-                        "Stage {} ({}) failed with status {}",
-                        idx + 1,
-                        stage.name(),
-                        response.status()
-                    );
-                    return Err(response);
-                }
+        let mut dctx = match Box::pin(self.run(ctx, None, None)).await {
+            Ok(RunOutcome::Early(response)) => {
+                error!(
+                    function = "execute_harmony_responses",
+                    "Unexpected early response during Responses iteration"
+                );
+                return Err(response);
             }
-        }
+            Ok(RunOutcome::Final(dctx, _)) => dctx,
+            Err(response) => return Err(response),
+        };
 
-        // Extract ResponsesIterationResult from context
-        // This should have been set by HarmonyResponseProcessingStage
-        ctx.state
-            .response
+        dctx.response
             .responses_iteration_result
             .take()
             .ok_or_else(|| {
@@ -1198,18 +1064,17 @@ impl RequestPipeline {
             })
     }
 
-    /// Execute Harmony Responses pipeline iteration with streaming support
+    /// Execute a Harmony Responses pipeline iteration with streaming support.
     ///
-    /// This version executes the pipeline up to the dispatch stage and returns
-    /// the raw ExecutionResult (with stream) and LoadGuards for token-level streaming processing.
-    /// The caller is responsible for keeping load_guards alive until stream processing completes.
+    /// Runs through dispatch and returns the raw ExecutionResult (with
+    /// stream) and LoadGuards for token-level streaming processing. The
+    /// caller keeps load_guards alive until stream processing completes.
     pub async fn execute_harmony_responses_streaming(
         &self,
         request: &openai_protocol::responses::ResponsesRequest,
         harmony_ctx: &ResponsesContext,
         tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Result<(ExecutionResult, Option<LoadGuards>), Response> {
-        // Create RequestContext for this Responses request
         let mut ctx = RequestContext::for_responses(
             Arc::new(request.clone()),
             None,
@@ -1218,31 +1083,19 @@ impl RequestPipeline {
         );
         ctx.input.tenant_request_meta = tenant_request_meta;
 
-        for (idx, stage) in self.stages.iter().enumerate() {
-            match stage.execute(&mut ctx).await {
-                Ok(Some(response)) => {
-                    error!(
-                        "Stage {} ({}) returned unexpected response during streaming Responses",
-                        idx + 1,
-                        stage.name()
-                    );
-                    return Err(response);
-                }
-                Ok(None) => continue,
-                Err(response) => {
-                    error!(
-                        "Stage {} ({}) failed with status {}",
-                        idx + 1,
-                        stage.name(),
-                        response.status()
-                    );
-                    return Err(response);
-                }
+        let mut dctx = match Box::pin(self.run(ctx, None, None)).await {
+            Ok(RunOutcome::Early(response)) => {
+                error!(
+                    function = "execute_harmony_responses_streaming",
+                    "Unexpected early response during streaming Responses"
+                );
+                return Err(response);
             }
-        }
+            Ok(RunOutcome::Final(dctx, _)) => dctx,
+            Err(response) => return Err(response),
+        };
 
-        // Extract execution_result (the raw stream from workers) and load_guards
-        let execution_result = ctx.state.response.execution_result.take().ok_or_else(|| {
+        let execution_result = dctx.response.execution_result.take().ok_or_else(|| {
             error!(
                 function = "execute_harmony_responses_streaming",
                 "No ExecutionResult produced by pipeline"
@@ -1253,9 +1106,25 @@ impl RequestPipeline {
             )
         })?;
 
-        let load_guards = ctx.state.load_guards.take();
+        let load_guards = dctx.load_guards.take();
 
         Ok((execution_result, load_guards))
+    }
+}
+
+#[cfg(test)]
+impl RequestPipeline {
+    /// Mode-bearing construction descriptor for the parity test. Stage
+    /// ordering itself is structural (see `PipelineStages`), so only the
+    /// per-mode args and optional stages need freezing.
+    fn signature(&self) -> String {
+        format!(
+            "{}|rate_limit={}|encode={}|{}",
+            self.stages.worker_selection.signature(),
+            self.stages.rate_limit.is_some(),
+            self.stages.encode.is_some(),
+            self.stages.request_building.signature(),
+        )
     }
 }
 
@@ -1264,219 +1133,65 @@ mod build_parity_tests {
     use super::*;
     use crate::routers::grpc::mode::Mode;
 
-    fn sigs(p: &RequestPipeline) -> Vec<String> {
-        p.stages.iter().map(|s| s.signature()).collect()
-    }
-
-    fn v(stages: &[&str]) -> Vec<String> {
-        stages.iter().map(|s| (*s).to_string()).collect()
-    }
-
-    /// Hand-transcribed expected stage signatures + metrics backend label per
-    /// endpoint/mode. Do not regenerate from `build()` output, or this stops
-    /// guarding anything: it exists to catch a wrong `build`/`mode.rs` mapping
-    /// (a flipped `inject_pd_metadata`, wrong `plan_kind`, or swapped
-    /// `WorkerSelectionMode`).
-    ///
-    /// Signature format: stages with no mode-varying args emit their short type
-    /// name; the mode-bearing overrides append their args.
-    /// `ChatGenerateRequestBuildingStage` is a composite wrapping the chat and
-    /// generate request-building stages, both fed the same mode args.
-    fn golden(endpoint: Endpoint, mode: Mode) -> (Vec<String>, &'static str) {
+    /// Hand-transcribed expected construction descriptor + metrics backend
+    /// label per endpoint/mode. Do not regenerate from `build()` output, or
+    /// this stops guarding anything: it exists to catch a wrong
+    /// `build`/`mode.rs` mapping (a flipped `inject_pd_metadata`, wrong
+    /// `plan_kind`, or swapped `WorkerSelectionMode`). Stage ordering is
+    /// structural in `PipelineStages` and needs no golden.
+    fn golden(endpoint: Endpoint, mode: Mode) -> (String, &'static str) {
         const REGULAR: &str = metrics_labels::BACKEND_REGULAR;
         const PD: &str = metrics_labels::BACKEND_PD;
-        match (endpoint, mode) {
-            (Endpoint::Chat, Mode::Regular) => (
-                v(&[
-                    "ChatGeneratePreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(Regular)",
-                    "ClientAcquisitionStage",
-                    "ChatGenerateRequestBuildingStage(ChatRequestBuildingStage(inject_pd_metadata=false, Single), GenerateRequestBuildingStage(inject_pd_metadata=false, Single))",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "ChatGenerateResponseProcessingStage",
-                ]),
-                REGULAR,
+        let (selection, inject, plan, backend) = match mode {
+            Mode::Regular => ("Regular", "false", "Single", REGULAR),
+            Mode::PrefillDecode => ("PrefillDecode", "true", "PrefillDecode", PD),
+            Mode::EncodePrefillDecode => {
+                ("EncodePrefillDecode", "false", "EncodePrefillDecode", PD)
+            }
+        };
+        let encode = matches!(mode, Mode::EncodePrefillDecode);
+        let build = match endpoint {
+            Endpoint::Chat => format!(
+                "ChatGenerateRequestBuildingStage(ChatRequestBuildingStage(inject_pd_metadata={inject}, {plan}), GenerateRequestBuildingStage(inject_pd_metadata={inject}, {plan}))"
             ),
-            (Endpoint::Chat, Mode::PrefillDecode) => (
-                v(&[
-                    "ChatGeneratePreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(PrefillDecode)",
-                    "ClientAcquisitionStage",
-                    "ChatGenerateRequestBuildingStage(ChatRequestBuildingStage(inject_pd_metadata=true, PrefillDecode), GenerateRequestBuildingStage(inject_pd_metadata=true, PrefillDecode))",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "ChatGenerateResponseProcessingStage",
-                ]),
-                PD,
+            Endpoint::Messages => {
+                format!("MessageRequestBuildingStage(inject_pd_metadata={inject}, {plan})")
+            }
+            Endpoint::Completion => {
+                format!("CompletionRequestBuildingStage(inject_pd_metadata={inject}, {plan})")
+            }
+            Endpoint::Harmony => {
+                format!("HarmonyRequestBuildingStage(inject_pd_metadata={inject}, {plan})")
+            }
+            Endpoint::Embeddings | Endpoint::Classify => {
+                "EmbeddingRequestBuildingStage".to_string()
+            }
+        };
+        let rate_limit = !matches!(endpoint, Endpoint::Embeddings | Endpoint::Classify);
+        // Harmony never carries the encode stage.
+        let encode = encode && !matches!(endpoint, Endpoint::Harmony);
+        (
+            format!(
+                "WorkerSelectionStage({selection})|rate_limit={rate_limit}|encode={encode}|{build}"
             ),
-            (Endpoint::Chat, Mode::EncodePrefillDecode) => (
-                v(&[
-                    "ChatGeneratePreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(EncodePrefillDecode)",
-                    "ClientAcquisitionStage",
-                    "EncodeStage",
-                    "ChatGenerateRequestBuildingStage(ChatRequestBuildingStage(inject_pd_metadata=false, EncodePrefillDecode), GenerateRequestBuildingStage(inject_pd_metadata=false, EncodePrefillDecode))",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "ChatGenerateResponseProcessingStage",
-                ]),
-                PD,
-            ),
-            (Endpoint::Messages, Mode::Regular) => (
-                v(&[
-                    "MessagePreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(Regular)",
-                    "ClientAcquisitionStage",
-                    "MessageRequestBuildingStage(inject_pd_metadata=false, Single)",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "MessageResponseProcessingStage",
-                ]),
-                REGULAR,
-            ),
-            (Endpoint::Messages, Mode::PrefillDecode) => (
-                v(&[
-                    "MessagePreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(PrefillDecode)",
-                    "ClientAcquisitionStage",
-                    "MessageRequestBuildingStage(inject_pd_metadata=true, PrefillDecode)",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "MessageResponseProcessingStage",
-                ]),
-                PD,
-            ),
-            (Endpoint::Messages, Mode::EncodePrefillDecode) => (
-                v(&[
-                    "MessagePreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(EncodePrefillDecode)",
-                    "ClientAcquisitionStage",
-                    "EncodeStage",
-                    "MessageRequestBuildingStage(inject_pd_metadata=false, EncodePrefillDecode)",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "MessageResponseProcessingStage",
-                ]),
-                PD,
-            ),
-            (Endpoint::Completion, Mode::Regular) => (
-                v(&[
-                    "CompletionPreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(Regular)",
-                    "ClientAcquisitionStage",
-                    "CompletionRequestBuildingStage(inject_pd_metadata=false, Single)",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "CompletionResponseProcessingStage",
-                ]),
-                REGULAR,
-            ),
-            (Endpoint::Completion, Mode::PrefillDecode) => (
-                v(&[
-                    "CompletionPreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(PrefillDecode)",
-                    "ClientAcquisitionStage",
-                    "CompletionRequestBuildingStage(inject_pd_metadata=true, PrefillDecode)",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "CompletionResponseProcessingStage",
-                ]),
-                PD,
-            ),
-            (Endpoint::Completion, Mode::EncodePrefillDecode) => (
-                v(&[
-                    "CompletionPreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(EncodePrefillDecode)",
-                    "ClientAcquisitionStage",
-                    "EncodeStage",
-                    "CompletionRequestBuildingStage(inject_pd_metadata=false, EncodePrefillDecode)",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "CompletionResponseProcessingStage",
-                ]),
-                PD,
-            ),
-            (Endpoint::Harmony, Mode::Regular) => (
-                v(&[
-                    "HarmonyPreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(Regular)",
-                    "ClientAcquisitionStage",
-                    "HarmonyRequestBuildingStage(inject_pd_metadata=false, Single)",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "HarmonyResponseProcessingStage",
-                ]),
-                REGULAR,
-            ),
-            (Endpoint::Harmony, Mode::PrefillDecode) => (
-                v(&[
-                    "HarmonyPreparationStage",
-                    "RateLimitReserveStage",
-                    "WorkerSelectionStage(PrefillDecode)",
-                    "ClientAcquisitionStage",
-                    "HarmonyRequestBuildingStage(inject_pd_metadata=true, PrefillDecode)",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "HarmonyResponseProcessingStage",
-                ]),
-                PD,
-            ),
-            // Embeddings and classify share prep + request building; classify
-            // only swaps the response processor.
-            (Endpoint::Embeddings, Mode::Regular) => (
-                v(&[
-                    "EmbeddingPreparationStage",
-                    "WorkerSelectionStage(Regular)",
-                    "ClientAcquisitionStage",
-                    "EmbeddingRequestBuildingStage",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "EmbeddingResponseProcessingStage",
-                ]),
-                REGULAR,
-            ),
-            (Endpoint::Classify, Mode::Regular) => (
-                v(&[
-                    "EmbeddingPreparationStage",
-                    "WorkerSelectionStage(Regular)",
-                    "ClientAcquisitionStage",
-                    "EmbeddingRequestBuildingStage",
-                    "DispatchMetadataStage",
-                    "RequestExecutionStage",
-                    "ClassifyResponseProcessingStage",
-                ]),
-                REGULAR,
-            ),
-            (endpoint, mode) => panic!("no golden for invalid combo {endpoint:?}/{mode:?}"),
-        }
+            backend,
+        )
     }
 
-    /// Assert `build(endpoint, mode)` matches the hand-transcribed golden (stage
-    /// sequence + mode-bearing args + metrics backend label).
     fn assert_parity(endpoint: Endpoint, mode: Mode, deps: &PipelineDeps) {
-        let (expected_sigs, expected_backend) = golden(endpoint, mode);
+        let (expected_sig, expected_backend) = golden(endpoint, mode);
         let built = RequestPipeline::build(endpoint, mode, deps)
             .unwrap_or_else(|| panic!("build({endpoint:?}, {mode:?}) should be valid"));
         assert_eq!(
-            sigs(&built),
-            expected_sigs,
-            "stage parity for {endpoint:?}/{mode:?}"
+            built.signature(),
+            expected_sig,
+            "construction parity for {endpoint:?}/{mode:?}"
         );
         assert_eq!(
             built.backend_type, expected_backend,
             "backend_type parity for {endpoint:?}/{mode:?}"
         );
+        assert_eq!(built.mode, mode, "mode parity for {endpoint:?}/{mode:?}");
     }
 
     #[test]
@@ -1588,17 +1303,20 @@ mod alias_pipeline_tests {
         );
 
         assert_eq!(ctx.input.model_id, CANONICAL_MODEL);
-        assert_eq!(ctx.generate_request().model, CANONICAL_MODEL);
+        assert_eq!(ctx.generate_request_arc().model, CANONICAL_MODEL);
 
-        for stage in pipeline.stages.iter() {
-            assert!(stage.execute(&mut ctx).await.unwrap().is_none());
-            if ctx.state.workers.is_some() {
-                break;
-            }
-        }
+        // Ingress up to worker selection: the canonical id must already be in
+        // place when selection runs.
+        pipeline.stages.preparation.execute(&mut ctx).await.unwrap();
+        pipeline
+            .stages
+            .worker_selection
+            .execute(&mut ctx)
+            .await
+            .unwrap();
 
         assert_eq!(ctx.input.model_id, CANONICAL_MODEL);
-        assert_eq!(ctx.generate_request().model, CANONICAL_MODEL);
+        assert_eq!(ctx.generate_request_arc().model, CANONICAL_MODEL);
         assert!(ctx.state.tokenizer.is_some());
         match ctx.state.workers.as_ref().unwrap() {
             WorkerSelection::Disaggregated {
@@ -1608,6 +1326,565 @@ mod alias_pipeline_tests {
                 assert_eq!(decode.url(), "grpc://decode:30000");
             }
             WorkerSelection::Single { .. } => panic!("expected PD worker selection"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod request_release_tests {
+    use std::{
+        pin::Pin,
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Mutex, PoisonError, Weak,
+        },
+        time::Duration,
+    };
+
+    use futures::Stream;
+    use llm_tokenizer::{traits::Tokenizer, MockTokenizer, TokenizerRegistry};
+    use openai_protocol::{
+        completion::CompletionRequest, model_card::ModelCard, worker::HealthCheckConfig,
+    };
+    use portpicker::pick_unused_port;
+    use smg_grpc_client::{common_proto as common, tokenspeed_proto as ts};
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
+    use tonic::{transport::Server, Request as TonicRequest, Response as TonicResponse, Status};
+    use ts::token_speed_scheduler_server::{TokenSpeedScheduler, TokenSpeedSchedulerServer};
+
+    use super::*;
+    use crate::{
+        config::types::PolicyConfig,
+        worker::{BasicWorkerBuilder, ConnectionMode, RuntimeType, WorkerType},
+    };
+
+    const MODEL: &str = "request-release-test-model";
+
+    type GenStream = Pin<Box<dyn Stream<Item = Result<ts::GenerateResponse, Status>> + Send>>;
+    type KvEventStream = Pin<Box<dyn Stream<Item = Result<common::KvEventBatch, Status>> + Send>>;
+    type TokenizerStream =
+        Pin<Box<dyn Stream<Item = Result<common::GetTokenizerChunk, Status>> + Send>>;
+
+    /// TokenSpeed stub gated on the parsed request's drop probe: it withholds
+    /// its tokens (or, with `gate_rpc`, the generate RPC itself) until the
+    /// probe reaches zero strong references or a deadline passes, recording
+    /// the outcome in `released`. An ungated stub (no probe) answers
+    /// immediately -- used for the PD prefill leg. `fail_first` makes the
+    /// first generate call return UNAVAILABLE, for retry-replay tests; every
+    /// call's input token ids and engine request id are recorded.
+    #[derive(Clone, Default)]
+    struct GatedScheduler {
+        probe: Option<Weak<CompletionRequest>>,
+        gate_rpc: bool,
+        released: Arc<AtomicBool>,
+        fail_first: bool,
+        calls: Arc<AtomicUsize>,
+        seen_input_ids: Arc<Mutex<Vec<Vec<u32>>>>,
+        seen_request_ids: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl GatedScheduler {
+        async fn await_probe(probe: &Weak<CompletionRequest>, released: &AtomicBool) {
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+            while probe.strong_count() > 0 && tokio::time::Instant::now() < deadline {
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+            released.store(probe.strong_count() == 0, Ordering::SeqCst);
+        }
+    }
+
+    fn generate_frames(request_id: &str) -> Vec<Result<ts::GenerateResponse, Status>> {
+        use ts::generate_response::Response as GenResp;
+        vec![
+            Ok(ts::GenerateResponse {
+                request_id: request_id.to_string(),
+                response: Some(GenResp::Chunk(ts::GenerateStreamChunk {
+                    token_ids: vec![100],
+                    prompt_tokens: 2,
+                    completion_tokens: 1,
+                    cached_tokens: 0,
+                    output_logprobs: None,
+                    index: 0,
+                })),
+            }),
+            Ok(ts::GenerateResponse {
+                request_id: request_id.to_string(),
+                response: Some(GenResp::Complete(ts::GenerateComplete {
+                    output_ids: vec![100],
+                    finish_reason: "stop".to_string(),
+                    prompt_tokens: 2,
+                    completion_tokens: 1,
+                    cached_tokens: 0,
+                    output_logprobs: None,
+                    matched_stop: None,
+                    index: 0,
+                })),
+            }),
+        ]
+    }
+
+    #[tonic::async_trait]
+    impl TokenSpeedScheduler for GatedScheduler {
+        type GenerateStream = GenStream;
+        type SubscribeKvEventsStream = KvEventStream;
+        type GetTokenizerStream = TokenizerStream;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test stub; the gate task ends at its deadline"
+        )]
+        async fn generate(
+            &self,
+            request: TonicRequest<ts::GenerateRequest>,
+        ) -> Result<TonicResponse<Self::GenerateStream>, Status> {
+            let request = request.into_inner();
+            self.seen_input_ids
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(request.tokenized.map(|t| t.input_ids).unwrap_or_default());
+            self.seen_request_ids
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(request.request_id.clone());
+            if self.fail_first && self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(Status::unavailable("release-test induced failure"));
+            }
+            if self.gate_rpc {
+                if let Some(probe) = &self.probe {
+                    Self::await_probe(probe, &self.released).await;
+                }
+            }
+            let request_id = request.request_id;
+            let (tx, rx) = mpsc::channel(8);
+            let probe = (!self.gate_rpc).then(|| self.probe.clone()).flatten();
+            let released = Arc::clone(&self.released);
+            tokio::spawn(async move {
+                if let Some(probe) = probe {
+                    Self::await_probe(&probe, &released).await;
+                }
+                for frame in generate_frames(&request_id) {
+                    if tx.send(frame).await.is_err() {
+                        return;
+                    }
+                }
+            });
+            Ok(TonicResponse::new(Box::pin(ReceiverStream::new(rx))))
+        }
+
+        async fn health_check(
+            &self,
+            _request: TonicRequest<ts::HealthCheckRequest>,
+        ) -> Result<TonicResponse<ts::HealthCheckResponse>, Status> {
+            Ok(TonicResponse::new(ts::HealthCheckResponse {
+                healthy: true,
+                message: "ok".to_string(),
+            }))
+        }
+
+        async fn abort(
+            &self,
+            _request: TonicRequest<ts::AbortRequest>,
+        ) -> Result<TonicResponse<ts::AbortResponse>, Status> {
+            Ok(TonicResponse::new(ts::AbortResponse {
+                success: true,
+                message: String::new(),
+            }))
+        }
+
+        async fn get_model_info(
+            &self,
+            _request: TonicRequest<ts::GetModelInfoRequest>,
+        ) -> Result<TonicResponse<ts::GetModelInfoResponse>, Status> {
+            Ok(TonicResponse::new(ts::GetModelInfoResponse {
+                model_path: MODEL.to_string(),
+                tokenizer_path: MODEL.to_string(),
+                served_model_name: MODEL.to_string(),
+                model_type: "mock".to_string(),
+                architectures: vec!["MockForCausalLM".to_string()],
+                max_context_length: 32768,
+                max_req_input_len: 32768,
+                vocab_size: 32000,
+                eos_token_ids: vec![2],
+                pad_token_id: 0,
+                bos_token_id: 1,
+                weight_version: "mock".to_string(),
+                default_sampling_params_json: String::new(),
+                supports_vision: false,
+                ..Default::default()
+            }))
+        }
+
+        async fn get_server_info(
+            &self,
+            _request: TonicRequest<ts::GetServerInfoRequest>,
+        ) -> Result<TonicResponse<ts::GetServerInfoResponse>, Status> {
+            Ok(TonicResponse::new(ts::GetServerInfoResponse {
+                max_total_num_tokens: 1_000_000,
+                tokenspeed_version: "mock".to_string(),
+                ..Default::default()
+            }))
+        }
+
+        async fn get_loads(
+            &self,
+            _request: TonicRequest<ts::GetLoadsRequest>,
+        ) -> Result<TonicResponse<ts::GetLoadsResponse>, Status> {
+            Err(Status::unimplemented("release-test stub"))
+        }
+
+        async fn subscribe_kv_events(
+            &self,
+            _request: TonicRequest<common::SubscribeKvEventsRequest>,
+        ) -> Result<TonicResponse<Self::SubscribeKvEventsStream>, Status> {
+            Err(Status::unimplemented("release-test stub"))
+        }
+
+        async fn flush_cache(
+            &self,
+            _request: TonicRequest<common::FlushCacheRequest>,
+        ) -> Result<TonicResponse<common::FlushCacheResponse>, Status> {
+            Err(Status::unimplemented("release-test stub"))
+        }
+
+        async fn start_profile(
+            &self,
+            _request: TonicRequest<common::StartProfileRequest>,
+        ) -> Result<TonicResponse<common::ProfileResponse>, Status> {
+            Err(Status::unimplemented("release-test stub"))
+        }
+
+        async fn stop_profile(
+            &self,
+            _request: TonicRequest<common::StopProfileRequest>,
+        ) -> Result<TonicResponse<common::ProfileResponse>, Status> {
+            Err(Status::unimplemented("release-test stub"))
+        }
+
+        async fn get_tokenizer(
+            &self,
+            _request: TonicRequest<common::GetTokenizerRequest>,
+        ) -> Result<TonicResponse<Self::GetTokenizerStream>, Status> {
+            Err(Status::unimplemented("release-test stub"))
+        }
+    }
+
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test helper; the stub server lives for the test process"
+    )]
+    async fn spawn_stub(scheduler: GatedScheduler) -> u16 {
+        let port = pick_unused_port().expect("no free port for release-test stub");
+        let addr = format!("127.0.0.1:{port}").parse().expect("stub addr");
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(TokenSpeedSchedulerServer::new(scheduler))
+                .serve(addr)
+                .await
+                .expect("release-test stub server");
+        });
+        for _ in 0..100 {
+            if tokio::net::TcpStream::connect(("127.0.0.1", port))
+                .await
+                .is_ok()
+            {
+                return port;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("release-test stub on port {port} never came up");
+    }
+
+    fn register_worker(registry: &WorkerRegistry, port: u16, worker_type: WorkerType) {
+        let worker = BasicWorkerBuilder::new(format!("grpc://127.0.0.1:{port}"))
+            .worker_type(worker_type)
+            .connection_mode(ConnectionMode::Grpc)
+            .runtime_type(RuntimeType::TokenSpeed)
+            .model(ModelCard::new(MODEL))
+            .health_config(HealthCheckConfig {
+                disable_health_check: true,
+                ..Default::default()
+            })
+            .build();
+        registry
+            .register(Arc::new(worker))
+            .expect("register release-test worker");
+    }
+
+    async fn components(worker_registry: Arc<WorkerRegistry>) -> Arc<SharedComponents> {
+        let tokenizer_registry = Arc::new(TokenizerRegistry::new());
+        let tokenizer = Arc::new(MockTokenizer::new()) as Arc<dyn Tokenizer>;
+        tokenizer_registry
+            .load(
+                "tokenizer-id",
+                MODEL,
+                "test",
+                || async move { Ok(tokenizer) },
+            )
+            .await
+            .expect("load mock tokenizer");
+        Arc::new(SharedComponents {
+            tokenizer_registry,
+            worker_registry,
+            tool_parser_factory: ToolParserFactory::default(),
+            reasoning_parser_factory: ReasoningParserFactory::default(),
+            parser_resolver: utils::ParserResolver::disabled(),
+            multimodal: None,
+        })
+    }
+
+    fn completion_request(stream: bool) -> Arc<CompletionRequest> {
+        Arc::new(
+            serde_json::from_value(serde_json::json!({
+                "model": MODEL,
+                "prompt": "Hello world",
+                "stream": stream,
+            }))
+            .expect("completion request"),
+        )
+    }
+
+    fn completion_pipeline(worker_registry: &Arc<WorkerRegistry>, mode: Mode) -> RequestPipeline {
+        let deps = PipelineDeps::pair(
+            worker_registry.clone(),
+            Arc::new(PolicyRegistry::new(PolicyConfig::Random)),
+            None,
+        );
+        RequestPipeline::build(Endpoint::Completion, mode, &deps).expect("completion pipeline")
+    }
+
+    fn fast_retry_config(max_retries: u32) -> RetryConfig {
+        RetryConfig {
+            max_retries,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 2,
+            backoff_multiplier: 1.0,
+            jitter_factor: 0.0,
+        }
+    }
+
+    async fn run_and_drain(
+        pipeline: RequestPipeline,
+        components: Arc<SharedComponents>,
+        request: Arc<CompletionRequest>,
+    ) -> bytes::Bytes {
+        let response = pipeline
+            .execute_completion(
+                request,
+                None,
+                MODEL.to_string(),
+                components,
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert_eq!(response.status(), http::StatusCode::OK);
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("drain SSE body")
+    }
+
+    /// The stream task must run off the response spec: the stub refuses to
+    /// emit tokens until the parsed request has been freed, so a stream that
+    /// still pinned it would stall past the stub's deadline.
+    #[tokio::test]
+    async fn streaming_releases_parsed_request_before_first_token() {
+        let request = completion_request(true);
+        let released = Arc::new(AtomicBool::new(false));
+        let port = spawn_stub(GatedScheduler {
+            probe: Some(Arc::downgrade(&request)),
+            released: Arc::clone(&released),
+            ..Default::default()
+        })
+        .await;
+
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        register_worker(&worker_registry, port, WorkerType::Regular);
+        let pipeline = completion_pipeline(&worker_registry, Mode::Regular);
+        let components = components(worker_registry).await;
+
+        let body = run_and_drain(pipeline, components, request).await;
+
+        assert!(
+            released.load(Ordering::SeqCst),
+            "the parsed request must be freed before the first token"
+        );
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains("data: [DONE]"), "stream must finish: {body}");
+    }
+
+    /// grpc_pd twin: the decode leg's stream task must not pin the parsed
+    /// request either (the prefill stub answers immediately).
+    #[tokio::test]
+    async fn pd_streaming_releases_parsed_request_before_first_token() {
+        let request = completion_request(true);
+        let released = Arc::new(AtomicBool::new(false));
+        let prefill_port = spawn_stub(GatedScheduler::default()).await;
+        let decode_port = spawn_stub(GatedScheduler {
+            probe: Some(Arc::downgrade(&request)),
+            released: Arc::clone(&released),
+            ..Default::default()
+        })
+        .await;
+
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        register_worker(&worker_registry, prefill_port, WorkerType::Prefill);
+        register_worker(&worker_registry, decode_port, WorkerType::Decode);
+        let pipeline = completion_pipeline(&worker_registry, Mode::PrefillDecode);
+        let components = components(worker_registry).await;
+
+        let body = run_and_drain(pipeline, components, request).await;
+
+        assert!(
+            released.load(Ordering::SeqCst),
+            "the parsed request must be freed before the first decode token"
+        );
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains("data: [DONE]"), "stream must finish: {body}");
+    }
+
+    /// The parsed request dies at the build boundary even with the retry
+    /// window open: only the execution plan is retained for replay. The stub
+    /// refuses to answer the generate RPC until the probe frees.
+    #[tokio::test]
+    async fn buffered_dispatch_releases_parsed_request_even_with_retries_enabled() {
+        let request = completion_request(false);
+        let released = Arc::new(AtomicBool::new(false));
+        let port = spawn_stub(GatedScheduler {
+            probe: Some(Arc::downgrade(&request)),
+            gate_rpc: true,
+            released: Arc::clone(&released),
+            ..Default::default()
+        })
+        .await;
+
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        register_worker(&worker_registry, port, WorkerType::Regular);
+        let pipeline = completion_pipeline(&worker_registry, Mode::Regular);
+        let components = components(worker_registry).await;
+
+        let retry = fast_retry_config(3);
+        let response = pipeline
+            .execute_completion(
+                request,
+                None,
+                MODEL.to_string(),
+                components,
+                None,
+                None,
+                Some(&retry),
+            )
+            .await;
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        assert!(
+            released.load(Ordering::SeqCst),
+            "the parsed request must be freed before the upstream answers"
+        );
+    }
+
+    /// grpc_pd twin of the dispatch-release probe: the gated decode leg
+    /// answers only after the parsed request is freed.
+    #[tokio::test]
+    async fn pd_buffered_dispatch_releases_parsed_request_before_upstream_responds() {
+        let request = completion_request(false);
+        let released = Arc::new(AtomicBool::new(false));
+        let prefill_port = spawn_stub(GatedScheduler::default()).await;
+        let decode_port = spawn_stub(GatedScheduler {
+            probe: Some(Arc::downgrade(&request)),
+            gate_rpc: true,
+            released: Arc::clone(&released),
+            ..Default::default()
+        })
+        .await;
+
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        register_worker(&worker_registry, prefill_port, WorkerType::Prefill);
+        register_worker(&worker_registry, decode_port, WorkerType::Decode);
+        let pipeline = completion_pipeline(&worker_registry, Mode::PrefillDecode);
+        let components = components(worker_registry).await;
+
+        let response = pipeline
+            .execute_completion(
+                request,
+                None,
+                MODEL.to_string(),
+                components,
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        assert!(
+            released.load(Ordering::SeqCst),
+            "the parsed request must be freed before the decode leg answers"
+        );
+    }
+
+    /// A failed first dispatch retries from the retained plan: the second
+    /// attempt must send identical token ids without re-tokenizing, under a
+    /// fresh per-attempt engine id, and the parsed request must already be
+    /// gone when the first attempt is sent.
+    #[tokio::test]
+    async fn retry_replays_identical_token_ids_from_the_retained_plan() {
+        let request = completion_request(false);
+        let probe = Arc::downgrade(&request);
+        let seen_ids = Arc::new(Mutex::new(Vec::new()));
+        let seen_request_ids = Arc::new(Mutex::new(Vec::new()));
+        let port = spawn_stub(GatedScheduler {
+            fail_first: true,
+            seen_input_ids: Arc::clone(&seen_ids),
+            seen_request_ids: Arc::clone(&seen_request_ids),
+            ..Default::default()
+        })
+        .await;
+
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        register_worker(&worker_registry, port, WorkerType::Regular);
+        let pipeline = completion_pipeline(&worker_registry, Mode::Regular);
+        let components = components(worker_registry).await;
+
+        let retry = fast_retry_config(2);
+        let response = pipeline
+            .execute_completion(
+                request,
+                None,
+                MODEL.to_string(),
+                components,
+                None,
+                None,
+                Some(&retry),
+            )
+            .await;
+        assert_eq!(response.status(), http::StatusCode::OK);
+        assert_eq!(
+            probe.strong_count(),
+            0,
+            "request freed at the build boundary"
+        );
+
+        {
+            let seen = seen_ids.lock().unwrap_or_else(PoisonError::into_inner);
+            assert_eq!(seen.len(), 2, "503 then 200 must mean two attempts");
+            assert_eq!(
+                seen[0], seen[1],
+                "the retry must replay identical input ids"
+            );
+            assert!(
+                !seen[0].is_empty(),
+                "attempts must carry the tokenized prompt"
+            );
+        }
+        {
+            let ids = seen_request_ids
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            assert_eq!(ids.len(), 2);
+            assert!(ids[0].starts_with("cmpl_") && ids[1].starts_with("cmpl_"));
+            assert_ne!(ids[0], ids[1], "each attempt gets a fresh engine id");
         }
     }
 }
@@ -1688,7 +1965,7 @@ mod rate_limit_reserve_tests {
     }
 
     #[tokio::test]
-    async fn reserves_exactly_once_across_retry_attempts() {
+    async fn reserve_is_admitted_once_and_cached_on_the_cell() {
         // Admits one 5-token reservation but not two (5 + 5 > 6).
         let manager = manager_with_tokens_per_minute(6);
         let components = test_components().await;
@@ -1697,15 +1974,10 @@ mod rate_limit_reserve_tests {
 
         let stage = RateLimitReserveStage::new(Some(manager));
 
-        // Simulate two retry attempts sharing the same cell, as router.rs does.
-        assert!(
-            stage.execute(&mut ctx).await.unwrap().is_none(),
-            "first attempt should reserve and be admitted"
-        );
-        assert!(
-            stage.execute(&mut ctx).await.unwrap().is_none(),
-            "second attempt should see the cached Admitted outcome and skip reserving again"
-        );
+        assert!(stage.execute(&mut ctx).await.is_ok());
+        // A second pass (defensive; ingress runs once) sees the cached
+        // Admitted outcome and does not reserve again.
+        assert!(stage.execute(&mut ctx).await.is_ok());
 
         assert!(matches!(
             ctx.input.rate_limit_cell.as_ref().unwrap().peek(),
@@ -1714,7 +1986,7 @@ mod rate_limit_reserve_tests {
     }
 
     #[tokio::test]
-    async fn denial_is_cached_for_should_retry_to_read() {
+    async fn denial_is_cached_on_the_cell() {
         // Too small for even one 5-token reservation.
         let manager = manager_with_tokens_per_minute(3);
         let components = test_components().await;
@@ -1723,12 +1995,9 @@ mod rate_limit_reserve_tests {
 
         let stage = RateLimitReserveStage::new(Some(manager));
 
-        let result = stage.execute(&mut ctx).await;
-        let response = result.expect_err("should be denied");
+        let response = stage.execute(&mut ctx).await.expect_err("should be denied");
         assert_eq!(response.status(), http::StatusCode::TOO_MANY_REQUESTS);
 
-        // This is the signal router.rs's `should_retry` reads to stop the
-        // retry loop instead of retrying a rate-limit denial.
         assert!(matches!(
             ctx.input.rate_limit_cell.as_ref().unwrap().peek(),
             Some(RateLimitOutcome::Denied)
@@ -1742,7 +2011,7 @@ mod rate_limit_reserve_tests {
         ctx.input.rate_limit_cell = Some(Arc::new(RateLimitCell::new()));
 
         let stage = RateLimitReserveStage::new(None);
-        assert!(stage.execute(&mut ctx).await.unwrap().is_none());
+        assert!(stage.execute(&mut ctx).await.is_ok());
         assert!(ctx.input.rate_limit_cell.as_ref().unwrap().peek().is_none());
     }
 
@@ -1754,7 +2023,7 @@ mod rate_limit_reserve_tests {
         let mut ctx = ctx_with_tokens(components, 5);
 
         let stage = RateLimitReserveStage::new(Some(manager));
-        assert!(stage.execute(&mut ctx).await.unwrap().is_none());
+        assert!(stage.execute(&mut ctx).await.is_ok());
     }
 
     #[tokio::test]
@@ -1771,7 +2040,7 @@ mod rate_limit_reserve_tests {
         ctx.input.rate_limit_cell = Some(Arc::new(RateLimitCell::new()));
 
         let stage = RateLimitReserveStage::new(Some(manager.clone()));
-        assert!(stage.execute(&mut ctx).await.unwrap().is_none());
+        assert!(stage.execute(&mut ctx).await.is_ok());
 
         RequestPipeline::settle_reservation(ctx.input.rate_limit_cell.as_deref(), 0, 0).await;
 

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -2,10 +2,10 @@
 //!
 //! Ingress phase (owns the parsed request): preparation → rate-limit reserve
 //! → worker selection → client acquisition → encode (EPD) → request building.
-//! Request building is the terminal consumer: it yields `(ExecutionPlan,
+//! Request building is the last reader: it yields `(ExecutionPlan,
 //! ResponseSpec)` and the request drops at [`RequestContext::into_dispatch`].
 //!
-//! Dispatch phase (no request, by type structure): per-attempt worker
+//! Dispatch phase (no request, by construction): per-attempt worker
 //! re-selection + dispatch of the retained plan, then response processing.
 //! The plan is held until the retry window closes (first non-retryable
 //! response).
@@ -443,9 +443,11 @@ impl RequestPipeline {
                 )
             })?;
             dctx.clients = Some(acquire_clients(workers, &dctx.model_id).await?);
-            if let Some(plan) = plan.as_mut() {
-                helpers::restamp_plan_for_attempt(plan, stamp, workers)?;
-            }
+            let retained = plan.as_mut().ok_or_else(|| {
+                error!(function = "run_attempt", "Execution plan already consumed");
+                error::internal_error("execution_plan_consumed", "Execution plan already consumed")
+            })?;
+            helpers::restamp_plan_for_attempt(retained, stamp, workers)?;
             if let Some(decoder) = dctx.response.stop_decoder.as_mut() {
                 decoder.reset();
             }

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -1095,6 +1095,14 @@ pub enum ProtoRequest {
 }
 
 impl ProtoRequest {
+    /// Serialized wire size, for the release metric.
+    pub fn wire_len(&self) -> usize {
+        match self {
+            Self::Generate(request) => request.wire_len(),
+            Self::Embed(request) => request.wire_len(),
+        }
+    }
+
     /// Get request ID from either variant
     pub fn request_id(&self) -> &str {
         match self {
@@ -1299,6 +1307,18 @@ impl ProtoGenerateRequest {
         }
     }
 
+    /// Serialized wire size, for the release metric.
+    pub fn wire_len(&self) -> usize {
+        use prost::Message;
+        match self {
+            Self::Sglang(req) => req.encoded_len(),
+            Self::Vllm(req) => req.encoded_len(),
+            Self::Trtllm(req) => req.encoded_len(),
+            Self::Mlx(req) => req.encoded_len(),
+            Self::TokenSpeed(req) => req.encoded_len(),
+        }
+    }
+
     /// Clone for a PD leg that carries no multimodal pixels (see
     /// `clear_mm_pixel_values`), without ever duplicating them: detach,
     /// clone, reattach to `self`. vLLM keeps `mm_hashes`/placeholders and the
@@ -1441,6 +1461,18 @@ impl ProtoGenerateRequest {
             Self::Trtllm(req) => &req.request_id,
             Self::Mlx(req) => &req.request_id,
             Self::TokenSpeed(req) => &req.request_id,
+        }
+    }
+
+    /// Set request ID (retry attempts re-mint per-execution engine ids on
+    /// the retained plan).
+    pub fn set_request_id(&mut self, request_id: String) {
+        match self {
+            Self::Sglang(req) => req.request_id = request_id,
+            Self::Vllm(req) => req.request_id = request_id,
+            Self::Trtllm(req) => req.request_id = request_id,
+            Self::Mlx(req) => req.request_id = request_id,
+            Self::TokenSpeed(req) => req.request_id = request_id,
         }
     }
 
@@ -2208,6 +2240,15 @@ pub enum ProtoEmbedRequest {
 }
 
 impl ProtoEmbedRequest {
+    /// Serialized wire size, for the release metric.
+    pub fn wire_len(&self) -> usize {
+        use prost::Message;
+        match self {
+            Self::Sglang(req) => req.encoded_len(),
+            Self::Vllm(req) => req.encoded_len(),
+        }
+    }
+
     /// Get SGLang variant
     #[expect(
         clippy::panic,
@@ -2252,6 +2293,14 @@ impl ProtoEmbedRequest {
         match self {
             Self::Sglang(req) => &req.request_id,
             Self::Vllm(req) => &req.request_id,
+        }
+    }
+
+    /// Set request ID.
+    pub fn set_request_id(&mut self, request_id: String) {
+        match self {
+            Self::Sglang(req) => req.request_id = request_id,
+            Self::Vllm(req) => req.request_id = request_id,
         }
     }
 }

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -11,13 +11,11 @@ use llm_tokenizer::{
     traits::Tokenizer,
 };
 use openai_protocol::{
-    chat::{ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse},
-    common::{
-        FunctionCallResponse, StringOrArray, Tool, ToolCall, ToolChoice, ToolChoiceValue, Usage,
-    },
-    completion::{CompletionChoice, CompletionRequest, CompletionResponse},
-    generate::{GenerateMetaInfo, GenerateRequest, GenerateResponse},
-    messages::{self, CreateMessageRequest, Message},
+    chat::{ChatChoice, ChatCompletionMessage, ChatCompletionResponse},
+    common::{FunctionCallResponse, Tool, ToolCall, ToolChoice, ToolChoiceValue, Usage},
+    completion::{CompletionChoice, CompletionResponse},
+    generate::{GenerateMetaInfo, GenerateResponse},
+    messages::{self, Message},
 };
 use reasoning_parser::ParserFactory as ReasoningParserFactory;
 use tool_parser::ParserFactory as ToolParserFactory;
@@ -29,6 +27,7 @@ use crate::routers::{
         common::{response_collection, response_formatting},
         context::{DispatchMetadata, ExecutionResult},
         proto_wrapper::ProtoGenerateComplete,
+        spec::{ChatResponseSpec, CompletionResponseSpec, MessagesResponseSpec},
         utils,
     },
 };
@@ -61,7 +60,8 @@ impl ResponseProcessor {
         &self,
         complete: &ProtoGenerateComplete,
         index: usize,
-        original_request: &ChatCompletionRequest,
+        original_request: &ChatResponseSpec,
+        model: &str,
         tokenizer: &Arc<dyn Tokenizer>,
         stop_decoder: &mut StopSequenceDecoder,
         history_tool_calls_count: usize,
@@ -113,7 +113,7 @@ impl ResponseProcessor {
             if let Some(mut parser) = utils::create_reasoning_parser(
                 &self.reasoning_parser_factory,
                 reasoning_parser_name,
-                &original_request.model,
+                model,
             ) {
                 // If the template injected `<think>` in the prefill (thinking toggle
                 // is supported and effectively ON), start in reasoning mode.
@@ -170,14 +170,14 @@ impl ResponseProcessor {
                 (tool_calls, processed_text) = utils::parse_json_schema_response(
                     &processed_text,
                     original_request.tool_choice.as_ref(),
-                    &original_request.model,
+                    model,
                     history_tool_calls_count,
                 );
             } else if tool_parser_available {
                 (tool_calls, processed_text) = self
                     .parse_tool_calls(
                         &processed_text,
-                        &original_request.model,
+                        model,
                         tool_parser_name,
                         original_request.tools.as_deref().unwrap_or(&[]),
                         history_tool_calls_count,
@@ -239,26 +239,27 @@ impl ResponseProcessor {
     pub async fn process_non_streaming_chat_response(
         &self,
         execution_result: ExecutionResult,
-        chat_request: Arc<ChatCompletionRequest>,
+        chat_request: ChatResponseSpec,
         dispatch: DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_decoder: &mut StopSequenceDecoder,
         request_logprobs: bool,
     ) -> Result<ChatCompletionResponse, axum::response::Response> {
-        let reasoning_parser_name = self.parser_resolver.reasoning_parser(&chat_request.model);
-        let tool_parser_name = self.parser_resolver.tool_parser(&chat_request.model);
+        let model = &dispatch.model;
+        let reasoning_parser_name = self.parser_resolver.reasoning_parser(model);
+        let tool_parser_name = self.parser_resolver.tool_parser(model);
         // Collect all responses from the execution result
         let all_responses =
             response_collection::collect_responses(execution_result, request_logprobs).await?;
 
-        let history_tool_calls_count = utils::get_history_tool_calls_count(&chat_request);
+        let history_tool_calls_count = chat_request.history_tool_calls_count;
 
         // Check parser availability once upfront (not per choice)
         let reasoning_parser_available = chat_request.separate_reasoning
             && utils::check_reasoning_parser_availability(
                 &self.reasoning_parser_factory,
                 reasoning_parser_name.as_deref(),
-                &chat_request.model,
+                model,
             );
 
         let tool_choice_enabled = !matches!(
@@ -271,22 +272,18 @@ impl ResponseProcessor {
             && utils::check_tool_parser_availability(
                 &self.tool_parser_factory,
                 tool_parser_name.as_deref(),
-                &chat_request.model,
+                model,
             );
 
         // Log once per request (not per choice)
         if chat_request.separate_reasoning && !reasoning_parser_available {
             tracing::debug!(
-                "No reasoning parser found for model '{}', skipping reasoning parsing",
-                chat_request.model
+                "No reasoning parser found for model '{model}', skipping reasoning parsing"
             );
         }
 
         if chat_request.tools.is_some() && tool_choice_enabled && !tool_parser_available {
-            tracing::debug!(
-                "No tool parser found for model '{}', skipping tool call parsing",
-                chat_request.model
-            );
+            tracing::debug!("No tool parser found for model '{model}', skipping tool call parsing");
         }
 
         // Process all choices
@@ -297,6 +294,7 @@ impl ResponseProcessor {
                     complete,
                     index,
                     &chat_request,
+                    model,
                     &tokenizer,
                     stop_decoder,
                     history_tool_calls_count,
@@ -396,7 +394,6 @@ impl ResponseProcessor {
     pub async fn process_non_streaming_generate_response(
         &self,
         execution_result: ExecutionResult,
-        _generate_request: Arc<GenerateRequest>,
         dispatch: DispatchMetadata,
         stop_decoder: &mut StopSequenceDecoder,
         request_logprobs: bool,
@@ -504,15 +501,14 @@ impl ResponseProcessor {
     pub async fn process_non_streaming_messages_response(
         &self,
         execution_result: ExecutionResult,
-        messages_request: Arc<CreateMessageRequest>,
+        messages_request: MessagesResponseSpec,
         dispatch: DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_decoder: &mut StopSequenceDecoder,
     ) -> Result<Message, axum::response::Response> {
-        let reasoning_parser_name = self
-            .parser_resolver
-            .reasoning_parser(&messages_request.model);
-        let tool_parser_name = self.parser_resolver.tool_parser(&messages_request.model);
+        let model = &dispatch.model;
+        let reasoning_parser_name = self.parser_resolver.reasoning_parser(model);
+        let tool_parser_name = self.parser_resolver.tool_parser(model);
         // Collect all responses (no logprobs for Messages API)
         let all_responses = response_collection::collect_responses(execution_result, false).await?;
 
@@ -549,7 +545,7 @@ impl ResponseProcessor {
         let reasoning_requires_special_tokens = utils::reasoning_parser_requires_special_tokens(
             &self.reasoning_parser_factory,
             reasoning_parser_name.as_deref(),
-            &messages_request.model,
+            model,
         );
         let separate_reasoning = reasoning_requires_special_tokens
             || matches!(
@@ -563,7 +559,7 @@ impl ResponseProcessor {
             && utils::check_reasoning_parser_availability(
                 &self.reasoning_parser_factory,
                 reasoning_parser_name.as_deref(),
-                &messages_request.model,
+                model,
             );
 
         let tool_choice_enabled = !matches!(
@@ -572,25 +568,21 @@ impl ResponseProcessor {
         );
 
         let tool_parser_available = tool_choice_enabled
-            && messages_request.tools.is_some()
+            && messages_request.has_tools
             && utils::check_tool_parser_availability(
                 &self.tool_parser_factory,
                 tool_parser_name.as_deref(),
-                &messages_request.model,
+                model,
             );
 
         if separate_reasoning && !reasoning_parser_available {
             tracing::debug!(
-                "No reasoning parser found for model '{}', reasoning content will not be separated",
-                messages_request.model
+                "No reasoning parser found for model '{model}', reasoning content will not be separated"
             );
         }
 
-        if messages_request.tools.is_some() && tool_choice_enabled && !tool_parser_available {
-            tracing::debug!(
-                "No tool parser found for model '{}', skipping tool call parsing",
-                messages_request.model
-            );
+        if messages_request.has_tools && tool_choice_enabled && !tool_parser_available {
+            tracing::debug!("No tool parser found for model '{model}', skipping tool call parsing");
         }
 
         // Decode tokens through stop decoder
@@ -636,7 +628,7 @@ impl ResponseProcessor {
             if let Some(mut parser) = utils::create_reasoning_parser(
                 &self.reasoning_parser_factory,
                 reasoning_parser_name.as_deref(),
-                &messages_request.model,
+                model,
             ) {
                 // If thinking is effectively ON and template has a toggle, start in reasoning mode.
                 {
@@ -670,7 +662,7 @@ impl ResponseProcessor {
         // Step 2: Parse tool calls
         let mut tool_calls: Option<Vec<ToolCall>> = None;
 
-        if tool_choice_enabled && messages_request.tools.is_some() {
+        if tool_choice_enabled && messages_request.has_tools {
             // Check if JSON schema constraint was used (specific tool or any/required mode)
             let has_structural_tag = self
                 .tool_parser_factory
@@ -692,24 +684,17 @@ impl ResponseProcessor {
                 (tool_calls, processed_text) = utils::parse_json_schema_response(
                     &processed_text,
                     chat_tool_choice.as_ref(),
-                    &messages_request.model,
-                    utils::message_utils::get_history_tool_calls_count_messages(&messages_request),
+                    model,
+                    messages_request.history_tool_calls_count,
                 );
             } else if tool_parser_available {
-                let chat_tools = messages_request
-                    .tools
-                    .as_deref()
-                    .map(utils::message_utils::extract_chat_tools)
-                    .unwrap_or_default();
                 (tool_calls, processed_text) = self
                     .parse_tool_calls(
                         &processed_text,
-                        &messages_request.model,
+                        model,
                         tool_parser_name.as_deref(),
-                        &chat_tools,
-                        utils::message_utils::get_history_tool_calls_count_messages(
-                            &messages_request,
-                        ),
+                        &messages_request.chat_tools,
+                        messages_request.history_tool_calls_count,
                     )
                     .await;
             }
@@ -817,21 +802,18 @@ impl ResponseProcessor {
     pub async fn process_non_streaming_completion_response(
         &self,
         execution_result: ExecutionResult,
-        completion_req: Arc<CompletionRequest>,
+        completion_req: CompletionResponseSpec,
         dispatch: DispatchMetadata,
         _tokenizer: Arc<dyn Tokenizer>,
         stop_decoder: &mut StopSequenceDecoder,
     ) -> Result<CompletionResponse, axum::response::Response> {
-        let request_logprobs = completion_req.logprobs.is_some();
+        let request_logprobs = completion_req.logprobs;
         let per_prompt_results = match execution_result {
             ExecutionResult::Batch { results } => results,
             other => vec![other],
         };
-        let choices_per_prompt = completion_req.n.unwrap_or(1).max(1);
-        let prompt_texts: Vec<&str> = match &completion_req.prompt {
-            StringOrArray::String(text) => vec![text.as_str()],
-            StringOrArray::Array(texts) => texts.iter().map(String::as_str).collect(),
-        };
+        let choices_per_prompt = completion_req.choices_per_prompt;
+        let prompt_texts = &completion_req.prompt_texts;
 
         // Drain all sub-streams concurrently; decoding below stays sequential
         // (shared stop decoder).
@@ -847,7 +829,10 @@ impl ResponseProcessor {
         let mut choices = Vec::new();
 
         for (prompt_index, all_responses) in collected.into_iter().enumerate() {
-            let prompt_text = prompt_texts.get(prompt_index).copied().unwrap_or_default();
+            let prompt_text = prompt_texts
+                .get(prompt_index)
+                .map(String::as_str)
+                .unwrap_or_default();
             let index_offset = prompt_index as u32 * choices_per_prompt;
             // n>1 choices share one prompt: max within a prompt, summed across prompts.
             let mut prompt_tokens = 0u32;

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -98,6 +98,8 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
             // (out of scope for this phase; see RequestPipeline::build's
             // stage-insertion comment).
             None,
+            // Tool-loop iterations are not retried.
+            None,
         )
         .await;
 
@@ -595,6 +597,8 @@ async fn execute_tool_loop_streaming_internal(
                 ctx.components.clone(),
                 Some(params.tenant_request_meta.clone()),
                 // Responses endpoint hasn't opted into tenant rate limiting yet.
+                None,
+                // Tool-loop iterations are not retried.
                 None,
             )
             .await;

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -25,10 +25,10 @@ pub(crate) struct ChatPreparationStage;
 
 #[async_trait]
 impl PipelineStage for ChatPreparationStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response> {
         let request = ctx.chat_request_arc();
         self.prepare_chat(ctx, &request).await?;
-        Ok(None)
+        Ok(())
     }
 
     fn name(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -8,11 +8,13 @@ use crate::routers::{
     error,
     grpc::{
         client::GenerateRequestBuildOptions,
-        common::stages::{helpers, PipelineStage},
+        common::stages::{helpers, BuildStage},
         context::{
-            ClientSelection, ExecutionPlan, ExecutionPlanKind, PreparationOutput, RequestContext,
+            AttemptStamp, BuildOutput, ClientSelection, ExecutionPlan, ExecutionPlanKind,
+            PreparationOutput, RequestContext,
         },
         multimodal::{assemble_multimodal_data, assemble_multimodal_data_after_encode},
+        spec::{ChatResponseSpec, ResponseSpec},
         utils,
     },
 };
@@ -35,12 +37,12 @@ impl ChatRequestBuildingStage {
 }
 
 #[async_trait]
-impl PipelineStage for ChatRequestBuildingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+impl BuildStage for ChatRequestBuildingStage {
+    async fn build(&self, ctx: &mut RequestContext) -> Result<BuildOutput, Response> {
         // Take preparation state (last consumer — worker_selection already ran)
         let prep = ctx.state.preparation.take().ok_or_else(|| {
             error!(
-                function = "ChatRequestBuildingStage::execute",
+                function = "ChatRequestBuildingStage::build",
                 "Preparation not completed"
             );
             error::internal_error("preparation_not_completed", "Preparation not completed")
@@ -48,7 +50,7 @@ impl PipelineStage for ChatRequestBuildingStage {
 
         let clients = ctx.state.clients.as_ref().ok_or_else(|| {
             error!(
-                function = "ChatRequestBuildingStage::execute",
+                function = "ChatRequestBuildingStage::build",
                 "Client acquisition not completed"
             );
             error::internal_error(
@@ -80,7 +82,7 @@ impl PipelineStage for ChatRequestBuildingStage {
 
         // Build chat request
         let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
-        let request_id = helpers::resolve_request_id(
+        let (request_id, id_stamp) = helpers::resolve_request_id_stamp(
             &ctx.input.request_type,
             ctx.input.tenant_request_meta.as_ref(),
             "chatcmpl-",
@@ -106,7 +108,7 @@ impl PipelineStage for ChatRequestBuildingStage {
                     .await
             };
             Some(assembled.map_err(|e| {
-                error!(function = "ChatRequestBuildingStage::execute", error = %e, "Failed to assemble multimodal request");
+                error!(function = "ChatRequestBuildingStage::build", error = %e, "Failed to assemble multimodal request");
                 error::bad_request("multimodal_not_supported", format!("{e}"))
             })?)
         } else {
@@ -137,13 +139,15 @@ impl PipelineStage for ChatRequestBuildingStage {
                 },
             )
             .map_err(|e| {
-                error!(function = "ChatRequestBuildingStage::execute", error = %e, "Failed to build generate request");
+                error!(function = "ChatRequestBuildingStage::build", error = %e, "Failed to build generate request");
                 error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
             })?;
 
-        helpers::apply_sampling_defaults_to_generate_request(
+        let sampling_mask =
+            helpers::SamplingDefaultsMask::from_request_type(&ctx.input.request_type);
+        let sampling_baseline = helpers::apply_sampling_defaults(
             &mut proto_request,
-            &ctx.input.request_type,
+            sampling_mask,
             ctx.state.workers.as_ref(),
         );
 
@@ -173,8 +177,16 @@ impl PipelineStage for ChatRequestBuildingStage {
             helpers::maybe_inject_pd_rendezvous(&mut proto_request, workers);
         }
 
-        ctx.state.execution_plan = Some(ExecutionPlan::generate(self.plan_kind, proto_request));
-        Ok(None)
+        Ok(BuildOutput {
+            plan: ExecutionPlan::generate(self.plan_kind, proto_request),
+            spec: ResponseSpec::Chat(ChatResponseSpec::from(chat_request.as_ref())),
+            stamp: AttemptStamp {
+                id: id_stamp,
+                sampling_mask,
+                sampling_baseline,
+                inject_pd_metadata: self.inject_pd_metadata,
+            },
+        })
     }
 
     fn name(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -179,7 +179,7 @@ impl BuildStage for ChatRequestBuildingStage {
 
         Ok(BuildOutput {
             plan: ExecutionPlan::generate(self.plan_kind, proto_request),
-            spec: ResponseSpec::Chat(ChatResponseSpec::from(chat_request.as_ref())),
+            spec: ResponseSpec::Chat(Box::new(ChatResponseSpec::from(chat_request.as_ref()))),
             stamp: AttemptStamp {
                 id: id_stamp,
                 sampling_mask,

--- a/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
@@ -114,7 +114,7 @@ impl ProcessStage for ChatResponseProcessingStage {
                 .clone()
                 .process_streaming_response(
                     execution_result,
-                    chat_request,
+                    *chat_request,
                     dispatch,
                     tokenizer,
                     skip_special_tokens,
@@ -148,7 +148,7 @@ impl ProcessStage for ChatResponseProcessingStage {
             .processor
             .process_non_streaming_chat_response(
                 execution_result,
-                chat_request,
+                *chat_request,
                 dispatch,
                 tokenizer,
                 stop_decoder,

--- a/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
@@ -12,9 +12,10 @@ use tracing::error;
 use crate::routers::{
     error,
     grpc::{
-        common::stages::{helpers, PipelineStage, RateLimitCell},
-        context::{FinalResponse, RequestContext},
+        common::stages::{helpers, ProcessStage, RateLimitCell},
+        context::{DispatchContext, FinalResponse},
         regular::{processor, streaming},
+        spec::ResponseSpec,
     },
 };
 
@@ -37,27 +38,29 @@ impl ChatResponseProcessingStage {
 }
 
 #[async_trait]
-impl PipelineStage for ChatResponseProcessingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        self.process_chat_response(ctx).await
-    }
-
-    fn name(&self) -> &'static str {
-        "ChatResponseProcessing"
-    }
-}
-
-impl ChatResponseProcessingStage {
-    async fn process_chat_response(
+impl ProcessStage for ChatResponseProcessingStage {
+    async fn process(
         &self,
-        ctx: &mut RequestContext,
+        ctx: &mut DispatchContext,
+        spec: ResponseSpec,
     ) -> Result<Option<Response>, Response> {
-        let is_streaming = ctx.is_streaming();
+        let ResponseSpec::Chat(chat_request) = spec else {
+            error!(
+                function = "ChatResponseProcessingStage::process",
+                "Wrong response spec"
+            );
+            return Err(error::internal_error(
+                "wrong_response_spec",
+                "Wrong response spec",
+            ));
+        };
+
+        let is_streaming = ctx.streaming;
 
         // Extract execution result
-        let execution_result = ctx.state.response.execution_result.take().ok_or_else(|| {
+        let execution_result = ctx.response.execution_result.take().ok_or_else(|| {
             error!(
-                function = "ChatResponseProcessingStage::execute",
+                function = "ChatResponseProcessingStage::process",
                 "No execution result"
             );
             error::internal_error("no_execution_result", "No execution result")
@@ -65,12 +68,11 @@ impl ChatResponseProcessingStage {
 
         // Get dispatch metadata (needed by both streaming and non-streaming)
         let dispatch = ctx
-            .state
             .dispatch
             .as_ref()
             .ok_or_else(|| {
                 error!(
-                    function = "ChatResponseProcessingStage::execute",
+                    function = "ChatResponseProcessingStage::process",
                     "Dispatch metadata not set"
                 );
                 error::internal_error("dispatch_metadata_not_set", "Dispatch metadata not set")
@@ -80,7 +82,7 @@ impl ChatResponseProcessingStage {
         // Get cached tokenizer (resolved once in preparation stage)
         let tokenizer = ctx.tokenizer_arc().ok_or_else(|| {
             error!(
-                function = "ChatResponseProcessingStage::process_chat_response",
+                function = "ChatResponseProcessingStage::process",
                 "Tokenizer not cached in context"
             );
             error::internal_error(
@@ -92,28 +94,27 @@ impl ChatResponseProcessingStage {
         if is_streaming {
             // Read derived skip_special_tokens (set in preparation, survives request_building .take())
             let skip_special_tokens = ctx
-                .state
                 .response
                 .skip_special_tokens
-                .unwrap_or_else(|| ctx.chat_request().skip_special_tokens);
+                .unwrap_or(chat_request.skip_special_tokens);
 
             // Reserved (if tenant rate limiting is enabled): settled with real
             // usage inside the streaming processor on success, or abandoned
             // via the attached ReservationAttachment's Drop below on early
             // disconnect/error.
             let reservation = ctx
-                .input
                 .rate_limit_cell
                 .as_deref()
                 .and_then(RateLimitCell::take_for_streaming_handoff);
 
-            // Streaming: Use StreamingProcessor and return SSE response
+            // Streaming: Use StreamingProcessor and return SSE response. The
+            // stream task consumes the spec, never the parsed request.
             let response = self
                 .streaming_processor
                 .clone()
                 .process_streaming_response(
                     execution_result,
-                    ctx.chat_request_arc(), // Cheap Arc clone (8 bytes)
+                    chat_request,
                     dispatch,
                     tokenizer,
                     skip_special_tokens,
@@ -123,23 +124,18 @@ impl ChatResponseProcessingStage {
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) to the response body for proper RAII lifecycle.
-            let response = helpers::attach_response_guards(
-                response,
-                ctx.state.load_guards.take(),
-                reservation,
-            );
+            let response =
+                helpers::attach_response_guards(response, ctx.load_guards.take(), reservation);
 
             return Ok(Some(response));
         }
 
         // Non-streaming: Delegate to ResponseProcessor
-        let request_logprobs = ctx.chat_request().logprobs;
+        let request_logprobs = chat_request.logprobs;
 
-        let chat_request = ctx.chat_request_arc();
-
-        let stop_decoder = ctx.state.response.stop_decoder.as_mut().ok_or_else(|| {
+        let stop_decoder = ctx.response.stop_decoder.as_mut().ok_or_else(|| {
             error!(
-                function = "ChatResponseProcessingStage::execute",
+                function = "ChatResponseProcessingStage::process",
                 "Stop decoder not initialized"
             );
             error::internal_error(
@@ -161,8 +157,12 @@ impl ChatResponseProcessingStage {
             .await?;
 
         // Store the final response
-        ctx.state.response.final_response = Some(FinalResponse::Chat(response));
+        ctx.response.final_response = Some(FinalResponse::Chat(response));
 
         Ok(None)
+    }
+
+    fn name(&self) -> &'static str {
+        "ChatResponseProcessing"
     }
 }

--- a/model_gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
@@ -20,8 +20,9 @@ use tracing::error;
 use crate::routers::{
     error,
     grpc::{
-        common::stages::PipelineStage,
-        context::{ExecutionResult, FinalResponse, RequestContext, WorkerSelection},
+        common::stages::ProcessStage,
+        context::{DispatchContext, ExecutionResult, FinalResponse, WorkerSelection},
+        spec::ResponseSpec,
     },
 };
 
@@ -88,9 +89,9 @@ impl ClassifyResponseProcessingStage {
     }
 
     /// Extract id2label mapping from the selected worker's model card.
-    fn get_id2label_from_context(ctx: &RequestContext) -> HashMap<u32, String> {
+    fn get_id2label_from_context(ctx: &DispatchContext) -> HashMap<u32, String> {
         // Get the selected worker
-        let worker = match ctx.state.workers.as_ref() {
+        let worker = match ctx.workers.as_ref() {
             Some(WorkerSelection::Single { worker }) => worker,
             Some(WorkerSelection::Disaggregated { prefill, .. }) => prefill, // Use prefill worker for model info
             None => return HashMap::new(),
@@ -114,12 +115,27 @@ impl Default for ClassifyResponseProcessingStage {
 }
 
 #[async_trait]
-impl PipelineStage for ClassifyResponseProcessingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        // Extract execution result
-        let execution_result = ctx.state.response.execution_result.take().ok_or_else(|| {
+impl ProcessStage for ClassifyResponseProcessingStage {
+    async fn process(
+        &self,
+        ctx: &mut DispatchContext,
+        spec: ResponseSpec,
+    ) -> Result<Option<Response>, Response> {
+        if !matches!(spec, ResponseSpec::Classify) {
             error!(
-                function = "ClassifyResponseProcessingStage::execute",
+                function = "ClassifyResponseProcessingStage::process",
+                "Wrong response spec"
+            );
+            return Err(error::internal_error(
+                "wrong_response_spec",
+                "Wrong response spec",
+            ));
+        }
+
+        // Extract execution result
+        let execution_result = ctx.response.execution_result.take().ok_or_else(|| {
+            error!(
+                function = "ClassifyResponseProcessingStage::process",
                 "Execution result missing"
             );
             error::internal_error("execution_result_missing", "Execution result missing")
@@ -130,7 +146,7 @@ impl PipelineStage for ClassifyResponseProcessingStage {
             response
         } else {
             error!(
-                function = "ClassifyResponseProcessingStage::execute",
+                function = "ClassifyResponseProcessingStage::process",
                 "Invalid execution result: expected Embedding"
             );
             return Err(error::internal_error(
@@ -144,7 +160,7 @@ impl PipelineStage for ClassifyResponseProcessingStage {
 
         if logits.is_empty() {
             error!(
-                function = "ClassifyResponseProcessingStage::execute",
+                function = "ClassifyResponseProcessingStage::process",
                 "Empty logits received from scheduler"
             );
             return Err(error::internal_error(
@@ -174,9 +190,9 @@ impl PipelineStage for ClassifyResponseProcessingStage {
         };
 
         // Get dispatch metadata
-        let dispatch = ctx.state.dispatch.as_ref().ok_or_else(|| {
+        let dispatch = ctx.dispatch.as_ref().ok_or_else(|| {
             error!(
-                function = "ClassifyResponseProcessingStage::execute",
+                function = "ClassifyResponseProcessingStage::process",
                 "Dispatch metadata missing"
             );
             error::internal_error("dispatch_missing", "Dispatch metadata missing")
@@ -202,7 +218,7 @@ impl PipelineStage for ClassifyResponseProcessingStage {
         );
 
         // Store in context for pipeline to extract
-        ctx.state.response.final_response = Some(FinalResponse::Classify(response));
+        ctx.response.final_response = Some(FinalResponse::Classify(response));
 
         Ok(None)
     }

--- a/model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs
@@ -24,7 +24,7 @@ pub(crate) struct CompletionPreparationStage;
 
 #[async_trait]
 impl PipelineStage for CompletionPreparationStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response> {
         let request = ctx.completion_request_arc();
 
         let tokenizer =
@@ -84,7 +84,7 @@ impl PipelineStage for CompletionPreparationStage {
 
         ctx.state.response.stop_decoder = Some(stop_decoder);
 
-        Ok(None)
+        Ok(())
     }
 
     fn name(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
@@ -12,18 +12,18 @@ use async_trait::async_trait;
 use axum::response::Response;
 use openai_protocol::completion::CompletionRequest;
 use tracing::error;
-use uuid::Uuid;
 
 use crate::routers::{
     error,
     grpc::{
         backend_client::BackendClient,
-        common::stages::{helpers, PipelineStage},
+        common::stages::{helpers, BuildStage},
         context::{
-            ClientSelection, CompletionItem, ExecutionPlan, ExecutionPlanKind, PreparationOutput,
-            RequestContext, RequestType, WorkerSelection,
+            AttemptStamp, BuildOutput, ClientSelection, CompletionItem, ExecutionPlan,
+            ExecutionPlanKind, PreparationOutput, RequestContext, WorkerSelection,
         },
         proto_wrapper::ProtoGenerateRequest,
+        spec::{CompletionResponseSpec, ResponseSpec},
     },
 };
 
@@ -49,9 +49,9 @@ impl CompletionRequestBuildingStage {
         request_id: String,
         item: &CompletionItem,
         completion_request: &CompletionRequest,
-        request_type: &RequestType,
+        sampling_mask: Option<helpers::SamplingDefaultsMask>,
         workers: Option<&WorkerSelection>,
-    ) -> Result<ProtoGenerateRequest, Response> {
+    ) -> Result<(ProtoGenerateRequest, Option<helpers::SamplingBaseline>), Response> {
         let mut proto_request = builder_client
             .build_completion_request(
                 request_id,
@@ -61,7 +61,7 @@ impl CompletionRequestBuildingStage {
             )
             .map_err(|e| {
                 error!(
-                    function = "CompletionRequestBuildingStage::execute",
+                    function = "CompletionRequestBuildingStage::build",
                     error = %e,
                     "Failed to build generate request"
                 );
@@ -71,11 +71,8 @@ impl CompletionRequestBuildingStage {
                 )
             })?;
 
-        helpers::apply_sampling_defaults_to_generate_request(
-            &mut proto_request,
-            request_type,
-            workers,
-        );
+        let sampling_baseline =
+            helpers::apply_sampling_defaults(&mut proto_request, sampling_mask, workers);
 
         if self.inject_pd_metadata {
             if let Some(workers) = workers {
@@ -90,16 +87,16 @@ impl CompletionRequestBuildingStage {
             helpers::maybe_inject_pd_rendezvous(&mut proto_request, workers);
         }
 
-        Ok(proto_request)
+        Ok((proto_request, sampling_baseline))
     }
 }
 
 #[async_trait]
-impl PipelineStage for CompletionRequestBuildingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+impl BuildStage for CompletionRequestBuildingStage {
+    async fn build(&self, ctx: &mut RequestContext) -> Result<BuildOutput, Response> {
         let prep = ctx.state.preparation.as_ref().ok_or_else(|| {
             error!(
-                function = "CompletionRequestBuildingStage::execute",
+                function = "CompletionRequestBuildingStage::build",
                 "Preparation not completed"
             );
             error::internal_error("preparation_not_completed", "Preparation not completed")
@@ -107,7 +104,7 @@ impl PipelineStage for CompletionRequestBuildingStage {
 
         let PreparationOutput::Completion { items, .. } = prep else {
             error!(
-                function = "CompletionRequestBuildingStage::execute",
+                function = "CompletionRequestBuildingStage::build",
                 "Preparation output is not a completion"
             );
             return Err(error::internal_error(
@@ -118,7 +115,7 @@ impl PipelineStage for CompletionRequestBuildingStage {
 
         let clients = ctx.state.clients.as_ref().ok_or_else(|| {
             error!(
-                function = "CompletionRequestBuildingStage::execute",
+                function = "CompletionRequestBuildingStage::build",
                 "Client acquisition not completed"
             );
             error::internal_error(
@@ -137,12 +134,14 @@ impl PipelineStage for CompletionRequestBuildingStage {
         let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
         let request_type = &ctx.input.request_type;
         let workers = ctx.state.workers.as_ref();
+        let sampling_mask = helpers::SamplingDefaultsMask::from_request_type(request_type);
+        let mut sampling_baseline = None;
         // Each built request is finalized by the client below: it resolves
         // string `stop`s its engine can't match and reports the router's
         // residual trim obligation.
         let tokenizer = ctx.tokenizer_arc();
 
-        let plan = match items.as_slice() {
+        let (plan, id_stamp) = match items.as_slice() {
             [] => {
                 return Err(error::internal_error(
                     "preparation_not_completed",
@@ -150,68 +149,79 @@ impl PipelineStage for CompletionRequestBuildingStage {
                 ))
             }
             [item] => {
-                let mut proto_request = self.build_proto_request(
+                let (request_id, id_stamp) = helpers::resolve_request_id_stamp(
+                    request_type,
+                    ctx.input.tenant_request_meta.as_ref(),
+                    "cmpl_",
+                    disaggregated,
+                );
+                let (mut proto_request, baseline) = self.build_proto_request(
                     builder_client,
-                    helpers::resolve_request_id(
-                        request_type,
-                        ctx.input.tenant_request_meta.as_ref(),
-                        "cmpl_",
-                        disaggregated,
-                    ),
+                    request_id,
                     item,
                     &completion_request,
-                    request_type,
+                    sampling_mask,
                     workers,
                 )?;
+                sampling_baseline = baseline;
                 ctx.state.response.router_stop_obligations = builder_client
                     .finalize_generate_request(&mut proto_request, tokenizer.as_ref());
-                ExecutionPlan::generate(self.plan_kind, proto_request)
+                (
+                    ExecutionPlan::generate(self.plan_kind, proto_request),
+                    id_stamp,
+                )
             }
             batch_items => {
-                // The shared id (client rid or middleware request id) stays
-                // clean for the response; per-sub engine ids get a uniqueness
-                // suffix in PD mode and whenever the shared id is stable
-                // across pipeline executions (middleware-derived).
-                let middleware_id =
-                    helpers::middleware_request_id(ctx.input.tenant_request_meta.as_ref());
-                let (shared_request_id, always_unique_subs) = match request_type.rid() {
-                    Some(rid) => (rid.to_string(), false),
-                    None => match middleware_id {
-                        Some(request_id) => (request_id.to_string(), true),
-                        None => (format!("cmpl_{}", Uuid::now_v7()), false),
-                    },
-                };
+                let (shared_request_id, batch_stamp) = helpers::resolve_batch_id_stamp(
+                    request_type,
+                    ctx.input.tenant_request_meta.as_ref(),
+                    "cmpl_",
+                    disaggregated,
+                );
                 let mut requests = Vec::with_capacity(batch_items.len());
                 for (i, item) in batch_items.iter().enumerate() {
-                    let sub_request_id = if disaggregated || always_unique_subs {
-                        format!("{shared_request_id}-p{i}-{}", Uuid::now_v7())
-                    } else {
-                        format!("{shared_request_id}-p{i}")
-                    };
-                    let mut proto_request = self.build_proto_request(
+                    let (mut proto_request, baseline) = self.build_proto_request(
                         builder_client,
-                        sub_request_id,
+                        helpers::batch_sub_id(&shared_request_id, i, batch_stamp.unique_subs),
                         item,
                         &completion_request,
-                        request_type,
+                        sampling_mask,
                         workers,
                     )?;
+                    // Every sub-request shares the CompletionRequest's
+                    // sampling params, so the first baseline stands for all.
+                    if sampling_baseline.is_none() {
+                        sampling_baseline = baseline;
+                    }
                     // Same CompletionRequest per prompt: every iteration
                     // yields the same residual duty, so keep the last.
                     ctx.state.response.router_stop_obligations = builder_client
                         .finalize_generate_request(&mut proto_request, tokenizer.as_ref());
                     requests.push(proto_request);
                 }
-                ExecutionPlan::Batch {
-                    kind: self.plan_kind,
-                    shared_request_id,
-                    requests,
-                }
+                (
+                    ExecutionPlan::Batch {
+                        kind: self.plan_kind,
+                        shared_request_id,
+                        requests,
+                    },
+                    helpers::IdStamp::Batch(batch_stamp),
+                )
             }
         };
 
-        ctx.state.execution_plan = Some(plan);
-        Ok(None)
+        Ok(BuildOutput {
+            plan,
+            spec: ResponseSpec::Completion(CompletionResponseSpec::from(
+                completion_request.as_ref(),
+            )),
+            stamp: AttemptStamp {
+                id: id_stamp,
+                sampling_mask,
+                sampling_baseline,
+                inject_pd_metadata: self.inject_pd_metadata,
+            },
+        })
     }
 
     fn name(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
@@ -15,9 +15,10 @@ use tracing::error;
 use crate::routers::{
     error,
     grpc::{
-        common::stages::{helpers, PipelineStage, RateLimitCell},
-        context::{FinalResponse, RequestContext},
+        common::stages::{helpers, ProcessStage, RateLimitCell},
+        context::{DispatchContext, FinalResponse},
         regular::{processor, streaming},
+        spec::ResponseSpec,
     },
 };
 
@@ -40,25 +41,39 @@ impl CompletionResponseProcessingStage {
 }
 
 #[async_trait]
-impl PipelineStage for CompletionResponseProcessingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        let is_streaming = ctx.is_streaming();
-
-        let execution_result = ctx.state.response.execution_result.take().ok_or_else(|| {
+impl ProcessStage for CompletionResponseProcessingStage {
+    async fn process(
+        &self,
+        ctx: &mut DispatchContext,
+        spec: ResponseSpec,
+    ) -> Result<Option<Response>, Response> {
+        let ResponseSpec::Completion(completion_request) = spec else {
             error!(
-                function = "CompletionResponseProcessingStage::execute",
+                function = "CompletionResponseProcessingStage::process",
+                "Wrong response spec"
+            );
+            return Err(error::internal_error(
+                "wrong_response_spec",
+                "Wrong response spec",
+            ));
+        };
+
+        let is_streaming = ctx.streaming;
+
+        let execution_result = ctx.response.execution_result.take().ok_or_else(|| {
+            error!(
+                function = "CompletionResponseProcessingStage::process",
                 "No execution result"
             );
             error::internal_error("no_execution_result", "No execution result")
         })?;
 
         let dispatch = ctx
-            .state
             .dispatch
             .as_ref()
             .ok_or_else(|| {
                 error!(
-                    function = "CompletionResponseProcessingStage::execute",
+                    function = "CompletionResponseProcessingStage::process",
                     "Dispatch metadata not set"
                 );
                 error::internal_error("dispatch_metadata_not_set", "Dispatch metadata not set")
@@ -67,7 +82,7 @@ impl PipelineStage for CompletionResponseProcessingStage {
 
         let tokenizer = ctx.tokenizer_arc().ok_or_else(|| {
             error!(
-                function = "CompletionResponseProcessingStage::execute",
+                function = "CompletionResponseProcessingStage::process",
                 "Tokenizer not cached in context"
             );
             error::internal_error(
@@ -82,7 +97,6 @@ impl PipelineStage for CompletionResponseProcessingStage {
             // via the attached ReservationAttachment's Drop below on early
             // disconnect/error.
             let reservation = ctx
-                .input
                 .rate_limit_cell
                 .as_deref()
                 .and_then(RateLimitCell::take_for_streaming_handoff);
@@ -92,7 +106,7 @@ impl PipelineStage for CompletionResponseProcessingStage {
                 .clone()
                 .process_completion_streaming_response(
                     execution_result,
-                    ctx.completion_request_arc(),
+                    completion_request,
                     dispatch,
                     tokenizer,
                     reservation.clone(),
@@ -101,21 +115,16 @@ impl PipelineStage for CompletionResponseProcessingStage {
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) to the response body for proper RAII lifecycle.
-            let response = helpers::attach_response_guards(
-                response,
-                ctx.state.load_guards.take(),
-                reservation,
-            );
+            let response =
+                helpers::attach_response_guards(response, ctx.load_guards.take(), reservation);
 
             return Ok(Some(response));
         }
 
         // Non-streaming path
-        let completion_request = ctx.completion_request_arc();
-
-        let stop_decoder = ctx.state.response.stop_decoder.as_mut().ok_or_else(|| {
+        let stop_decoder = ctx.response.stop_decoder.as_mut().ok_or_else(|| {
             error!(
-                function = "CompletionResponseProcessingStage::execute",
+                function = "CompletionResponseProcessingStage::process",
                 "Stop decoder not initialized"
             );
             error::internal_error(
@@ -135,7 +144,7 @@ impl PipelineStage for CompletionResponseProcessingStage {
             )
             .await?;
 
-        ctx.state.response.final_response = Some(FinalResponse::Completion(response));
+        ctx.response.final_response = Some(FinalResponse::Completion(response));
 
         Ok(None)
     }

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
@@ -24,7 +24,7 @@ impl EmbeddingPreparationStage {
 
 #[async_trait]
 impl PipelineStage for EmbeddingPreparationStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response> {
         // Extract text from embedding or classify request (both use same preparation)
         let text = match &ctx.input.request_type {
             RequestType::Embedding(req) => req.extract_text_for_routing(),
@@ -72,7 +72,7 @@ impl PipelineStage for EmbeddingPreparationStage {
             token_ids,
         });
 
-        Ok(None)
+        Ok(())
     }
 
     fn name(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
@@ -9,9 +9,10 @@ use crate::routers::{
     grpc::{
         backend_client::BackendClient,
         client::GrpcClient,
-        common::stages::{helpers, PipelineStage},
-        context::{ExecutionPlan, RequestContext, RequestType},
+        common::stages::{helpers, BuildStage},
+        context::{AttemptStamp, BuildOutput, ExecutionPlan, RequestContext, RequestType},
         proto_wrapper::ProtoEmbedRequest,
+        spec::ResponseSpec,
     },
 };
 
@@ -31,12 +32,12 @@ impl Default for EmbeddingRequestBuildingStage {
 }
 
 #[async_trait]
-impl PipelineStage for EmbeddingRequestBuildingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+impl BuildStage for EmbeddingRequestBuildingStage {
+    async fn build(&self, ctx: &mut RequestContext) -> Result<BuildOutput, Response> {
         // Preparation output should have tokenized input
         let prep_output = ctx.state.preparation.as_ref().ok_or_else(|| {
             error!(
-                function = "EmbeddingRequestBuildingStage::execute",
+                function = "EmbeddingRequestBuildingStage::build",
                 "Preparation output missing"
             );
             error::internal_error("preparation_missing", "Preparation output missing")
@@ -50,18 +51,29 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
             .and_then(|c| c.single())
             .ok_or_else(|| {
                 error!(
-                    function = "EmbeddingRequestBuildingStage::execute",
+                    function = "EmbeddingRequestBuildingStage::build",
                     "Client not selected"
                 );
                 error::internal_error("client_missing", "Client not selected")
             })?;
 
         // Embeddings/classify are single-worker only (never disaggregated).
-        let prefix = match &ctx.input.request_type {
-            RequestType::Classify(_) => "classify-",
-            _ => "embed-",
+        let (prefix, spec) = match &ctx.input.request_type {
+            RequestType::Classify(_) => ("classify-", ResponseSpec::Classify),
+            RequestType::Embedding(_) => ("embed-", ResponseSpec::Embedding),
+            request_type => {
+                error!(
+                    function = "EmbeddingRequestBuildingStage::build",
+                    request_type = %request_type,
+                    "{request_type} should not reach this stage"
+                );
+                return Err(error::internal_error(
+                    "wrong_pipeline",
+                    format!("{request_type} should use its dedicated pipeline"),
+                ));
+            }
         };
-        let request_id = helpers::resolve_request_id(
+        let (request_id, id_stamp) = helpers::resolve_request_id_stamp(
             &ctx.input.request_type,
             ctx.input.tenant_request_meta.as_ref(),
             prefix,
@@ -83,7 +95,7 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
             }
             BackendClient::Grpc(GrpcClient::Trtllm(_)) => {
                 error!(
-                    function = "EmbeddingRequestBuildingStage::execute",
+                    function = "EmbeddingRequestBuildingStage::build",
                     "TensorRT-LLM embedding not yet supported"
                 );
                 return Err(error::not_implemented(
@@ -93,7 +105,7 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
             }
             BackendClient::Grpc(GrpcClient::Mlx(_)) => {
                 error!(
-                    function = "EmbeddingRequestBuildingStage::execute",
+                    function = "EmbeddingRequestBuildingStage::build",
                     "MLX embedding not supported"
                 );
                 return Err(error::not_implemented(
@@ -103,7 +115,7 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
             }
             BackendClient::Grpc(GrpcClient::TokenSpeed(_)) => {
                 error!(
-                    function = "EmbeddingRequestBuildingStage::execute",
+                    function = "EmbeddingRequestBuildingStage::build",
                     "TokenSpeed backend does not support embeddings"
                 );
                 return Err(error::not_implemented(
@@ -119,11 +131,24 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
             }
         };
 
-        ctx.state.execution_plan = Some(ExecutionPlan::embed(proto_req));
-        Ok(None)
+        Ok(BuildOutput {
+            plan: ExecutionPlan::embed(proto_req),
+            spec,
+            stamp: AttemptStamp {
+                id: id_stamp,
+                sampling_mask: None,
+                sampling_baseline: None,
+                inject_pd_metadata: false,
+            },
+        })
     }
 
     fn name(&self) -> &'static str {
         "EmbeddingRequestBuilding"
+    }
+
+    #[cfg(test)]
+    fn signature(&self) -> String {
+        "EmbeddingRequestBuildingStage".to_string()
     }
 }

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/response_processing.rs
@@ -8,9 +8,10 @@ use tracing::error;
 use crate::routers::{
     error,
     grpc::{
-        common::stages::PipelineStage,
-        context::{ExecutionResult, FinalResponse, RequestContext},
+        common::stages::ProcessStage,
+        context::{DispatchContext, ExecutionResult, FinalResponse},
         proto_wrapper::ProtoEmbedComplete,
+        spec::ResponseSpec,
     },
 };
 
@@ -30,12 +31,27 @@ impl Default for EmbeddingResponseProcessingStage {
 }
 
 #[async_trait]
-impl PipelineStage for EmbeddingResponseProcessingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        // Extract execution result
-        let execution_result = ctx.state.response.execution_result.take().ok_or_else(|| {
+impl ProcessStage for EmbeddingResponseProcessingStage {
+    async fn process(
+        &self,
+        ctx: &mut DispatchContext,
+        spec: ResponseSpec,
+    ) -> Result<Option<Response>, Response> {
+        if !matches!(spec, ResponseSpec::Embedding) {
             error!(
-                function = "EmbeddingResponseProcessingStage::execute",
+                function = "EmbeddingResponseProcessingStage::process",
+                "Wrong response spec"
+            );
+            return Err(error::internal_error(
+                "wrong_response_spec",
+                "Wrong response spec",
+            ));
+        }
+
+        // Extract execution result
+        let execution_result = ctx.response.execution_result.take().ok_or_else(|| {
+            error!(
+                function = "EmbeddingResponseProcessingStage::process",
                 "Execution result missing"
             );
             error::internal_error("execution_result_missing", "Execution result missing")
@@ -46,7 +62,7 @@ impl PipelineStage for EmbeddingResponseProcessingStage {
             response
         } else {
             error!(
-                function = "EmbeddingResponseProcessingStage::execute",
+                function = "EmbeddingResponseProcessingStage::process",
                 "Invalid execution result: expected Embedding"
             );
             return Err(error::internal_error(
@@ -61,7 +77,7 @@ impl PipelineStage for EmbeddingResponseProcessingStage {
             .map_err(|boxed_err| *boxed_err)?;
 
         // Store in context for pipeline to extract
-        ctx.state.response.final_response = Some(FinalResponse::Embedding(embedding_response));
+        ctx.response.final_response = Some(FinalResponse::Embedding(embedding_response));
 
         Ok(None)
     }
@@ -78,10 +94,10 @@ impl EmbeddingResponseProcessingStage {
     )]
     fn convert_response(
         &self,
-        ctx: &RequestContext,
+        ctx: &DispatchContext,
         proto: ProtoEmbedComplete,
     ) -> Result<EmbeddingResponse, Box<Response>> {
-        let dispatch = ctx.state.dispatch.as_ref().ok_or_else(|| {
+        let dispatch = ctx.dispatch.as_ref().ok_or_else(|| {
             error!(
                 function = "EmbeddingResponseProcessingStage::convert_response",
                 "Dispatch metadata missing in context"

--- a/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
@@ -25,10 +25,10 @@ pub(crate) struct GeneratePreparationStage;
 
 #[async_trait]
 impl PipelineStage for GeneratePreparationStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response> {
         let request = ctx.generate_request_arc();
         self.prepare_generate(ctx, &request).await?;
-        Ok(None)
+        Ok(())
     }
 
     fn name(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
@@ -7,8 +7,12 @@ use tracing::error;
 use crate::routers::{
     error,
     grpc::{
-        common::stages::{helpers, PipelineStage},
-        context::{ClientSelection, ExecutionPlan, ExecutionPlanKind, RequestContext},
+        common::stages::{helpers, BuildStage},
+        context::{
+            AttemptStamp, BuildOutput, ClientSelection, ExecutionPlan, ExecutionPlanKind,
+            RequestContext,
+        },
+        spec::{GenerateResponseSpec, ResponseSpec},
     },
 };
 
@@ -30,11 +34,11 @@ impl GenerateRequestBuildingStage {
 }
 
 #[async_trait]
-impl PipelineStage for GenerateRequestBuildingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+impl BuildStage for GenerateRequestBuildingStage {
+    async fn build(&self, ctx: &mut RequestContext) -> Result<BuildOutput, Response> {
         let prep = ctx.state.preparation.as_ref().ok_or_else(|| {
             error!(
-                function = "GenerateRequestBuildingStage::execute",
+                function = "GenerateRequestBuildingStage::build",
                 "Preparation not completed"
             );
             error::internal_error("preparation_not_completed", "Preparation not completed")
@@ -42,7 +46,7 @@ impl PipelineStage for GenerateRequestBuildingStage {
 
         let clients = ctx.state.clients.as_ref().ok_or_else(|| {
             error!(
-                function = "GenerateRequestBuildingStage::execute",
+                function = "GenerateRequestBuildingStage::build",
                 "Client acquisition not completed"
             );
             error::internal_error(
@@ -60,7 +64,7 @@ impl PipelineStage for GenerateRequestBuildingStage {
         };
 
         let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
-        let request_id = helpers::resolve_request_id(
+        let (request_id, id_stamp) = helpers::resolve_request_id_stamp(
             &ctx.input.request_type,
             ctx.input.tenant_request_meta.as_ref(),
             "gen-",
@@ -76,13 +80,15 @@ impl PipelineStage for GenerateRequestBuildingStage {
                 prep.token_ids().to_vec(),
             )
             .map_err(|e| {
-                error!(function = "GenerateRequestBuildingStage::execute", error = %e, "Failed to build generate request");
+                error!(function = "GenerateRequestBuildingStage::build", error = %e, "Failed to build generate request");
                 error::bad_request("build_request_failed", e)
             })?;
 
-        helpers::apply_sampling_defaults_to_generate_request(
+        let sampling_mask =
+            helpers::SamplingDefaultsMask::from_request_type(&ctx.input.request_type);
+        let sampling_baseline = helpers::apply_sampling_defaults(
             &mut proto_request,
-            &ctx.input.request_type,
+            sampling_mask,
             ctx.state.workers.as_ref(),
         );
 
@@ -104,8 +110,16 @@ impl PipelineStage for GenerateRequestBuildingStage {
             helpers::maybe_inject_pd_rendezvous(&mut proto_request, workers);
         }
 
-        ctx.state.execution_plan = Some(ExecutionPlan::generate(self.plan_kind, proto_request));
-        Ok(None)
+        Ok(BuildOutput {
+            plan: ExecutionPlan::generate(self.plan_kind, proto_request),
+            spec: ResponseSpec::Generate(GenerateResponseSpec::from(generate_request.as_ref())),
+            stamp: AttemptStamp {
+                id: id_stamp,
+                sampling_mask,
+                sampling_baseline,
+                inject_pd_metadata: self.inject_pd_metadata,
+            },
+        })
     }
 
     fn name(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
@@ -9,9 +9,10 @@ use tracing::error;
 use crate::routers::{
     error,
     grpc::{
-        common::stages::{helpers, PipelineStage, RateLimitCell},
-        context::{FinalResponse, RequestContext},
+        common::stages::{helpers, ProcessStage, RateLimitCell},
+        context::{DispatchContext, FinalResponse},
         regular::{processor, streaming},
+        spec::ResponseSpec,
     },
 };
 
@@ -36,28 +37,30 @@ impl GenerateResponseProcessingStage {
 }
 
 #[async_trait]
-impl PipelineStage for GenerateResponseProcessingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        self.process_generate_response(ctx).await
-    }
-
-    fn name(&self) -> &'static str {
-        "GenerateResponseProcessing"
-    }
-}
-
-impl GenerateResponseProcessingStage {
-    async fn process_generate_response(
+impl ProcessStage for GenerateResponseProcessingStage {
+    async fn process(
         &self,
-        ctx: &mut RequestContext,
+        ctx: &mut DispatchContext,
+        spec: ResponseSpec,
     ) -> Result<Option<Response>, Response> {
+        let ResponseSpec::Generate(generate_request) = spec else {
+            error!(
+                function = "GenerateResponseProcessingStage::process",
+                "Wrong response spec"
+            );
+            return Err(error::internal_error(
+                "wrong_response_spec",
+                "Wrong response spec",
+            ));
+        };
+
         let start_time = Instant::now();
-        let is_streaming = ctx.is_streaming();
+        let is_streaming = ctx.streaming;
 
         // Extract execution result
-        let execution_result = ctx.state.response.execution_result.take().ok_or_else(|| {
+        let execution_result = ctx.response.execution_result.take().ok_or_else(|| {
             error!(
-                function = "GenerateResponseProcessingStage::execute",
+                function = "GenerateResponseProcessingStage::process",
                 "No execution result"
             );
             error::internal_error("no_execution_result", "No execution result")
@@ -65,12 +68,11 @@ impl GenerateResponseProcessingStage {
 
         // Get dispatch metadata (needed by both streaming and non-streaming)
         let dispatch = ctx
-            .state
             .dispatch
             .as_ref()
             .ok_or_else(|| {
                 error!(
-                    function = "GenerateResponseProcessingStage::execute",
+                    function = "GenerateResponseProcessingStage::process",
                     "Dispatch metadata not set"
                 );
                 error::internal_error("dispatch_metadata_not_set", "Dispatch metadata not set")
@@ -80,7 +82,7 @@ impl GenerateResponseProcessingStage {
         // Get cached tokenizer (resolved once in preparation stage)
         let tokenizer = ctx.tokenizer_arc().ok_or_else(|| {
             error!(
-                function = "GenerateResponseProcessingStage::process_generate_response",
+                function = "GenerateResponseProcessingStage::process",
                 "Tokenizer not cached in context"
             );
             error::internal_error(
@@ -95,7 +97,6 @@ impl GenerateResponseProcessingStage {
             // via the attached ReservationAttachment's Drop below on early
             // disconnect/error.
             let reservation = ctx
-                .input
                 .rate_limit_cell
                 .as_deref()
                 .and_then(RateLimitCell::take_for_streaming_handoff);
@@ -106,7 +107,7 @@ impl GenerateResponseProcessingStage {
                 .clone()
                 .process_streaming_generate(
                     execution_result,
-                    ctx.generate_request_arc(), // Cheap Arc clone (8 bytes)
+                    generate_request,
                     dispatch,
                     tokenizer,
                     reservation.clone(),
@@ -115,22 +116,18 @@ impl GenerateResponseProcessingStage {
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) to the response body for proper RAII lifecycle.
-            let response = helpers::attach_response_guards(
-                response,
-                ctx.state.load_guards.take(),
-                reservation,
-            );
+            let response =
+                helpers::attach_response_guards(response, ctx.load_guards.take(), reservation);
 
             return Ok(Some(response));
         }
 
         // Non-streaming: Delegate to ResponseProcessor
-        let request_logprobs = ctx.generate_request().return_logprob.unwrap_or(false);
-        let generate_request = ctx.generate_request_arc();
+        let request_logprobs = generate_request.return_logprob;
 
-        let stop_decoder = ctx.state.response.stop_decoder.as_mut().ok_or_else(|| {
+        let stop_decoder = ctx.response.stop_decoder.as_mut().ok_or_else(|| {
             error!(
-                function = "GenerateResponseProcessingStage::execute",
+                function = "GenerateResponseProcessingStage::process",
                 "Stop decoder not initialized"
             );
             error::internal_error(
@@ -143,7 +140,6 @@ impl GenerateResponseProcessingStage {
             .processor
             .process_non_streaming_generate_response(
                 execution_result,
-                generate_request,
                 dispatch,
                 stop_decoder,
                 request_logprobs,
@@ -152,8 +148,12 @@ impl GenerateResponseProcessingStage {
             .await?;
 
         // Store the final response
-        ctx.state.response.final_response = Some(FinalResponse::Generate(result_array));
+        ctx.response.final_response = Some(FinalResponse::Generate(result_array));
 
         Ok(None)
+    }
+
+    fn name(&self) -> &'static str {
+        "GenerateResponseProcessing"
     }
 }

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -36,10 +36,10 @@ fn invalid_multimodal_request(error: impl Display) -> Response {
 
 #[async_trait]
 impl PipelineStage for MessagePreparationStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response> {
         let request = ctx.messages_request_arc();
         self.prepare_messages(ctx, &request).await?;
-        Ok(None)
+        Ok(())
     }
 
     fn name(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -9,11 +9,13 @@ use crate::routers::{
     error,
     grpc::{
         client::GenerateRequestBuildOptions,
-        common::stages::{helpers, PipelineStage},
+        common::stages::{helpers, BuildStage},
         context::{
-            ClientSelection, ExecutionPlan, ExecutionPlanKind, PreparationOutput, RequestContext,
+            AttemptStamp, BuildOutput, ClientSelection, ExecutionPlan, ExecutionPlanKind,
+            PreparationOutput, RequestContext,
         },
         multimodal::{assemble_multimodal_data, assemble_multimodal_data_after_encode},
+        spec::{MessagesResponseSpec, ResponseSpec},
         utils,
     },
 };
@@ -37,12 +39,12 @@ impl MessageRequestBuildingStage {
 }
 
 #[async_trait]
-impl PipelineStage for MessageRequestBuildingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+impl BuildStage for MessageRequestBuildingStage {
+    async fn build(&self, ctx: &mut RequestContext) -> Result<BuildOutput, Response> {
         // Take preparation state (last consumer — worker_selection already ran)
         let prep = ctx.state.preparation.take().ok_or_else(|| {
             error!(
-                function = "MessageRequestBuildingStage::execute",
+                function = "MessageRequestBuildingStage::build",
                 "Preparation not completed"
             );
             error::internal_error("preparation_not_completed", "Preparation not completed")
@@ -50,7 +52,7 @@ impl PipelineStage for MessageRequestBuildingStage {
 
         let clients = ctx.state.clients.as_ref().ok_or_else(|| {
             error!(
-                function = "MessageRequestBuildingStage::execute",
+                function = "MessageRequestBuildingStage::build",
                 "Client acquisition not completed"
             );
             error::internal_error(
@@ -82,7 +84,7 @@ impl PipelineStage for MessageRequestBuildingStage {
 
         // Build message request
         let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
-        let request_id = helpers::resolve_request_id(
+        let (request_id, id_stamp) = helpers::resolve_request_id_stamp(
             &ctx.input.request_type,
             ctx.input.tenant_request_meta.as_ref(),
             "msg_",
@@ -108,7 +110,7 @@ impl PipelineStage for MessageRequestBuildingStage {
                     .await
             };
             Some(assembled.map_err(|e| {
-                error!(function = "MessageRequestBuildingStage::execute", error = %e, "Failed to assemble multimodal request");
+                error!(function = "MessageRequestBuildingStage::build", error = %e, "Failed to assemble multimodal request");
                 error::bad_request("multimodal_not_supported", format!("{e}"))
             })?)
         } else {
@@ -138,13 +140,15 @@ impl PipelineStage for MessageRequestBuildingStage {
                 },
             )
             .map_err(|e| {
-                error!(function = "MessageRequestBuildingStage::execute", error = %e, "Failed to build generate request");
+                error!(function = "MessageRequestBuildingStage::build", error = %e, "Failed to build generate request");
                 error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
             })?;
 
-        helpers::apply_sampling_defaults_to_generate_request(
+        let sampling_mask =
+            helpers::SamplingDefaultsMask::from_request_type(&ctx.input.request_type);
+        let sampling_baseline = helpers::apply_sampling_defaults(
             &mut proto_request,
-            &ctx.input.request_type,
+            sampling_mask,
             ctx.state.workers.as_ref(),
         );
 
@@ -173,8 +177,16 @@ impl PipelineStage for MessageRequestBuildingStage {
             helpers::maybe_inject_pd_rendezvous(&mut proto_request, workers);
         }
 
-        ctx.state.execution_plan = Some(ExecutionPlan::generate(self.plan_kind, proto_request));
-        Ok(None)
+        Ok(BuildOutput {
+            plan: ExecutionPlan::generate(self.plan_kind, proto_request),
+            spec: ResponseSpec::Messages(MessagesResponseSpec::from(messages_request.as_ref())),
+            stamp: AttemptStamp {
+                id: id_stamp,
+                sampling_mask,
+                sampling_baseline,
+                inject_pd_metadata: self.inject_pd_metadata,
+            },
+        })
     }
 
     fn name(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/regular/stages/messages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/response_processing.rs
@@ -13,9 +13,10 @@ use tracing::error;
 use crate::routers::{
     error,
     grpc::{
-        common::stages::{helpers, PipelineStage, RateLimitCell},
-        context::{FinalResponse, RequestContext},
+        common::stages::{helpers, ProcessStage, RateLimitCell},
+        context::{DispatchContext, FinalResponse},
         regular::{processor, streaming},
+        spec::ResponseSpec,
     },
 };
 
@@ -38,14 +39,29 @@ impl MessageResponseProcessingStage {
 }
 
 #[async_trait]
-impl PipelineStage for MessageResponseProcessingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        let is_streaming = ctx.is_streaming();
+impl ProcessStage for MessageResponseProcessingStage {
+    async fn process(
+        &self,
+        ctx: &mut DispatchContext,
+        spec: ResponseSpec,
+    ) -> Result<Option<Response>, Response> {
+        let ResponseSpec::Messages(messages_request) = spec else {
+            error!(
+                function = "MessageResponseProcessingStage::process",
+                "Wrong response spec"
+            );
+            return Err(error::internal_error(
+                "wrong_response_spec",
+                "Wrong response spec",
+            ));
+        };
+
+        let is_streaming = ctx.streaming;
 
         // Extract execution result
-        let execution_result = ctx.state.response.execution_result.take().ok_or_else(|| {
+        let execution_result = ctx.response.execution_result.take().ok_or_else(|| {
             error!(
-                function = "MessageResponseProcessingStage::execute",
+                function = "MessageResponseProcessingStage::process",
                 "No execution result"
             );
             error::internal_error("no_execution_result", "No execution result")
@@ -53,12 +69,11 @@ impl PipelineStage for MessageResponseProcessingStage {
 
         // Get dispatch metadata
         let dispatch = ctx
-            .state
             .dispatch
             .as_ref()
             .ok_or_else(|| {
                 error!(
-                    function = "MessageResponseProcessingStage::execute",
+                    function = "MessageResponseProcessingStage::process",
                     "Dispatch metadata not set"
                 );
                 error::internal_error("dispatch_metadata_not_set", "Dispatch metadata not set")
@@ -68,7 +83,7 @@ impl PipelineStage for MessageResponseProcessingStage {
         // Get cached tokenizer
         let tokenizer = ctx.tokenizer_arc().ok_or_else(|| {
             error!(
-                function = "MessageResponseProcessingStage::execute",
+                function = "MessageResponseProcessingStage::process",
                 "Tokenizer not cached in context"
             );
             error::internal_error(
@@ -79,14 +94,13 @@ impl PipelineStage for MessageResponseProcessingStage {
 
         if is_streaming {
             // Read derived skip_special_tokens (set in preparation, survives request_building .take())
-            let skip_special_tokens = ctx.state.response.skip_special_tokens.unwrap_or(true);
+            let skip_special_tokens = ctx.response.skip_special_tokens.unwrap_or(true);
 
             // Reserved (if tenant rate limiting is enabled): settled with real
             // usage inside the streaming processor on success, or abandoned
             // via the attached ReservationAttachment's Drop below on early
             // disconnect/error.
             let reservation = ctx
-                .input
                 .rate_limit_cell
                 .as_deref()
                 .and_then(RateLimitCell::take_for_streaming_handoff);
@@ -97,7 +111,7 @@ impl PipelineStage for MessageResponseProcessingStage {
                 .clone()
                 .process_messages_streaming_response(
                     execution_result,
-                    ctx.messages_request_arc(),
+                    messages_request,
                     dispatch,
                     tokenizer,
                     skip_special_tokens,
@@ -107,21 +121,16 @@ impl PipelineStage for MessageResponseProcessingStage {
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) for RAII lifecycle.
-            let response = helpers::attach_response_guards(
-                response,
-                ctx.state.load_guards.take(),
-                reservation,
-            );
+            let response =
+                helpers::attach_response_guards(response, ctx.load_guards.take(), reservation);
 
             return Ok(Some(response));
         }
 
         // Non-streaming: delegate to ResponseProcessor
-        let messages_request = ctx.messages_request_arc();
-
-        let stop_decoder = ctx.state.response.stop_decoder.as_mut().ok_or_else(|| {
+        let stop_decoder = ctx.response.stop_decoder.as_mut().ok_or_else(|| {
             error!(
-                function = "MessageResponseProcessingStage::execute",
+                function = "MessageResponseProcessingStage::process",
                 "Stop decoder not initialized"
             );
             error::internal_error(
@@ -142,7 +151,7 @@ impl PipelineStage for MessageResponseProcessingStage {
             .await?;
 
         // Store the final response
-        ctx.state.response.final_response = Some(FinalResponse::Messages(response));
+        ctx.response.final_response = Some(FinalResponse::Messages(response));
 
         Ok(None)
     }

--- a/model_gateway/src/routers/grpc/regular/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/preparation.rs
@@ -39,7 +39,7 @@ impl Default for ChatGeneratePreparationStage {
 
 #[async_trait]
 impl PipelineStage for ChatGeneratePreparationStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<(), Response> {
         match &ctx.input.request_type {
             RequestType::Chat(_) => self.chat_stage.execute(ctx).await,
             RequestType::Generate(_) => self.generate_stage.execute(ctx).await,

--- a/model_gateway/src/routers/grpc/regular/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/request_building.rs
@@ -8,8 +8,8 @@ use super::{chat::ChatRequestBuildingStage, generate::GenerateRequestBuildingSta
 use crate::routers::{
     error as grpc_error,
     grpc::{
-        common::stages::PipelineStage,
-        context::{ExecutionPlanKind, RequestContext, RequestType},
+        common::stages::BuildStage,
+        context::{BuildOutput, ExecutionPlanKind, RequestContext, RequestType},
     },
 };
 
@@ -33,14 +33,14 @@ impl ChatGenerateRequestBuildingStage {
 }
 
 #[async_trait]
-impl PipelineStage for ChatGenerateRequestBuildingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+impl BuildStage for ChatGenerateRequestBuildingStage {
+    async fn build(&self, ctx: &mut RequestContext) -> Result<BuildOutput, Response> {
         match &ctx.input.request_type {
-            RequestType::Chat(_) => self.chat_stage.execute(ctx).await,
-            RequestType::Generate(_) => self.generate_stage.execute(ctx).await,
+            RequestType::Chat(_) => self.chat_stage.build(ctx).await,
+            RequestType::Generate(_) => self.generate_stage.build(ctx).await,
             request_type => {
                 error!(
-                    function = "ChatGenerateRequestBuildingStage::execute",
+                    function = "ChatGenerateRequestBuildingStage::build",
                     request_type = %request_type,
                     "{request_type} should not reach this stage"
                 );

--- a/model_gateway/src/routers/grpc/regular/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/response_processing.rs
@@ -1,7 +1,7 @@
 //! Response processing stage for the chat + generate pipeline
 //!
 //! Dispatches to ChatResponseProcessingStage or GenerateResponseProcessingStage
-//! based on request type.
+//! based on the response spec.
 
 use std::sync::Arc;
 
@@ -13,9 +13,10 @@ use super::{chat::ChatResponseProcessingStage, generate::GenerateResponseProcess
 use crate::routers::{
     error,
     grpc::{
-        common::stages::PipelineStage,
-        context::{RequestContext, RequestType},
+        common::stages::ProcessStage,
+        context::DispatchContext,
         regular::{processor, streaming},
+        spec::ResponseSpec,
     },
 };
 
@@ -41,20 +42,24 @@ impl ChatGenerateResponseProcessingStage {
 }
 
 #[async_trait]
-impl PipelineStage for ChatGenerateResponseProcessingStage {
-    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        match &ctx.input.request_type {
-            RequestType::Chat(_) => self.chat_stage.execute(ctx).await,
-            RequestType::Generate(_) => self.generate_stage.execute(ctx).await,
-            request_type => {
+impl ProcessStage for ChatGenerateResponseProcessingStage {
+    async fn process(
+        &self,
+        ctx: &mut DispatchContext,
+        spec: ResponseSpec,
+    ) -> Result<Option<Response>, Response> {
+        // Dispatch on the spec: the only request-derived signal post-build.
+        match spec {
+            ResponseSpec::Chat(_) => self.chat_stage.process(ctx, spec).await,
+            ResponseSpec::Generate(_) => self.generate_stage.process(ctx, spec).await,
+            _ => {
                 error!(
-                    function = "ChatGenerateResponseProcessingStage::execute",
-                    request_type = %request_type,
-                    "{request_type} should not reach this stage"
+                    function = "ChatGenerateResponseProcessingStage::process",
+                    "response spec should not reach this stage"
                 );
                 Err(error::internal_error(
                     "wrong_pipeline",
-                    format!("{request_type} should use its dedicated pipeline"),
+                    "response spec should use its dedicated pipeline",
                 ))
             }
         }

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -16,16 +16,15 @@ use llm_tokenizer::{
     traits::Tokenizer,
 };
 use openai_protocol::{
-    chat::{ChatCompletionRequest, ChatCompletionStreamResponse},
+    chat::ChatCompletionStreamResponse,
     common::{
         ChatLogProbs, FunctionCallDelta, StringOrArray, Tool, ToolCallDelta, ToolChoice,
         ToolChoiceValue, Usage,
     },
-    completion::{CompletionRequest, CompletionStreamChoice, CompletionStreamResponse},
-    generate::GenerateRequest,
+    completion::{CompletionStreamChoice, CompletionStreamResponse},
     messages::{
-        self, ContentBlock, ContentBlockDelta, CreateMessageRequest, Message, MessageDelta,
-        MessageDeltaUsage, MessageStreamEvent,
+        self, ContentBlock, ContentBlockDelta, Message, MessageDelta, MessageDeltaUsage,
+        MessageStreamEvent,
     },
 };
 use reasoning_parser::{ParserFactory as ReasoningParserFactory, ParserResult, ReasoningParser};
@@ -42,6 +41,10 @@ use crate::{
             common::{response_formatting::CompletionTokenTracker, responses::build_sse_response},
             context,
             proto_wrapper::{ProtoResponseVariant, ProtoStream},
+            spec::{
+                ChatResponseSpec, CompletionResponseSpec, GenerateResponseSpec,
+                MessagesResponseSpec,
+            },
             utils,
             utils::message_utils,
         },
@@ -123,7 +126,7 @@ impl StreamingProcessor {
     pub async fn process_streaming_response(
         self: Arc<Self>,
         execution_result: context::ExecutionResult,
-        chat_request: Arc<ChatCompletionRequest>,
+        chat_request: ChatResponseSpec,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         skip_special_tokens: bool,
@@ -238,7 +241,7 @@ impl StreamingProcessor {
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
-        original_request: Arc<ChatCompletionRequest>,
+        original_request: ChatResponseSpec,
         tx: &SseSender,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
@@ -265,7 +268,7 @@ impl StreamingProcessor {
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
-        original_request: Arc<ChatCompletionRequest>,
+        original_request: ChatResponseSpec,
         tx: &SseSender,
         pd_timing: Option<context::PdTiming>,
         reservation: Option<Arc<SharedReservationHandle>>,
@@ -278,7 +281,7 @@ impl StreamingProcessor {
         let separate_reasoning = original_request.separate_reasoning;
         let tool_choice = &original_request.tool_choice;
         let tools = &original_request.tools;
-        let history_tool_calls_count = utils::get_history_tool_calls_count(&original_request);
+        let history_tool_calls_count = original_request.history_tool_calls_count;
         let stream_options = &original_request.stream_options;
 
         // Phase 1: Initialize state tracking (per-index for n>1 support)
@@ -750,7 +753,7 @@ impl StreamingProcessor {
             // produce one for every expected `n>1` choice has only partial
             // usage -- settling with that would understate the real cost.
             // Keep the reserved amount as final instead.
-            let expected_choices = original_request.n.unwrap_or(1).max(1);
+            let expected_choices = original_request.expected_choices;
             if (prompt_tokens.len() as u32) < expected_choices {
                 handle.close_reserved_only().await;
             } else {
@@ -785,7 +788,7 @@ impl StreamingProcessor {
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
-        original_request: Arc<ChatCompletionRequest>,
+        original_request: ChatResponseSpec,
         tx: &SseSender,
         pd_timing: context::PdTiming,
         reservation: Option<Arc<SharedReservationHandle>>,
@@ -840,7 +843,7 @@ impl StreamingProcessor {
     pub async fn process_streaming_generate(
         self: Arc<Self>,
         execution_result: context::ExecutionResult,
-        generate_request: Arc<GenerateRequest>,
+        generate_request: GenerateResponseSpec,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         reservation: Option<Arc<SharedReservationHandle>>,
@@ -855,15 +858,10 @@ impl StreamingProcessor {
                 .weight_version
                 .clone()
                 .unwrap_or_else(|| "default".to_string()),
-            return_logprob: generate_request.return_logprob.unwrap_or(false),
+            return_logprob: generate_request.return_logprob,
             backend_type: self.backend_type,
             model: dispatch.model.clone(),
-            expected_choices: generate_request
-                .sampling_params
-                .as_ref()
-                .and_then(|p| p.n)
-                .unwrap_or(1)
-                .max(1),
+            expected_choices: generate_request.expected_choices,
         };
 
         // Spawn background task based on execution mode
@@ -1738,7 +1736,7 @@ impl StreamingProcessor {
     pub async fn process_messages_streaming_response(
         self: Arc<Self>,
         execution_result: context::ExecutionResult,
-        messages_request: Arc<CreateMessageRequest>,
+        messages_request: MessagesResponseSpec,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         skip_special_tokens: bool,
@@ -1867,7 +1865,7 @@ impl StreamingProcessor {
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
-        original_request: Arc<CreateMessageRequest>,
+        original_request: MessagesResponseSpec,
         tx: &SseSender,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
@@ -1880,7 +1878,7 @@ impl StreamingProcessor {
         let request_id = &dispatch.request_id;
         let model = &dispatch.model;
 
-        let has_tools = original_request.tools.is_some();
+        let has_tools = original_request.has_tools;
 
         // Content block state machine
         let mut current_block_index: u32 = 0;
@@ -1990,15 +1988,10 @@ impl StreamingProcessor {
                 Some(messages::ToolChoice::Tool { .. })
             );
 
-        let history_tool_calls_count =
-            message_utils::get_history_tool_calls_count_messages(&original_request);
+        let history_tool_calls_count = original_request.history_tool_calls_count;
 
-        // Pre-convert Messages tools to Chat tools for parser reuse (done once upfront)
-        let chat_tools: Vec<Tool> = original_request
-            .tools
-            .as_deref()
-            .map(message_utils::extract_chat_tools)
-            .unwrap_or_default();
+        // Messages tools pre-converted to Chat tools for parser reuse
+        let chat_tools: &[Tool] = &original_request.chat_tools;
 
         // Create fresh streaming tool parser (not pooled — streaming parsers maintain state)
         let mut streaming_tool_parser: Option<Box<dyn ToolParser>> =
@@ -2222,7 +2215,7 @@ impl StreamingProcessor {
                     }
                 } else if let Some(ref mut parser) = streaming_tool_parser {
                     // Regular/required tool choice: use incremental parser
-                    match parser.parse_incremental(&normal_text, &chat_tools).await {
+                    match parser.parse_incremental(&normal_text, chat_tools).await {
                         Ok(StreamingParseResult {
                             normal_text: text,
                             calls,
@@ -2583,7 +2576,7 @@ impl StreamingProcessor {
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
-        original_request: Arc<CreateMessageRequest>,
+        original_request: MessagesResponseSpec,
         tx: &SseSender,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
@@ -2629,7 +2622,7 @@ impl StreamingProcessor {
     pub async fn process_completion_streaming_response(
         self: Arc<Self>,
         execution_result: context::ExecutionResult,
-        completion_request: Arc<CompletionRequest>,
+        completion_request: CompletionResponseSpec,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         reservation: Option<Arc<SharedReservationHandle>>,
@@ -2652,20 +2645,13 @@ impl StreamingProcessor {
         )]
         tokio::spawn(async move {
             let start_time = Instant::now();
-            let choices_per_prompt = completion_request.n.unwrap_or(1).max(1);
+            let choices_per_prompt = completion_request.choices_per_prompt;
             let echo = completion_request.echo;
-            let include_usage = completion_request
-                .stream_options
-                .as_ref()
-                .and_then(|opts| opts.include_usage)
-                .unwrap_or(false);
-            let prompt_texts: Vec<&str> = match &completion_request.prompt {
-                StringOrArray::String(text) => vec![text.as_str()],
-                StringOrArray::Array(texts) => texts.iter().map(String::as_str).collect(),
-            };
+            let include_usage = completion_request.include_usage;
 
             // Fail-fast: the first stream error cancels the remaining units
             // (their streams abort on drop) and fails the whole request.
+            let completion_request = &completion_request;
             let outcomes =
                 try_join_all(units.into_iter().enumerate().map(|(prompt_index, unit)| {
                     let stop_params = (
@@ -2677,9 +2663,18 @@ impl StreamingProcessor {
                     );
                     let dispatch = dispatch.clone();
                     let tokenizer = tokenizer.clone();
-                    let completion_request = completion_request.clone();
                     let prompt_text = if echo {
-                        prompt_texts.get(prompt_index).copied().unwrap_or_default()
+                        match completion_request.prompt_texts.get(prompt_index) {
+                            Some(text) => text.as_str(),
+                            None => {
+                                warn!(
+                                    prompt_index,
+                                    prompt_texts_len = completion_request.prompt_texts.len(),
+                                    "echo requested but no prompt text for this prompt index"
+                                );
+                                ""
+                            }
+                        }
                     } else {
                         ""
                     };
@@ -2851,7 +2846,7 @@ impl StreamingProcessor {
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
-        completion_request: Arc<CompletionRequest>,
+        completion_request: &CompletionResponseSpec,
         prompt_text: &str,
         index_offset: u32,
         tx: &SseSender,
@@ -2865,8 +2860,6 @@ impl StreamingProcessor {
 
         let echo = completion_request.echo;
         let suffix = completion_request.suffix.as_deref();
-        // TODO: wire per-token logprob streaming when backend support is available
-        let _request_logprobs = completion_request.logprobs.is_some();
 
         let mut stop_decoders: HashMap<u32, StopSequenceDecoder> = HashMap::new();
         let mut is_firsts: HashMap<u32, bool> = HashMap::new();
@@ -3142,7 +3135,7 @@ impl StreamingProcessor {
         // via a `Complete` message. A clean EOF partway through this unit's
         // `n>1` choices (some completed, others didn't) must not be treated
         // as full usage.
-        let expected_choices = completion_request.n.unwrap_or(1).max(1);
+        let expected_choices = completion_request.choices_per_prompt;
         let saw_complete = completed_indices.len() as u32 >= expected_choices;
 
         Ok(CompletionStreamOutcome {
@@ -3165,7 +3158,7 @@ impl StreamingProcessor {
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
-        original_request: Arc<CompletionRequest>,
+        original_request: &CompletionResponseSpec,
         prompt_text: &str,
         index_offset: u32,
         tx: &SseSender,

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -39,11 +39,7 @@ use crate::{
     app_context::AppContext,
     config::types::RetryConfig,
     middleware::TenantRequestMeta,
-    observability::metrics::{metrics_labels, Metrics},
-    routers::{
-        common::retry::{is_retryable_response, RetryExecutor},
-        error, RouterTrait,
-    },
+    routers::{error, RouterTrait},
     worker::{WorkerRegistry, WorkerType},
 };
 
@@ -466,17 +462,10 @@ impl GrpcRouter {
             .unwrap_or_else(|| self.retry_config.clone())
     }
 
-    /// A rate-limit denial must never be retried -- retrying immediately
-    /// against the same tenant budget defeats `retry_after_secs`.
-    fn reservation_denied(cell: &RateLimitCell) -> bool {
-        matches!(cell.peek(), Some(RateLimitOutcome::Denied))
-    }
-
-    /// Resolve `model_id` to its canonical form once, before a retry loop
-    /// starts. Every dispatch attempt for that logical request must reuse
-    /// this same value -- re-resolving the alias fresh per attempt (as
-    /// `RequestContext::new` otherwise would) lets an alias repointed
-    /// mid-retry dispatch a different model than whatever the tenant
+    /// Resolve `model_id` to its canonical form once, before the pipeline
+    /// runs. Every dispatch attempt for that logical request reuses this
+    /// value -- re-resolving mid-request would let an alias repointed during
+    /// the retry window dispatch a different model than whatever the tenant
     /// rate-limit reservation was actually made for, bypassing that model's
     /// own policy and settling its usage against the wrong budget.
     fn resolve_canonical_model_id(&self, model_id: &str) -> String {
@@ -485,34 +474,6 @@ impl GrpcRouter {
             .as_deref()
             .unwrap_or(model_id)
             .to_string()
-    }
-
-    /// Retry metrics for one backoff, labeled per mode: Regular emits a single
-    /// `regular` worker label; PD/EPD emit `prefill` and `decode` (never
-    /// `encode`).
-    fn record_retry(&self, endpoint: &'static str) {
-        match self.mode {
-            Mode::Regular => {
-                Metrics::record_worker_retry(metrics_labels::WORKER_REGULAR, endpoint);
-            }
-            Mode::PrefillDecode | Mode::EncodePrefillDecode => {
-                Metrics::record_worker_retry(metrics_labels::WORKER_PREFILL, endpoint);
-                Metrics::record_worker_retry(metrics_labels::WORKER_DECODE, endpoint);
-            }
-        }
-    }
-
-    /// Record retry-exhaustion metrics, labeled per mode (see [`Self::record_retry`]).
-    fn record_retries_exhausted(&self, endpoint: &'static str) {
-        match self.mode {
-            Mode::Regular => {
-                Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_REGULAR, endpoint);
-            }
-            Mode::PrefillDecode | Mode::EncodePrefillDecode => {
-                Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_PREFILL, endpoint);
-                Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_DECODE, endpoint);
-            }
-        }
     }
 
     /// Close a reservation that a non-2xx final response never got the
@@ -558,9 +519,8 @@ impl GrpcRouter {
             _ => &self.pipeline,
         };
 
-        // Clone values needed for retry closure. Canonicalize once, up
-        // front, so every attempt (and the reservation `RateLimitReserveStage`
-        // makes on the first one) targets the same model -- see
+        // Canonicalize once, up front, so every dispatch attempt (and the
+        // reservation) targets the same model -- see
         // `resolve_canonical_model_id`'s doc comment. The body's own `model`
         // field is rewritten to match: by this point `model_id_cloned` is
         // already canonical, so `RequestContext::new`'s own alias resolve
@@ -569,57 +529,22 @@ impl GrpcRouter {
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
         let mut canonical_body = body;
         canonical_body.model = model_id_cloned.clone();
-        let request = Arc::new(canonical_body);
-        let headers_cloned = headers.cloned();
-        let components = self.shared_components.clone();
-        let tenant_meta_cloned = tenant_meta.clone();
         let rate_limit_cell = Arc::new(RateLimitCell::new());
-
         let retry_config = self.resolve_retry_config_for_canonical(&model_id_cloned);
 
-        let response = RetryExecutor::execute_response_with_retry(
-            &retry_config,
-            // Operation: execute pipeline (creates fresh context each attempt)
-            |_attempt| {
-                let request = Arc::clone(&request);
-                let headers = headers_cloned.clone();
-                let model_id = model_id_cloned.clone();
-                let components = Arc::clone(&components);
-                let tenant_meta = tenant_meta_cloned.clone();
-                let rate_limit_cell = Arc::clone(&rate_limit_cell);
-                async move {
-                    pipeline
-                        .execute_chat(
-                            request,
-                            headers,
-                            model_id,
-                            components,
-                            Some(tenant_meta),
-                            Some(rate_limit_cell),
-                        )
-                        .await
-                }
-            },
-            // Should retry: a rate-limit denial must never be retried
-            // (retrying immediately against the same tenant budget defeats
-            // retry_after_secs); otherwise check if status is retryable.
-            |res, _attempt| {
-                if Self::reservation_denied(&rate_limit_cell) {
-                    return false;
-                }
-                is_retryable_response(res)
-            },
-            // On backoff: record retry metrics
-            |delay, attempt| {
-                self.record_retry(metrics_labels::ENDPOINT_CHAT);
-                Metrics::record_worker_retry_backoff(attempt, delay);
-            },
-            // On exhausted: record exhaustion
-            || {
-                self.record_retries_exhausted(metrics_labels::ENDPOINT_CHAT);
-            },
-        )
-        .await;
+        // The request Arc moves into the pipeline: no handle survives out
+        // here, so the parsed request frees at the build boundary.
+        let response = pipeline
+            .execute_chat(
+                Arc::new(canonical_body),
+                headers.cloned(),
+                model_id_cloned,
+                self.shared_components.clone(),
+                Some(tenant_meta.clone()),
+                Some(rate_limit_cell.clone()),
+                Some(&retry_config),
+            )
+            .await;
 
         Self::close_reservation_if_unsettled(&rate_limit_cell, response.status()).await;
         response
@@ -635,62 +560,27 @@ impl GrpcRouter {
     ) -> Response {
         debug!("Processing generate request for model: {}", model_id);
 
-        // Clone values needed for retry closure. Canonicalize once, up
-        // front -- see `resolve_canonical_model_id`'s doc comment. Rewrite
-        // the body's `model` field to match; see `route_chat_impl`.
+        // Canonicalize once, up front -- see `resolve_canonical_model_id`'s
+        // doc comment. Rewrite the body's `model` field to match; see
+        // `route_chat_impl`.
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
         let mut canonical_body = body;
         canonical_body.model = model_id_cloned.clone();
-        let request = Arc::new(canonical_body);
-        let headers_cloned = headers.cloned();
-        let components = self.shared_components.clone();
-        let tenant_meta_cloned = tenant_meta.clone();
-        let pipeline = &self.pipeline;
         let rate_limit_cell = Arc::new(RateLimitCell::new());
-
         let retry_config = self.resolve_retry_config_for_canonical(&model_id_cloned);
 
-        let response = RetryExecutor::execute_response_with_retry(
-            &retry_config,
-            // Operation: execute pipeline (creates fresh context each attempt)
-            |_attempt| {
-                let request = Arc::clone(&request);
-                let headers = headers_cloned.clone();
-                let model_id = model_id_cloned.clone();
-                let components = Arc::clone(&components);
-                let tenant_meta = tenant_meta_cloned.clone();
-                let rate_limit_cell = Arc::clone(&rate_limit_cell);
-                async move {
-                    pipeline
-                        .execute_generate(
-                            request,
-                            headers,
-                            model_id,
-                            components,
-                            Some(tenant_meta),
-                            Some(rate_limit_cell),
-                        )
-                        .await
-                }
-            },
-            // Should retry: a rate-limit denial must never be retried; see route_chat_impl.
-            |res, _attempt| {
-                if Self::reservation_denied(&rate_limit_cell) {
-                    return false;
-                }
-                is_retryable_response(res)
-            },
-            // On backoff: record retry metrics
-            |delay, attempt| {
-                self.record_retry(metrics_labels::ENDPOINT_GENERATE);
-                Metrics::record_worker_retry_backoff(attempt, delay);
-            },
-            // On exhausted: record exhaustion
-            || {
-                self.record_retries_exhausted(metrics_labels::ENDPOINT_GENERATE);
-            },
-        )
-        .await;
+        let response = self
+            .pipeline
+            .execute_generate(
+                Arc::new(canonical_body),
+                headers.cloned(),
+                model_id_cloned,
+                self.shared_components.clone(),
+                Some(tenant_meta.clone()),
+                Some(rate_limit_cell.clone()),
+                Some(&retry_config),
+            )
+            .await;
 
         Self::close_reservation_if_unsettled(&rate_limit_cell, response.status()).await;
         response
@@ -803,59 +693,27 @@ impl GrpcRouter {
     ) -> Response {
         debug!("Processing messages request for model: {}", model_id);
 
-        // Clone values needed for retry closure. Canonicalize once, up
-        // front -- see `resolve_canonical_model_id`'s doc comment. Rewrite
-        // the body's `model` field to match; see `route_chat_impl`.
+        // Canonicalize once, up front -- see `resolve_canonical_model_id`'s
+        // doc comment. Rewrite the body's `model` field to match; see
+        // `route_chat_impl`.
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
         let mut canonical_body = body;
         canonical_body.model = model_id_cloned.clone();
-        let request = Arc::new(canonical_body);
-        let headers_cloned = headers.cloned();
-        let components = self.shared_components.clone();
-        let tenant_meta_cloned = tenant_meta.clone();
-        let pipeline = &self.messages_pipeline;
         let rate_limit_cell = Arc::new(RateLimitCell::new());
-
         let retry_config = self.resolve_retry_config_for_canonical(&model_id_cloned);
 
-        let response = RetryExecutor::execute_response_with_retry(
-            &retry_config,
-            |_attempt| {
-                let request = Arc::clone(&request);
-                let headers = headers_cloned.clone();
-                let model_id = model_id_cloned.clone();
-                let components = Arc::clone(&components);
-                let tenant_meta = tenant_meta_cloned.clone();
-                let rate_limit_cell = Arc::clone(&rate_limit_cell);
-                async move {
-                    pipeline
-                        .execute_messages(
-                            request,
-                            headers,
-                            model_id,
-                            components,
-                            Some(tenant_meta),
-                            Some(rate_limit_cell),
-                        )
-                        .await
-                }
-            },
-            // Should retry: a rate-limit denial must never be retried; see route_chat_impl.
-            |res, _attempt| {
-                if Self::reservation_denied(&rate_limit_cell) {
-                    return false;
-                }
-                is_retryable_response(res)
-            },
-            |delay, attempt| {
-                self.record_retry(metrics_labels::ENDPOINT_MESSAGES);
-                Metrics::record_worker_retry_backoff(attempt, delay);
-            },
-            || {
-                self.record_retries_exhausted(metrics_labels::ENDPOINT_MESSAGES);
-            },
-        )
-        .await;
+        let response = self
+            .messages_pipeline
+            .execute_messages(
+                Arc::new(canonical_body),
+                headers.cloned(),
+                model_id_cloned,
+                self.shared_components.clone(),
+                Some(tenant_meta.clone()),
+                Some(rate_limit_cell.clone()),
+                Some(&retry_config),
+            )
+            .await;
 
         Self::close_reservation_if_unsettled(&rate_limit_cell, response.status()).await;
         response
@@ -877,53 +735,21 @@ impl GrpcRouter {
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
         let mut canonical_body = body;
         canonical_body.model = model_id_cloned.clone();
-        let request = Arc::new(canonical_body);
-        let headers_cloned = headers.cloned();
-        let components = self.shared_components.clone();
-        let tenant_meta_cloned = tenant_meta.clone();
-        let pipeline = &self.completion_pipeline;
         let rate_limit_cell = Arc::new(RateLimitCell::new());
-
         let retry_config = self.resolve_retry_config_for_canonical(&model_id_cloned);
 
-        let response = RetryExecutor::execute_response_with_retry(
-            &retry_config,
-            |_attempt| {
-                let request = Arc::clone(&request);
-                let headers = headers_cloned.clone();
-                let model_id = model_id_cloned.clone();
-                let components = Arc::clone(&components);
-                let tenant_meta = tenant_meta_cloned.clone();
-                let rate_limit_cell = Arc::clone(&rate_limit_cell);
-                async move {
-                    pipeline
-                        .execute_completion(
-                            request,
-                            headers,
-                            model_id,
-                            components,
-                            Some(tenant_meta),
-                            Some(rate_limit_cell),
-                        )
-                        .await
-                }
-            },
-            // Should retry: a rate-limit denial must never be retried; see route_chat_impl.
-            |res, _attempt| {
-                if Self::reservation_denied(&rate_limit_cell) {
-                    return false;
-                }
-                is_retryable_response(res)
-            },
-            |delay, attempt| {
-                self.record_retry(metrics_labels::ENDPOINT_COMPLETIONS);
-                Metrics::record_worker_retry_backoff(attempt, delay);
-            },
-            || {
-                self.record_retries_exhausted(metrics_labels::ENDPOINT_COMPLETIONS);
-            },
-        )
-        .await;
+        let response = self
+            .completion_pipeline
+            .execute_completion(
+                Arc::new(canonical_body),
+                headers.cloned(),
+                model_id_cloned,
+                self.shared_components.clone(),
+                Some(tenant_meta.clone()),
+                Some(rate_limit_cell.clone()),
+                Some(&retry_config),
+            )
+            .await;
 
         Self::close_reservation_if_unsettled(&rate_limit_cell, response.status()).await;
         response

--- a/model_gateway/src/routers/grpc/spec.rs
+++ b/model_gateway/src/routers/grpc/spec.rs
@@ -1,0 +1,183 @@
+//! Per-endpoint response specs: the pipeline contract between request
+//! building and response processing.
+//!
+//! Request building is the terminal consumer of the parsed request; the spec
+//! it produces is the only request-derived channel available to response
+//! processing and streaming tasks. The Harmony variant is the one sanctioned
+//! exception: its tool loop re-reads the request across iterations, so its
+//! spec explicitly owns a handle to it.
+
+use std::{collections::HashMap, sync::Arc};
+
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    common::{StreamOptions, StringOrArray, Tool, ToolChoice},
+    completion::CompletionRequest,
+    generate::GenerateRequest,
+    messages::{self, CreateMessageRequest},
+    responses::ResponsesRequest,
+};
+use serde_json::Value;
+
+use crate::routers::grpc::utils;
+
+/// Response-phase contract for one request, produced by request building.
+#[derive(Clone)]
+pub(crate) enum ResponseSpec {
+    Chat(ChatResponseSpec),
+    Generate(GenerateResponseSpec),
+    Completion(CompletionResponseSpec),
+    Messages(MessagesResponseSpec),
+    /// Embedding/classify response processing needs only dispatch metadata.
+    Embedding,
+    Classify,
+    Harmony(HarmonyResponseSpec),
+}
+
+#[derive(Clone)]
+pub(crate) struct ChatResponseSpec {
+    pub separate_reasoning: bool,
+    pub tool_choice: Option<ToolChoice>,
+    pub tools: Option<Vec<Tool>>,
+    pub history_tool_calls_count: usize,
+    pub stream_options: Option<StreamOptions>,
+    pub chat_template_kwargs: Option<HashMap<String, Value>>,
+    pub reasoning_effort: Option<String>,
+    /// `n`, normalized.
+    pub expected_choices: u32,
+    pub logprobs: bool,
+    pub stop: Option<StringOrArray>,
+    pub stop_token_ids: Option<Vec<u32>>,
+    pub no_stop_trim: bool,
+    pub ignore_eos: bool,
+    /// Fallback when preparation derived no override.
+    pub skip_special_tokens: bool,
+}
+
+impl From<&ChatCompletionRequest> for ChatResponseSpec {
+    fn from(request: &ChatCompletionRequest) -> Self {
+        Self {
+            separate_reasoning: request.separate_reasoning,
+            tool_choice: request.tool_choice.clone(),
+            tools: request.tools.clone(),
+            history_tool_calls_count: utils::get_history_tool_calls_count(request),
+            stream_options: request.stream_options.clone(),
+            chat_template_kwargs: request.chat_template_kwargs.clone(),
+            reasoning_effort: request.reasoning_effort.clone(),
+            expected_choices: request.n.unwrap_or(1).max(1),
+            logprobs: request.logprobs,
+            stop: request.stop.clone(),
+            stop_token_ids: request.stop_token_ids.clone(),
+            no_stop_trim: request.no_stop_trim,
+            ignore_eos: request.ignore_eos,
+            skip_special_tokens: request.skip_special_tokens,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct GenerateResponseSpec {
+    pub return_logprob: bool,
+    /// `sampling_params.n`, normalized.
+    pub expected_choices: u32,
+}
+
+impl From<&GenerateRequest> for GenerateResponseSpec {
+    fn from(request: &GenerateRequest) -> Self {
+        Self {
+            return_logprob: request.return_logprob.unwrap_or(false),
+            expected_choices: request
+                .sampling_params
+                .as_ref()
+                .and_then(|p| p.n)
+                .unwrap_or(1)
+                .max(1),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct MessagesResponseSpec {
+    pub thinking: Option<messages::ThinkingConfig>,
+    pub tool_choice: Option<messages::ToolChoice>,
+    pub has_tools: bool,
+    pub history_tool_calls_count: usize,
+    /// Messages tools pre-converted to Chat tools for parser reuse.
+    pub chat_tools: Vec<Tool>,
+    pub stop_sequences: Option<Vec<String>>,
+}
+
+impl From<&CreateMessageRequest> for MessagesResponseSpec {
+    fn from(request: &CreateMessageRequest) -> Self {
+        Self {
+            thinking: request.thinking.clone(),
+            tool_choice: request.tool_choice.clone(),
+            has_tools: request.tools.is_some(),
+            history_tool_calls_count: utils::message_utils::get_history_tool_calls_count_messages(
+                request,
+            ),
+            chat_tools: request
+                .tools
+                .as_deref()
+                .map(utils::message_utils::extract_chat_tools)
+                .unwrap_or_default(),
+            stop_sequences: request.stop_sequences.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CompletionResponseSpec {
+    /// `n`, normalized.
+    pub choices_per_prompt: u32,
+    pub echo: bool,
+    pub suffix: Option<String>,
+    pub logprobs: bool,
+    pub include_usage: bool,
+    /// Populated only when `echo` (choices prepend their prompt text).
+    pub prompt_texts: Vec<String>,
+    pub stop: Option<StringOrArray>,
+    pub stop_token_ids: Option<Vec<u32>>,
+    pub skip_special_tokens: bool,
+    pub no_stop_trim: bool,
+    pub ignore_eos: bool,
+}
+
+impl From<&CompletionRequest> for CompletionResponseSpec {
+    fn from(request: &CompletionRequest) -> Self {
+        let prompt_texts = if request.echo {
+            match &request.prompt {
+                StringOrArray::String(text) => vec![text.clone()],
+                StringOrArray::Array(texts) => texts.clone(),
+            }
+        } else {
+            Vec::new()
+        };
+        Self {
+            choices_per_prompt: request.n.unwrap_or(1).max(1),
+            echo: request.echo,
+            suffix: request.suffix.clone(),
+            logprobs: request.logprobs.is_some(),
+            include_usage: request
+                .stream_options
+                .as_ref()
+                .and_then(|opts| opts.include_usage)
+                .unwrap_or(false),
+            prompt_texts,
+            stop: request.stop.clone(),
+            stop_token_ids: request.stop_token_ids.clone(),
+            skip_special_tokens: request.skip_special_tokens,
+            no_stop_trim: request.no_stop_trim,
+            ignore_eos: request.ignore_eos,
+        }
+    }
+}
+
+/// Harmony's spec owns the request: the tool loop and channel parsers
+/// legitimately re-read it after dispatch. Post-build code reaches the
+/// request only through this explicit handle.
+#[derive(Clone)]
+pub(crate) enum HarmonyResponseSpec {
+    Chat(Arc<ChatCompletionRequest>),
+    Responses(Arc<ResponsesRequest>),
+}

--- a/model_gateway/src/routers/grpc/spec.rs
+++ b/model_gateway/src/routers/grpc/spec.rs
@@ -1,9 +1,9 @@
 //! Per-endpoint response specs: the pipeline contract between request
 //! building and response processing.
 //!
-//! Request building is the terminal consumer of the parsed request; the spec
-//! it produces is the only request-derived channel available to response
-//! processing and streaming tasks. The Harmony variant is the one sanctioned
+//! Request building is the last reader of the parsed request; the spec it
+//! produces is the only request-derived input available to response
+//! processing and streaming tasks. The Harmony variant is the one deliberate
 //! exception: its tool loop re-reads the request across iterations, so its
 //! spec explicitly owns a handle to it.
 
@@ -24,7 +24,7 @@ use crate::routers::grpc::utils;
 /// Response-phase contract for one request, produced by request building.
 #[derive(Clone)]
 pub(crate) enum ResponseSpec {
-    Chat(ChatResponseSpec),
+    Chat(Box<ChatResponseSpec>),
     Generate(GenerateResponseSpec),
     Completion(CompletionResponseSpec),
     Messages(MessagesResponseSpec),


### PR DESCRIPTION
## Description

### Problem

- The parsed request (messages, prompt text, image data) stays in memory for the whole request, even though nothing needs it once the backend request is built. On a streaming response it sits there until the last token.
- A retry re-runs the whole pipeline — tokenize again, render the chat template again, process images again, rebuild the backend request — just to send the same request to a different worker.

Closes #2246.

### Solution

Split the pipeline in two at request building: request building becomes the last code that can read the request, the request is dropped right after it, and retries redo only the second half.

**Before** — one context owns the request end to end, and the retry loop re-runs everything:

```
retry loop ┌──────────────────────────────────────────────────────────┐
           │ 1 prepare → 2 rate-limit → 3 select worker → 4 client →  │
           │ 5 encode → 6 build → 7 metadata → 8 dispatch → 9 respond │
           └──────────────────────────────────────────────────────────┘
             RequestContext (owns the request) flows through all 9 steps
```

**After** — same steps, same order. Two changes: the request dies at step 6, and a retry restarts at step 7 instead of step 1:

```
runs once   ┌────────────────────────────────────────────┐
            │ 1 prepare → 2 rate-limit → 3 select worker │  RequestContext
            │ → 4 client → 5 encode → 6 build            │  (owns the request)
            └──────────────────┬─────────────────────────┘
                               │  into_dispatch(): request dropped here
retry loop  ┌──────────────────▼─────────────────────────┐
per attempt │ [retry only: redo 3+4, patch the plan]     │  DispatchContext
            │ 7 metadata → 8 dispatch → 9 respond        │  (no request field)
            └────────────────────────────────────────────┘
```

Steps 7–9 run on `DispatchContext`, which has no request field — code there cannot read the request because there is nothing to read. The compiler enforces this, not review.

New types, and why each exists:

- **`DispatchContext`** — the post-build context. Same data as before, minus the request.
- **`RequestContext::into_dispatch()`** — the boundary. Copies out the two strings still needed, drops the request, returns the `DispatchContext`.
- **`ResponseSpec`** (new `grpc/spec.rs`) — the handful of request fields response processing still needs (tools, stop settings, `n`, …), copied out at build; one small struct per endpoint family. Harmony is the one deliberate exception: its tool loop re-reads the request between iterations, so its spec keeps an `Arc` handle to it, visibly.
- **`AttemptStamp`** — what a retry needs to patch the already-built request for a new worker: the engine-id minting rule, the sampling-defaults mask and baseline, and whether PD metadata must be re-injected.
- **`RoutingSnapshot` + `WireConstraint`** — what worker re-selection needs after the request is gone, plus the rule that a retry may only pick a worker with the same runtime and transport (the built request cannot be converted to another backend's format).

Retry behavior, spelled out:

- A retry re-selects a worker, patches the retained plan (fresh engine id, the new worker's PD bootstrap rooms, the new worker's sampling defaults applied over the build-time baseline), and dispatches. No re-tokenization.
- Failures before the build boundary (bad request, rate-limit denial) are not retried — they return before the retry loop starts.
- An EPD retry swaps only the prefill/decode pair. The first attempt's encode jobs keep running and their rendezvous rooms are left untouched: those rooms point at the encode workers, and the new prefill pulls from them.

## Changes

- `context.rs`: `RequestContext` (ingress) / `DispatchContext` (post-build) split; `into_dispatch()` drops the request; the `ExecutionPlan` is retained across attempts, cloned per attempt, moved on the last one
- New `spec.rs`: per-endpoint `ResponseSpec` structs; `HarmonyResponseSpec` holds the request handle for the tool loop
- Stage traits split by phase: `PipelineStage` (ingress) / `BuildStage` (build) / `ProcessStage` (dispatch)
- Retry loop moved from the router into `pipeline.rs`; per-attempt re-selection is pinned to the plan's runtime + transport
- Response processors and streaming tasks read the spec instead of `Arc<Request>`
- New metric `smg_router_request_buffers_released_early_bytes_total`: request bytes freed at the build boundary
- Rebased onto current main: the DP-rank pin logic ported onto the `PdProtocol` table from #2330, and the attention-DP changes from #2326 preserved

## Test Plan

- Release probes (`pipeline.rs`): `Weak` handles to the request prove it is freed before the first streamed token, and before the upstream even answers a buffered dispatch — regular and PD, with and without retries enabled
- Retry replay: an induced first-dispatch failure retries from the retained plan with identical token ids and a fresh engine id — no re-tokenization
- Engine-id rules frozen by unit tests: bare `rid` stays stable; `rid` under PD and middleware-derived ids get a fresh suffix per attempt; minted ids are fresh; batch shared/sub-id rules covered
- Sampling on retry: worker B's defaults apply over the build-time baseline, never over worker A's leftovers
- EPD retry: the PD KV room is re-minted for the new prefill while the encode rooms survive untouched
- `cargo test -p smg --lib`: 1846 passed, 0 failed; `cargo clippy -p smg --lib --tests -- -D warnings` and `cargo +nightly fmt --all --check` clean locally; e2e (1-GPU realtime + responses), openai-realtime, and Go unit tests green on CI for the rebased head; the full CI unit-test job is re-running after the lint fix in the latest commit

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
