### PR TITLE
fix(router): pre-size dispatch serialization buffers; trim slack before freezing

### DIFF
--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -62,6 +62,16 @@ pub fn extract_routing_key_hint(headers: Option<&HeaderMap>) -> Option<&str> {
     extract_routing_key_hint_named(headers, &HEADER_ROUTING_KEY)
 }
 
+/// Declared size of the incoming raw body; pre-sizes reserialization buffers.
+pub fn content_length(headers: Option<&HeaderMap>) -> Option<usize> {
+    headers?
+        .get(http::header::CONTENT_LENGTH)?
+        .to_str()
+        .ok()?
+        .parse()
+        .ok()
+}
+
 fn extract_header_value<'a>(headers: Option<&'a HeaderMap>, name: &HeaderName) -> Option<&'a str> {
     headers
         .and_then(|h| h.get(name))

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -48,6 +48,35 @@ pub mod worker_selection;
 /// framing non-chunked; h2 is unaffected.
 pub(crate) const STREAM_UPSTREAM_BODY_OVER: usize = 1 << 20;
 
+/// Buffer capacity for reserializing a parsed request of `raw_len` incoming
+/// bytes: the round trip stays close to raw size, and the 1/16 + 512B slack
+/// absorbs injected fields (bootstrap, kv_transfer_params, dp ranks) and
+/// widened floats.
+pub(crate) fn serialized_capacity(raw_len: usize) -> usize {
+    raw_len + raw_len / 16 + 512
+}
+
+/// `serde_json::to_vec` into a buffer pre-sized from the raw request length,
+/// avoiding doubling growth (and its final huge memcpy) for large bodies.
+pub(crate) fn serialize_json_sized<T: serde::Serialize>(
+    value: &T,
+    raw_len: Option<usize>,
+) -> serde_json::Result<Vec<u8>> {
+    let mut buf = Vec::with_capacity(raw_len.map_or(128, serialized_capacity));
+    serde_json::to_writer(&mut buf, value)?;
+    Ok(buf)
+}
+
+/// `Bytes::from(Vec)` keeps the Vec's capacity, so unshrunk doubling growth
+/// (up to 2x len) would be retained for the buffer's whole lifetime; trade
+/// one bounded memcpy to free it. The threshold is double the intended
+/// pre-size slack so well-hinted buffers are never re-copied.
+pub(crate) fn trim_serialization_slack(buf: &mut Vec<u8>) {
+    if buf.capacity() > buf.len() + buf.len() / 8 + 1024 {
+        buf.shrink_to_fit();
+    }
+}
+
 pub(crate) fn attach_sized_body(
     builder: reqwest::RequestBuilder,
     body: bytes::Bytes,
@@ -60,5 +89,42 @@ pub(crate) fn attach_sized_body(
         )))
     } else {
         builder.body(body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sized_serialization_never_doubles_for_large_bodies() {
+        let raw = serde_json::to_vec(&serde_json::json!({
+            "text": "x".repeat(8 << 20),
+            "stream": false,
+        }))
+        .unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+
+        let body = serialize_json_sized(&parsed, Some(raw.len())).unwrap();
+
+        assert_eq!(body.len(), raw.len());
+        assert_eq!(body.capacity(), serialized_capacity(raw.len()));
+        assert!(body.capacity() <= body.len() + body.len() / 8 + 1024);
+    }
+
+    #[test]
+    fn trim_frees_doubling_slack_but_keeps_presized_buffers() {
+        // Mimic a 5MiB body landing in an 8MiB doubling-growth buffer.
+        let mut grown = Vec::with_capacity(8 << 20);
+        grown.resize(5 << 20, b'x');
+        trim_serialization_slack(&mut grown);
+        assert!(grown.capacity() <= grown.len() + grown.len() / 8 + 1024);
+        assert_eq!(grown.len(), 5 << 20);
+
+        let mut sized = Vec::with_capacity(serialized_capacity(1 << 20));
+        sized.resize(1 << 20, b'y');
+        let capacity = sized.capacity();
+        trim_serialization_slack(&mut sized);
+        assert_eq!(sized.capacity(), capacity);
     }
 }

--- a/model_gateway/src/routers/common/request_lease.rs
+++ b/model_gateway/src/routers/common/request_lease.rs
@@ -4,6 +4,7 @@ use std::sync::{Mutex, MutexGuard, PoisonError};
 
 use bytes::Bytes;
 
+use super::trim_serialization_slack;
 use crate::{config::types::RetryConfig, observability::metrics::Metrics};
 
 /// When a [`RequestLease`] lets go of the parsed request.
@@ -113,7 +114,11 @@ impl<T> RequestLease<T> {
         f: impl FnOnce(LeaseView<'_, T>) -> Result<Vec<u8>, E>,
     ) -> Result<Bytes, E> {
         let mut inner = self.lock();
-        let body = Bytes::from(f(Self::view(&inner))?);
+        let mut buf = f(Self::view(&inner))?;
+        // The frozen memo can outlive dispatch (retry replay); never let it
+        // drag growth slack along.
+        trim_serialization_slack(&mut buf);
+        let body = Bytes::from(buf);
         inner.body = SerializedBody::Single(body.clone());
         Ok(body)
     }
@@ -126,7 +131,9 @@ impl<T> RequestLease<T> {
         f: impl FnOnce(LeaseView<'_, T>) -> Result<(Vec<u8>, Vec<u8>), E>,
     ) -> Result<(Bytes, Bytes), E> {
         let mut inner = self.lock();
-        let (prefill, decode) = f(Self::view(&inner))?;
+        let (mut prefill, mut decode) = f(Self::view(&inner))?;
+        trim_serialization_slack(&mut prefill);
+        trim_serialization_slack(&mut decode);
         let legs = (Bytes::from(prefill), Bytes::from(decode));
         inner.body = SerializedBody::Legs(legs.0.clone(), legs.1.clone());
         Ok(legs)

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -45,7 +45,9 @@ use crate::{
             overload,
             request_lease::{ReleasePoint, RequestLease, RoutingDerivatives},
             retry::{is_retryable_response, RetryExecutor},
+            serialize_json_sized,
             sse::{SseEncoder, SSE_CHANNEL_BUFFER},
+            trim_serialization_slack,
         },
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},
@@ -488,6 +490,8 @@ impl PDRouter {
             return shed;
         }
 
+        let raw_body_len = header_utils::content_length(headers);
+
         // Keyed-load accounting uses the same effective key as selection:
         // rid-derived first, header fallback. Built before the lease releases.
         let load_guards = lease.with_view(|view| {
@@ -538,9 +542,9 @@ impl PDRouter {
                     }
 
                     Ok((
-                        serde_json::to_vec(&prefill_json)
+                        serialize_json_sized(&prefill_json, raw_body_len)
                             .map_err(|e| Box::new(Self::handle_serialization_error(e)))?,
-                        serde_json::to_vec(&json_request)
+                        serialize_json_sized(&json_request, raw_body_len)
                             .map_err(|e| Box::new(Self::handle_serialization_error(e)))?,
                     ))
                 });
@@ -636,9 +640,9 @@ impl PDRouter {
             }
 
             Ok((
-                serde_json::to_vec(&prefill_json_request)
+                serialize_json_sized(&prefill_json_request, raw_body_len)
                     .map_err(|e| Box::new(Self::handle_serialization_error(e)))?,
-                serde_json::to_vec(&decode_json_request)
+                serialize_json_sized(&decode_json_request, raw_body_len)
                     .map_err(|e| Box::new(Self::handle_serialization_error(e)))?,
             ))
         });
@@ -1130,7 +1134,9 @@ impl PDRouter {
         if let (Some(obj), Some(params)) = (decode_json.as_object_mut(), decode_params) {
             obj.insert("kv_transfer_params".to_string(), params);
         }
-        let decode_body = match serde_json::to_vec(&decode_json) {
+        // The leg's own serialized length bounds the reserialization; the
+        // slack covers the injected kv_transfer_params.
+        let decode_body = match serialize_json_sized(&decode_json, Some(decode_body.len())) {
             Ok(body) => Bytes::from(body),
             Err(e) => return Self::handle_serialization_error(e),
         };
@@ -1588,9 +1594,13 @@ impl PDRouter {
 
         Self::merge_logprobs_in_json(&prefill_json, &mut decode_json);
 
-        // Return merged response
-        match serde_json::to_vec(&decode_json) {
-            Ok(body) => Self::non_stream_pd_json_response(status, Bytes::from(body)),
+        // Return merged response; the two leg bodies together bound the
+        // merge, and the trim drops whatever the prefill leg didn't add.
+        match serialize_json_sized(&decode_json, Some(decode_body.len() + prefill_body.len())) {
+            Ok(mut body) => {
+                trim_serialization_slack(&mut body);
+                Self::non_stream_pd_json_response(status, Bytes::from(body))
+            }
             Err(e) => {
                 error!("Failed to serialize merged response: {}", e);
                 Self::non_stream_pd_json_response(status, decode_body)

--- a/model_gateway/src/routers/http/request_body.rs
+++ b/model_gateway/src/routers/http/request_body.rs
@@ -15,7 +15,10 @@ use serde::{
 use serde_json::value::{to_raw_value, RawValue};
 
 use crate::{
-    routers::openai::{is_stripped_sglang_default, strip_default_sglang_fields, SGLANG_FIELDS},
+    routers::{
+        common::{serialize_json_sized, serialized_capacity},
+        openai::{is_stripped_sglang_default, strip_default_sglang_fields, SGLANG_FIELDS},
+    },
     worker::{Worker, WorkerError},
 };
 
@@ -32,12 +35,13 @@ pub(crate) fn serialize_request_body<T: Serialize>(
     typed_req: &T,
     canonical_model: Option<&str>,
     worker: &dyn Worker,
+    raw_len: Option<usize>,
 ) -> Result<Vec<u8>, RequestBodyError> {
     if worker.mutates_request() {
-        return value_request_body(typed_req, canonical_model, worker);
+        return value_request_body(typed_req, canonical_model, worker, raw_len);
     }
 
-    let bytes = to_vec_value_compatible(typed_req).map_err(RequestBodyError::Serialize)?;
+    let bytes = to_vec_value_compatible(typed_req, raw_len).map_err(RequestBodyError::Serialize)?;
     let canonical_raw = canonical_model
         .map(to_raw_value)
         .transpose()
@@ -47,14 +51,19 @@ pub(crate) fn serialize_request_body<T: Serialize>(
     // the Value pipeline rather than skipping the hooks.
     let mut body = match serde_json::from_slice::<RawBody>(&bytes) {
         Ok(body) => body,
-        Err(_) => return value_request_body(typed_req, canonical_model, worker),
+        Err(_) => return value_request_body(typed_req, canonical_model, worker, raw_len),
     };
     if let Some(model) = canonical_raw.as_deref() {
         body.set_model(model);
     }
     body.strip_default_sglang_fields();
     if body.mutated {
-        serde_json::to_vec(&body).map_err(RequestBodyError::Serialize)
+        // Edits only strip fields or swap the model id, so the first pass
+        // plus the canonical id bounds the reserialization.
+        let capacity = bytes.len() + canonical_raw.as_deref().map_or(0, |m| m.get().len());
+        let mut out = Vec::with_capacity(capacity);
+        serde_json::to_writer(&mut out, &body).map_err(RequestBodyError::Serialize)?;
+        Ok(out)
     } else {
         Ok(bytes)
     }
@@ -67,6 +76,7 @@ fn value_request_body<T: Serialize>(
     typed_req: &T,
     canonical_model: Option<&str>,
     worker: &dyn Worker,
+    raw_len: Option<usize>,
 ) -> Result<Vec<u8>, RequestBodyError> {
     let mut json_val = serde_json::to_value(typed_req).map_err(RequestBodyError::Serialize)?;
     if let Some(canonical_model) = canonical_model {
@@ -76,7 +86,7 @@ fn value_request_body<T: Serialize>(
         .prepare_request(json_val)
         .map_err(RequestBodyError::Prepare)?;
     strip_default_sglang_fields(&mut json_val);
-    serde_json::to_vec(&json_val).map_err(RequestBodyError::Serialize)
+    serialize_json_sized(&json_val, raw_len).map_err(RequestBodyError::Serialize)
 }
 
 /// `serde_json::to_value` stores `f32` widened to `f64`, so the `Value`
@@ -94,8 +104,11 @@ impl serde_json::ser::Formatter for F32WideningFormatter {
     }
 }
 
-fn to_vec_value_compatible<T: Serialize>(value: &T) -> Result<Vec<u8>, serde_json::Error> {
-    let mut buf = Vec::with_capacity(128);
+fn to_vec_value_compatible<T: Serialize>(
+    value: &T,
+    raw_len: Option<usize>,
+) -> Result<Vec<u8>, serde_json::Error> {
+    let mut buf = Vec::with_capacity(raw_len.map_or(128, serialized_capacity));
     let mut ser = serde_json::Serializer::with_formatter(&mut buf, F32WideningFormatter);
     value.serialize(&mut ser)?;
     Ok(buf)
@@ -238,7 +251,7 @@ mod tests {
         assert!(!worker.mutates_request());
         let req = generate_request(json!({}));
 
-        let body = serialize_request_body(&req, None, &worker).unwrap();
+        let body = serialize_request_body(&req, None, &worker, None).unwrap();
 
         assert_eq!(body, value_path_bytes(&req, None, &worker));
         let parsed: Value = serde_json::from_slice(&body).unwrap();
@@ -250,7 +263,7 @@ mod tests {
         let worker = worker();
         let req = generate_request(json!({}));
 
-        let body = serialize_request_body(&req, Some("canonical-model"), &worker).unwrap();
+        let body = serialize_request_body(&req, Some("canonical-model"), &worker, None).unwrap();
 
         assert_eq!(
             body,
@@ -266,7 +279,7 @@ mod tests {
         assert!(worker.mutates_request());
         let req = generate_request(json!({}));
 
-        let body = serialize_request_body(&req, None, &worker).unwrap();
+        let body = serialize_request_body(&req, None, &worker, None).unwrap();
 
         assert_eq!(body, value_path_bytes(&req, None, &worker));
         let parsed: Value = serde_json::from_slice(&body).unwrap();
@@ -285,7 +298,7 @@ mod tests {
             "min_p": 0.0
         }));
 
-        let body = serialize_request_body(&req, None, &worker).unwrap();
+        let body = serialize_request_body(&req, None, &worker, None).unwrap();
 
         assert_eq!(body, value_path_bytes(&req, None, &worker));
         let parsed: Value = serde_json::from_slice(&body).unwrap();
@@ -304,10 +317,10 @@ mod tests {
         // body needs editing.
         let req = generate_request(json!({"return_hidden_states": true}));
 
-        let body = serialize_request_body(&req, None, &worker).unwrap();
+        let body = serialize_request_body(&req, None, &worker, None).unwrap();
 
         assert_eq!(body, value_path_bytes(&req, None, &worker));
-        assert_eq!(body, to_vec_value_compatible(&req).unwrap());
+        assert_eq!(body, to_vec_value_compatible(&req, None).unwrap());
     }
 
     #[test]
@@ -315,7 +328,8 @@ mod tests {
         let worker = worker();
         let req = generate_request(json!({}));
 
-        let body = String::from_utf8(serialize_request_body(&req, None, &worker).unwrap()).unwrap();
+        let body =
+            String::from_utf8(serialize_request_body(&req, None, &worker, None).unwrap()).unwrap();
 
         // `to_value` widens `f32` to `f64`; the plain writer would emit the
         // shorter `0.7` and change wire bytes.
@@ -334,13 +348,13 @@ mod tests {
         }))
         .unwrap();
 
-        let plain = serialize_request_body(&req, None, &worker).unwrap();
+        let plain = serialize_request_body(&req, None, &worker, None).unwrap();
         assert_eq!(plain, value_path_bytes(&req, None, &worker));
         let parsed: Value = serde_json::from_slice(&plain).unwrap();
         assert!(parsed.get("separate_reasoning").is_none());
         assert_eq!(parsed["skip_special_tokens"], true);
 
-        let aliased = serialize_request_body(&req, Some("canonical-model"), &worker).unwrap();
+        let aliased = serialize_request_body(&req, Some("canonical-model"), &worker, None).unwrap();
         assert_eq!(
             aliased,
             value_path_bytes(&req, Some("canonical-model"), &worker)
@@ -353,15 +367,32 @@ mod tests {
         let req = vec![1, 2, 3];
 
         // The raw editor rejects the shape, so this exercises the fallback.
-        let direct = to_vec_value_compatible(&req).unwrap();
+        let direct = to_vec_value_compatible(&req, None).unwrap();
         assert!(serde_json::from_slice::<RawBody>(&direct).is_err());
 
-        let body = serialize_request_body(&req, Some("canonical-model"), &worker).unwrap();
+        let body = serialize_request_body(&req, Some("canonical-model"), &worker, None).unwrap();
 
         assert_eq!(
             body,
             value_path_bytes(&req, Some("canonical-model"), &worker)
         );
         assert_eq!(body, b"[1,2,3]");
+    }
+
+    #[test]
+    fn presized_body_capacity_stays_within_slack_of_len() {
+        let worker = worker();
+        let req = generate_request(json!({ "text": "x".repeat(32 << 20) }));
+        let raw_len = serde_json::to_vec(&req).unwrap().len();
+
+        let body = serialize_request_body(&req, None, &worker, Some(raw_len)).unwrap();
+
+        assert!(body.len() > 32 << 20);
+        assert!(
+            body.capacity() <= body.len() + body.len() / 8 + 1024,
+            "capacity {} must stay within slack of len {}",
+            body.capacity(),
+            body.len()
+        );
     }
 }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -568,12 +568,13 @@ impl Router {
 
         // Note: Using borrowed reference avoids heap allocation
         events::RequestSentEvent { url: worker.url() }.emit();
+        let raw_body_len = header_utils::content_length(headers);
         let mut headers_with_trace = headers.cloned().unwrap_or_default();
         inject_trace_context_http(&mut headers_with_trace);
         let headers = Some(&headers_with_trace);
 
         let response = match lease.serialize_with(|view| {
-            serialize_request_body(view.request, canonical_model, worker.as_ref())
+            serialize_request_body(view.request, canonical_model, worker.as_ref(), raw_body_len)
         }) {
             Ok(body) => {
                 // Past this point dispatch needs only the serialized bytes;


### PR DESCRIPTION
## Description

### Problem

Serializing a request body for dispatch starts from a small Vec and doubles as it grows. A 35MB body lands in a 64MiB-capacity buffer, and `Bytes::from(Vec)` keeps the full capacity for as long as the Bytes lives - for the lease memo that can be the whole retry window. Cost per in-dispatch request: ~29MiB of dead capacity plus a ~32MiB memcpy on the final doubling.

### Solution

Pre-size every dispatch serialization from a known length hint, and trim slack at the two freeze points where buffers can outlive dispatch.

- The incoming `Content-Length` seeds the hint on the main dispatch path; a parse-then-reserialize round trip tracks the raw size closely (`raw + raw/16 + 512` absorbs injected bootstrap/kv fields).
- Mutated re-serializes are bounded by the first pass length; PD leg and merge serializations use per-leg hints.
- The lease memo (`serialize_with`/`serialize_legs_with`) trims doubling slack before freezing, so even hint-less chunked bodies never retain 2x. Well-hinted buffers are never re-copied (trim threshold is double the pre-size slack).

## Changes

- New helpers in `routers/common`: `serialized_capacity`, `serialize_json_sized`, `trim_serialization_slack`; `header_utils::content_length`
- Seven serialization sites converted (fast path, mutated path, Value pipeline, PD legs, sequential-decode re-serialize, logprob merge)
- Lease memo freeze points trim before `Bytes::from`

## Test Plan

- 8MiB synthetic body: capacity equals the pre-size, within slack - never doubles
- Trim frees a doubled buffer but leaves a pre-sized one untouched
- 32MiB body through the real fast path with the raw-length hint stays within slack
- `cargo test -p smg --lib` 1803 passed; fmt silent; `cargo clippy --all-targets -- -D warnings` clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>