### PR TITLE
perf(routing): collapse the O(workers) per-selection passes

### DIFF
--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -99,6 +99,10 @@ pub(crate) type LoadReceiver = watch::Receiver<HashMap<String, WorkerLoadRespons
 #[derive(Debug)]
 pub struct CacheAwarePolicy {
     config: CacheAwareConfig,
+    /// Either `*_token_usage_threshold` sits below its disabled `1.0`
+    /// default. Computed once so a disabled config skips the per-selection
+    /// backend-usage bounds scan entirely.
+    kv_pressure_enabled: bool,
     /// String-based trees for HTTP connections (text input)
     string_trees: Arc<DashMap<String, Arc<Tree>>>,
     /// Token-based trees for gRPC connections (pre-tokenized input)
@@ -316,8 +320,12 @@ impl CacheAwarePolicy {
             None
         };
 
+        let kv_pressure_enabled = config.balance_token_usage_threshold < 1.0
+            || config.overload_token_usage_threshold < 1.0;
+
         Self {
             config,
+            kv_pressure_enabled,
             string_trees,
             token_trees,
             _eviction_task: eviction_task,
@@ -490,6 +498,9 @@ impl CacheAwarePolicy {
     /// pressure is instead applied per request, to the selected candidate,
     /// in [`Self::gate_selected_candidate`].
     fn is_kv_imbalanced(&self, workers: &[Arc<dyn Worker>], healthy_indices: &[usize]) -> bool {
+        if !self.kv_pressure_enabled {
+            return false;
+        }
         // KV-based triggers — need a load snapshot; both default 1.0 = disabled.
         if let Some((min_usage, max_usage)) =
             self.backend_token_usage_bounds(workers, healthy_indices)
@@ -1120,9 +1131,11 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
     /// Backend loads feed the KV-usage gate and the waiting-prefill decay;
     /// both are disabled by default, so only configured policies poll.
     fn needs_backend_loads(&self) -> bool {
-        self.config.overlap_decay > 0.0
-            || self.config.balance_token_usage_threshold < 1.0
-            || self.config.overload_token_usage_threshold < 1.0
+        self.config.overlap_decay > 0.0 || self.kv_pressure_enabled
+    }
+
+    fn filters_unavailable_workers(&self) -> bool {
+        true
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -2361,6 +2374,23 @@ mod tests {
         assert!(
             !imbalanced(&policy, &workers),
             "default thresholds (1.0) must ignore KV usage entirely"
+        );
+    }
+
+    #[test]
+    fn kv_pressure_disabled_thresholds_never_scan_bounds() {
+        // Out-of-range usage would trip `max > 1.0` if the bounds were
+        // computed; the construction-time gate keeps the scan off entirely.
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        });
+        assert!(!policy.needs_backend_loads());
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        let _tx = inject_kv(&policy, &workers, &[5.0, 0.0]);
+        assert!(
+            !imbalanced(&policy, &workers),
+            "disabled thresholds must skip the bounds scan"
         );
     }
 

--- a/model_gateway/src/policies/least_load.rs
+++ b/model_gateway/src/policies/least_load.rs
@@ -385,6 +385,10 @@ impl LoadBalancingPolicy for LeastLoadPolicy {
         "least_load"
     }
 
+    fn filters_unavailable_workers(&self) -> bool {
+        true
+    }
+
     fn update_loads(&self, loads: &HashMap<String, WorkerLoadResponse>) {
         if let Ok(mut cached) = self.cached_loads.write() {
             cached.extend(loads.iter().map(|(k, v)| (k.clone(), v.clone())));

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -88,6 +88,15 @@ pub trait LoadBalancingPolicy: Send + Sync + Debug {
         false
     }
 
+    /// Whether `select_worker` applies the full [`Worker::is_available`]
+    /// eligibility test to every candidate itself, so callers may pass the
+    /// unfiltered pool instead of pre-filtering it. `false` for policies
+    /// that route on a weaker predicate (the hash policies skip the circuit
+    /// breaker) and so rely on the caller's availability filter.
+    fn filters_unavailable_workers(&self) -> bool {
+        false
+    }
+
     /// Drop any cached per-worker state for a removed worker.
     ///
     /// Called when a worker leaves the registry so load-aware policies don't

--- a/model_gateway/src/policies/power_of_two.rs
+++ b/model_gateway/src/policies/power_of_two.rs
@@ -55,6 +55,10 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
         "power_of_two"
     }
 
+    fn filters_unavailable_workers(&self) -> bool {
+        true
+    }
+
     fn update_loads(&self, loads: &HashMap<String, WorkerLoadResponse>) {
         self.scorer.update_loads(loads);
     }

--- a/model_gateway/src/policies/random.rs
+++ b/model_gateway/src/policies/random.rs
@@ -41,6 +41,10 @@ impl LoadBalancingPolicy for RandomPolicy {
         "random"
     }
 
+    fn filters_unavailable_workers(&self) -> bool {
+        true
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/model_gateway/src/policies/round_robin.rs
+++ b/model_gateway/src/policies/round_robin.rs
@@ -47,6 +47,10 @@ impl LoadBalancingPolicy for RoundRobinPolicy {
         "round_robin"
     }
 
+    fn filters_unavailable_workers(&self) -> bool {
+        true
+    }
+
     fn reset(&self) {
         self.counter.store(0, Ordering::Relaxed);
     }

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -282,26 +282,42 @@ impl WorkerSelectionStage {
 
         // Get workers for the specified model. The gRPC router serves both gRPC
         // and direct-ZMQ workers, so accept either transport (not HTTP).
-        let workers = self.worker_registry.get_workers_filtered(
-            model_filter,
-            Some(WorkerType::Regular),
-            None,  // grpc + zmq, filtered below
-            None,  // any runtime type
-            false, // get all workers, we'll filter by is_available() next
-        );
-
-        // Use into_iter() to take ownership of Arcs without cloning (avoids atomic inc/dec)
-        let available: Vec<Arc<dyn Worker>> = workers
-            .into_iter()
-            .filter(|w| w.connection_mode().uses_grpc_pipeline() && w.is_available())
-            .collect();
-
-        if available.is_empty() {
-            return None;
-        }
+        let shared;
+        let owned;
+        let pool: &[Arc<dyn Worker>] = match model_filter {
+            Some(model) => {
+                shared = self.worker_registry.get_by_model_matching(model, |w| {
+                    *w.worker_type() == WorkerType::Regular
+                        && w.connection_mode().uses_grpc_pipeline()
+                });
+                &shared
+            }
+            None => {
+                owned = self
+                    .worker_registry
+                    .get_workers_filtered(None, Some(WorkerType::Regular), None, None, false)
+                    .into_iter()
+                    .filter(|w| w.connection_mode().uses_grpc_pipeline())
+                    .collect::<Vec<_>>();
+                &owned
+            }
+        };
 
         // Get the appropriate policy for this model
         let policy = self.policy_registry.get_policy_or_default(model_id);
+
+        // Policies that apply the full availability test themselves take the
+        // pool directly; the rest keep the pre-filter pass.
+        let prefiltered: Vec<Arc<dyn Worker>>;
+        let available: &[Arc<dyn Worker>] = if policy.filters_unavailable_workers() {
+            pool
+        } else {
+            prefiltered = pool.iter().filter(|w| w.is_available()).cloned().collect();
+            &prefiltered
+        };
+        if available.is_empty() {
+            return None;
+        }
 
         // Get cached hash ring for consistent hashing (O(log n) lookup)
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
@@ -310,7 +326,7 @@ impl WorkerSelectionStage {
         // when enabled; otherwise delegates to the configured policy).
         let idx = self.policy_registry.select_worker(
             &policy,
-            &available,
+            available,
             &SelectWorkerInfo {
                 request_text: text,
                 tokens,

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -238,32 +238,50 @@ impl Router {
         } else {
             Some(model_id)
         };
-        let workers = self.worker_registry.get_workers_filtered(
-            model_filter,
-            Some(WorkerType::Regular),
-            Some(ConnectionMode::Http),
-            None,  // any runtime type
-            false, // get all workers, we'll filter by is_available() next
-        );
-
-        let available: Vec<Arc<dyn Worker>> = workers
-            .iter()
-            .filter(|w| w.is_available())
-            .cloned()
-            .collect();
-        if available.is_empty() {
-            return None;
-        }
+        let shared;
+        let owned;
+        let pool: &[Arc<dyn Worker>] = match model_filter {
+            Some(model) => {
+                shared = self.worker_registry.get_by_model_matching(model, |w| {
+                    *w.worker_type() == WorkerType::Regular
+                        && *w.connection_mode() == ConnectionMode::Http
+                });
+                &shared
+            }
+            None => {
+                owned = self.worker_registry.get_workers_filtered(
+                    None,
+                    Some(WorkerType::Regular),
+                    Some(ConnectionMode::Http),
+                    None,
+                    false,
+                );
+                &owned
+            }
+        };
 
         // Get the appropriate policy for this model
         let policy = self.policy_registry.get_policy_or_default(model_id);
+
+        // Policies that apply the full availability test themselves take the
+        // pool directly; the rest keep the pre-filter pass.
+        let prefiltered: Vec<Arc<dyn Worker>>;
+        let available: &[Arc<dyn Worker>] = if policy.filters_unavailable_workers() {
+            pool
+        } else {
+            prefiltered = pool.iter().filter(|w| w.is_available()).cloned().collect();
+            &prefiltered
+        };
+        if available.is_empty() {
+            return None;
+        }
 
         // Get cached hash ring for consistent hashing (O(log n) lookup)
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
 
         let idx = self.policy_registry.select_worker(
             &policy,
-            &available,
+            available,
             &SelectWorkerInfo {
                 request_text: text,
                 tokens,

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -346,13 +346,17 @@ impl RouterManager {
             }
         }
 
-        let workers = if let Some(model) = model_id {
-            self.worker_registry.get_by_model(model).to_vec()
+        let by_model;
+        let all;
+        let workers: &[Arc<dyn Worker>] = if let Some(model) = model_id {
+            by_model = self.worker_registry.get_by_model(model);
+            &by_model
         } else {
-            self.worker_registry.get_all()
+            all = self.worker_registry.get_all();
+            &all
         };
 
-        self.select_router_for_workers(&workers, model_id)
+        self.select_router_for_workers(workers, model_id)
             .or_else(|| {
                 let default = self
                     .default_router

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -379,6 +379,22 @@ impl WorkerRegistry {
             .unwrap_or_else(|| Arc::from(Self::EMPTY_WORKERS))
     }
 
+    /// Model-scoped candidate pool for selection hot paths: returns the
+    /// shared per-model slice as-is when every worker matches (an atomic
+    /// refcount bump, no per-request clone), cloning only the matching
+    /// workers when the pool is mixed.
+    pub fn get_by_model_matching(
+        &self,
+        model_id: &str,
+        matches: impl Fn(&Arc<dyn Worker>) -> bool,
+    ) -> Arc<[Arc<dyn Worker>]> {
+        let workers = self.get_by_model(model_id);
+        if workers.iter().all(&matches) {
+            return workers;
+        }
+        workers.iter().filter(|w| matches(w)).cloned().collect()
+    }
+
     /// Apply the absolute overload veto to `worker`, returning `true` when the
     /// flag transitioned. The only sanctioned writer of
     /// [`Worker::set_overloaded`]: counters and gauge move once per edge.
@@ -2693,6 +2709,44 @@ mod tests {
         let llama_workers_after = registry.get_by_model("llama-3");
         assert_eq!(llama_workers_after.len(), 1);
         assert_eq!(llama_workers_after[0].url(), "http://worker2:8080");
+    }
+
+    #[test]
+    fn get_by_model_matching_shares_the_slice_for_uniform_pools() {
+        let registry = WorkerRegistry::new();
+        for url in ["http://m1:8080", "http://m2:8080"] {
+            registry
+                .register(Arc::new(
+                    BasicWorkerBuilder::new(url)
+                        .model(ModelCard::new("m"))
+                        .worker_type(WorkerType::Regular)
+                        .build(),
+                ))
+                .unwrap();
+        }
+
+        let all = registry.get_by_model("m");
+        let matched =
+            registry.get_by_model_matching("m", |w| *w.worker_type() == WorkerType::Regular);
+        assert!(
+            Arc::ptr_eq(&all, &matched),
+            "uniform pool must reuse the shared per-model slice"
+        );
+
+        registry
+            .register(Arc::new(
+                BasicWorkerBuilder::new("http://m3:8080")
+                    .model(ModelCard::new("m"))
+                    .worker_type(WorkerType::Prefill)
+                    .build(),
+            ))
+            .unwrap();
+        let filtered =
+            registry.get_by_model_matching("m", |w| *w.worker_type() == WorkerType::Regular);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered
+            .iter()
+            .all(|w| *w.worker_type() == WorkerType::Regular));
     }
 
     // Health-checker integration tests moved to worker/manager.rs along with


### PR DESCRIPTION
## Description

### Problem

Every worker selection at 10,000 registered workers ran up to four O(workers) passes: a filtered clone out of the registry, a router-side availability re-filter (another clone), the policy's own gather, and an unconditional token-usage bounds scan (10k String-keyed map probes) that ran even with the thresholds at their disabled 1.0 defaults. About 2.7ms of CPU and two ~80KB allocations per selection - and selection rates tripled when the admission caps were re-derived.

### Solution

One pass where one pass suffices, and nothing when disabled.

- `get_by_model_matching` returns the registry's shared per-model slice untouched when every worker passes the static filter (the homogeneous production case: zero clones, one refcount bump); mixed pools still clone only the matches.
- Policies that provably filter availability internally (cache_aware, random, round_robin, least_load, power_of_two) declare `filters_unavailable_workers()`, and the router skips its pre-filter pass for them. The predicate equivalence is verified: the router's `is_available()` and the gather's `eligible()` are the same three terms.
- `consistent_hashing`/`prefix_hash` deliberately keep the pre-filter: they skip the circuit breaker internally for ring stability and depend on the router for CB exclusion. Passthrough/bucket/manual/dp_min_token also keep it (conservative default).
- The KV-pressure bounds scan is gated once at construction: thresholds at the documented disabled default mean `is_kv_imbalanced` early-returns and the O(workers) scan never runs.
- Same treatment applied to the gRPC selection stage and the IGW dispatch path's per-request `.to_vec()`.

## Changes

- `WorkerRegistry::get_by_model_matching`; `LoadBalancingPolicy::filters_unavailable_workers` (default false, five opt-ins)
- `kv_pressure_enabled` computed once in cache_aware construction; `needs_backend_loads` reuses it
- HTTP router + gRPC worker-selection stage skip the redundant pass for self-filtering policies

## Test Plan

- New: disabled-threshold fast path (poisoned 5.0 usage snapshot with default thresholds keeps affinity and reports no backend-load need); shared-slice reuse for uniform pools
- Predicate-difference analysis in the PR discussion: the one real divergence found (ring policies skip CB internally) is preserved, not papered over
- `cargo test -p smg --lib` 1808 passed; `routing_tests` 120; full integration suite (26 binaries) green including `api_tests` 107; clippy `--all-targets -- -D warnings` clean; fmt silent

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>