### PR TITLE
perf(protocols): stop default fields from defeating the serialize-once skip

### DIFF
--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -6,10 +6,10 @@ use validator::Validate;
 
 use super::{
     common::{
-        default_true, deserialize_null_as_false, validate_stop, ChatLogProbs, ContentPart,
-        Function, FunctionCall, FunctionChoice, GenerationRequest, ResponseFormat, StreamOptions,
-        StringOrArray, Tool, ToolCall, ToolCallDelta, ToolChoice, ToolChoiceValue, ToolReference,
-        Usage,
+        default_true, deserialize_null_as_false, is_false, is_true, validate_stop, ChatLogProbs,
+        ContentPart, Function, FunctionCall, FunctionChoice, GenerationRequest, ResponseFormat,
+        StreamOptions, StringOrArray, Tool, ToolCall, ToolCallDelta, ToolChoice, ToolChoiceValue,
+        ToolReference, Usage,
     },
     sampling_params::{validate_top_k_value, validate_top_p_value},
 };
@@ -285,15 +285,15 @@ pub struct ChatCompletionRequest {
     pub stop_token_ids: Option<Vec<u32>>,
 
     /// Skip trimming stop tokens from output
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub no_stop_trim: bool,
 
     /// Ignore end-of-sequence tokens during generation
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub ignore_eos: bool,
 
     /// Continue generating from final assistant message
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub continue_final_message: bool,
 
     /// Skip special tokens during detokenization
@@ -307,18 +307,18 @@ pub struct ChatCompletionRequest {
     pub session_params: Option<HashMap<String, Value>>,
 
     /// Separate reasoning content from final answer (O1-style models)
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub separate_reasoning: bool,
 
     /// Stream reasoning tokens during generation
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub stream_reasoning: bool,
 
     /// Chat template kwargs
     pub chat_template_kwargs: Option<HashMap<String, Value>>,
 
     /// Return model hidden states
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub return_hidden_states: bool,
 
     /// Random seed for sampling for deterministic outputs
@@ -817,6 +817,57 @@ mod tests {
             object.insert((*name).to_string(), field_value.clone());
         }
         serde_json::from_value(value).expect("request must deserialize")
+    }
+
+    #[test]
+    fn default_sglang_flags_are_omitted_and_absent_reads_defaults() {
+        let request = request_with_output_fields(&[]);
+        let value = serde_json::to_value(&request).expect("serialize");
+        for field in [
+            "no_stop_trim",
+            "ignore_eos",
+            "continue_final_message",
+            "return_hidden_states",
+            "separate_reasoning",
+            "stream_reasoning",
+        ] {
+            assert!(value.get(field).is_none(), "{field} serialized at default");
+        }
+
+        let back: ChatCompletionRequest = serde_json::from_value(value).expect("roundtrip");
+        assert!(!back.no_stop_trim);
+        assert!(!back.ignore_eos);
+        assert!(!back.continue_final_message);
+        assert!(!back.return_hidden_states);
+        assert!(back.separate_reasoning);
+        assert!(back.stream_reasoning);
+    }
+
+    #[test]
+    fn non_default_sglang_flags_round_trip() {
+        let request = request_with_output_fields(&[
+            ("no_stop_trim", json!(true)),
+            ("ignore_eos", json!(true)),
+            ("continue_final_message", json!(true)),
+            ("return_hidden_states", json!(true)),
+            ("separate_reasoning", json!(false)),
+            ("stream_reasoning", json!(false)),
+        ]);
+        let value = serde_json::to_value(&request).expect("serialize");
+        assert_eq!(value["no_stop_trim"], true);
+        assert_eq!(value["ignore_eos"], true);
+        assert_eq!(value["continue_final_message"], true);
+        assert_eq!(value["return_hidden_states"], true);
+        assert_eq!(value["separate_reasoning"], false);
+        assert_eq!(value["stream_reasoning"], false);
+
+        let back: ChatCompletionRequest = serde_json::from_value(value).expect("roundtrip");
+        assert!(back.no_stop_trim);
+        assert!(back.ignore_eos);
+        assert!(back.continue_final_message);
+        assert!(back.return_hidden_states);
+        assert!(!back.separate_reasoning);
+        assert!(!back.stream_reasoning);
     }
 
     #[test]

--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{self, value::SeqAccessDeserializer, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
 use serde_json::Value;
 use validator;
 
@@ -19,13 +22,31 @@ pub fn default_true() -> bool {
     true
 }
 
+/// Helper for `#[serde(skip_serializing_if = "is_false")]` on default-`false` flags.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if passes &T"
+)]
+pub fn is_false(v: &bool) -> bool {
+    !*v
+}
+
+/// Helper for `#[serde(skip_serializing_if = "is_true")]` on default-`true` flags.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if passes &T"
+)]
+pub fn is_true(v: &bool) -> bool {
+    *v
+}
+
 /// Deserialize a bool that also accepts JSON `null` (mapped to `false`).
 ///
 /// Use with `#[serde(default, deserialize_with = "deserialize_null_as_false")]`
 /// on fields that the OpenAI spec defines as `Optional[bool]` defaulting to `false`.
 pub fn deserialize_null_as_false<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
