### PR TITLE
perf(policies): move O(workers) scans and hashing out of placement-index guards

### DIFF
--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -148,7 +148,10 @@ pub struct CacheAwarePolicy {
     mesh_tree_sync: RwLock<Option<Arc<TreeSyncAdapter>>>,
     /// Hash-mode placement index (`cache_index = hash`): model →
     /// (boundary, head hash) → live holders. Empty in tree mode.
-    placement_index: Arc<DashMap<String, PlacementMap>>,
+    /// Inner maps are Arc'd and model entries are never removed, so a
+    /// cloned inner handle stays canonical and walking it never holds
+    /// an outer-shard guard.
+    placement_index: Arc<DashMap<String, Arc<PlacementMap>>>,
 }
 
 /// Hash-mode per-model placement map: (boundary position, xxh3 of the token
@@ -211,7 +214,7 @@ impl CacheAwarePolicy {
         let string_trees = Arc::new(DashMap::<String, Arc<Tree>>::new());
         let token_trees = Arc::new(DashMap::<String, Arc<TokenTree>>::new());
         let hash_index = Arc::new(DashMap::<String, PerModelHashIndex>::new());
-        let placement_index = Arc::new(DashMap::<String, PlacementMap>::new());
+        let placement_index = Arc::new(DashMap::<String, Arc<PlacementMap>>::new());
 
         // Start background eviction thread if configured
         let eviction_task = if config.cache_index == CacheIndexKind::Hash {
@@ -621,8 +624,13 @@ impl CacheAwarePolicy {
         for tree_ref in self.token_trees.iter() {
             tree_ref.value().remove_tenant_all(&tenant);
         }
-        for model in self.placement_index.iter() {
-            model.value().retain(|_, holders| {
+        let placement_maps: Vec<Arc<PlacementMap>> = self
+            .placement_index
+            .iter()
+            .map(|model| Arc::clone(model.value()))
+            .collect();
+        for placements in placement_maps {
+            placements.retain(|_, holders| {
                 holders.retain(|h| h.worker_url != url);
                 !holders.is_empty()
             });
@@ -1570,10 +1578,11 @@ impl CacheAwarePolicy {
             );
         }
 
+        let url_to_idx = Self::healthy_url_index(workers, healthy_indices);
         for &boundary in applicable.iter().rev() {
             let key = (boundary, hash_token_head(&tokens[..boundary]));
             let Some(holder_idx) =
-                self.live_holder_min_load(workers, healthy_indices, model_id, key, now)
+                self.live_holder_min_load(workers, &url_to_idx, model_id, key, now)
             else {
                 continue;
             };
@@ -1623,27 +1632,44 @@ impl CacheAwarePolicy {
         Some(idx)
     }
 
+    /// URL → healthy worker index; duplicate URLs resolve to the index
+    /// min-load selection would pick.
+    fn healthy_url_index<'a>(
+        workers: &'a [Arc<dyn Worker>],
+        healthy_indices: &[usize],
+    ) -> HashMap<&'a str, usize> {
+        let mut url_to_idx: HashMap<&str, usize> = HashMap::with_capacity(healthy_indices.len());
+        for &idx in healthy_indices {
+            url_to_idx
+                .entry(workers[idx].url())
+                .and_modify(|cur| {
+                    if (workers[idx].load(), idx) < (workers[*cur].load(), *cur) {
+                        *cur = idx;
+                    }
+                })
+                .or_insert(idx);
+        }
+        url_to_idx
+    }
+
     /// Least-loaded live holder of `key` among healthy workers, or `None`.
-    /// Expired holders are pruned in place (lazy expiry on read).
+    /// Expired holders are pruned in place (lazy expiry on read). Guarded
+    /// work is O(holder cap): resolution goes through `url_to_idx`.
     fn live_holder_min_load(
         &self,
         workers: &[Arc<dyn Worker>],
-        healthy_indices: &[usize],
+        url_to_idx: &HashMap<&str, usize>,
         model_id: &str,
         key: (usize, u64),
         now: Instant,
     ) -> Option<usize> {
         let ttl = Duration::from_secs(self.config.cache_ttl_secs);
-        let model = self.placement_index.get(model_id)?;
+        let model = Arc::clone(self.placement_index.get(model_id)?.value());
         let mut holders = model.get_mut(&key)?;
         holders.retain(|h| now.duration_since(h.last_touch) <= ttl);
-        healthy_indices
+        holders
             .iter()
-            .copied()
-            .filter(|&idx| {
-                let url = workers[idx].url();
-                holders.iter().any(|h| h.worker_url == url)
-            })
+            .filter_map(|h| url_to_idx.get(h.worker_url.as_str()).copied())
             .min_by_key(|&idx| (workers[idx].load(), idx))
     }
 
@@ -1658,10 +1684,16 @@ impl CacheAwarePolicy {
         now: Instant,
     ) {
         let ttl = Duration::from_secs(self.config.cache_ttl_secs);
-        let model = self
-            .placement_index
-            .entry(model_id.to_string())
-            .or_default();
+        let model = if let Some(entry) = self.placement_index.get(model_id) {
+            Arc::clone(entry.value())
+        } else {
+            Arc::clone(
+                self.placement_index
+                    .entry(model_id.to_string())
+                    .or_default()
+                    .value(),
+            )
+        };
         for &boundary in boundaries {
             let key = (boundary, hash_token_head(&tokens[..boundary]));
             let mut holders = model.entry(key).or_default();
@@ -1690,19 +1722,23 @@ impl CacheAwarePolicy {
     /// Drop expired holders and empty keys; refresh the per-model entry
     /// gauge. Returns total live entries across models.
     fn sweep_placement_index(
-        index: &DashMap<String, PlacementMap>,
+        index: &DashMap<String, Arc<PlacementMap>>,
         ttl: Duration,
         now: Instant,
     ) -> usize {
+        let models: Vec<(String, Arc<PlacementMap>)> = index
+            .iter()
+            .map(|model| (model.key().clone(), Arc::clone(model.value())))
+            .collect();
         let mut total = 0usize;
-        for model in index {
-            model.value().retain(|_, holders| {
+        for (model_id, placements) in models {
+            placements.retain(|_, holders| {
                 holders.retain(|h| now.duration_since(h.last_touch) <= ttl);
                 !holders.is_empty()
             });
-            let entries = model.value().len();
+            let entries = placements.len();
             total += entries;
-            Metrics::set_cache_placement_entries(model.key(), entries);
+            Metrics::set_cache_placement_entries(&model_id, entries);
         }
         total
     }
@@ -4022,17 +4058,17 @@ mod tests {
 
         policy.record_placement(model, &tokens, &[16], "http://w1:8000", t0);
 
-        let healthy = vec![0usize, 1];
+        let url_to_idx = CacheAwarePolicy::healthy_url_index(&workers, &[0, 1]);
         // Just inside the 180s default TTL: live.
         let live_at = t0 + Duration::from_secs(179);
         assert_eq!(
-            policy.live_holder_min_load(&workers, &healthy, model, key, live_at),
+            policy.live_holder_min_load(&workers, &url_to_idx, model, key, live_at),
             Some(0)
         );
         // Just past it: expired and pruned.
         let expired_at = t0 + Duration::from_secs(181);
         assert_eq!(
-            policy.live_holder_min_load(&workers, &healthy, model, key, expired_at),
+            policy.live_holder_min_load(&workers, &url_to_idx, model, key, expired_at),
             None
         );
         assert!(policy
@@ -4190,6 +4226,81 @@ mod tests {
         assert!(placements
             .get(&(16usize, hash_token_head(&fresh[..16])))
             .is_some());
+    }
+
+    #[test]
+    fn live_holder_resolution_skips_dead_holders_and_unknown_keys() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        let tokens: Vec<u32> = (0..16).collect();
+        let now = Instant::now();
+        let key = (16usize, hash_token_head(&tokens[..16]));
+        policy.record_placement("m", &tokens, &[16], "http://w1:8000", now);
+        policy.record_placement("m", &tokens, &[16], "http://w2:8000", now);
+
+        // w1 unhealthy: its holder entry must not resolve.
+        let url_to_idx = CacheAwarePolicy::healthy_url_index(&workers, &[1]);
+        assert_eq!(
+            policy.live_holder_min_load(&workers, &url_to_idx, "m", key, now),
+            Some(1)
+        );
+        // No healthy workers: no candidate.
+        let empty = CacheAwarePolicy::healthy_url_index(&workers, &[]);
+        assert_eq!(
+            policy.live_holder_min_load(&workers, &empty, "m", key, now),
+            None
+        );
+        // Unknown key: no candidate.
+        assert_eq!(
+            policy.live_holder_min_load(&workers, &url_to_idx, "m", (32, 7), now),
+            None
+        );
+    }
+
+    #[test]
+    fn healthy_url_index_duplicate_urls_resolve_to_least_loaded() {
+        let workers = make_workers(&["http://w1:8000", "http://w1:8000", "http://w2:8000"]);
+        workers[0].increment_load();
+
+        let url_to_idx = CacheAwarePolicy::healthy_url_index(&workers, &[0, 1, 2]);
+        assert_eq!(url_to_idx.len(), 2);
+        assert_eq!(url_to_idx["http://w1:8000"], 1);
+        assert_eq!(url_to_idx["http://w2:8000"], 2);
+
+        // Equal loads: the lower index wins, matching min-load tie-break.
+        let tied = make_workers(&["http://w1:8000", "http://w1:8000"]);
+        assert_eq!(
+            CacheAwarePolicy::healthy_url_index(&tied, &[0, 1])["http://w1:8000"],
+            0
+        );
+    }
+
+    #[test]
+    fn concurrent_record_and_sweep_keeps_live_placements() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
+        let now = Instant::now();
+        let ttl = Duration::from_secs(180);
+
+        std::thread::scope(|s| {
+            for t in 0..8u32 {
+                let policy = &policy;
+                s.spawn(move || {
+                    for i in 0..50u32 {
+                        let base = t * 1000 + i * 16;
+                        let tokens: Vec<u32> = (base..base + 16).collect();
+                        policy.record_placement("m", &tokens, &[16], "http://w1:8000", now);
+                        CacheAwarePolicy::sweep_placement_index(&policy.placement_index, ttl, now);
+                    }
+                });
+            }
+        });
+
+        let placements = policy.placement_index.get("m").unwrap();
+        assert_eq!(placements.len(), 400);
+        for entry in placements.iter() {
+            assert_eq!(entry.value().len(), 1);
+            assert_eq!(entry.value()[0].worker_url, "http://w1:8000");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

Three spots in the cache-aware placement index do heavy work while holding a lock, so concurrent requests for the same hot prefix keys serialize behind them:

- `live_holder_min_load` scans all workers (10,000 in production) doing string compares while holding the inner-shard write guard, to resolve at most 3 holder URLs.
- `record_placement` hashes up to 32KB of token head per boundary while holding the outer shard write guard.
- The TTL sweep holds each outer shard guard while walking the entire inner map, stalling every selection that lands on that shard; the stall grows with `--cache-ttl-secs`.

At the current admission rate these are 0.3-0.4ms exclusive holds on exactly the keys that matter most.

### Solution

Do the heavy work outside the guards; keep only O(1)-ish map operations inside.

- A url-to-index map is built once per selection pass (outside all guards), so holder resolution under the guard becomes at most 3 lookups instead of a 10,000-worker scan.
- Hashing happens before any guard is taken (the token slice is caller-owned and immutable, so nothing needs revalidation).
- Inner placement maps are now `Arc`ed: the sweep (and `remove_worker_by_url`, which had the same shape) snapshots handles under momentary guards and prunes with no outer shard held. Model entries are never removed or replaced anywhere, so a detached handle stays canonical - concurrent operations serialize on the same inner locks as before.

Behavior is identical: same placements, same eviction decisions, same metrics.

## Changes

- `healthy_url_index` helper; `live_holder_min_load` reduced to O(holder-cap) under the guard
- `record_placement` get-first with entry-fallback; hashing moved fully outside guards
- `PlacementMap` values Arc'ed; two-phase sweep and worker-removal (collect handles, then prune unguarded)

## Test Plan

- New: dead-holder/unknown-key resolution; duplicate-URL min-load tie-break; 8-thread record-vs-sweep race asserting zero lost placements
- All 60 existing cache_aware tests pass unmodified (two call sites updated for the new helper signature); `cargo test -p smg --lib` 1803 passed; `routing_tests` 120 passed
- `cargo +nightly fmt` silent; `cargo clippy --all-targets -- -D warnings` clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>