### PR TITLE
ci(e2e): merge-blocking realtime lane, crate filters, gate lint, and selection floors

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# Custom self-hosted runner labels used by this repo's workflows, so
+# actionlint's runner-label check recognizes them.
+self-hosted-runner:
+  labels:
+    - k8s-runner-cpu
+    - k8s-runner-gpu
+    - 1-gpu-h100
+    - 4-gpu-h100

--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -64,6 +64,11 @@ on:
         type: string
         default: ""
         description: "DP engines per ZMQ worker (grouped vLLM launch; empty = 1)"
+      min_selected:
+        required: false
+        type: number
+        default: 0
+        description: "Minimum effective (selected) test count; exported as E2E_MIN_SELECTED for the pytest harness floor check (0 = disabled)"
 
 jobs:
   run:
@@ -159,6 +164,7 @@ jobs:
           SHOW_WORKER_LOGS: "0"
           SHOW_ROUTER_LOGS: "1"
           E2E_LOG_DIR: e2e-logs
+          E2E_MIN_SELECTED: ${{ inputs.min_selected }}
           BRAVE_MCP_HOST: ${{ inputs.setup_agentic_deps && 'brave-search-mcp' || '' }}
         run: |
           bash scripts/ci_killall_sglang.sh "nuke_gpus"

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -456,6 +456,14 @@ jobs:
               - 'scripts/ci_build_wheel.sh'
               - 'crates/tokenizer/**'
               - 'crates/tool_parser/**'
+              # Router-embedded crates: changes here alter gateway behavior
+              # across every API surface, so they must trigger the e2e lanes.
+              - 'crates/auth/**'
+              - 'crates/kv_index/**'
+              - 'crates/mesh/**'
+              - 'crates/mm_rdma/**'
+              - 'crates/wasm/**'
+              - 'crates/workflow/**'
             chat-completions:
               - 'crates/reasoning_parser/**'
               - 'crates/multimodal/**'
@@ -533,12 +541,15 @@ jobs:
           - engine: sglang
             timeout: 36
             test_timeout: 28
+            min_selected: 204 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: vllm
             timeout: 24
             test_timeout: 18
+            min_selected: 202 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: trtllm
             timeout: 32
             test_timeout: 18
+            min_selected: 180 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           # tokenspeed builds from source (~30m cold), so keep the job
           # timeout generous even though the test step is short.
           # Admin-ops e2e (flush/profile) piggybacks here because this is
@@ -549,6 +560,7 @@ jobs:
             timeout: 50
             test_timeout: 18
             test_dirs: e2e_test/chat_completions e2e_test/router/test_admin_ops.py
+            min_selected: 114 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -557,6 +569,7 @@ jobs:
       timeout: ${{ matrix.timeout }}
       test_timeout: ${{ matrix.test_timeout }}
       test_dirs: ${{ matrix.test_dirs || 'e2e_test/chat_completions' }}
+      min_selected: ${{ matrix.min_selected }}
     secrets: inherit
 
   e2e-1gpu-chat-zmq:
@@ -584,9 +597,11 @@ jobs:
           - engine: vllm
             timeout: 46
             test_timeout: 40
+            min_selected: 202 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: tokenspeed
             timeout: 50
             test_timeout: 40
+            min_selected: 109 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -596,6 +611,7 @@ jobs:
       test_timeout: ${{ matrix.test_timeout }}
       test_dirs: e2e_test/chat_completions
       connection_mode: zmq
+      min_selected: ${{ matrix.min_selected }}
     secrets: inherit
 
   e2e-2gpu-chat-zmq-dp:
@@ -620,6 +636,7 @@ jobs:
         include:
           - engine: vllm
             timeout: 46
+            min_selected: 202 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           # The TokenSpeed ZMQ lane restarts the engine per model group, and
           # DP doubles model load + warmup. The ~22-minute TokenSpeed source
           # build eats the front of the budget, and at 50 the first dp run was
@@ -627,6 +644,7 @@ jobs:
           # leaves the tests the same ~40 minutes the test_timeout allows.
           - engine: tokenspeed
             timeout: 60
