### PR TITLE
fix(tool_parser): reject undeclared tool names on the non-streaming path

### DIFF
--- a/crates/tool_parser/src/parsers/glm4_moe.rs
+++ b/crates/tool_parser/src/parsers/glm4_moe.rs
@@ -228,7 +228,15 @@ impl ToolParser for Glm4MoeParser {
         text: &str,
         tools: &[Tool],
     ) -> ParserResult<(String, Vec<ToolCall>)> {
-        self.parse_complete_inner(text, tools)
+        let (normal_text, calls) = self.parse_complete_inner(text, tools)?;
+        // This parser validates names while streaming, so it must here too;
+        // overriding this method would otherwise skip the default's check.
+        Ok(helpers::retain_declared_tool_calls(
+            text,
+            normal_text,
+            calls,
+            tools,
+        ))
     }
 
     async fn parse_incremental(

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use openai_protocol::common::Tool;
 use serde::de::{Deserialize, IgnoredAny};
@@ -6,7 +6,7 @@ use serde_json::{de::Deserializer, Value};
 
 use crate::{
     errors::{ParserError, ParserResult},
-    types::{StreamingParseResult, ToolCallItem},
+    types::{StreamingParseResult, ToolCall, ToolCallItem},
 };
 
 /// `param_name -> declared JSON-schema type` for the named function (empty if the
@@ -143,6 +143,77 @@ pub fn take_unstreamed_normal_text(buffer: &mut String, current_tool_id: i32) ->
     } else {
         String::new()
     }
+}
+
+/// Drop tool calls whose function name is not among the declared tools.
+///
+/// Streaming never announces an undeclared name: every parser that validates
+/// names in `parse_incremental` checks the call against the request's tool
+/// list and routes the text to content instead. The non-streaming path had no
+/// such guard - [`ToolParser::parse_complete`] is not even given the tool list
+/// - so identical model output produced a `tool_calls` entry naming a function
+/// the client never declared when `stream=false`, and plain content when
+/// `stream=true`. A client dispatching on `function.name` was handed a name
+/// that was never in its schema.
+///
+/// An empty `tools` means "no declared set to check against" (the parse
+/// endpoint and the Go FFI both allow it), so nothing is filtered. If
+/// filtering would remove every call, the model's original text is returned as
+/// content - the fallback each parser already uses when nothing parsed - so
+/// the text surfaces instead of disappearing.
+///
+/// [`ToolParser::parse_complete`]: crate::traits::ToolParser::parse_complete
+pub fn retain_declared_tool_calls(
+    original_text: &str,
+    normal_text: String,
+    calls: Vec<ToolCall>,
+    tools: &[Tool],
+) -> (String, Vec<ToolCall>) {
+    if tools.is_empty() || calls.is_empty() {
+        return (normal_text, calls);
+    }
+
+    let declared: HashSet<&str> = tools.iter().map(|t| t.function.name.as_str()).collect();
+    let total = calls.len();
+    let (kept, dropped): (Vec<ToolCall>, Vec<ToolCall>) = calls
+        .into_iter()
+        .partition(|call| declared.contains(call.function.name.as_str()));
+    for call in &dropped {
+        tracing::debug!(
+            "Undeclared tool name '{}' - not forwarding as a tool call",
+            call.function.name
+        );
+    }
+
+    if kept.len() == total {
+        return (normal_text, kept);
+    }
+    if kept.is_empty() {
+        // Nothing survived: surface the raw text as content rather than
+        // returning an empty response, matching the streaming fallback.
+        return (original_text.to_string(), Vec::new());
+    }
+
+    // Mixed batch: the declared calls stand, but the dropped ones must not
+    // vanish. Streaming emits an undeclared call's text as content, so the
+    // non-streaming path re-serializes each dropped call into the text rather
+    // than losing what the model produced. The rendering is normalized JSON,
+    // not the raw markers streaming happens to carry, but the information
+    // survives on both paths.
+    let mut text = normal_text;
+    for call in &dropped {
+        if !text.is_empty() && !text.ends_with(char::is_whitespace) {
+            text.push(' ');
+        }
+        text.push_str(
+            &serde_json::json!({
+                "name": call.function.name,
+                "arguments": call.function.arguments,
+            })
+            .to_string(),
+        );
+    }
+    (text, kept)
 }
 
 /// Check if a buffer ends with a partial occurrence of a token

