### PR TITLE
test(e2e): report engine-filter deselections and enforce a selected-count floor

### DIFF
--- a/e2e_test/fixtures/hooks.py
+++ b/e2e_test/fixtures/hooks.py
@@ -30,6 +30,10 @@ from .markers import resolve_class_marker
 # vendor names — is out of scope for ZMQ.
 _ZMQ_LOCAL_WIRES = frozenset({"grpc", "http"})
 
+# Per-session selection accounting filled in by ``pytest_collection_modifyitems``
+# and printed as one greppable ``e2e selection:`` line after collection.
+_SELECTION_STATS_KEY: pytest.StashKey[dict] = pytest.StashKey()
+
 # ---------------------------------------------------------------------------
 # Marker registration
 # ---------------------------------------------------------------------------
@@ -91,6 +95,12 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "nightly: mark test as a nightly comprehensive benchmark",
     )
+
+    # ``hooks.py`` is not itself a conftest — only the functions conftest.py
+    # re-imports act as hooks — so the collection-summary reporter is
+    # registered here as a plugin object instead.
+    if not config.pluginmanager.has_plugin("e2e_selection_reporter"):
+        config.pluginmanager.register(_SelectionReporter(), "e2e_selection_reporter")
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +230,104 @@ def _filter_tokenspeed_dp_items(
     return kept, deselected
 
 
+def _filter_env_items(
+    items: list[pytest.Item],
+    engine: str | None,
+    vendor: str | None,
+    gpu_tier: str | None,
+) -> tuple[list[pytest.Item], dict[str, list[pytest.Item]]]:
+    """Split items into (selected, deselected-by-reason) for the env filter.
+
+    Each dropped item is attributed to the first filter that rejects it, in
+    ``engine`` → ``vendor`` → ``tier`` order.
+    """
+    selected: list[pytest.Item] = []
+    deselected_by: dict[str, list[pytest.Item]] = {"engine": [], "vendor": [], "tier": []}
+    for item in items:
+        # Filter by engine
+        if engine:
+            engine_marker = _get_marker(item, "engine")
+            if not engine_marker or engine not in engine_marker.args:
+                deselected_by["engine"].append(item)
+                continue
+        # Filter by vendor
+        if vendor:
+            vendor_marker = _get_marker(item, "vendor")
+            if not vendor_marker or vendor not in vendor_marker.args:
+                deselected_by["vendor"].append(item)
+                continue
+        # Filter by GPU tier
+        if gpu_tier is not None:
+            gpu_marker = _get_marker(item, "gpu")
+            gpu_count = gpu_marker.args[0] if gpu_marker else 1
+            if str(gpu_count) != gpu_tier:
+                deselected_by["tier"].append(item)
+                continue
+        selected.append(item)
+    return selected, deselected_by
+
+
+def _enforce_selection_floor(selected_count: int) -> None:
+    """Fail the session when fewer tests survived selection than the floor.
+
+    ``E2E_MIN_SELECTED`` (integer) arms the check; unset or blank disables it.
+    A violation aborts the run via ``pytest.exit`` so the CI log shows a
+    loud ``!!! Exit !!!`` banner instead of a quietly shrunken suite.
+    """
+    raw = (os.environ.get("E2E_MIN_SELECTED") or "").strip()
+    if not raw:
+        return
+    try:
+        floor = int(raw)
+    except ValueError:
+        pytest.exit(
+            f"e2e selection: E2E_MIN_SELECTED={raw!r} is not an integer",
+            returncode=1,
+        )
+    if selected_count < floor:
+        pytest.exit(
+            f"e2e selection: only {selected_count} tests selected, below the "
+            f"E2E_MIN_SELECTED floor of {floor}. The E2E_ENGINE/E2E_VENDOR/"
+            f"E2E_GPU_TIER env filter in e2e_test/fixtures/hooks.py is the "
+            f"likely cause (marker drift or a lane env-var typo).",
+            returncode=1,
+        )
+
+
+def _format_selection_line(stats: dict) -> str:
+    """Render the one-line, greppable ``e2e selection:`` summary."""
+    header = f"e2e selection: engine={stats['engine'] or '-'}"
+    if stats.get("vendor"):
+        header += f" vendor={stats['vendor']}"
+    header += f" tier={stats['tier'] or '-'}"
+    parts = [f"{stats['by_engine']} deselected by engine"]
+    if stats.get("vendor") or stats["by_vendor"]:
+        parts.append(f"{stats['by_vendor']} by vendor")
+    parts.append(f"{stats['by_tier']} by tier")
+    parts.append(f"{stats['by_zmq']} by zmq-dedup")
+    if stats["by_tokenspeed_dp"]:
+        parts.append(f"{stats['by_tokenspeed_dp']} by tokenspeed-dp")
+    return (
+        f"{header}: selected {stats['selected']} of {stats['collected']} collected "
+        f"({', '.join(parts)})"
+    )
+
+
+class _SelectionReporter:
+    """Terminal plugin printing the selection summary after collection.
+
+    Lives on the plugin manager (registered in ``pytest_configure``) because
+    ``hooks.py`` is not a conftest, so a module-level
+    ``pytest_report_collectionfinish`` here would never be discovered.
+    """
+
+    def pytest_report_collectionfinish(self, config: pytest.Config) -> str | None:
+        stats = config.stash.get(_SELECTION_STATS_KEY, None)
+        if not stats:
+            return None
+        return _format_selection_line(stats)
+
+
 def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
@@ -231,6 +339,11 @@ def pytest_collection_modifyitems(
     lane additionally drops the gRPC-only families (PD, EPD, multi-worker) and
     collapses ``grpc``/``http`` twins onto a single ZMQ run.
 
+    Every dropped item is reported through ``pytest_deselected`` (so terminal
+    output shows ``N deselected`` instead of silently running fewer tests than
+    collected) and tallied into the ``e2e selection:`` summary line. When
+    ``E2E_MIN_SELECTED`` is set, a final selection below it aborts the session.
+
     Ordering: items are sorted by ``(backend, model)`` so consecutive
     classes that share a backend cluster together. This is what lets
     ``infra.worker_pool`` reuse a single worker across many test classes
@@ -240,30 +353,31 @@ def pytest_collection_modifyitems(
     vendor = os.environ.get("E2E_VENDOR") or None
     gpu_tier = os.environ.get("E2E_GPU_TIER") or None
 
+    stats = {
+        "engine": engine,
+        "vendor": vendor,
+        "tier": gpu_tier,
+        "collected": len(items),
+        "by_engine": 0,
+        "by_vendor": 0,
+        "by_tier": 0,
+        "by_zmq": 0,
+        "by_tokenspeed_dp": 0,
+    }
+
     if any([engine, vendor, gpu_tier]):
-        selected: list[pytest.Item] = []
-        for item in items:
-            # Filter by engine
-            if engine:
-                engine_marker = _get_marker(item, "engine")
-                if not engine_marker or engine not in engine_marker.args:
-                    continue
-            # Filter by vendor
-            if vendor:
-                vendor_marker = _get_marker(item, "vendor")
-                if not vendor_marker or vendor not in vendor_marker.args:
-                    continue
-            # Filter by GPU tier
-            if gpu_tier is not None:
-                gpu_marker = _get_marker(item, "gpu")
-                gpu_count = gpu_marker.args[0] if gpu_marker else 1
-                if str(gpu_count) != gpu_tier:
-                    continue
-            selected.append(item)
+        selected, deselected_by = _filter_env_items(items, engine, vendor, gpu_tier)
+        stats["by_engine"] = len(deselected_by["engine"])
+        stats["by_vendor"] = len(deselected_by["vendor"])
+        stats["by_tier"] = len(deselected_by["tier"])
+        deselected = deselected_by["engine"] + deselected_by["vendor"] + deselected_by["tier"]
+        if deselected:
+            config.hook.pytest_deselected(items=deselected)
         items[:] = selected
 
     if get_connection_mode_override() == ConnectionMode.ZMQ:
         kept, deselected = _filter_zmq_items(items)
+        stats["by_zmq"] = len(deselected)
         if deselected:
             config.hook.pytest_deselected(items=deselected)
             items[:] = kept
@@ -272,11 +386,16 @@ def pytest_collection_modifyitems(
         # run under DP (see _TOKENSPEED_DP_BROKEN_MODELS).
         if get_runtime() == "tokenspeed" and get_zmq_engine_count() > 1:
             kept, deselected = _filter_tokenspeed_dp_items(items)
+            stats["by_tokenspeed_dp"] = len(deselected)
             if deselected:
                 config.hook.pytest_deselected(items=deselected)
                 items[:] = kept
 
+    stats["selected"] = len(items)
+    config.stash[_SELECTION_STATS_KEY] = stats
+
     items.sort(key=_pool_sort_key)
+    _enforce_selection_floor(len(items))
 
 
 def _pool_sort_key(item: pytest.Item) -> tuple:

--- a/e2e_test/fixtures/hooks.py
+++ b/e2e_test/fixtures/hooks.py
@@ -270,7 +270,9 @@ def _filter_env_items(
 def _enforce_selection_floor(selected_count: int) -> None:
     """Fail the session when fewer tests survived selection than the floor.
 
-    ``E2E_MIN_SELECTED`` (integer) arms the check; unset or blank disables it.
+    ``E2E_MIN_SELECTED`` (non-negative integer) arms the check; unset or blank
+    disables it. A non-integer or negative value is rejected loudly rather than
+    treated as "no floor", so a lane typo cannot quietly drop the guardrail.
     A violation aborts the run via ``pytest.exit`` so the CI log shows a
     loud ``!!! Exit !!!`` banner instead of a quietly shrunken suite.
     """
@@ -284,9 +286,16 @@ def _enforce_selection_floor(selected_count: int) -> None:
             f"e2e selection: E2E_MIN_SELECTED={raw!r} is not an integer",
             returncode=1,
         )
+    if floor < 0:
+        pytest.exit(
+            f"e2e selection: E2E_MIN_SELECTED={raw!r} must be non-negative; a "
+            f"negative floor would silently disable the check",
+            returncode=1,
+        )
     if selected_count < floor:
         pytest.exit(
-            f"e2e selection: only {selected_count} tests selected, below the "
+            f"e2e selection: only {selected_count} "
+            f"{'test' if selected_count == 1 else 'tests'} selected, below the "
             f"E2E_MIN_SELECTED floor of {floor}. The E2E_ENGINE/E2E_VENDOR/"
             f"E2E_GPU_TIER env filter in e2e_test/fixtures/hooks.py is the "
             f"likely cause (marker drift or a lane env-var typo).",

--- a/e2e_test/fixtures/test_hooks_env_filter.py
+++ b/e2e_test/fixtures/test_hooks_env_filter.py
@@ -1,0 +1,265 @@
+"""Unit tests for env-filter deselection reporting and the selection floor (no GPU).
+
+Mirrors the ``_FakeItem`` harness in ``test_hooks_zmq_filter.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fixtures import hooks
+
+
+class _FakeItem:
+    """Minimal stand-in for a pytest ``Item`` for the collection helpers.
+
+    Exposes only what the env filter, ``_filter_zmq_items`` and
+    ``_pool_sort_key`` touch: ``nodeid``, ``callspec.params``, ``cls`` (always
+    None so marker resolution falls back to ``get_closest_marker``), and a
+    name->marker mapping served through ``get_closest_marker``.
+    """
+
+    def __init__(self, nodeid, params=None, markers=None):
+        self.nodeid = nodeid
+        self.cls = None
+        self.callspec = SimpleNamespace(params=params) if params is not None else None
+        self._markers = markers or {}
+
+    def get_closest_marker(self, name):
+        return self._markers.get(name)
+
+
+class _FakeConfig:
+    """Fake ``pytest.Config`` recording ``pytest_deselected`` calls."""
+
+    def __init__(self):
+        self.stash = pytest.Stash()
+        self.deselected = []
+        self.hook = SimpleNamespace(pytest_deselected=self._record)
+
+    def _record(self, items):
+        self.deselected.extend(items)
+
+
+def _item(nodeid, engine=None, vendor=None, gpu=None, setup_backend=None):
+    markers = {}
+    if engine is not None:
+        markers["engine"] = pytest.mark.engine(*engine).mark
+    if vendor is not None:
+        markers["vendor"] = pytest.mark.vendor(*vendor).mark
+    if gpu is not None:
+        markers["gpu"] = pytest.mark.gpu(gpu).mark
+    params = {"setup_backend": setup_backend} if setup_backend is not None else None
+    return _FakeItem(nodeid, params=params, markers=markers)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Isolate every test from the ambient lane environment."""
+    for var in (
+        "E2E_ENGINE",
+        "E2E_VENDOR",
+        "E2E_GPU_TIER",
+        "E2E_CONNECTION_MODE",
+        "E2E_RUNTIME",
+        "E2E_ZMQ_ENGINE_COUNT",
+        "E2E_MIN_SELECTED",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _run(config, items):
+    hooks.pytest_collection_modifyitems(config, items)
+    return items
+
+
+def _summary(config):
+    return hooks._SelectionReporter().pytest_report_collectionfinish(config)
+
+
+# ---------------------------------------------------------------------------
+# _filter_env_items
+# ---------------------------------------------------------------------------
+
+
+def test_env_filter_attributes_drops_to_first_rejecting_dimension():
+    match = _item("t.py::test_a", engine=("sglang",), gpu=1)
+    wrong_engine = _item("t.py::test_b", engine=("vllm",), gpu=1)
+    no_marker = _item("t.py::test_c")
+    wrong_tier = _item("t.py::test_d", engine=("sglang",), gpu=4)
+    selected, deselected_by = hooks._filter_env_items(
+        [match, wrong_engine, no_marker, wrong_tier],
+        engine="sglang",
+        vendor=None,
+        gpu_tier="1",
+    )
+    assert selected == [match]
+    assert deselected_by["engine"] == [wrong_engine, no_marker]
+    assert deselected_by["vendor"] == []
+    assert deselected_by["tier"] == [wrong_tier]
+
+
+def test_env_filter_gpu_defaults_to_one_without_marker():
+    unmarked = _item("t.py::test_a")
+    selected, deselected_by = hooks._filter_env_items(
+        [unmarked], engine=None, vendor=None, gpu_tier="1"
+    )
+    assert selected == [unmarked]
+    assert deselected_by["tier"] == []
+
+
+def test_env_filter_by_vendor():
+    openai = _item("t.py::test_a", vendor=("openai",))
+    xai = _item("t.py::test_b", vendor=("xai",))
+    selected, deselected_by = hooks._filter_env_items(
+        [openai, xai], engine=None, vendor="openai", gpu_tier=None
+    )
+    assert selected == [openai]
+    assert deselected_by["vendor"] == [xai]
+
+
+# ---------------------------------------------------------------------------
+# pytest_collection_modifyitems: deselection reporting
+# ---------------------------------------------------------------------------
+
+
+def test_env_filtered_items_are_reported_deselected(monkeypatch):
+    monkeypatch.setenv("E2E_ENGINE", "sglang")
+    match = _item("t.py::test_a", engine=("sglang",))
+    wrong = _item("t.py::test_b", engine=("vllm",))
+    unmarked = _item("t.py::test_c")
+    config = _FakeConfig()
+    items = _run(config, [match, wrong, unmarked])
+    assert items == [match]
+    assert config.deselected == [wrong, unmarked]
+
+
+def test_no_env_filter_deselects_nothing():
+    a = _item("t.py::test_a")
+    b = _item("t.py::test_b")
+    config = _FakeConfig()
+    items = _run(config, [a, b])
+    assert items == [a, b]
+    assert config.deselected == []
+
+
+def test_env_and_zmq_filters_both_report(monkeypatch):
+    monkeypatch.setenv("E2E_ENGINE", "sglang")
+    monkeypatch.setenv("E2E_CONNECTION_MODE", "zmq")
+    grpc = _item("t.py::test_a[grpc]", engine=("sglang",), setup_backend="grpc")
+    http = _item("t.py::test_a[http]", engine=("sglang",), setup_backend="http")
+    wrong = _item("t.py::test_b", engine=("vllm",))
+    config = _FakeConfig()
+    items = _run(config, [grpc, http, wrong])
+    assert items == [grpc]
+    assert set(config.deselected) == {http, wrong}
+
+
+# ---------------------------------------------------------------------------
+# Summary line
+# ---------------------------------------------------------------------------
+
+
+def test_summary_line_counts_and_prefix(monkeypatch):
+    monkeypatch.setenv("E2E_ENGINE", "sglang")
+    monkeypatch.setenv("E2E_GPU_TIER", "1")
+    match = _item("t.py::test_a", engine=("sglang",), gpu=1)
+    wrong_engine = _item("t.py::test_b", engine=("vllm",), gpu=1)
+    unmarked = _item("t.py::test_c")
+    wrong_tier = _item("t.py::test_d", engine=("sglang",), gpu=4)
+    config = _FakeConfig()
+    _run(config, [match, wrong_engine, unmarked, wrong_tier])
+    line = _summary(config)
+    assert line == (
+        "e2e selection: engine=sglang tier=1: selected 1 of 4 collected "
+        "(2 deselected by engine, 1 by tier, 0 by zmq-dedup)"
+    )
+
+
+def test_summary_line_without_filters(monkeypatch):
+    a = _item("t.py::test_a")
+    config = _FakeConfig()
+    _run(config, [a])
+    line = _summary(config)
+    assert line == (
+        "e2e selection: engine=- tier=-: selected 1 of 1 collected "
+        "(0 deselected by engine, 0 by tier, 0 by zmq-dedup)"
+    )
+
+
+def test_summary_line_includes_vendor_and_zmq_counts(monkeypatch):
+    monkeypatch.setenv("E2E_VENDOR", "openai")
+    monkeypatch.setenv("E2E_CONNECTION_MODE", "zmq")
+    kept = _item("t.py::test_a[grpc]", vendor=("openai",), setup_backend="grpc")
+    twin = _item("t.py::test_a[http]", vendor=("openai",), setup_backend="http")
+    other_vendor = _item("t.py::test_b", vendor=("xai",))
+    config = _FakeConfig()
+    _run(config, [kept, twin, other_vendor])
+    line = _summary(config)
+    assert line == (
+        "e2e selection: engine=- vendor=openai tier=-: selected 1 of 3 collected "
+        "(0 deselected by engine, 1 by vendor, 0 by tier, 1 by zmq-dedup)"
+    )
+
+
+def test_summary_is_none_before_collection():
+    config = _FakeConfig()
+    assert _summary(config) is None
+
+
+# ---------------------------------------------------------------------------
+# E2E_MIN_SELECTED floor
+# ---------------------------------------------------------------------------
+
+
+def test_floor_unset_is_noop():
+    hooks._enforce_selection_floor(0)  # must not raise
+
+
+def test_floor_blank_is_noop(monkeypatch):
+    monkeypatch.setenv("E2E_MIN_SELECTED", "  ")
+    hooks._enforce_selection_floor(0)  # must not raise
+
+
+def test_floor_passes_at_and_above(monkeypatch):
+    monkeypatch.setenv("E2E_MIN_SELECTED", "2")
+    hooks._enforce_selection_floor(2)
+    hooks._enforce_selection_floor(3)
+
+
+def test_floor_fails_below(monkeypatch):
+    monkeypatch.setenv("E2E_MIN_SELECTED", "5")
+    with pytest.raises(pytest.exit.Exception) as excinfo:
+        hooks._enforce_selection_floor(1)
+    msg = str(excinfo.value)
+    assert "only 1 tests selected" in msg
+    assert "floor of 5" in msg
+    assert "E2E_ENGINE" in msg  # points at the env filter as the likely cause
+
+
+def test_floor_rejects_non_integer(monkeypatch):
+    monkeypatch.setenv("E2E_MIN_SELECTED", "lots")
+    with pytest.raises(pytest.exit.Exception) as excinfo:
+        hooks._enforce_selection_floor(100)
+    assert "not an integer" in str(excinfo.value)
+
+
+def test_floor_enforced_from_collection_hook(monkeypatch):
+    monkeypatch.setenv("E2E_ENGINE", "sglang")
+    monkeypatch.setenv("E2E_MIN_SELECTED", "2")
+    match = _item("t.py::test_a", engine=("sglang",))
+    wrong = _item("t.py::test_b", engine=("vllm",))
+    config = _FakeConfig()
+    with pytest.raises(pytest.exit.Exception):
+        hooks.pytest_collection_modifyitems(config, [match, wrong])
+
+
+def test_floor_satisfied_from_collection_hook(monkeypatch):
+    monkeypatch.setenv("E2E_ENGINE", "sglang")
+    monkeypatch.setenv("E2E_MIN_SELECTED", "1")
+    match = _item("t.py::test_a", engine=("sglang",))
+    wrong = _item("t.py::test_b", engine=("vllm",))
+    config = _FakeConfig()
+    items = _run(config, [match, wrong])
+    assert items == [match]

--- a/e2e_test/fixtures/test_hooks_env_filter.py
+++ b/e2e_test/fixtures/test_hooks_env_filter.py
@@ -233,9 +233,16 @@ def test_floor_fails_below(monkeypatch):
     with pytest.raises(pytest.exit.Exception) as excinfo:
         hooks._enforce_selection_floor(1)
     msg = str(excinfo.value)
-    assert "only 1 tests selected" in msg
+    assert "only 1 test selected" in msg  # singular for a one-test selection
     assert "floor of 5" in msg
     assert "E2E_ENGINE" in msg  # points at the env filter as the likely cause
+
+
+def test_floor_message_pluralizes_above_one(monkeypatch):
+    monkeypatch.setenv("E2E_MIN_SELECTED", "5")
+    with pytest.raises(pytest.exit.Exception) as excinfo:
+        hooks._enforce_selection_floor(2)
+    assert "only 2 tests selected" in str(excinfo.value)
 
 
 def test_floor_rejects_non_integer(monkeypatch):
@@ -243,6 +250,20 @@ def test_floor_rejects_non_integer(monkeypatch):
     with pytest.raises(pytest.exit.Exception) as excinfo:
         hooks._enforce_selection_floor(100)
     assert "not an integer" in str(excinfo.value)
+
+
+def test_floor_rejects_negative(monkeypatch):
+    """A negative floor can never trip, so take it as a typo, not "no floor"."""
+    monkeypatch.setenv("E2E_MIN_SELECTED", "-1")
+    with pytest.raises(pytest.exit.Exception) as excinfo:
+        hooks._enforce_selection_floor(0)
+    assert "must be non-negative" in str(excinfo.value)
+
+
+def test_floor_zero_is_armed_but_unbreakable(monkeypatch):
+    """Zero is a legal floor: explicitly armed, and no selection can fall under it."""
+    monkeypatch.setenv("E2E_MIN_SELECTED", "0")
+    hooks._enforce_selection_floor(0)
 
 
 def test_floor_enforced_from_collection_hook(monkeypatch):


### PR DESCRIPTION
## Description

### Problem

The env-var collection filter (`E2E_ENGINE` / `E2E_VENDOR` / `E2E_GPU_TIER`) in `e2e_test/fixtures/hooks.py` ended with `items[:] = selected` and never called `config.hook.pytest_deselected` — while the ZMQ filter directly below it does. Pytest printed `collected 274 items` and then silently ran fewer; nothing in any CI log revealed the delta (a seven-dimension suite audit measured tokenspeed lanes at ~44% effective selection with zero visibility).

There was also no guardrail: marker drift or a lane env-var typo could shrink a lane to a handful of tests and the lane would still go green.

### Solution

Make every collection-time drop visible and add an opt-in floor:

- The env filter now reports its drops through `config.hook.pytest_deselected(items=...)`, mirroring the ZMQ path, so the terminal header shows `collected N items / D deselected / S selected`.
- One greppable summary line is printed after collection (via a small plugin registered in `pytest_configure`, since `hooks.py` is not itself a conftest):
  `e2e selection: engine=sglang tier=1: selected 227 of 274 collected (40 deselected by engine, 7 by tier, 0 by zmq-dedup)`
  Vendor and tokenspeed-dp segments are appended only when those filters act.
- `E2E_MIN_SELECTED=<int>` arms a floor check after all filtering: a final selection below the floor aborts the session with `pytest.exit(..., returncode=1)`, naming the actual count, the floor, and pointing at the env filter as the likely cause. Unset/blank means no check, so this merges independently of the CI wiring (landed separately).

## Changes

- `e2e_test/fixtures/hooks.py`
  - Extracted the env filter into `_filter_env_items()` returning `(selected, deselected-by-reason)` with drops attributed engine → vendor → tier; `pytest_collection_modifyitems` now reports them via `pytest_deselected`.
  - Added `_SelectionReporter` (registered on the plugin manager in `pytest_configure`) implementing `pytest_report_collectionfinish` to emit the single `e2e selection:` line from stats stashed on `config`.
  - Added `_enforce_selection_floor()` implementing the `E2E_MIN_SELECTED` check (also rejects non-integer values loudly).
- `e2e_test/fixtures/test_hooks_env_filter.py` (new): CPU-only unit tests mirroring the `_FakeItem` harness of `test_hooks_zmq_filter.py`, covering per-dimension attribution, `pytest_deselected` reporting (env-only, none, env+zmq combined), exact summary-line contents (with and without filters, vendor+zmq case), and the floor (unset/blank no-op, at/above passes, below aborts, non-integer aborts, end-to-end through the collection hook).

## Test Plan

Verified locally (CPU only, Python 3.13.15 venv with `pip install ./e2e_test`, pytest 9.1.1):

New + existing hook unit tests:

```
$ cd e2e_test && PYTHONPATH=. pytest -q fixtures/test_hooks_env_filter.py fixtures/test_hooks_zmq_filter.py --noconftest
======================= 30 passed, 12 warnings in 8.10s ========================
```

Live pytest session against a sandbox suite (3 tests, one marked `engine("sglang")`) driving the real hooks:

```
$ E2E_ENGINE=sglang pytest test_demo.py
collected 3 items / 2 deselected / 1 selected
e2e selection: engine=sglang tier=-: selected 1 of 3 collected (2 deselected by engine, 0 by tier, 0 by zmq-dedup)
======================= 1 passed, 2 deselected in 0.00s ========================

$ E2E_ENGINE=sglang E2E_MIN_SELECTED=3 pytest test_demo.py; echo exit=$?
e2e selection: engine=sglang tier=-: selected 1 of 3 collected (2 deselected by engine, 0 by tier, 0 by zmq-dedup)
============================ 2 deselected in 0.09s =============================
! _pytest.outcomes.Exit: e2e selection: only 1 tests selected, below the E2E_MIN_SELECTED floor of 3. The E2E_ENGINE/E2E_VENDOR/E2E_GPU_TIER env filter in e2e_test/fixtures/hooks.py is the likely cause (marker drift or a lane env-var typo). !
exit=1
```

`python3 -m py_compile` passes on both touched files.

Not verifiable locally: full-suite collection through the real `conftest.py` (it imports `smg_client`, which needs `make generate-clients` output, and probes the `smg` wheel) and actual GPU lane runs. The GPU lanes must confirm the real deselected counts in their logs (`grep 'e2e selection:'`) and that filtered lanes still select the expected slices. `E2E_MIN_SELECTED` stays unarmed until the CI wiring PR sets it per lane.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

Python/CI-only change; cargo gates not applicable.