+            min_selected: 82 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -640,6 +658,7 @@ jobs:
       test_dirs: e2e_test/chat_completions
       connection_mode: zmq
       zmq_engine_count: "2"
+      min_selected: ${{ matrix.min_selected }}
     secrets: inherit
 
   e2e-1gpu-completions:
@@ -659,8 +678,10 @@ jobs:
         include:
           - engine: sglang
             timeout: 20
+            min_selected: 15 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: vllm
             timeout: 20
+            min_selected: 15 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -668,6 +689,7 @@ jobs:
       runner: 1-gpu-h100
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/completions
+      min_selected: ${{ matrix.min_selected }}
     secrets: inherit
 
   e2e-1gpu-embeddings:
@@ -687,8 +709,10 @@ jobs:
         include:
           - engine: sglang
             timeout: 20
+            min_selected: 18 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: vllm
             timeout: 20
+            min_selected: 20 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -697,6 +721,7 @@ jobs:
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/embeddings
       extra_deps: "sentence-transformers"
+      min_selected: ${{ matrix.min_selected }}
     secrets: inherit
 
   e2e-1gpu-realtime:
@@ -717,6 +742,7 @@ jobs:
       timeout: 25
       test_timeout: 20
       test_dirs: e2e_test/realtime
+      min_selected: 3 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     secrets: inherit
 
   e2e-1gpu-gateway:
@@ -736,8 +762,10 @@ jobs:
         include:
           - engine: sglang
             timeout: 20
+            min_selected: 23 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: vllm
             timeout: 20
+            min_selected: 3 # vllm gateway lane selects only 3 tests; floor covers all of them (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -746,6 +774,7 @@ jobs:
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/router
       test_filter: "--ignore=e2e_test/router/test_pd_mmlu.py"
+      min_selected: ${{ matrix.min_selected }}
     secrets: inherit
 
   # === 2 GPU ===
@@ -772,6 +801,7 @@ jobs:
       test_timeout: 20
       test_dirs: e2e_test/responses
       setup_agentic_deps: true
+      min_selected: 92 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     secrets: inherit
 
   e2e-2gpu-pd:
@@ -791,11 +821,14 @@ jobs:
         include:
           - engine: sglang
             timeout: 30
+            min_selected: 15 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: vllm
             timeout: 30
+            min_selected: 15 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: vllm
             kv_backend: mooncake
             timeout: 30
+            min_selected: 15 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -804,6 +837,7 @@ jobs:
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/router
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
+      min_selected: ${{ matrix.min_selected }}
     secrets: inherit
 
   # === 4 GPU ===
@@ -817,10 +851,13 @@ jobs:
         include:
           - engine: sglang
             timeout: 30
+            min_selected: 32 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: vllm
             timeout: 30
+            min_selected: 32 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: trtllm
             timeout: 45
+            min_selected: 24 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -828,6 +865,7 @@ jobs:
       runner: 4-gpu-h100
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/chat_completions
+      min_selected: ${{ matrix.min_selected }}
     secrets: inherit
 
   e2e-4gpu-gateway:
@@ -855,6 +893,7 @@ jobs:
       test_timeout: 65
       test_dirs: e2e_test/chat_completions/test_epd_multimodal.py
       extra_models: "Qwen/Qwen3.5-9B"
+      min_selected: 6 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     secrets: inherit
 
   # --- Vendor E2E: CPU-only cloud backend tests ---
@@ -1148,11 +1187,47 @@ jobs:
           path: benchmark_go_bindings/
 
   finish:
-    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-chat-zmq, e2e-2gpu-chat-zmq-dp, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-vendor, go-unit-tests, go-bindings-e2e]
+    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-chat-zmq, e2e-2gpu-chat-zmq-dp, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-realtime, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-vendor, go-unit-tests, go-bindings-e2e]
     if: always()
     runs-on: k8s-runner-cpu
