### PR TITLE
test(e2e): assert usage token arithmetic across endpoints

### DIFF
--- a/e2e_test/chat_completions/test_openai_server.py
+++ b/e2e_test/chat_completions/test_openai_server.py
@@ -132,10 +132,12 @@ class TestChatCompletion:
         is_firsts = {}
         is_finished = {}
         finish_reason_counts = {}
+        usage_seen = False
         for response in generator:
             # Capture usage from the final chunk
             usage = response.usage
             if usage is not None:
+                usage_seen = True
                 assert usage.prompt_tokens > 0, "usage.prompt_tokens was zero"
                 assert usage.completion_tokens > 0, "usage.completion_tokens was zero"
                 assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
@@ -164,6 +166,7 @@ class TestChatCompletion:
                     "top_logprobs count mismatch"
                 )
 
+        assert usage_seen, "stream_options.include_usage was set but no usage chunk arrived"
         for index in range(parallel_sample_num):
             assert index in finish_reason_counts, f"No finish_reason found for index {index}"
             assert finish_reason_counts[index] == 1, (

--- a/e2e_test/chat_completions/test_openai_server.py
+++ b/e2e_test/chat_completions/test_openai_server.py
@@ -87,7 +87,9 @@ class TestChatCompletion:
         assert response.created
         assert response.usage.prompt_tokens > 0
         assert response.usage.completion_tokens > 0
-        assert response.usage.total_tokens > 0
+        assert response.usage.total_tokens == (
+            response.usage.prompt_tokens + response.usage.completion_tokens
+        )
 
     @pytest.mark.parametrize(
         "logprobs",
@@ -136,7 +138,8 @@ class TestChatCompletion:
             if usage is not None:
                 assert usage.prompt_tokens > 0, "usage.prompt_tokens was zero"
                 assert usage.completion_tokens > 0, "usage.completion_tokens was zero"
-                assert usage.total_tokens > 0, "usage.total_tokens was zero"
+                assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+                assert response.choices == [], "usage chunk should carry no choices"
                 continue
 
             # Skip if no choices

--- a/e2e_test/completions/test_basic.py
+++ b/e2e_test/completions/test_basic.py
@@ -411,3 +411,4 @@ class TestCompletionBatch:
         assert usage is not None
         assert usage.prompt_tokens > 0
         assert usage.completion_tokens > 0
+        assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens

--- a/e2e_test/messages/test_basic.py
+++ b/e2e_test/messages/test_basic.py
@@ -36,6 +36,8 @@ class TestMessagesBasic:
         assert response.content[0].type == "text"
         assert len(response.content[0].text) > 0
         assert response.usage is not None
+        assert isinstance(response.usage.input_tokens, int)
+        assert isinstance(response.usage.output_tokens, int)
         assert response.usage.input_tokens > 0
         assert response.usage.output_tokens > 0
 

--- a/e2e_test/responses/test_state_management.py
+++ b/e2e_test/responses/test_state_management.py
@@ -34,6 +34,7 @@ class _StateManagementCloudBase:
         assert resp.status == "completed"
         assert len(resp.output_text) > 0
         assert resp.usage is not None
+        assert resp.usage.total_tokens == resp.usage.input_tokens + resp.usage.output_tokens
 
     def test_streaming_response(self, model, api_client):
         """Test streaming response."""
@@ -248,6 +249,7 @@ class TestStateManagementLocal:
         assert resp.status == "completed"
         assert len(resp.output_text) > 0
         assert resp.usage is not None
+        assert resp.usage.total_tokens == resp.usage.input_tokens + resp.usage.output_tokens
 
     def test_streaming_response(self, model, api_client):
         """Test streaming response."""
@@ -357,6 +359,7 @@ class TestStateManagementGptOss:
         assert resp.status == "completed"
         assert len(resp.output_text) > 0
         assert resp.usage is not None
+        assert resp.usage.total_tokens == resp.usage.input_tokens + resp.usage.output_tokens
 
     def test_streaming_response(self, model, api_client):
         """Test streaming response."""


### PR DESCRIPTION
## Description

### Problem

A seven-dimension audit of the e2e suite found that usage token arithmetic is asserted almost nowhere: the chat completions tests (`test_openai_server.py:88-90` non-streaming, `:134-140` streaming usage chunk) only check that each counter is `> 0`, so a gateway that reports `total_tokens != prompt_tokens + completion_tokens` would pass. The Responses API non-streaming create tests only check `usage is not None`, and the Messages tests do not pin the usage fields' types. Only `completions/test_basic.py` already asserted the sum identity in its non-streaming tests -- but its streaming usage-chunk block lacked it too.

### Solution

Add small additive asserts to the existing tests (no new test functions), reusing the sum-identity idiom already established in `completions/test_basic.py:46-47`:

- Chat: assert `prompt_tokens + completion_tokens == total_tokens` in the non-streaming basic test and on the streaming usage chunk, plus assert the usage chunk carries empty `choices` (verified against the gateway's usage-chunk construction in `model_gateway/src/routers/grpc/regular/streaming.rs` Phase 5, which builds the chunk with no choices, and `Usage::from_counts` in `crates/protocols/src/common.rs:553`, which defines `total_tokens = prompt + completion`).
- Completions: add the same identity to the streaming aggregated-usage block in `test_batch_streaming` (the non-streaming sites already had it).
- Responses: assert `input_tokens + output_tokens == total_tokens` in the non-streaming `test_basic_response_creation` (all three cloud-base variants). Note: the audit pointed at `test_basic_crud.py`, but that file asserts no usage at all; the non-streaming create that asserts usage lives in `test_state_management.py`, so the identity was added there.
- Messages: assert `input_tokens` / `output_tokens` are ints (they were already asserted positive; the Anthropic Messages usage object has no total field, so no identity applies).

## Changes

- `e2e_test/chat_completions/test_openai_server.py`: sum identity in `test_chat_completion` (replacing the weaker `total_tokens > 0`); sum identity + empty-choices assert on the streaming usage chunk in `test_chat_completion_stream`.
- `e2e_test/completions/test_basic.py`: sum identity on the aggregated usage chunk in `test_batch_streaming`.
- `e2e_test/responses/test_state_management.py`: `input_tokens + output_tokens == total_tokens` in `test_basic_response_creation` (3 occurrences across the cloud base mixins).
- `e2e_test/messages/test_basic.py`: `isinstance(..., int)` checks on `usage.input_tokens` / `usage.output_tokens` in `test_non_streaming_basic`.

## Test Plan

Verified locally (no GPU available):
- `python3 -m py_compile` on all four touched files: pass.
- `pytest --collect-only -q` on all four files (Python 3.13 venv with the suite's pinned deps, `PYTHONPATH=e2e_test`): 177 tests collected, no collection errors.
- Read the gateway's usage construction (`Usage::from_counts`, chat streaming Phase 5 usage chunk) to confirm the asserted contract is the one the router actually implements.

The GPU e2e lanes must confirm the new asserts hold at runtime against real backends (tokenspeed/vLLM/cloud vendors); no assertion here was invented beyond what the router code guarantees, so failures would indicate a real usage-accounting bug.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

Python/CI-only change; cargo gates not applicable.

</details>