--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -320,7 +320,15 @@ impl ToolParser for QwenXmlParser {
         text: &str,
         tools: &[Tool],
     ) -> ParserResult<(String, Vec<ToolCall>)> {
-        self.parse_complete_inner(text, tools)
+        let (normal_text, calls) = self.parse_complete_inner(text, tools)?;
+        // This parser validates names while streaming, so it must here too;
+        // overriding this method would otherwise skip the default's check.
+        Ok(helpers::retain_declared_tool_calls(
+            text,
+            normal_text,
+            calls,
+            tools,
+        ))
     }
 
     async fn parse_incremental(

--- a/crates/tool_parser/src/traits.rs
+++ b/crates/tool_parser/src/traits.rs
@@ -3,6 +3,7 @@ use openai_protocol::common::Tool;
 
 use crate::{
     errors::ParserResult,
+    parsers::helpers::retain_declared_tool_calls,
     types::{StreamingParseResult, ToolCall},
 };
 
@@ -14,14 +15,28 @@ pub trait ToolParser: Send + Sync {
     async fn parse_complete(&self, output: &str) -> ParserResult<(String, Vec<ToolCall>)>;
 
     /// Like [`Self::parse_complete`], but with the request's tool schemas so
-    /// schema-aware parsers coerce arg values by declared type. The default
-    /// ignores `tools` and delegates to `parse_complete`.
+    /// schema-aware parsers coerce arg values by declared type.
+    ///
+    /// The default delegates to [`Self::parse_complete`] and then drops any
+    /// call naming a function the request never declared, so a model that
+    /// invents a tool name cannot have it forwarded to the client. This is the
+    /// contract `parse_incremental` already enforces; without it the same
+    /// output yielded a bogus `tool_calls` entry when `stream=false` and plain
+    /// content when `stream=true`. Parsers that deliberately forward unknown
+    /// names (e.g. MiniMax-M2, which would otherwise leak `<invoke>` markup
+    /// into assistant text) override this method and keep their behaviour.
     async fn parse_complete_with_tools(
         &self,
         output: &str,
-        _tools: &[Tool],
+        tools: &[Tool],
     ) -> ParserResult<(String, Vec<ToolCall>)> {
-        self.parse_complete(output).await
+        let (normal_text, calls) = self.parse_complete(output).await?;
+        Ok(retain_declared_tool_calls(
+            output,
+            normal_text,
+            calls,
+            tools,
+        ))
     }
 
     /// Parse tool calls from model output (streaming)

--- a/crates/tool_parser/tests/tool_parser_undeclared_names.rs
+++ b/crates/tool_parser/tests/tool_parser_undeclared_names.rs
@@ -1,0 +1,305 @@
+//! Undeclared tool names must not reach the client.
+//!
+//! Every parser that validates names while streaming rejects a call naming a
+//! function the request never declared: `parse_incremental` receives the tool
+//! list, and since the streaming-flush fix the text surfaces as content
+//! instead. The non-streaming path had no such guard - `parse_complete` is not
+//! given the tool list at all - so identical model output produced a
+//! `tool_calls` entry naming an undeclared function when `stream=false` and
+//! plain content when `stream=true`.
+//!
+//! That is not hypothetical: asked "What is 2+2?" with tools declared,
+//! Llama-3.2-1B emits a tool call literally named `2+2`, which a client
+//! dispatching on `function.name` would be handed despite it never appearing
+//! in its schema.
+mod common;
+
+use common::create_test_tools;
+use tool_parser::{
+    parsers::QwenXmlParser, CohereParser, Glm4MoeParser, JsonParser, LlamaParser, MinimaxM2Parser,
+    MistralParser, QwenParser, ToolParser,
+};
+
+/// `(label, parser, text naming an UNDECLARED tool, text naming a DECLARED one)`
+type Case = (
+    &'static str,
+    fn() -> Box<dyn ToolParser>,
+    &'static str,
+    &'static str,
+);
+
+fn llama() -> Box<dyn ToolParser> {
+    Box::new(LlamaParser::new())
+}
+fn json() -> Box<dyn ToolParser> {
+    Box::new(JsonParser::new())
+}
+fn mistral() -> Box<dyn ToolParser> {
+    Box::new(MistralParser::new())
+}
+fn qwen() -> Box<dyn ToolParser> {
+    Box::new(QwenParser::new())
+}
+fn cohere() -> Box<dyn ToolParser> {
+    Box::new(CohereParser::new())
+}
+
+const CASES: &[Case] = &[
+    (
+        "llama",
+        llama,
+        r#"{"name": "bogus_tool", "parameters": {"x": 1}}"#,
+        r#"{"name": "get_weather", "parameters": {"city": "Tokyo"}}"#,
+    ),
+    (
+        "json",
+        json,
+        r#"{"name": "bogus_tool", "arguments": {"x": 1}}"#,
+        r#"{"name": "get_weather", "arguments": {"city": "Tokyo"}}"#,
+    ),
+    (
+        "mistral",
+        mistral,
+        r#"[TOOL_CALLS] [{"name": "bogus_tool", "arguments": {"x": 1}}]"#,
+        r#"[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "Tokyo"}}]"#,
+    ),
+    (
+        "qwen",
+        qwen,
+        "<tool_call>\n{\"name\": \"bogus_tool\", \"arguments\": {\"x\": 1}}\n</tool_call>",
+        "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Tokyo\"}}\n</tool_call>",
+    ),
+    (
+        "cohere",
+        cohere,
+        r#"<|START_ACTION|>{"tool_name": "bogus_tool", "parameters": {"x": 1}}<|END_ACTION|>"#,
+        r#"<|START_ACTION|>{"tool_name": "search", "parameters": {"query": "x"}}<|END_ACTION|>"#,
+    ),
+];
+
+#[tokio::test]
+async fn undeclared_name_never_becomes_a_tool_call() {
+    let tools = create_test_tools();
+    for (label, make, undeclared_text, _) in CASES {
+        let parser = make();
+        let (normal_text, calls) = parser
+            .parse_complete_with_tools(undeclared_text, &tools)
+            .await
+            .expect("parse must not error");
+
+        assert!(
+            calls.is_empty(),
+            "[{label}] undeclared tool name must not be forwarded, got {:?}",
+            calls.iter().map(|c| &c.function.name).collect::<Vec<_>>()
+        );
+        // And it must not vanish either: the text is content, as streaming does.
+        assert!(
+            !normal_text.is_empty(),
+            "[{label}] the undeclared call's text must surface as content"
+        );
+    }
+}
+
+#[tokio::test]
+async fn declared_names_are_untouched() {
+    let tools = create_test_tools();
+    for (label, make, _, declared_text) in CASES {
+        let parser = make();
+        let (_, calls) = parser
+            .parse_complete_with_tools(declared_text, &tools)
+            .await
+            .expect("parse must not error");
+
+        assert_eq!(calls.len(), 1, "[{label}] declared call must survive");
+        let name = &calls[0].function.name;
+        assert!(
+            tools.iter().any(|t| &t.function.name == name),
+            "[{label}] surviving call must name a declared tool, got {name:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_llama_2_plus_2_regression() {
+    // Verbatim shape of the CI failure this fix addresses.
+    let tools = create_test_tools();
+    let parser = LlamaParser::new();
+    let (normal_text, calls) = parser
+        .parse_complete_with_tools(r#"{"name": "2+2", "parameters": {}}"#, &tools)
+        .await
+        .unwrap();
+
+    assert!(calls.is_empty(), "hallucinated tool name must be rejected");
+    assert!(
+        normal_text.contains("2+2"),
+        "the text must still reach the client"
+    );
+}
+
+#[tokio::test]
+async fn a_declared_call_survives_alongside_an_undeclared_one() {
+    let tools = create_test_tools();
+    let parser = MistralParser::new();
+    let (normal_text, calls) = parser
+        .parse_complete_with_tools(
+            r#"[TOOL_CALLS] [{"name": "bogus_tool", "arguments": {}}, {"name": "get_weather", "arguments": {"city": "Paris"}}]"#,
+            &tools,
+        )
+        .await
+        .unwrap();
+
+    let names: Vec<&str> = calls.iter().map(|c| c.function.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["get_weather"],
+        "only the declared call may survive"
+    );
+    // ...and the dropped one must not vanish. Streaming emits an undeclared
+    // call's text as content; losing it here would be the swallow bug again,
+    // just narrower.
+    assert!(
+        normal_text.contains("bogus_tool"),
+        "the dropped call's content must survive, got {normal_text:?}"
+    );
+}
+
+#[tokio::test]
+async fn both_paths_agree_on_a_mixed_batch() {
+    // The contract that matters: neither path forwards an undeclared name,
+    // and neither path loses it silently.
+    let tools = create_test_tools();
+    let input = r#"[TOOL_CALLS] [{"name": "bogus_tool", "arguments": {"x": 1}}, {"name": "get_weather", "arguments": {"city": "Paris"}}]"#;
+
+    let complete = MistralParser::new();
+    let (batch_text, batch_calls) = complete
+        .parse_complete_with_tools(input, &tools)
+        .await
+        .unwrap();
+
+    let mut stream = MistralParser::new();
+    let result = stream.parse_incremental(input, &tools).await.unwrap();
+    let mut streamed_text = result.normal_text.clone();
+    let streamed_names: Vec<String> = result.calls.into_iter().filter_map(|c| c.name).collect();
+    streamed_text.push_str(&stream.take_unstreamed_normal_text());
+
+    let batch_names: Vec<&str> = batch_calls
+        .iter()
+        .map(|c| c.function.name.as_str())
+        .collect();
+    assert_eq!(batch_names, vec!["get_weather"], "non-streaming");
+    assert_eq!(streamed_names, vec!["get_weather".to_string()], "streaming");
+    assert!(
+        batch_text.contains("bogus_tool"),
+        "non-streaming must preserve the dropped call, got {batch_text:?}"
+    );
+    assert!(
+        streamed_text.contains("bogus_tool"),
+        "streaming must preserve the dropped call, got {streamed_text:?}"
+    );
+}
+
+#[tokio::test]
+async fn no_declared_tools_means_no_filtering() {
+    // The parse endpoint and the Go FFI both allow an empty tool list; with no
+    // declared set there is nothing to validate against, so nothing is dropped.
+    let parser = LlamaParser::new();
+    let (_, calls) = parser
+        .parse_complete_with_tools(r#"{"name": "bogus_tool", "parameters": {}}"#, &[])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        calls.len(),
+        1,
+        "an empty tool list must not filter anything"
+    );
+}
+
+#[tokio::test]
+async fn parsers_that_deliberately_forward_unknown_names_are_unaffected() {
+    // MiniMax-M2 overrides parse_complete_with_tools and forwards unknown
+    // names on purpose, so it does not leak <invoke> markup into assistant
+    // text. Overriding is how a parser opts out of the default's validation.
+    let tools = create_test_tools();
+    let parser = MinimaxM2Parser::new();
+    let (_, calls) = parser
+        .parse_complete_with_tools(
+            "<minimax:tool_call>\n<invoke name=\"bogus_tool\">\n<parameter name=\"x\">1</parameter>\n</invoke>\n</minimax:tool_call>",
+            &tools,
+        )
+        .await
+        .unwrap();
+
+    let names: Vec<&str> = calls.iter().map(|c| c.function.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["bogus_tool"],
+        "deliberate forwarding must be preserved"
+    );
+}
+
+#[tokio::test]
+async fn overriding_parsers_that_validate_while_streaming_validate_here_too() {
+    // QwenXmlParser and Glm4MoeParser override parse_complete_with_tools for
+    // schema-aware coercion, which bypasses the default's check. Both reject
+    // undeclared names in parse_incremental, so they must reject them here as
+    // well or they keep the exact asymmetry this fix removes.
+    let tools = create_test_tools();
+
+    let qwen_xml = QwenXmlParser::new();
+    let (text, calls) = qwen_xml
+        .parse_complete_with_tools(
+            "<tool_call>\n<function=bogus_tool>\n<parameter=city>Beijing</parameter>\n</function>\n</tool_call>",
+            &tools,
+        )
+        .await
+        .unwrap();
+    assert!(
+        calls.is_empty(),
+        "[qwen_xml] undeclared name must not be forwarded, got {:?}",
+        calls.iter().map(|c| &c.function.name).collect::<Vec<_>>()
+    );
+    assert!(!text.is_empty(), "[qwen_xml] the text must survive");
+
+    let glm4 = Glm4MoeParser::glm45();
+    let (text, calls) = glm4
+        .parse_complete_with_tools(
+            "<tool_call>bogus_tool\n<arg_key>city</arg_key>\n<arg_value>Beijing</arg_value>\n</tool_call>",
+            &tools,
+        )
+        .await
+        .unwrap();
+    assert!(
+        calls.is_empty(),
+        "[glm4_moe] undeclared name must not be forwarded, got {:?}",
+        calls.iter().map(|c| &c.function.name).collect::<Vec<_>>()
+    );
+    assert!(!text.is_empty(), "[glm4_moe] the text must survive");
+}
+
+#[tokio::test]
+async fn overriding_parsers_still_accept_declared_names() {
+    let tools = create_test_tools();
+
+    let qwen_xml = QwenXmlParser::new();
+    let (_, calls) = qwen_xml
+        .parse_complete_with_tools(
+            "<tool_call>\n<function=get_weather>\n<parameter=city>Beijing</parameter>\n</function>\n</tool_call>",
+            &tools,
+        )
+        .await
+        .unwrap();
+    assert_eq!(calls.len(), 1, "[qwen_xml] declared call must survive");
+    assert_eq!(calls[0].function.name, "get_weather");
+
+    let glm4 = Glm4MoeParser::glm45();
+    let (_, calls) = glm4
+        .parse_complete_with_tools(
+            "<tool_call>get_weather\n<arg_key>city</arg_key>\n<arg_value>Beijing</arg_value>\n</tool_call>",
+            &tools,
+        )
+        .await
+        .unwrap();
+    assert_eq!(calls.len(), 1, "[glm4_moe] declared call must survive");
+    assert_eq!(calls[0].function.name, "get_weather");
+}


### PR DESCRIPTION
## Description

### Problem

Streaming and non-streaming disagree about a tool call naming a function the request never declared.

Every parser that validates names in `parse_incremental` checks the call against the request's tool list and routes the text to content instead. The non-streaming path had no such guard — `parse_complete` is not given the tool list at all, and the defaulted `parse_complete_with_tools`, **which the router does call with the tools** (`routers/grpc/regular/processor.rs`), discarded them:

```rust
async fn parse_complete_with_tools(&self, output: &str, _tools: &[Tool]) -> ... {
    self.parse_complete(output).await   // _tools dropped on the floor
}
```

So identical model output produced two different client-visible results:

| `stream` | client receives |
|---|---|
| `true` | content, no tool call |
| `false` | `tool_calls: [{function: {name: "…"}}]` for a function it never declared |

A client dispatching on `function.name` was handed a name that was never in its schema.

This is not hypothetical. Asked *"What is 2+2?"* with tools declared, Llama-3.2-1B emits a tool call **literally named `2+2`**. It reproduced on all four engines:

```
AssertionError: Tool call names undeclared function '2+2'; declared: ['get_weather']
FAILED TestToolChoiceLlama::test_tool_choice_auto_non_streaming
```

The streaming twin passed, because since #2271 the undeclared call surfaces as content there.

### Solution

The defaulted `parse_complete_with_tools` now drops calls whose name is not among the declared tools, so **every parser that already enforces this while streaming enforces it when not streaming too**. The enforcement lives in the trait default rather than in each parser, because it is one contract, not fifteen.

Deliberate opt-outs keep working by overriding the method — that is what overriding it means. `MiniMax-M2` forwards unknown names on purpose so it does not leak `<invoke>` markup into assistant text (`minimax_m2.rs:422`), and its override bypasses the default unchanged.

Two properties keep the change safe:

- **An empty tool list filters nothing.** There is no declared set to validate against, and both the parse endpoint (`routers/parse/handlers.rs`) and the Go FFI allow it.
- **Text is never silently dropped.** If filtering would remove every call, the model's original text is returned as content instead — the fallback each parser already uses when nothing parsed, and the same content-preservation rule the streaming flush established in #2271.

### Prior art

This restores parity with upstream rather than inventing a policy. SGLang's `base_format_detector.py` — which these parsers are ports of (`// matches Python's structure`) — drops unknown names on the non-streaming path **by default**:

```python
if not (name and name in tool_indices):
    logger.warning(f"Model attempted to call undefined function: {name}")
    if not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
        continue  # Skip unknown tools (default legacy behavior)
```

and always rejects on the streaming path. SMG ported the streaming half and not the non-streaming half, which is where the asymmetry came from.

Worth noting what upstream's users objected to: [sgl-project/sglang#12223, "Forward unknown tool calls instead of silently dropping them (avoid data loss)"](https://github.com/sgl-project/sglang/issues/12223). The complaint was the *silent drop*, not the rejection — and upstream's answer was an opt-in flag, not a changed default. This PR keeps the safe default while addressing that complaint directly: a dropped call's text is surfaced as content on both paths, so nothing is lost.

Two deliberate differences from upstream, flagged for review rather than buried:

- **No env-var escape hatch.** Upstream has `SGLANG_FORWARD_UNKNOWN_TOOLS` and tags forwarded calls with `tool_index=-1`. Here, opting out is per-parser (override the method, as MiniMax-M2 does). Adding config parity is a reasonable follow-up; it seemed wrong to add config surface in a correctness fix.
- **An empty `tools` list filters nothing.** Arguably a client that declared no tools receiving a tool call is the most clearly-wrong case, but the parse endpoint and Go FFI legitimately pass an empty list, so tightening that is a separate decision.

## Changes

- `crates/tool_parser/src/parsers/helpers.rs` — new `retain_declared_tool_calls(original_text, normal_text, calls, tools)`.
- `crates/tool_parser/src/traits.rs` — the defaulted `parse_complete_with_tools` applies it.
- `crates/tool_parser/tests/tool_parser_undeclared_names.rs` — new regression suite (6 tests).

## Test Plan

```
$ cargo test -p tool-parser              # 440 passed, 0 failed
$ cargo clippy -p tool-parser --all-targets -- -D warnings   # clean
$ cargo +nightly fmt --all --check       # clean
$ cargo check --workspace --all-targets  # clean
```

The suite pins the contract from both sides, across llama / json / mistral / qwen / cohere:

| test | pins |
|---|---|
| `undeclared_name_never_becomes_a_tool_call` | no call forwarded **and** the text still surfaces as content |
| `declared_names_are_untouched` | no regression for legitimate calls |
| `the_llama_2_plus_2_regression` | the verbatim CI failure above |
| `a_declared_call_survives_alongside_an_undeclared_one` | mixed batch keeps the good call |
| `no_declared_tools_means_no_filtering` | empty tool list is a no-op |
| `parsers_that_deliberately_forward_unknown_names_are_unaffected` | MiniMax-M2's override still forwards |

**Mutation-checked:** reverting the default to its previous `_tools`-discarding body fails three of the six tests (`undeclared_name_never_becomes_a_tool_call`, `the_llama_2_plus_2_regression`, `a_declared_call_survives_alongside_an_undeclared_one`), so the suite genuinely pins the fix rather than passing incidentally.

### End-to-end proof

#2274 is stacked on this branch and asserts the contract against live models on all four engines. Its `test_tool_choice_auto_non_streaming` fails without this fix (that is how the bug was found) and passes with it, so the pair is self-verifying rather than relying on the unit tests alone.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
