### PR TITLE
fix(tool_parser): flush unconsumed streaming buffer as content instead of swallowing it

### DIFF
--- a/crates/tool_parser/src/parsers/cohere.rs
+++ b/crates/tool_parser/src/parsers/cohere.rs
@@ -327,6 +327,12 @@ impl ToolParser for CohereParser {
         helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
     }
 
+    fn take_unstreamed_normal_text(&mut self) -> String {
+        // Covers both a partial START_ACTION held in Text state and an action
+        // block whose END_ACTION never arrived (truncated stream).
+        helpers::take_unstreamed_normal_text(&mut self.buffer, self.current_tool_id)
+    }
+
     fn reset(&mut self) {
         self.state = ParseState::Text;
         helpers::reset_parser_state(

--- a/crates/tool_parser/src/parsers/cohere.rs
+++ b/crates/tool_parser/src/parsers/cohere.rs
@@ -329,8 +329,16 @@ impl ToolParser for CohereParser {
 
     fn take_unstreamed_normal_text(&mut self) -> String {
         // Covers both a partial START_ACTION held in Text state and an action
-        // block whose END_ACTION never arrived (truncated stream).
-        helpers::take_unstreamed_normal_text(&mut self.buffer, self.current_tool_id)
+        // block whose END_ACTION never arrived (truncated stream). Text held
+        // in the Text state still carries response markers, which every other
+        // emission path in this parser strips, so clean it the same way rather
+        // than leaking control tokens into client-visible content.
+        let text = helpers::take_unstreamed_normal_text(&mut self.buffer, self.current_tool_id);
+        if text.is_empty() {
+            text
+        } else {
+            Self::clean_text(&text)
+        }
     }
 
     fn reset(&mut self) {

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -124,6 +124,27 @@ pub fn get_unstreamed_args(
     }])
 }
 
+/// End-of-stream flush: take any text still buffered as a *prospective* tool
+/// call so the caller can emit it as normal content instead of dropping it.
+///
+/// Returns the buffer verbatim when no tool call was ever announced this
+/// request (`current_tool_id == -1`): the buffered text was only ever a
+/// tool-call *candidate* (e.g. a bare `{` prefix or a partial start marker)
+/// that never materialized, so it is content. Once a tool call has been
+/// announced (`current_tool_id >= 0`), the buffered tail is tool-call syntax
+/// (separators, closing brackets, or a partially-streamed call whose
+/// remaining arguments are recovered via [`get_unstreamed_args`]) and is
+/// discarded — matching the non-streaming path, which drops trailing
+/// non-JSON text once tool calls were extracted.
+pub fn take_unstreamed_normal_text(buffer: &mut String, current_tool_id: i32) -> String {
+    let text = std::mem::take(buffer);
+    if current_tool_id == -1 {
+        text
+    } else {
+        String::new()
+    }
+}
+
 /// Check if a buffer ends with a partial occurrence of a token
 /// Returns Some(length) if there's a partial match, None otherwise
 pub fn ends_with_partial_token(buffer: &str, token: &str) -> Option<usize> {
@@ -244,59 +265,130 @@ pub(crate) fn handle_json_tool_streaming(
     streamed_args_for_tool: &mut Vec<String>,
     prev_tool_call_arr: &mut Vec<Value>,
 ) -> ParserResult<StreamingParseResult> {
-    // Check if we have content to parse
-    if start_idx >= current_text.len() {
-        return Ok(StreamingParseResult::default());
-    }
+    // Text this call has bailed out of tool parsing (see the loop below).
+    let mut normal_text = String::new();
+    // Where the next JSON value starts in `current_text`.
+    let mut cursor = start_idx;
 
-    // Extract JSON string from current position
-    let json_str = &current_text[start_idx..];
-
-    // When current_tool_name_sent is false, don't allow partial strings to avoid
-    // parsing incomplete tool names as empty strings
-    let allow_partial_strings = *current_tool_name_sent;
-
-    // Parse partial JSON
-    let (obj, end_idx) = match partial_json.parse_value(json_str, allow_partial_strings) {
-        Ok(result) => result,
-        Err(_) => {
-            return Ok(StreamingParseResult::default());
+    // Each iteration parses one JSON value. A value that can never become a
+    // declared tool call is emitted as content and the loop advances past it,
+    // so a declared call trailing a non-tool value in the same chunk still
+    // becomes tool-call deltas. Looping rather than recursing keeps stack
+    // depth constant however many values a single chunk carries.
+    let (current_tool_call, end_idx, is_complete) = loop {
+        if cursor >= current_text.len() {
+            if cursor > start_idx {
+                buffer.clear();
+            }
+            return Ok(StreamingParseResult {
+                normal_text,
+                calls: vec![],
+            });
         }
+
+        let json_str = &current_text[cursor..];
+
+        // When current_tool_name_sent is false, don't allow partial strings to avoid
+        // parsing incomplete tool names as empty strings
+        let allow_partial_strings = *current_tool_name_sent;
+
+        let Ok((obj, end_idx)) = partial_json.parse_value(json_str, allow_partial_strings) else {
+            // Not parseable yet - keep it buffered for the next chunk.
+            if cursor > start_idx {
+                *buffer = json_str.to_string();
+            }
+            return Ok(StreamingParseResult {
+                normal_text,
+                calls: vec![],
+            });
+        };
+
+        // Check if JSON is complete - validate only the parsed portion.
+        // Ensure end_idx is on a valid UTF-8 character boundary
+        let safe_end_idx = if json_str.is_char_boundary(end_idx) {
+            end_idx
+        } else {
+            // Find the nearest valid character boundary before end_idx
+            (0..end_idx)
+                .rev()
+                .find(|&i| json_str.is_char_boundary(i))
+                .unwrap_or(0)
+        };
+        let is_complete = is_complete_json(&json_str[..safe_end_idx]);
+
+        // Normalize all tool call fields first (handles tool_name -> name, parameters -> arguments)
+        // This must happen before validation since different LLMs use different field names
+        let current_tool_call = normalize_tool_call_fields(obj);
+
+        // A value that can never become a declared tool call is content: a
+        // complete value with no `name`, or a `name` (complete by construction,
+        // since partial strings are disallowed until the name is sent) that is
+        // not among the declared tools. Dropping it here is what left streams
+        // with neither content nor tool-call deltas, while the non-streaming
+        // path returned the same text as content.
+        let consumed = match current_tool_call.get("name").and_then(|v| v.as_str()) {
+            Some(name) if !tool_indices.contains_key(name) => {
+                tracing::debug!(
+                    "Undeclared tool name '{}' - emitting buffered text as content",
+                    name
+                );
+                reset_current_tool_state(
+                    buffer,
+                    current_tool_name_sent,
+                    streamed_args_for_tool,
+                    prev_tool_call_arr,
+                );
+                if is_complete {
+                    cursor + safe_end_idx
+                } else {
+                    current_text.len()
+                }
+            }
+            None if is_complete => cursor + safe_end_idx,
+            _ => {
+                // A declared tool call: hand it to the streaming cases below,
+                // leaving the buffer holding everything from this value on.
+                if cursor > start_idx {
+                    *buffer = current_text[cursor..].to_string();
+                }
+                break (current_tool_call, end_idx, is_complete);
+            }
+        };
+
+        // The first bail-out emits any marker prefix too, matching the
+        // non-streaming fallback which returns unparsed tool text verbatim.
+        let emit_from = if cursor > start_idx { cursor } else { 0 };
+        normal_text.push_str(&current_text[emit_from..consumed]);
+        cursor = consumed;
+
+        // Keep parsing only if another *bare* JSON value follows. Anything
+        // else - prose, or a marker-framed call such as qwen's
+        // `</tool_call><tool_call>{..}` - stays buffered: a later chunk lets
+        // the parser re-run its own marker detection over it, but if this was
+        // the final chunk the end-of-stream flush surfaces it as content
+        // instead. Marker-aware re-entry belongs in the parsers, which own
+        // their start markers; see `take_unstreamed_normal_text`.
+        let tail = &current_text[cursor..];
+        let value_start = tail
+            .char_indices()
+            .find(|(_, c)| !c.is_whitespace() && *c != ',' && *c != ';')
+            .map_or(tail.len(), |(i, _)| i);
+        if !tail[value_start..].starts_with(['{', '[']) {
+            *buffer = tail.to_string();
+            return Ok(StreamingParseResult {
+                normal_text,
+                calls: vec![],
+            });
+        }
+        // Separators between adjacent values belong to the emitted text.
+        normal_text.push_str(&tail[..value_start]);
+        cursor += value_start;
     };
 
-    // Check if JSON is complete - validate only the parsed portion
-    // Ensure end_idx is on a valid UTF-8 character boundary
-    let safe_end_idx = if json_str.is_char_boundary(end_idx) {
-        end_idx
-    } else {
-        // Find the nearest valid character boundary before end_idx
-        (0..end_idx)
-            .rev()
-            .find(|&i| json_str.is_char_boundary(i))
-            .unwrap_or(0)
+    let mut result = StreamingParseResult {
+        normal_text,
+        calls: vec![],
     };
-    let is_complete = is_complete_json(&json_str[..safe_end_idx]);
-
-    // Normalize all tool call fields first (handles tool_name -> name, parameters -> arguments)
-    // This must happen before validation since different LLMs use different field names
-    let current_tool_call = normalize_tool_call_fields(obj);
-
-    // Validate tool name if present
-    if let Some(name) = current_tool_call.get("name").and_then(|v| v.as_str()) {
-        if !tool_indices.contains_key(name) {
-            // Invalid tool name - skip this tool, preserve indexing for next tool
-            tracing::debug!("Invalid tool name '{}' - skipping", name);
-            reset_current_tool_state(
-                buffer,
-                current_tool_name_sent,
-                streamed_args_for_tool,
-                prev_tool_call_arr,
-            );
-            return Ok(StreamingParseResult::default());
-        }
-    }
-
-    let mut result = StreamingParseResult::default();
 
     // Case 1: Handle tool name streaming
     if !*current_tool_name_sent {
@@ -388,7 +480,7 @@ pub(crate) fn handle_json_tool_streaming(
 
         // If complete, advance to next tool
         if is_complete {
-            *buffer = current_text[start_idx + end_idx..].to_string();
+            *buffer = current_text[cursor + end_idx..].to_string();
             *current_tool_name_sent = false;
             *current_tool_id += 1;
         }

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -413,8 +413,19 @@ pub(crate) fn handle_json_tool_streaming(
             }
         }
     }
-    // Case 2: Handle streaming arguments
-    else if let Some(cur_arguments) = current_tool_call.get("arguments") {
+
+    // Case 2: Handle streaming arguments. This is deliberately not an `else`:
+    // when the whole call arrives in one chunk, Case 1 sends the name and the
+    // arguments must still stream in the *same* invocation. There is no later
+    // call to fall back on - the router stops feeding the parser once the
+    // engine stream ends - so returning here would emit a tool call with an
+    // empty `arguments`, and `get_unstreamed_tool_args()` could not recover
+    // them either because only this branch populates `prev_tool_call_arr`.
+    // `current_tool_name_sent` implies `current_tool_id >= 0`.
+    if *current_tool_name_sent {
+        let Some(cur_arguments) = current_tool_call.get("arguments") else {
+            return Ok(result);
+        };
         let tool_id = *current_tool_id as usize;
         let sent = streamed_args_for_tool
             .get(tool_id)

--- a/crates/tool_parser/src/parsers/json.rs
+++ b/crates/tool_parser/src/parsers/json.rs
@@ -294,6 +294,10 @@ impl ToolParser for JsonParser {
         helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
     }
 
+    fn take_unstreamed_normal_text(&mut self) -> String {
+        helpers::take_unstreamed_normal_text(&mut self.buffer, self.current_tool_id)
+    }
+
     fn reset(&mut self) {
         helpers::reset_parser_state(
             &mut self.buffer,

--- a/crates/tool_parser/src/parsers/llama.rs
+++ b/crates/tool_parser/src/parsers/llama.rs
@@ -231,6 +231,10 @@ impl ToolParser for LlamaParser {
         helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
     }
 
+    fn take_unstreamed_normal_text(&mut self) -> String {
+        helpers::take_unstreamed_normal_text(&mut self.buffer, self.current_tool_id)
+    }
+
     fn reset(&mut self) {
         helpers::reset_parser_state(
             &mut self.buffer,

--- a/crates/tool_parser/src/parsers/mistral.rs
+++ b/crates/tool_parser/src/parsers/mistral.rs
@@ -315,6 +315,10 @@ impl ToolParser for MistralParser {
         helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
     }
 
+    fn take_unstreamed_normal_text(&mut self) -> String {
+        helpers::take_unstreamed_normal_text(&mut self.buffer, self.current_tool_id)
+    }
+
     fn reset(&mut self) {
         helpers::reset_parser_state(
             &mut self.buffer,

--- a/crates/tool_parser/src/parsers/qwen.rs
+++ b/crates/tool_parser/src/parsers/qwen.rs
@@ -251,7 +251,21 @@ impl ToolParser for QwenParser {
         helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
     }
 
+    fn take_unstreamed_normal_text(&mut self) -> String {
+        // `normal_text_buffer` may be holding back a suffix that looked like a
+        // partial "</tool_call>" tag; at end of stream it is real text when no
+        // tool call was ever announced, and marker debris otherwise.
+        let held = std::mem::take(&mut self.normal_text_buffer);
+        let tail = helpers::take_unstreamed_normal_text(&mut self.buffer, self.current_tool_id);
+        if self.current_tool_id == -1 {
+            held + &tail
+        } else {
+            String::new()
+        }
+    }
+
     fn reset(&mut self) {
+        self.normal_text_buffer.clear();
         helpers::reset_parser_state(
             &mut self.buffer,
             &mut self.prev_tool_call_arr,

--- a/crates/tool_parser/src/traits.rs
+++ b/crates/tool_parser/src/traits.rs
@@ -45,6 +45,23 @@ pub trait ToolParser: Send + Sync {
         None
     }
 
+    /// Take any text still buffered by the streaming parser that never became
+    /// a tool call, transferring ownership to the caller.
+    ///
+    /// Streaming consumers call this once at end of stream, alongside
+    /// [`Self::get_unstreamed_tool_args`]: text held back as a *prospective*
+    /// tool call (a bare `{` prefix, a partial start marker, or tool JSON
+    /// that never completed) must be surfaced as normal content instead of
+    /// being silently dropped — mirroring the non-streaming fallback that
+    /// returns unparsable tool text verbatim. Parsers that announced a tool
+    /// call from the buffered text return an empty string (the remaining
+    /// arguments are recovered via `get_unstreamed_tool_args`).
+    ///
+    /// The default returns an empty string (parser holds no buffered text).
+    fn take_unstreamed_normal_text(&mut self) -> String {
+        String::new()
+    }
+
     /// Reset the parser state for reuse across requests.
     /// This should clear all buffers and reset state to initial values.
     fn reset(&mut self) {

--- a/crates/tool_parser/tests/tool_parser_streaming_flush.rs
+++ b/crates/tool_parser/tests/tool_parser_streaming_flush.rs
@@ -19,6 +19,9 @@
 //!    swallowed — and nothing is invented once a tool call was announced.
 //! 3. A declared tool call trailing a non-tool value in the same chunk still
 //!    becomes tool-call deltas rather than stranded text.
+//! 4. A call whose name and arguments both land in one chunk streams *both*
+//!    in that chunk. There is no later parser call to fall back on, so a name
+//!    without arguments would reach the client as an unusable tool call.
 mod common;
 
 use common::{create_test_tools, streaming_helpers};
@@ -200,6 +203,7 @@ async fn streaming_never_swallows_content() {
             label: "llama: nothing invented after a completed tool call",
             feed: Feed::Chunks(&[r#"{"name": "get_weather", "parameters": {"city": "Tokyo"}}"#]),
             call: Some("get_weather"),
+            args_contain: Some(r#"{"city":"Tokyo"}"#),
             ..BLANK
         },
         Case {
@@ -208,6 +212,48 @@ async fn streaming_never_swallows_content() {
             label: "llama: announced call whose arguments are truncated",
             feed: Feed::Chunks(&[r#"{"name": "get_weather", "parameters": {"city": "Par"#]),
             call: Some("get_weather"),
+            ..BLANK
+        },
+        // --- a call whose name and arguments arrive together must stream both
+        //     in that single invocation: no later call ever comes
+        Case {
+            label: "json: whole declared call inside one chunk",
+            make: json,
+            feed: Feed::Chunks(&[r#"{"name": "get_weather", "arguments": {"city": "Tokyo"}}"#]),
+            call: Some("get_weather"),
+            args_contain: Some(r#"{"city":"Tokyo"}"#),
+            ..BLANK
+        },
+        Case {
+            label: "mistral: declared call after an undeclared one streams its args",
+            make: mistral,
+            feed: Feed::Chunks(&[
+                r#"[TOOL_CALLS] [{"name": "bogus", "arguments": {}}, {"name": "get_weather", "arguments": {"city": "Paris"}}"#,
+                "]",
+            ]),
+            text: r#"[TOOL_CALLS] [{"name": "bogus", "arguments": {}}, "#,
+            call: Some("get_weather"),
+            args_contain: Some(r#"{"city":"Paris"}"#),
+            ..BLANK
+        },
+        Case {
+            label: "cohere: complete action block streams name and arguments",
+            make: cohere,
+            feed: Feed::Chunks(&[
+                r#"<|START_ACTION|>{"tool_name": "search", "parameters": {"query": "rust"}}<|END_ACTION|>"#,
+                " done",
+            ]),
+            call: Some("search"),
+            args_contain: Some(r#"{"query":"rust"}"#),
+            ..BLANK
+        },
+        Case {
+            // Every other cohere emission path strips response markers; the
+            // flush must too, rather than leaking control tokens as content.
+            label: "cohere: response markers stripped from the flushed text",
+            make: cohere,
+            feed: Feed::Chunks(&["<|START_RESPONSE|>Hello<|START_AC"]),
+            flush: "Hello<|START_AC",
             ..BLANK
         },
         // --- text still buffered at end of stream is recovered by the flush
@@ -263,6 +309,7 @@ async fn streaming_never_swallows_content() {
             ]),
             text: r#"{"note": "checking"} "#,
             call: Some("get_weather"),
+            args_contain: Some(r#"{"city":"Tokyo"}"#),
             ..BLANK
         },
         Case {
@@ -274,6 +321,7 @@ async fn streaming_never_swallows_content() {
             )]),
             text: r#"{"name": "bogus_tool", "arguments": {}}"#,
             call: Some("get_weather"),
+            args_contain: Some(r#"{"city":"Paris"}"#),
             ..BLANK
         },
     ];

--- a/crates/tool_parser/tests/tool_parser_streaming_flush.rs
+++ b/crates/tool_parser/tests/tool_parser_streaming_flush.rs
@@ -9,7 +9,7 @@
 //! empty stream — no tool_call deltas AND no content deltas — while the
 //! non-streaming path correctly fell back to returning the text as content.
 //!
-//! Three properties are covered here:
+//! Four properties are covered here:
 //! 1. Text that is definitively not a declared tool call (complete JSON with
 //!    a missing or undeclared name) is surfaced as normal text mid-stream
 //!    instead of being buffered forever or silently dropped, while legitimate
@@ -248,6 +248,19 @@ async fn streaming_never_swallows_content() {
             ..BLANK
         },
         Case {
+            // The helper bails out on the undeclared, still-incomplete value
+            // and emits the whole chunk, so `normal_text_buffer` holds back
+            // the trailing partial `</tool_call>`. With no tool call ever
+            // announced that suffix is real text, not marker debris.
+            label: "qwen: partial </tool_call> held in normal_text_buffer",
+            make: qwen,
+            feed: Feed::Chunks(&[r#"<tool_call>
+{"name": "bogus"</tool"#]),
+            text: "<tool_call>\n{\"name\": \"bogus\"",
+            flush: "</tool",
+            ..BLANK
+        },
+        Case {
             // Every other cohere emission path strips response markers; the
             // flush must too, rather than leaking control tokens as content.
             label: "cohere: response markers stripped from the flushed text",
@@ -381,15 +394,40 @@ async fn partial_declared_name_keeps_buffering() {
 }
 
 #[tokio::test]
-async fn reset_clears_the_streaming_buffer() {
-    let mut parser = LlamaParser::new();
+async fn reset_clears_the_streaming_buffers() {
     let tools = create_test_tools();
 
-    parser
+    // The shared buffer every helper-based parser holds.
+    let mut llama = LlamaParser::new();
+    llama
         .parse_incremental(r#"{"name": "get_wea"#, &tools)
         .await
         .unwrap();
-    parser.reset();
+    llama.reset();
+    assert_eq!(
+        llama.take_unstreamed_normal_text(),
+        "",
+        "reset must clear the streaming buffer"
+    );
 
-    assert_eq!(parser.take_unstreamed_normal_text(), "");
+    // Qwen additionally parks a partial `</tool_call>` in `normal_text_buffer`,
+    // which reset() must clear too or it bleeds into the next request.
+    let held = r#"<tool_call>
+{"name": "bogus"</tool"#;
+    let mut qwen = QwenParser::new();
+    qwen.parse_incremental(held, &tools).await.unwrap();
+    let mut drained = QwenParser::new();
+    drained.parse_incremental(held, &tools).await.unwrap();
+    assert_eq!(
+        drained.take_unstreamed_normal_text(),
+        "</tool",
+        "precondition: normal_text_buffer is holding the partial end token"
+    );
+
+    qwen.reset();
+    assert_eq!(
+        qwen.take_unstreamed_normal_text(),
+        "",
+        "reset must clear normal_text_buffer, not just the main buffer"
+    );
 }

--- a/crates/tool_parser/tests/tool_parser_streaming_flush.rs
+++ b/crates/tool_parser/tests/tool_parser_streaming_flush.rs
@@ -1,0 +1,347 @@
+//! Streaming buffered-content flush tests
+//!
+//! Regression tests for the streaming content-loss bug observed on PR #2261's
+//! e2e runs (all four engines, deterministic): Llama-3.2-1B with
+//! `--tool-call-parser llama`, tools present, `tool_choice=auto`, streaming.
+//! When the model emits `{`-prefixed text that never becomes a valid declared
+//! tool call, the incremental parser buffered everything while waiting for a
+//! tool call that never materialized and the client received a completely
+//! empty stream — no tool_call deltas AND no content deltas — while the
+//! non-streaming path correctly fell back to returning the text as content.
+//!
+//! Three properties are covered here:
+//! 1. Text that is definitively not a declared tool call (complete JSON with
+//!    a missing or undeclared name) is surfaced as normal text mid-stream
+//!    instead of being buffered forever or silently dropped, while legitimate
+//!    tool calls keep streaming unchanged.
+//! 2. Text still buffered at end of stream (truncated JSON, partial start
+//!    markers) is recoverable via the end-of-stream flush instead of being
+//!    swallowed — and nothing is invented once a tool call was announced.
+//! 3. A declared tool call trailing a non-tool value in the same chunk still
+//!    becomes tool-call deltas rather than stranded text.
+mod common;
+
+use common::{create_test_tools, streaming_helpers};
+use tool_parser::{
+    types::ToolCallItem, CohereParser, JsonParser, LlamaParser, MistralParser, QwenParser,
+    ToolParser,
+};
+
+/// Representative Llama-3.2-1B output for "What's the weather in Tokyo?" with
+/// declared tools: `{`-prefixed JSON that never becomes a valid declared tool
+/// call because the function name is under a non-standard key (the parser
+/// only recognizes `name`). The CI worker-log artifacts do not record raw
+/// generations, so this reproduces the failure class rather than the literal
+/// string.
+const NON_TOOL_JSON: &str =
+    r#"{"type": "function", "function": "get_weather", "parameters": {"city": "Tokyo"}}"#;
+
+/// Valid, complete JSON in llama tool shape, but the name is not among the
+/// declared tools.
+const UNDECLARED_TOOL_JSON: &str =
+    r#"{"name": "get_stock_price", "parameters": {"ticker": "AAPL"}}"#;
+
+type MakeParser = fn() -> Box<dyn ToolParser>;
+
+fn llama() -> Box<dyn ToolParser> {
+    Box::new(LlamaParser::new())
+}
+fn json() -> Box<dyn ToolParser> {
+    Box::new(JsonParser::new())
+}
+fn mistral() -> Box<dyn ToolParser> {
+    Box::new(MistralParser::new())
+}
+fn qwen() -> Box<dyn ToolParser> {
+    Box::new(QwenParser::new())
+}
+fn cohere() -> Box<dyn ToolParser> {
+    Box::new(CohereParser::new())
+}
+
+/// How a case chunks its input.
+enum Feed {
+    /// Explicit chunk boundaries, chosen to split mid-token.
+    Chunks(&'static [&'static str]),
+    /// Realistic 2-3 char chunks: many chunk boundaries inside the JSON.
+    Realistic(&'static str),
+}
+
+/// Drive a parser through chunked streaming and collect everything it emits.
+#[expect(
+    clippy::unwrap_used,
+    reason = "test helper; allow-unwrap-in-tests only covers #[test] fns"
+)]
+async fn stream(parser: &mut dyn ToolParser, feed: &Feed) -> (String, Vec<ToolCallItem>) {
+    let owned_chunks;
+    let owned_refs;
+    let chunks: &[&str] = match feed {
+        Feed::Chunks(chunks) => chunks,
+        Feed::Realistic(input) => {
+            owned_chunks = streaming_helpers::create_realistic_chunks(input);
+            owned_refs = owned_chunks.iter().map(String::as_str).collect::<Vec<_>>();
+            &owned_refs
+        }
+    };
+    let tools = create_test_tools();
+    let mut normal_text = String::new();
+    let mut calls = Vec::new();
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        normal_text.push_str(&result.normal_text);
+        calls.extend(result.calls);
+    }
+    (normal_text, calls)
+}
+
+fn announced(calls: &[ToolCallItem]) -> Option<&str> {
+    calls.iter().find_map(|c| c.name.as_deref())
+}
+
+/// Everything the parser streamed as tool-call argument fragments.
+fn streamed_args(calls: &[ToolCallItem]) -> String {
+    calls.iter().map(|c| c.parameters.as_str()).collect()
+}
+
+// ============================================================================
+// One table, three properties per row: what the client sees streamed, which
+// declared tool (if any) was announced, and what the end-of-stream flush
+// yields. Asserting all three for every case is what pins the bug: the
+// regression produced an empty stream *and* an empty flush.
+// ============================================================================
+
+struct Case {
+    label: &'static str,
+    make: MakeParser,
+    feed: Feed,
+    /// Exactly what the client must receive as content.
+    text: &'static str,
+    /// The declared tool the parser must announce, if any.
+    call: Option<&'static str>,
+    /// A substring the streamed arguments must contain, when a call is made.
+    args_contain: Option<&'static str>,
+    /// What the end-of-stream flush must return.
+    flush: &'static str,
+}
+
+/// Defaults for the common shape: streams nothing, announces nothing, flushes
+/// nothing. Each row overrides only what it is actually about.
+const BLANK: Case = Case {
+    label: "",
+    make: llama,
+    feed: Feed::Chunks(&[]),
+    text: "",
+    call: None,
+    args_contain: None,
+    flush: "",
+};
+
+#[tokio::test]
+async fn streaming_never_swallows_content() {
+    let cases = [
+        // --- definitively-not-a-tool JSON must surface as content mid-stream
+        Case {
+            label: "llama: no `name` key at all, split mid-token",
+            feed: Feed::Realistic(NON_TOOL_JSON),
+            text: NON_TOOL_JSON,
+            ..BLANK
+        },
+        Case {
+            label: "llama: undeclared name split across chunk boundaries",
+            feed: Feed::Chunks(&[
+                r#"{"name": "get_st"#,
+                r#"ock_price", "para"#,
+                r#"meters": {"ticker": "AAPL"}}"#,
+            ]),
+            text: UNDECLARED_TOOL_JSON,
+            ..BLANK
+        },
+        Case {
+            label: "json: plain answer that happens to be JSON",
+            make: json,
+            feed: Feed::Realistic(r#"{"result": 42, "status": "ok"}"#),
+            text: r#"{"result": 42, "status": "ok"}"#,
+            ..BLANK
+        },
+        Case {
+            // Content-preserving, markers included: everything the model
+            // emitted reaches the client, as the non-streaming path does too.
+            label: "mistral: undeclared name inside [TOOL_CALLS] array",
+            make: mistral,
+            feed: Feed::Chunks(&[
+                "[TOOL_CALLS] ",
+                r#"[{"name": "frobni"#,
+                r#"cate", "arguments"#,
+                r#"": {"x": 1}}]"#,
+            ]),
+            text: r#"[TOOL_CALLS] [{"name": "frobnicate", "arguments": {"x": 1}}]"#,
+            ..BLANK
+        },
+        Case {
+            label: "qwen: complete JSON inside markers with no `name` key",
+            make: qwen,
+            feed: Feed::Chunks(&["<tool_call>\n", r#"{"foo": "#, "1}", "\n</tool_call>"]),
+            text: "<tool_call>\n{\"foo\": 1}\n</tool_call>",
+            ..BLANK
+        },
+        // --- legitimate tool calls keep streaming, and invent no content
+        Case {
+            label: "llama: a real declared call still streams name and args",
+            feed: Feed::Chunks(&[
+                r#"{"name": "get_we"#,
+                r#"ather", "parameters"#, // codespell:ignore ather
+                r#"": {"city": "Tokyo"}}"#,
+            ]),
+            call: Some("get_weather"),
+            args_contain: Some(r#"{"city":"Tokyo"}"#),
+            ..BLANK
+        },
+        Case {
+            label: "llama: nothing invented after a completed tool call",
+            feed: Feed::Chunks(&[r#"{"name": "get_weather", "parameters": {"city": "Tokyo"}}"#]),
+            call: Some("get_weather"),
+            ..BLANK
+        },
+        Case {
+            // The buffered tail is tool syntax, not content: flushing it as
+            // text would duplicate the announced call.
+            label: "llama: announced call whose arguments are truncated",
+            feed: Feed::Chunks(&[r#"{"name": "get_weather", "parameters": {"city": "Par"#]),
+            call: Some("get_weather"),
+            ..BLANK
+        },
+        // --- text still buffered at end of stream is recovered by the flush
+        Case {
+            label: "llama: stream ends mid-name (could still become get_weather)",
+            feed: Feed::Chunks(&[r#"{"name": "get_wea"#]),
+            flush: r#"{"name": "get_wea"#,
+            ..BLANK
+        },
+        Case {
+            label: "llama: partial <|python_tag|> held back at end of stream",
+            feed: Feed::Chunks(&["Sure, let me check <|py"]),
+            flush: "Sure, let me check <|py",
+            ..BLANK
+        },
+        Case {
+            label: "json: truncated prefix of the declared `search`",
+            make: json,
+            feed: Feed::Chunks(&[r#"{"name": "sea"#]),
+            flush: r#"{"name": "sea"#,
+            ..BLANK
+        },
+        Case {
+            label: "mistral: truncated tool call after the marker",
+            make: mistral,
+            feed: Feed::Chunks(&[r#"[TOOL_CALLS] [{"unknown"#]),
+            flush: r#"[TOOL_CALLS] [{"unknown"#,
+            ..BLANK
+        },
+        Case {
+            label: "qwen: truncated tool call after the marker",
+            make: qwen,
+            feed: Feed::Chunks(&["<tool_call>\n{\"a\": 1"]),
+            flush: "<tool_call>\n{\"a\": 1",
+            ..BLANK
+        },
+        Case {
+            label: "cohere: START_ACTION seen, END_ACTION never arrived",
+            make: cohere,
+            feed: Feed::Chunks(&[
+                r#"<|START_ACTION|>{"tool_name": "search", "parameters": {"query": "x"#,
+            ]),
+            flush: r#"{"tool_name": "search", "parameters": {"query": "x"#,
+            ..BLANK
+        },
+        // --- a declared call trailing a non-tool value in the SAME chunk must
+        //     still become tool-call deltas, never stranded text
+        Case {
+            label: "json: adjacent non-tool value then a declared call",
+            make: json,
+            feed: Feed::Chunks(&[
+                r#"{"note": "checking"} {"name": "get_weather", "arguments": {"city": "Tokyo"}}"#,
+            ]),
+            text: r#"{"note": "checking"} "#,
+            call: Some("get_weather"),
+            ..BLANK
+        },
+        Case {
+            label: "json: adjacent undeclared call then a declared call",
+            make: json,
+            feed: Feed::Chunks(&[concat!(
+                r#"{"name": "bogus_tool", "arguments": {}}"#,
+                r#"{"name": "get_weather", "arguments": {"city": "Paris"}}"#
+            )]),
+            text: r#"{"name": "bogus_tool", "arguments": {}}"#,
+            call: Some("get_weather"),
+            ..BLANK
+        },
+    ];
+
+    for case in &cases {
+        let mut parser = (case.make)();
+        let (text, calls) = stream(parser.as_mut(), &case.feed).await;
+
+        assert_eq!(text, case.text, "[{}] streamed content", case.label);
+        assert_eq!(announced(&calls), case.call, "[{}] tool call", case.label);
+        if let Some(fragment) = case.args_contain {
+            let args = streamed_args(&calls);
+            assert!(
+                args.contains(fragment),
+                "[{}] arguments must be streamed, got {args:?}",
+                case.label
+            );
+        }
+        assert_eq!(
+            parser.take_unstreamed_normal_text(),
+            case.flush,
+            "[{}] end-of-stream flush",
+            case.label
+        );
+        assert_eq!(
+            parser.take_unstreamed_normal_text(),
+            "",
+            "[{}] flush must drain: a second take returns nothing",
+            case.label
+        );
+    }
+}
+
+#[tokio::test]
+async fn partial_declared_name_keeps_buffering() {
+    let mut parser = LlamaParser::new();
+    let tools = create_test_tools();
+
+    // "get_we" is a prefix of the declared "get_weather": the parser must NOT
+    // bail out to normal text while the name string is still open.
+    let result = parser
+        .parse_incremental(r#"{"name": "get_we"#, &tools)
+        .await
+        .unwrap();
+    assert_eq!(result.normal_text, "");
+    assert!(result.calls.is_empty());
+
+    let result = parser
+        .parse_incremental(r#"ather", "parameters": {"city": "Paris"}}"#, &tools) // codespell:ignore ather
+        .await
+        .unwrap();
+    assert_eq!(
+        announced(&result.calls),
+        Some("get_weather"),
+        "declared tool call must be announced once the name completes"
+    );
+}
+
+#[tokio::test]
+async fn reset_clears_the_streaming_buffer() {
+    let mut parser = LlamaParser::new();
+    let tools = create_test_tools();
+
+    parser
+        .parse_incremental(r#"{"name": "get_wea"#, &tools)
+        .await
+        .unwrap();
+    parser.reset();
+
+    assert_eq!(parser.take_unstreamed_normal_text(), "");
+}

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -626,9 +626,29 @@ impl StreamingProcessor {
             }
         }
 
-        // Phase 3: Check unstreamed tool args
+        // Phase 3: End-of-stream parser flush: first any text still buffered
+        // as a prospective tool call that never materialized (dropping it
+        // produced fully-empty streams), then any parsed-but-unstreamed tool
+        // arguments.
         for (index, parser) in &tool_parsers {
-            let parser_guard = parser.lock().await;
+            let mut parser_guard = parser.lock().await;
+
+            let leftover_text = parser_guard.take_unstreamed_normal_text();
+            if !leftover_text.is_empty() {
+                let content_chunk = ChatCompletionStreamResponse::builder(request_id, model)
+                    .created(created)
+                    .add_choice_content(*index, "assistant", leftover_text)
+                    .maybe_system_fingerprint(system_fingerprint)
+                    .build();
+
+                let sse_chunk = sse_encoder
+                    .encode_data(&content_chunk)
+                    .map_err(|e| format!("Failed to serialize content chunk: {e}"))?;
+                tx.send(Ok(sse_chunk))
+                    .await
+                    .map_err(|_| "Failed to send flushed content chunk".to_string())?;
+            }
+
             if let Some(unstreamed_items) = parser_guard.get_unstreamed_tool_args() {
                 for tool_call_item in unstreamed_items {
                     let tool_call_delta = ToolCallDelta {
@@ -2340,7 +2360,42 @@ impl StreamingProcessor {
             }
         }
 
-        // Phase 3: Flush unstreamed tool args from the incremental parser
+        // Phase 3: End-of-stream parser flush: first any text still buffered
+        // as a prospective tool call that never materialized (dropping it
+        // produced fully-empty streams), then any parsed-but-unstreamed tool
+        // arguments.
+        if let Some(ref mut parser) = streaming_tool_parser {
+            let leftover_text = parser.take_unstreamed_normal_text();
+            if !leftover_text.is_empty() {
+                if !text_block_open {
+                    Self::send_messages_event(
+                        tx,
+                        &mut sse_buffer,
+                        &MessageStreamEvent::ContentBlockStart {
+                            index: current_block_index,
+                            content_block: ContentBlock::Text {
+                                text: String::new(),
+                                citations: None,
+                            },
+                        },
+                    )
+                    .await?;
+                    text_block_open = true;
+                }
+                Self::send_messages_event(
+                    tx,
+                    &mut sse_buffer,
+                    &MessageStreamEvent::ContentBlockDelta {
+                        index: current_block_index,
+                        delta: ContentBlockDelta::TextDelta {
+                            text: leftover_text,
+                        },
+                    },
+                )
+                .await?;
+            }
+        }
+
         if let Some(ref parser) = streaming_tool_parser {
             if let Some(unstreamed_items) = parser.get_unstreamed_tool_args() {
                 for tool_call_item in unstreamed_items {


### PR DESCRIPTION
## Description

### Problem

Streaming tool parsing can swallow an **entire completion**. When the incremental parser buffers text as a prospective tool call and that tool call never materializes, nothing ever flushes the buffer: the client receives a stream with **no tool_call deltas AND no content deltas**, while the non-streaming path correctly falls back to returning the same text as content.

PR #2261's strict e2e contract checks exposed this deterministically on **all four engines** (sglang, vllm, trtllm, tokenspeed — gRPC and ZMQ alike): `TestToolChoiceLlama::test_tool_choice_auto_streaming` (Llama-3.2-1B, `--tool-call-parser llama`, tools declared, `tool_choice=auto`) failed with `Expected non-empty streamed text when no tool call was made`.

The failure class:

- `LlamaParser::has_tool_markers()` treats any `text.trim_start().starts_with('{')` as a tool start, so a `{`-prefixed *answer* is routed into `helpers::handle_json_tool_streaming()`.
- There, a **complete JSON value with no `name` field** matched no handling branch at all → buffered forever, never emitted.
- A complete but **undeclared** `name` hit the invalid-name branch, which *silently cleared the buffer* → text destroyed.
- Truncated/unparseable JSON at end of stream stayed in the buffer → dropped when the stream finished. No end-of-stream flush existed anywhere.

Two further defects are fixed in the second commit, both reachable whenever a call is fully formed by the time the parser sees it:

- **Arguments were dropped for a call completed in one invocation.** Case 1 sent the tool name and returned, leaving Case 2 — which streams arguments and is the only branch that populates `prev_tool_call_arr` — behind an `else` that only ran on a *later* `parse_incremental()` call. No such call arrives: the router skips empty deltas and only re-feeds the parser when the stop decoder retained a partial stop-sequence match. So `take_unstreamed_normal_text()` returned `""` (a tool was announced) and `get_unstreamed_tool_args()` returned `None` (never populated). The client got a tool call with a name, **empty arguments**, and `finish_reason: "tool_calls"`.
- **The Cohere flush leaked control markers**, returning its buffer verbatim while every other emission path in that parser strips response markers via `clean_text()`.

### Solution

**1 — Mid-stream bail-out.** `handle_json_tool_streaming()` now parses one JSON value per iteration of an internal loop. A value that can never become a declared tool call — a complete value with no name, or a name not among the declared tools — is emitted as `normal_text` and the cursor advances past it, so a declared call trailing a non-tool value in the same chunk still becomes tool-call deltas. Iterating rather than recursing keeps stack depth constant however many values a chunk carries.

**2 — End-of-stream flush.** New trait method `ToolParser::take_unstreamed_normal_text()` (default: empty) drains text still buffered when the stream finishes (truncated tool JSON, partial start markers like `<|py`). Implemented via a shared helper for the five parsers that use the shared JSON streaming helper, and wired into both router stream-finish sites next to the existing `get_unstreamed_tool_args()` flush:

- Chat Completions Phase 3 (`process_streaming_chunks_inner` — shared by single and PD mode, gRPC and ZMQ transports),
- Messages API Phase 3 (`process_messages_streaming_chunks` — also reached from PD mode).

**3 — Arguments stream in the same invocation.** Case 2 now runs alongside Case 1, guarded on `current_tool_name_sent`. This also fixes two knock-on defects: a Mistral array whose declared call follows an undeclared one no longer re-emits that call's JSON as content on the next chunk, and **Cohere streams arguments at all for the first time** — each action block is handed to the helper exactly once, so only Case 1 had ever run for it.

Legit buffering is preserved: partial `bot_token` suffixes and incomplete-but-potentially-valid tool JSON keep buffering mid-stream, and once a tool call has been announced the flush returns nothing (the buffered tail is tool syntax; remaining arguments are recovered via `get_unstreamed_tool_args()`, and non-streaming likewise drops trailing text once tool calls were extracted).

**Parsers sharing the hole (all fixed uniformly):** `llama` and `json` (bare-`{`/`[` heuristic — full empty-stream failure mode), `mistral`, `qwen`, `cohere` (marker-gated, so plain text was safe, but a started-and-never-completed tool call, an undeclared name, or a truncated stream lost content the same way). Parsers with custom streaming (deepseek, kimik2, glm, pythonic, …) don't use this helper and keep their existing behavior via the trait default.

## Changes

- `crates/tool_parser/src/parsers/helpers.rs` — `handle_json_tool_streaming()` loops over adjacent values, bailing out to `normal_text` for complete-JSON-without-name and for undeclared names (instead of buffering forever / silently clearing); Case 2 no longer hides behind an `else`; new `take_unstreamed_normal_text(buffer, current_tool_id)` end-of-stream helper.
- `crates/tool_parser/src/traits.rs` — new defaulted `ToolParser::take_unstreamed_normal_text()`.
- `crates/tool_parser/src/parsers/{llama,json,mistral,qwen,cohere}.rs` — implement the flush; `QwenParser` also drains `normal_text_buffer` (a held partial `</tool_call>` suffix is real text when no tool call was ever announced) and now clears it in `reset()` (pre-existing reset gap); `CohereParser` routes the flush through `clean_text()`.
- `model_gateway/src/routers/grpc/regular/streaming.rs` — both stream-finish sites emit the flushed text as a content delta / `text_delta` before the unstreamed-args flush.
- `crates/tool_parser/tests/tool_parser_streaming_flush.rs` — new regression suite: one table asserting, for every case, what reaches the client as content, which tool is announced, which arguments stream, and what the end-of-stream flush yields.

## Test Plan

```
$ cargo test -p tool-parser            # 434 passed, 0 failed
$ cargo check --workspace --all-targets  # clean
$ cargo +nightly fmt --all --check       # clean
$ cargo clippy -p tool-parser --all-targets -- -D warnings  # clean
```

**Mutation-checked, not just green.** Each of the four behaviours is pinned by a test that fails when the corresponding fix is reverted:

| Reverted | Failing assertion |
|---|---|
| no-name bail-out | `[llama: no `name` key at all] streamed content` |
| end-of-stream flush | `[llama: stream ends mid-name] end-of-stream flush` |
| Case-1 fall-through | `[llama: a real declared call still streams name and args] arguments must be streamed` |
| Cohere `clean_text` | `[cohere: response markers stripped from the flushed text] end-of-stream flush` |

**Stack safety.** The adjacent-value drain is iterative, so a chunk carrying 500,000 adjacent JSON values parses in 0.03s. A recursive formulation aborts the process (`SIGABRT`) at ~4,000 in release.

The e2e contract that exposed the bug (`test_tool_choice_auto_streaming`'s "non-empty streamed text when no tool call was made") is expected to pass once PR #2261's lanes run against this fix.

### Known gaps (follow-ups, not regressions)

- `drain`-style re-entry only recognizes bare `{`/`[` tails, so a declared call framed by a start marker (`<tool_call>`, `[TOOL_CALLS]`) in the *same final chunk* is flushed as text rather than parsed. Marker-aware re-entry belongs in the parsers, which own their markers.
- The Go bindings (`bindings/golang/src/grpc_converter.rs`) have no end-of-stream flush at all — not even the pre-existing `get_unstreamed_tool_args()` — so the swallowing bug persists there.
- ~10 parsers with custom streaming hold their own buffers and inherit the `""` trait default.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
