### PR TITLE
chore(deps): bump SGLang to 0.5.18

### DIFF
--- a/.github/workflows/nightly-engine-docker.yml
+++ b/.github/workflows/nightly-engine-docker.yml
@@ -46,8 +46,8 @@ jobs:
             base_image_ref: vllm/vllm-openai:v0.27.1
             engine_ver: v0.27.1
           - engine: sglang
-            base_image_ref: lmsysorg/sglang:v0.5.17
-            engine_ver: v0.5.17
+            base_image_ref: lmsysorg/sglang:v0.5.18
+            engine_ver: v0.5.18
           - engine: trtllm
             base_image_ref: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24
             engine_ver: 1.3.0rc24

--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -2,7 +2,7 @@ name: Release SMG+SGLang Docker Image
 
 run-name: >-
   SMG+SGLang |
-  ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.17' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.17') }} |
+  ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.18' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.18') }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
   smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. lmsysorg/sglang:v0.5.17)'
-        default: 'lmsysorg/sglang:v0.5.17'
+        description: 'Base image (e.g. lmsysorg/sglang:v0.5.18)'
+        default: 'lmsysorg/sglang:v0.5.18'
         required: true
         type: string
       sglang_repo:
@@ -47,7 +47,7 @@ on:
         default: 'v1.9.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.9.0-sglang-v0.5.17)'