-    permissions: {}
+    permissions:
+      contents: read
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Self-check: every e2e-* job defined in this workflow must gate merge
+      # via finish.needs AND the failure check below. Keeps a new (or
+      # forgotten) lane from silently becoming non-blocking.
+      - name: Gate-integrity lint
+        run: |
+          python3 - <<'EOF'
+          import re, sys
+
+          path = ".github/workflows/pr-test-rust.yml"
+          src = open(path).read()
+          jobs = re.findall(r"^  (e2e-[a-z0-9-]*):", src, re.M)
+          if not jobs:
+              sys.exit("gate-integrity lint: found no e2e-* job definitions; lint is broken")
+          fin = re.search(r"^  finish:\n(.*?)(?=^  \S|\Z)", src, re.M | re.S)
+          if not fin:
+              sys.exit("gate-integrity lint: could not locate the finish job")
+          body = fin.group(1)
+          needs_m = re.search(r"needs:\s*\[([^\]]*)\]", body)
+          if not needs_m:
+              sys.exit("gate-integrity lint: finish.needs not found in inline-list form")
+          needs = {n.strip() for n in needs_m.group(1).split(",")}
+          missing_needs = sorted(j for j in jobs if j not in needs)
+          missing_check = sorted(j for j in jobs if f"needs.{j}.result" not in body)
+          if missing_needs or missing_check:
+              if missing_needs:
+                  print(f"e2e jobs missing from finish.needs: {missing_needs}")
+              if missing_check:
+                  print(f"e2e jobs missing from the finish failure check: {missing_check}")
+              sys.exit(1)
+          print(f"OK: all {len(jobs)} e2e-* jobs gate merge: {sorted(jobs)}")
+          EOF
+
       - name: Check CI result
         run: |
           if [[ "${{ needs.pre-commit.result }}" == "failure" || \
@@ -1167,6 +1242,7 @@ jobs:
                 "${{ needs.e2e-2gpu-chat-zmq-dp.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-completions.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-embeddings.result }}" == "failure" || \
+                "${{ needs.e2e-1gpu-realtime.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-gateway.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-responses.result }}" == "failure" || \
                 "${{ needs.e2e-2gpu-pd.result }}" == "failure" || \

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1206,7 +1206,7 @@ jobs:
 
           path = ".github/workflows/pr-test-rust.yml"
           src = open(path).read()
-          jobs = re.findall(r"^  (e2e-[a-z0-9-]*):", src, re.M)
+          jobs = re.findall(r"^  (e2e-[a-z0-9_-]*):", src, re.M)
           if not jobs:
               sys.exit("gate-integrity lint: found no e2e-* job definitions; lint is broken")
           fin = re.search(r"^  finish:\n(.*?)(?=^  \S|\Z)", src, re.M | re.S)
@@ -1218,7 +1218,15 @@ jobs:
               sys.exit("gate-integrity lint: finish.needs not found in inline-list form")
           needs = {n.strip() for n in needs_m.group(1).split(",")}
           missing_needs = sorted(j for j in jobs if j not in needs)
-          missing_check = sorted(j for j in jobs if f"needs.{j}.result" not in body)
+          # Search only the failure-check step, not the whole job body — a
+          # comment elsewhere must not satisfy the check.
+          check = re.search(
+              r"- name: Check CI result\n(.*?)(?=^      - name:|\Z)", body, re.M | re.S
+          )
+          if not check:
+              sys.exit("gate-integrity lint: could not locate the 'Check CI result' step")
+          check_body = check.group(1)
+          missing_check = sorted(j for j in jobs if f"needs.{j}.result" not in check_body)
           if missing_needs or missing_check:
               if missing_needs:
                   print(f"e2e jobs missing from finish.needs: {missing_needs}")


### PR DESCRIPTION
## Description

### Problem

A seven-dimension audit of the e2e suite found four gate-integrity gaps in the CI workflows:

1. `e2e-1gpu-realtime` (pr-test-rust.yml:702) was missing from `finish.needs` and from the finish job's failure check — a red realtime lane could not block merge.
2. The `detect-changes` `common` filter omitted six crates (`auth`, `kv_index`, `mesh`, `mm_rdma`, `wasm`, `workflow`); PRs touching only them ran zero e2e lanes. `kv_index` is actively developed (#2159, #2161, #2133 are cache-index features).
3. Nothing prevented gap (1) from recurring the next time a lane is added.
4. Per-lane effective (selected) test counts can shrink silently — a collection regression deselects tests and the lane still goes green.

### Solution

1. Add `e2e-1gpu-realtime` to `finish.needs` and to the failure-check conditions, mirroring the other lanes.
2. Add the six crates to the `common` filter. All six are router-embedded and affect gateway behavior across API surfaces, so `common` (which fans out to every lane) is the right family for all of them rather than a narrower one — `kv_index` in particular drives cache-aware routing used by chat, gateway, and pd lanes alike.
3. Gate-integrity lint: a dependency-free inline-python step in the `finish` job that extracts every `^  e2e-[a-z0-9-]*:` job definition and fails if any name is absent from `finish.needs` OR from the failure-check block. The `finish` job gains `contents: read` and a checkout step to read the workflow file.
4. Selection floors: `e2e-gpu-job.yml` gains an optional `min_selected` input (number, default 0) exported as `E2E_MIN_SELECTED` in the pytest step env; every GPU lane sets a per-engine floor at ~95% (rounded down) of the audit's measured effective count. The mechanism is inert until the harness-side `E2E_MIN_SELECTED` check (sibling PR) merges; either merge order is safe.

The audit's line citations (finish at :1151, failure check :1158-1178, filters :438-510, realtime :702) all matched `origin/main` as read; none were stale.

## Changes

- `.github/workflows/pr-test-rust.yml`
  - `finish.needs` and the failure check now include `e2e-1gpu-realtime`.
  - `detect-changes` `common` filter: added `crates/{auth,kv_index,mesh,mm_rdma,wasm,workflow}/**`.
  - New "Gate-integrity lint" step in `finish` (plus checkout and `contents: read`).
  - Per-lane `min_selected` values (each tagged `# floor ≈ 95% of measured effective (e2e audit 2026-08-21)`): chat 204/202/180/114 (sglang/vllm/trtllm/tokenspeed), chat-zmq 202/109, chat-zmq-dp 202/82, completions 15/15, embeddings 18/20, realtime 3, gateway 23 (sglang) and 3 (vllm — that lane selects only 3 tests, so the floor covers all of them), responses 92, pd 15×3, 4gpu-chat 32/32/24, epd 6.
  - `e2e-4gpu-gateway` has no audit-measured count, so it keeps the default floor of 0 — follow-up once a measurement exists.
- `.github/workflows/e2e-gpu-job.yml`
  - New optional `min_selected` input (number, default 0), exported as `E2E_MIN_SELECTED` in the "Run E2E tests" step env.

## Test Plan

Verified locally (CPU-only; this change is YAML + inline python, no cargo surface):

- `yaml.safe_load` parses both edited workflow files cleanly.
- Gate-integrity lint run against the edited `pr-test-rust.yml`: `OK: all 13 e2e-* jobs gate merge: ['e2e-1gpu-chat', 'e2e-1gpu-chat-zmq', 'e2e-1gpu-completions', 'e2e-1gpu-embeddings', 'e2e-1gpu-gateway', 'e2e-1gpu-realtime', 'e2e-1gpu-responses', 'e2e-2gpu-chat-zmq-dp', 'e2e-2gpu-pd', 'e2e-4gpu-chat', 'e2e-4gpu-epd', 'e2e-4gpu-gateway', 'e2e-vendor']`.
- Negative test: the same lint run against the pre-fix `origin/main` file exits 1 with `missing from needs: ['e2e-1gpu-realtime']` and `missing from failure check: ['e2e-1gpu-realtime']` — it detects exactly the audit's finding.

Must be confirmed by the GPU lanes on this PR (this workflow edit itself trips the `common` filter, so all lanes run):

- All e2e lanes still launch and pass with the new `min_selected` plumbing (the input is exported but unread by the harness until the sibling `E2E_MIN_SELECTED` PR merges, so it cannot fail lanes yet).
- The gate-integrity lint step passes in the real `finish` job environment.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

Python/CI-only change; cargo gates not applicable.

</details>
