### PR TITLE
fix(messages): serialize cache-token usage counters as integers, not null

### DIFF
--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -792,15 +792,8 @@ impl ResponseProcessor {
         };
 
         // Step 5: Build usage
-        let usage = messages::Usage {
-            input_tokens: complete.prompt_tokens(),
-            output_tokens: complete.completion_tokens(),
-            cache_creation_input_tokens: None,
-            cache_read_input_tokens: None,
-            cache_creation: None,
-            server_tool_use: None,
-            service_tier: None,
-        };
+        let usage =
+            messages_usage_from_counts(complete.prompt_tokens(), complete.completion_tokens());
 
         // Step 6: Build Message
         Ok(Message {
@@ -979,6 +972,21 @@ fn normalize_assistant_content(text: String) -> Option<String> {
     }
 }
 
+/// Usage for a unary Messages response. Cache counters are integer zeros,
+/// never null: the Anthropic wire contract has always-present cache counters
+/// (0 when caching is unused) and clients do arithmetic on them.
+fn messages_usage_from_counts(input_tokens: u32, output_tokens: u32) -> messages::Usage {
+    messages::Usage {
+        input_tokens,
+        output_tokens,
+        cache_creation_input_tokens: Some(0),
+        cache_read_input_tokens: Some(0),
+        cache_creation: None,
+        server_tool_use: None,
+        service_tier: None,
+    }
+}
+
 #[cfg(test)]
 mod content_normalization_tests {
     use super::normalize_assistant_content;
@@ -991,5 +999,22 @@ mod content_normalization_tests {
             normalize_assistant_content("\n\nDone.".to_string()),
             Some("\n\nDone.".to_string())
         );
+    }
+}
+
+#[cfg(test)]
+mod messages_usage_wire_tests {
+    use super::messages_usage_from_counts;
+
+    /// The contract is about the serialized JSON, not the Rust struct: cache
+    /// counters must be present as integer zeros (a struct-level Some(0) that
+    /// a serde attr silently skipped would still fail here).
+    #[test]
+    fn cache_counters_serialize_as_integer_zeros() {
+        let v = serde_json::to_value(messages_usage_from_counts(25, 150)).unwrap();
+        assert_eq!(v["input_tokens"], 25);
+        assert_eq!(v["output_tokens"], 150);
+        assert_eq!(v["cache_creation_input_tokens"], 0);
+        assert_eq!(v["cache_read_input_tokens"], 0);
     }
 }

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -2000,15 +2000,7 @@ impl StreamingProcessor {
             model: model.clone(),
             stop_reason: None,
             stop_sequence: None,
-            usage: messages::Usage {
-                input_tokens: 0,
-                output_tokens: 0,
-                cache_creation_input_tokens: None,
-                cache_read_input_tokens: None,
-                cache_creation: None,
-                server_tool_use: None,
-                service_tier: None,
-            },
+            usage: Self::initial_messages_usage(),
         };
         Self::send_messages_event(
             tx,
@@ -2480,13 +2472,10 @@ impl StreamingProcessor {
                     stop_reason,
                     stop_sequence,
                 },
-                usage: MessageDeltaUsage {
-                    output_tokens: completion_tokens.total(),
-                    input_tokens: None,
-                    cache_creation_input_tokens: None,
-                    cache_read_input_tokens: None,
-                    server_tool_use: None,
-                },
+                usage: Self::final_messages_delta_usage(
+                    completion_tokens.total(),
+                    saw_complete.then_some(prompt_tokens),
+                ),
             },
         )
         .await?;
@@ -3187,6 +3176,39 @@ impl StreamingProcessor {
             .with_cached_tokens(total_cached)
             .with_reasoning_tokens(total_reasoning)
     }