+        description: 'Override image tag (e.g. v1.9.0-sglang-v0.5.18)'
         required: false
         type: string
 
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ${{ github.event_name == 'push' && fromJSON('["lmsysorg/sglang:v0.5.17"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.17')) }}
+        base_image: ${{ github.event_name == 'push' && fromJSON('["lmsysorg/sglang:v0.5.18"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.18')) }}
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: sglang

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -31,9 +31,12 @@ classifiers = [
 
 [project.optional-dependencies]
 vllm = ["vllm>=0.19.0", "pyzmq>=25.0.0", "msgspec>=0.18.0"]
-# 0.5.13 is the first release with the shmem load snapshots that replaced
-# the WatchLoadUpdateReq piggyback path (removed upstream in v0.5.14).
-sglang = ["sglang>=0.5.17"]
+# 0.5.18 dropped the server_args parameter from
+# create_load_snapshot_reader(); the floor tracks that signature, which the
+# request manager calls unconditionally. (Earlier floors recorded the shmem
+# load snapshots that replaced the WatchLoadUpdateReq piggyback path in
+# 0.5.13, removed upstream in v0.5.14.)
+sglang = ["sglang>=0.5.18"]
 # smg-grpc-proto>=0.4.7 is the first release that ships mlx_engine_pb2;
 # without this floor, installing [mlx] against an older proto build would
 # crash at import time when smg_grpc_servicer.mlx.server runs.

--- a/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
@@ -239,8 +239,10 @@ class GrpcRequestManager:
 
         # Schedulers publish per-dp-rank LoadSnapshots (SHM; zmq for
         # multi-node DP). This manager fills sglang's TokenizerManager role.
+        # sglang 0.5.18 dropped the server_args parameter; the reader now
+        # derives dp_size from the process-global parallel config itself.
         self.load_snapshot_reader = create_load_snapshot_reader(
-            server_args, port_args, caller="TokenizerManager"
+            port_args, caller="TokenizerManager"
         )
 
         # Communicators for request/response patterns with scheduler

--- a/grpc_servicer/smg_grpc_servicer/sglang/server.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/server.py
@@ -21,6 +21,7 @@ from grpc_reflection.v1alpha import reflection
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
 from sglang.srt.managers.disagg_service import start_disagg_service
+from sglang.srt.runtime_context import publish
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import kill_process_tree
 from sglang.utils import get_exception_traceback
@@ -51,6 +52,18 @@ async def serve_grpc(
             this to wire its admin endpoints to the scheduler, so the
             callback signature is a public contract.
     """
+
+    # Install the process-wide runtime context before any sglang machinery
+    # runs here. Since 0.5.18 the config is published per process and read
+    # through `get_parallel()` rather than threaded from ServerArgs, so
+    # anything that reads a parallel dimension (the load-snapshot reader is
+    # the first) raises "config not published" until this happens. This
+    # process fills sglang's TokenizerManager role, so it publishes the
+    # tokenizer role exactly as the upstream engine entry point does; the
+    # scheduler subprocesses publish their own role when they start.
+    # Re-publish is last-publish-wins upstream, so this is safe if the caller
+    # already published.
+    publish(server_args, role="tokenizer")
 
     # Start bootstrap server BEFORE launching scheduler processes (only in PREFILL mode)
     # This ensures the bootstrap server is ready when prefill schedulers try to register

--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -21,7 +21,7 @@ echo "Using uv version: $(uv --version)"
 # Install CUDA toolkit (nvcc) — required for SGLang JIT kernel compilation.
 # SGLang >= 0.5.9 JIT-compiles CUDA kernels (RoPE, etc.) at runtime via tvm_ffi,
 # which invokes nvcc. The CI runners have CUDA runtime (driver) but not the compiler.
-# sglang 0.5.16 pins torch==2.11.0, whose default PyPI wheels are CUDA 13, so the
+# sglang 0.5.18 pins torch==2.13.0, whose default PyPI wheels are CUDA 13, so the
 # compiler must be nvcc 13 to match the runtime headers (a 12.x nvcc is replaced).
 CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 if [ ! -x "${CUDA_HOME}/bin/nvcc" ] || ! "${CUDA_HOME}/bin/nvcc" --version | grep -q "release 13\."; then
@@ -43,7 +43,7 @@ fi
 
 # Install SGLang with all dependencies
 echo "Installing SGLang..."
-uv pip install --prerelease=allow "sglang[all]==0.5.17"
+uv pip install --prerelease=allow "sglang[all]==0.5.18"
 
 # Install flashinfer-jit-cache: sglang bundles flashinfer_python but only for attention ops.
 # Multi-GPU models need trtllm_comm kernels (fused allreduce + layernorm) which FlashInfer
@@ -72,13 +72,13 @@ fi
 
 # Install mooncake for SGLang PD disaggregation (KV transfer)
 # Mooncake's native transfer engine requires InfiniBand/RDMA libraries at runtime.
-# Package and pin track upstream sglang v0.5.16 CI on the cu13 stack
-# (cuda13 wheel variant + nvrtc, since torch 2.11 defaults to CUDA 13):
-# https://github.com/sgl-project/sglang/blob/v0.5.16/scripts/ci/cuda/ci_install_dependency.sh
+# Package and pin track upstream sglang v0.5.18 CI on the cu13 stack
+# (cuda13 wheel variant + nvrtc, since torch 2.13 defaults to CUDA 13):
+# https://github.com/sgl-project/sglang/blob/v0.5.18/scripts/ci/cuda/ci_install_dependency.sh
 echo "Installing mooncake system dependencies..."
 sudo apt-get install -y --no-install-recommends libnuma-dev libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils
 echo "Installing mooncake..."
-uv pip install mooncake-transfer-engine-cuda13==0.3.11.post1 nvidia-cuda-nvrtc
+uv pip install mooncake-transfer-engine-cuda13==0.3.12.post1 nvidia-cuda-nvrtc
 
 # Install gRPC packages from source (not PyPI) so PR changes are always tested
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."


### PR DESCRIPTION
## Description

### Problem

We pin SGLang 0.5.17. Upstream 0.5.18 is released, and it changes a signature the servicer calls unconditionally:

```
0.5.17: def create_load_snapshot_reader(server_args, port_args, caller: str)
0.5.18: def create_load_snapshot_reader(port_args, caller: str)
```

`GrpcRequestManager` passes `server_args` positionally, and there is no version guard anywhere in the sglang servicer — every import and call is unconditional. So a straight version bump raises at construction and **every SGLang worker fails to start**. This is the third consecutive break in the load-metrics path (0.5.13 moved to shmem load snapshots, 0.5.16 replaced `GetLoadsReqInput`/`GetLoadsReqOutput` with `LoadSnapshot`).

Separately, the install script had drifted: the mooncake pin and two comments still tracked upstream's 0.5.16 CI, which the 0.5.17 bump left behind.

### Solution

Drop the `server_args` argument and move the floor to `sglang>=0.5.18`. The call cannot work against both signatures and the servicer has no shim layer, so the floor moves with it rather than adding one.

I diffed the rest of the coupling surface between the two tags rather than assuming. **Unchanged, byte-identical:** `LoadSnapshot` (all 34 fields the load conversion reads), `VALID_SECTIONS`, `KVEventBatch`, `BlockRemoved`, `AllBlocksCleared`, `ZmqEventPublisher.offset_endpoint_port`, `BatchTokenIDOutput`, `run_scheduler_process` (the 10-positional-arg call in the scheduler launcher), and `get_tokenizer`.

**`BlockStored` is also unchanged**, which is worth stating because 0.5.18 does add `BlockStoredMetadata` and `BlockStoredWithMetadata` nearby. Upstream deliberately keeps the new types out of the tagged union — their own comment says adding both would give msgspec duplicate tags — so a typed consumer still decodes the shared tag as the base `BlockStored` and ignores the trailing metadata. Our `SubscribeKvEvents` decoder is unaffected.

### Why this release

0.5.18 is the release that adds the Muse-Glimmer model family upstream (sgl-project/sglang#34262), so it is what unblocks serving that family on the SGLang lane. That is the motivation, but this PR stands alone as a routine currency bump and does not depend on anything else landing.

## Changes

- `grpc_servicer/smg_grpc_servicer/sglang/request_manager.py` — drop `server_args` from the `create_load_snapshot_reader` call, with a comment naming the release that changed it.
- `grpc_servicer/pyproject.toml` — floor to `sglang>=0.5.18`; the adjacent comment now records the signature change rather than the stale 0.5.13 note.
- `scripts/ci_install_sglang.sh` — pin `sglang[all]==0.5.18`; mooncake `0.3.11.post1` → `0.3.12.post1` to match upstream's CI for this release (it has used that since 0.5.17); refresh the two comments that named 0.5.16 and torch 2.11 (0.5.18 moves the stack to torch 2.13, still CUDA 13, so the nvcc-13 requirement is unchanged). The `"sglang[all]==X.Y.Z"` literal is preserved because `scripts/check_engine_versions.sh` parses it.
- `.github/workflows/nightly-engine-docker.yml`, `.github/workflows/release-sglang-docker.yml` — base image and tag strings to `v0.5.18` (`lmsysorg/sglang:v0.5.18` is published).

## Test Plan

Local checks are limited to what runs without a GPU, so CI is the real gate here and this is why the PR is a draft:

- `bash -n scripts/ci_install_sglang.sh` clean; both workflow files parse as YAML; `request_manager.py` compiles; `scripts/check_engine_versions.sh`'s regex still extracts `0.5.18` from the pin.
- Upstream symbol comparison between `v0.5.17` and `v0.5.18` as described above.

What CI must confirm, since there is no Python test coverage of the sglang servicer (`grpc_servicer/tests` runs on a CPU runner with no sglang installed):

- The sglang e2e lanes — chat, completions, embeddings, gateway, multi-GPU and PD tiers — all of which fail immediately on an ImportError or signature break at worker startup, which is the main risk class here.
- Two soft-fail paths worth watching in the logs rather than trusting green: the `KVEventBatch` msgspec decode swallows errors into a warning and continues, and `reasoning_tokens` is read via `getattr` with a `None` default. Neither turns CI red if upstream renamed something.
- Install-time risk from the torch 2.11 → 2.13 stack move (triton 3.7.1, torchvision 0.28.0, torchcodec 0.15.0) and the new `SGLANG_CACHE_DIR` behavior, which makes the first launch after upgrading recompile kernels once.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>