-    D: serde::Deserializer<'de>,
+    D: Deserializer<'de>,
 {
     Option::<bool>::deserialize(deserializer).map(|opt| opt.unwrap_or(false))
 }
@@ -479,13 +500,13 @@ impl Serialize for FunctionCall {
 }
 
 impl<'de> Deserialize<'de> for FunctionCall {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let value = Value::deserialize(deserializer)?;
         match &value {
             Value::String(s) => match s.as_str() {
                 "none" => Ok(FunctionCall::None),
                 "auto" => Ok(FunctionCall::Auto),
-                other => Err(serde::de::Error::custom(format!(
+                other => Err(de::Error::custom(format!(
                     "unknown function_call value: \"{other}\""
                 ))),
             },
@@ -493,12 +514,12 @@ impl<'de> Deserialize<'de> for FunctionCall {
                 if let Some(Value::String(name)) = map.get("name") {
                     Ok(FunctionCall::Function { name: name.clone() })
                 } else {
-                    Err(serde::de::Error::custom(
+                    Err(de::Error::custom(
                         "function_call object must have a \"name\" string field",
                     ))
                 }
             }
-            _ => Err(serde::de::Error::custom(
+            _ => Err(de::Error::custom(
                 "function_call must be a string or object",
             )),
         }
@@ -661,11 +682,101 @@ pub struct ErrorDetail {
 // Input Types
 // ============================================================================
 
-#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
 #[serde(untagged)]
 pub enum InputIds {
     Single(Vec<i32>),
     Batch(Vec<Vec<i32>>),
+}
+
+/// Shape probe for the first `input_ids` element: it alone picks the variant,
+/// so the rest parses in place instead of through untagged-enum buffering.
+enum FirstInputId {
+    Id(i32),
+    Ids(Vec<i32>),
+}
+
+impl<'de> Deserialize<'de> for FirstInputId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct FirstInputIdVisitor;
+
+        impl<'de> Visitor<'de> for FirstInputIdVisitor {
+            type Value = FirstInputId;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a token id or an array of token ids")
+            }
+
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                i32::try_from(v)
+                    .map(FirstInputId::Id)
+                    .map_err(|_| E::invalid_value(de::Unexpected::Signed(v), &self))
+            }
+
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                i32::try_from(v)
+                    .map(FirstInputId::Id)
+                    .map_err(|_| E::invalid_value(de::Unexpected::Unsigned(v), &self))
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, seq: A) -> Result<Self::Value, A::Error> {
+                Deserialize::deserialize(SeqAccessDeserializer::new(seq)).map(FirstInputId::Ids)
+            }
+        }
+
+        deserializer.deserialize_any(FirstInputIdVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for InputIds {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct InputIdsVisitor;
+
+        impl<'de> Visitor<'de> for InputIdsVisitor {
+            type Value = InputIds;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("an array of token ids or an array of token id arrays")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                // An empty array is Single, matching untagged first-match order.
+                let Some(first) = seq.next_element::<FirstInputId>()? else {
+                    return Ok(InputIds::Single(Vec::new()));
+                };
+                let remaining = seq.size_hint().unwrap_or(0);
+                match first {
+                    FirstInputId::Id(id) => {
+                        let mut ids = Vec::with_capacity(remaining.saturating_add(1));
+                        ids.push(id);
+                        while let Some(id) = seq.next_element()? {
+                            ids.push(id);
+                        }
+                        Ok(InputIds::Single(ids))
+                    }
+                    FirstInputId::Ids(head) => {
+                        let mut seqs = Vec::with_capacity(remaining.saturating_add(1));
+                        seqs.push(head);
+                        while let Some(ids) = seq.next_element()? {
+                            seqs.push(ids);
+                        }
+                        Ok(InputIds::Batch(seqs))
+                    }
+                }
+            }
+        }
+
+        deserializer.deserialize_seq(InputIdsVisitor)
+    }
 }
 
 /// LoRA adapter path - can be single path or batch of paths (SGLang extension)
@@ -919,6 +1030,51 @@ mod tests {
         assert!(ConversationRef::Id(String::new()).is_empty());
         assert!(!ConversationRef::Id("conv_1".to_string()).is_empty());
         assert!(ConversationRef::Object { id: String::new() }.is_empty());
+    }
+
+    #[test]
+    fn input_ids_deserializes_single() {
+        let ids: InputIds = serde_json::from_str("[1, -2, 3]").unwrap();
+        assert!(matches!(ids, InputIds::Single(ref v) if v == &[1, -2, 3]));
+    }
+
+    #[test]
+    fn input_ids_deserializes_batch() {
+        let ids: InputIds = serde_json::from_str("[[1, 2], [3], []]").unwrap();
+        assert!(matches!(ids, InputIds::Batch(ref v) if v == &[vec![1, 2], vec![3], vec![]]));
+    }
+
+    #[test]
+    fn input_ids_empty_array_is_single() {
+        let ids: InputIds = serde_json::from_str("[]").unwrap();
+        assert!(matches!(ids, InputIds::Single(ref v) if v.is_empty()));
+    }
+
+    #[test]
+    fn input_ids_rejects_invalid_input() {
+        for input in [
+            "[1, [2]]",
+            "[[1], 2]",
+            "[\"a\"]",
+            "[1.5]",
+            "[5000000000]",
+            "\"nope\"",
+            "null",
+            "7",
+        ] {
+            assert!(
+                serde_json::from_str::<InputIds>(input).is_err(),
+                "accepted {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn input_ids_round_trip() {
+        for input in [json!([1, 2, 3]), json!([[1, 2], [3]]), json!([])] {
+            let ids: InputIds = serde_json::from_value(input.clone()).unwrap();
+            assert_eq!(serde_json::to_value(&ids).unwrap(), input);
+        }
     }
 
     #[test]

--- a/crates/protocols/src/completion.rs
+++ b/crates/protocols/src/completion.rs
@@ -116,11 +116,11 @@ pub struct CompletionRequest {
     pub stop_token_ids: Option<Vec<u32>>,
 
     /// Skip trimming stop tokens from output
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub no_stop_trim: bool,
 
     /// Ignore end-of-sequence tokens during generation
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub ignore_eos: bool,
 
     /// Skip special tokens during detokenization
@@ -134,7 +134,7 @@ pub struct CompletionRequest {
     pub session_params: Option<HashMap<String, Value>>,
 
     /// Return model hidden states
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub return_hidden_states: bool,
 
     /// Sampling seed for deterministic outputs
@@ -280,4 +280,49 @@ pub struct CompletionStreamChoice {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logprobs: Option<LogProbs>,
     pub finish_reason: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(mut extra: Value) -> CompletionRequest {
+        let mut value = serde_json::json!({"model": "m", "prompt": "hello"});
+        value
+            .as_object_mut()
+            .expect("object")
+            .append(extra.as_object_mut().expect("object"));
+        serde_json::from_value(value).expect("request must deserialize")
+    }
+
+    #[test]
+    fn default_sglang_flags_are_omitted_and_absent_reads_defaults() {
+        let value = serde_json::to_value(req(serde_json::json!({}))).expect("serialize");
+        for field in ["no_stop_trim", "ignore_eos", "return_hidden_states"] {
+            assert!(value.get(field).is_none(), "{field} serialized at default");
+        }
+
+        let back: CompletionRequest = serde_json::from_value(value).expect("roundtrip");
+        assert!(!back.no_stop_trim);
+        assert!(!back.ignore_eos);
+        assert!(!back.return_hidden_states);
+    }
+
+    #[test]
+    fn non_default_sglang_flags_round_trip() {
+        let value = serde_json::to_value(req(serde_json::json!({
+            "no_stop_trim": true,
+            "ignore_eos": true,
+            "return_hidden_states": true
+        })))
+        .expect("serialize");
+        assert_eq!(value["no_stop_trim"], true);
+        assert_eq!(value["ignore_eos"], true);
+        assert_eq!(value["return_hidden_states"], true);
+
+        let back: CompletionRequest = serde_json::from_value(value).expect("roundtrip");
+        assert!(back.no_stop_trim);
+        assert!(back.ignore_eos);
+        assert!(back.return_hidden_states);
+    }
 }

--- a/crates/protocols/src/generate.rs
+++ b/crates/protocols/src/generate.rs
@@ -5,7 +5,7 @@ use serde_json::{Map, Value};
 use validator::Validate;
 
 use super::{
-    common::{default_true, deserialize_null_as_false, GenerationRequest, InputIds},
+    common::{default_true, deserialize_null_as_false, is_false, GenerationRequest, InputIds},
     sampling_params::SamplingParams,
 };
 use crate::validated::Normalizable;
@@ -88,7 +88,7 @@ pub struct GenerateRequest {
     pub log_metrics: bool,
 
     /// Return model hidden states
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub return_hidden_states: bool,
 
     /// The modalities of the image data [image, multi-images, video]
@@ -331,6 +331,27 @@ mod tests {
 
     fn req() -> GenerateRequest {
         serde_json::from_value(serde_json::json!({"model": "m"})).expect("minimal request")
+    }
+
+    #[test]
+    fn return_hidden_states_false_is_omitted_and_absent_reads_false() {
+        let r = req();
+        let v = serde_json::to_value(&r).expect("serialize");
+        assert!(v.get("return_hidden_states").is_none());
+
+        let back: GenerateRequest = serde_json::from_value(v).expect("roundtrip");
+        assert!(!back.return_hidden_states);
+    }
+
+    #[test]
+    fn return_hidden_states_true_round_trips() {
+        let mut r = req();
+        r.return_hidden_states = true;
+        let v = serde_json::to_value(&r).expect("serialize");
+        assert_eq!(v["return_hidden_states"], true);
+
+        let back: GenerateRequest = serde_json::from_value(v).expect("roundtrip");
+        assert!(back.return_hidden_states);
     }
 
     #[test]

--- a/model_gateway/src/routers/http/request_body.rs
+++ b/model_gateway/src/routers/http/request_body.rs
@@ -311,6 +311,19 @@ mod tests {
     }
 
     #[test]
+    fn default_generate_body_reuses_the_direct_serialization() {
+        let worker = worker();
+        // No default-noise field survives serialization, so the strip is a
+        // no-op and the first serialization goes out as-is.
+        let req = generate_request(json!({}));
+
+        let body = serialize_request_body(&req, None, &worker, None).unwrap();
+
+        assert_eq!(body, value_path_bytes(&req, None, &worker));
+        assert_eq!(body, to_vec_value_compatible(&req, None).unwrap());
+    }
+
+    #[test]
     fn untouched_body_reuses_the_direct_serialization() {
         let worker = worker();
         // `return_hidden_states: true` survives the strip, so nothing in this
@@ -350,6 +363,9 @@ mod tests {
 
         let plain = serialize_request_body(&req, None, &worker, None).unwrap();
         assert_eq!(plain, value_path_bytes(&req, None, &worker));
+        // Default-noise flags are omitted at serialization, so the strip is a
+        // no-op and the first serialization goes out as-is.
+        assert_eq!(plain, to_vec_value_compatible(&req, None).unwrap());
         let parsed: Value = serde_json::from_slice(&plain).unwrap();
         assert!(parsed.get("separate_reasoning").is_none());
         assert_eq!(parsed["skip_special_tokens"], true);
@@ -359,6 +375,22 @@ mod tests {
             aliased,
             value_path_bytes(&req, Some("canonical-model"), &worker)
         );
+    }
+
+    #[test]
+    fn default_completion_body_reuses_the_direct_serialization() {
+        let worker = worker();
+        let req: openai_protocol::completion::CompletionRequest = serde_json::from_value(json!({
+            "model": "alias-model",
+            "prompt": "hello",
+            "temperature": 0.7
+        }))
+        .unwrap();
+
+        let body = serialize_request_body(&req, None, &worker, None).unwrap();
+
+        assert_eq!(body, value_path_bytes(&req, None, &worker));
+        assert_eq!(body, to_vec_value_compatible(&req, None).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

#2139 added a skip that reuses the first serialization of an unmutated request body instead of re-encoding it. It never fires: several non-Option fields with constant defaults always serialize (for example `GenerateRequest::return_hidden_states: false`), so `strip_default_sglang_fields` finds them, marks every body mutated, and the router re-encodes the full body on every dispatch. On 35MB video bodies that is a full second serialization per request on the buffered path.

### Solution

Skip serializing fields that sit at their strip-default value, so a default request round-trips byte-identical and the reuse skip actually fires:

- `GenerateRequest`: `return_hidden_states`
- `ChatCompletionRequest`: `no_stop_trim`, `ignore_eos`, `continue_final_message`, `return_hidden_states` (skip when false); `separate_reasoning`, `stream_reasoning` (skip when true - the strip removes these at any value, so their mere presence marked chat bodies mutated)
- `CompletionRequest`: `no_stop_trim`, `ignore_eos`, `return_hidden_states` (same defect, same code path)
- Plus a manual `InputIds` deserializer replacing the untagged enum, which removes serde's internal double-buffering of large token arrays

`skip_special_tokens` is deliberately untouched: the strip keeps it, so it never defeats the skip, and its presence is an asserted wire contract.

## Changes

- serde attributes + `is_false`/`is_true` helpers in `crates/protocols` (chat, completion, generate)
- Manual `InputIds` Deserialize in `common.rs`
- Reuse-proof tests wired through the real `serialize_request_body` path

## Test Plan

- Skip-fires proofs for generate, chat, and completion: returned bytes are pointer-equal to the first serialization (any strip/set_model edit necessarily changes bytes, so byte-equality proves `mutated == false`)
- Roundtrip tests prove absent fields deserialize identically to omitted defaults, at default and non-default values
- Known caveat documented: model-alias traffic always re-encodes (`set_model` marks mutated unconditionally) - mitigated since #2264 by borrowed-slice re-encode with a pre-sized buffer
- `cargo test -p openai-protocol` 237 passed; `cargo test -p smg --lib` 1808 passed; `api_tests` 107, `routing_tests` 120, `spec_test` 96 green; clippy `--all-targets -- -D warnings` clean; fmt silent

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>