+
+    /// Skeleton usage for the `message_start` event. Cache counters are
+    /// integer zeros, never null: the Anthropic wire contract has
+    /// always-present cache counters and clients do arithmetic on them.
+    fn initial_messages_usage() -> messages::Usage {
+        messages::Usage {
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_input_tokens: Some(0),
+            cache_read_input_tokens: Some(0),
+            cache_creation: None,
+            server_tool_use: None,
+            service_tier: None,
+        }
+    }
+
+    /// Usage for the final `message_delta` event. `authoritative_input` is the
+    /// prompt count only when a `Complete` was seen; a clean EOF without one
+    /// must serialize `input_tokens: null` rather than claim a zero-token
+    /// prompt. Cache counters follow the same integer-not-null contract as
+    /// [`Self::initial_messages_usage`].
+    fn final_messages_delta_usage(
+        output_tokens: u32,
+        authoritative_input: Option<u32>,
+    ) -> MessageDeltaUsage {
+        MessageDeltaUsage {
+            output_tokens,
+            input_tokens: authoritative_input,
+            cache_creation_input_tokens: Some(0),
+            cache_read_input_tokens: Some(0),
+            server_tool_use: None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -3214,5 +3236,34 @@ mod tests {
                 .and_then(|details| details.reasoning_tokens),
             Some(3)
         );
+    }
+
+    /// Wire contract: cache counters serialize as integer zeros, never null,
+    /// in both the message_start skeleton and the final message_delta usage.
+    #[test]
+    fn messages_usage_cache_counters_serialize_as_integer_zeros() {
+        let start = serde_json::to_value(StreamingProcessor::initial_messages_usage()).unwrap();
+        assert_eq!(start["input_tokens"], 0);
+        assert_eq!(start["output_tokens"], 0);
+        assert_eq!(start["cache_creation_input_tokens"], 0);
+        assert_eq!(start["cache_read_input_tokens"], 0);
+
+        let delta =
+            serde_json::to_value(StreamingProcessor::final_messages_delta_usage(15, Some(25)))
+                .unwrap();
+        assert_eq!(delta["output_tokens"], 15);
+        assert_eq!(delta["input_tokens"], 25);
+        assert_eq!(delta["cache_creation_input_tokens"], 0);
+        assert_eq!(delta["cache_read_input_tokens"], 0);
+    }
+
+    /// A clean EOF without a `Complete` message has no authoritative prompt
+    /// count: `input_tokens` must serialize as null, not a fabricated zero.
+    #[test]
+    fn message_delta_input_tokens_null_without_authoritative_usage() {
+        let delta =
+            serde_json::to_value(StreamingProcessor::final_messages_delta_usage(15, None)).unwrap();
+        assert!(delta["input_tokens"].is_null());
+        assert_eq!(delta["cache_creation_input_tokens"], 0);
     }
 }


### PR DESCRIPTION
## Description

### Problem

The Anthropic Messages API returns `usage.cache_creation_input_tokens` and `usage.cache_read_input_tokens` as always-present integer counters — `0` when prompt caching is unused (the official SDK types accept an integer or null for these fields, so `0` is valid under both readings). SMG's gRPC `/v1/messages` surface sets both fields to `None`, which serializes as `null` in all three places a usage object is emitted: the unary response, the streaming `message_start` skeleton, and the final `message_delta`. Clients and cost dashboards that do arithmetic on these counters read `null` as "unknown" (or worse, break) where the real API says "zero".

The final `message_delta` also always sent `input_tokens: null`, even though the stream tracks an authoritative prompt count once the backend's `Complete` message arrives — the live API reports the cumulative input count there.

### Solution

Build the three usage objects through small dedicated constructors that pin the integer-not-null contract:

- `messages_usage_from_counts` (unary), `initial_messages_usage` (`message_start`), and `final_messages_delta_usage` (`message_delta`) all emit `Some(0)` for the two cache counters.
- `final_messages_delta_usage` takes the prompt count as `Option<u32>`, filled via `saw_complete.then_some(prompt_tokens)` — a clean EOF without a `Complete` keeps `input_tokens: null` rather than fabricating a zero-token prompt (preserving the existing "no usage" vs "zero tokens" distinction the tracker documents).

Genuinely optional structures (`cache_creation` breakdown, `server_tool_use`, `service_tier`) stay `None`. Inbound parsing and the OpenAI chat surface are untouched.

## Changes

- `model_gateway/src/routers/grpc/regular/processor.rs`: extract `messages_usage_from_counts` with integer-zero cache counters; unary response uses it.
- `model_gateway/src/routers/grpc/regular/streaming.rs`: extract `initial_messages_usage` / `final_messages_delta_usage`; `message_start` and `message_delta` use them; `message_delta` now carries authoritative cumulative `input_tokens` when available.
- Wire-contract tests assert on the serialized JSON (`serde_json::to_value`), not the Rust structs, so a serde attribute silently skipping a `Some(0)` would still fail: integer zeros in all three shapes, and `input_tokens` null-without-`Complete` / present-with-`Complete`.

## Test Plan

- `cargo test -p smg --lib` — 1815 passed (3 new: `messages_usage_wire_tests::cache_counters_serialize_as_integer_zeros`, `streaming::tests::messages_usage_cache_counters_serialize_as_integer_zeros`, `streaming::tests::message_delta_input_tokens_null_without_authoritative_usage`).
- `cargo test -p smg --test messages_test --test messages_streaming_test --test api_tests` — 139 passed.
- Before/after: a `/v1/messages` unary response previously carried `"cache_creation_input_tokens": null`; it now carries `"cache_creation_input_tokens": 0` (same for `cache_read_input_tokens`, and in `message_start`/`message_delta` events), matching live Anthropic API behavior.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>