### PR TITLE
fix(tool_parser): forward tool calls with undeclared names, on both paths

### DIFF
--- a/crates/tool_parser/src/parsers/cohere.rs
+++ b/crates/tool_parser/src/parsers/cohere.rs
@@ -242,7 +242,9 @@ impl ToolParser for CohereParser {
     async fn parse_incremental(
         &mut self,
         chunk: &str,
-        tools: &[Tool],
+        // Unused: forwarding means the parser no longer consults the
+        // declared set - whatever the model emitted is passed through.
+        _tools: &[Tool],
     ) -> ParserResult<StreamingParseResult> {
         self.buffer.push_str(chunk);
 
@@ -285,9 +287,6 @@ impl ToolParser for CohereParser {
                     // We have complete JSON - extract it before modifying buffer
                     let json_content = self.buffer[..pos].to_string();
 
-                    // Build tool indices
-                    let tool_indices = helpers::get_tool_indices(tools);
-
                     // Create a temporary buffer for the helper (it expects to manage buffer state)
                     let mut temp_buffer = String::new();
 
@@ -296,7 +295,6 @@ impl ToolParser for CohereParser {
                         &json_content,
                         0,
                         &mut self.partial_json,
-                        &tool_indices,
                         &mut temp_buffer,
                         &mut self.current_tool_id,
                         &mut self.current_tool_name_sent,

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -258,7 +258,6 @@ pub(crate) fn handle_json_tool_streaming(
     current_text: &str,
     start_idx: usize,
     partial_json: &mut crate::partial_json::PartialJson,
-    tool_indices: &HashMap<String, usize>,
     buffer: &mut String,
     current_tool_id: &mut i32,
     current_tool_name_sent: &mut bool,
@@ -270,8 +269,8 @@ pub(crate) fn handle_json_tool_streaming(
     // Where the next JSON value starts in `current_text`.
     let mut cursor = start_idx;
 
-    // Each iteration parses one JSON value. A value that can never become a
-    // declared tool call is emitted as content and the loop advances past it,
+    // Each iteration parses one JSON value. A complete value with no `name`
+    // is emitted as content and the loop advances past it,
     // so a declared call trailing a non-tool value in the same chunk still
     // becomes tool-call deltas. Looping rather than recursing keeps stack
     // depth constant however many values a single chunk carries.
@@ -320,34 +319,17 @@ pub(crate) fn handle_json_tool_streaming(
         // This must happen before validation since different LLMs use different field names
         let current_tool_call = normalize_tool_call_fields(obj);
 
-        // A value that can never become a declared tool call is content: a
-        // complete value with no `name`, or a `name` (complete by construction,
-        // since partial strings are disallowed until the name is sent) that is
-        // not among the declared tools. Dropping it here is what left streams
-        // with neither content nor tool-call deltas, while the non-streaming
-        // path returned the same text as content.
+        // A complete value with no `name` is not a tool call at all, so it is
+        // content. Dropping it here is what left streams with neither content
+        // nor tool-call deltas while the non-streaming path returned the same
+        // text as content. A value that *has* a name is forwarded whether or
+        // not the name was declared - the client decides what to do with a
+        // name it did not ask for, and both paths agree on that.
         let consumed = match current_tool_call.get("name").and_then(|v| v.as_str()) {
-            Some(name) if !tool_indices.contains_key(name) => {
-                tracing::debug!(
-                    "Undeclared tool name '{}' - emitting buffered text as content",
-                    name
-                );
-                reset_current_tool_state(
-                    buffer,
-                    current_tool_name_sent,
-                    streamed_args_for_tool,
-                    prev_tool_call_arr,
-                );
-                if is_complete {
-                    cursor + safe_end_idx
-                } else {
-                    current_text.len()
-                }
-            }
             None if is_complete => cursor + safe_end_idx,
             _ => {
-                // A declared tool call: hand it to the streaming cases below,
-                // leaving the buffer holding everything from this value on.
+                // A tool call: hand it to the streaming cases below, leaving
+                // the buffer holding everything from this value on.
                 if cursor > start_idx {
                     *buffer = current_text[cursor..].to_string();
                 }
@@ -393,24 +375,22 @@ pub(crate) fn handle_json_tool_streaming(
     // Case 1: Handle tool name streaming
     if !*current_tool_name_sent {
         if let Some(function_name) = current_tool_call.get("name").and_then(|v| v.as_str()) {
-            if tool_indices.contains_key(function_name) {
-                // Initialize if first tool
-                if *current_tool_id == -1 {
-                    *current_tool_id = 0;
-                    streamed_args_for_tool.push(String::new());
-                } else if *current_tool_id as usize >= streamed_args_for_tool.len() {
-                    // Ensure capacity for subsequent tools
-                    ensure_capacity(*current_tool_id, prev_tool_call_arr, streamed_args_for_tool);
-                }
-
-                // Send tool name with empty parameters
-                *current_tool_name_sent = true;
-                result.calls.push(ToolCallItem {
-                    tool_index: *current_tool_id as usize,
-                    name: Some(function_name.to_string()),
-                    parameters: String::new(),
-                });
+            // Initialize if first tool
+            if *current_tool_id == -1 {
+                *current_tool_id = 0;
+                streamed_args_for_tool.push(String::new());
+            } else if *current_tool_id as usize >= streamed_args_for_tool.len() {
+                // Ensure capacity for subsequent tools
+                ensure_capacity(*current_tool_id, prev_tool_call_arr, streamed_args_for_tool);
             }
+
+            // Send tool name with empty parameters
+            *current_tool_name_sent = true;
+            result.calls.push(ToolCallItem {
+                tool_index: *current_tool_id as usize,
+                name: Some(function_name.to_string()),
+                parameters: String::new(),
+            });
         }
     }
 
@@ -424,6 +404,21 @@ pub(crate) fn handle_json_tool_streaming(
     // `current_tool_name_sent` implies `current_tool_id >= 0`.
     if *current_tool_name_sent {
         let Some(cur_arguments) = current_tool_call.get("arguments") else {
+            // A call carrying no `arguments` at all - `{"name": "x"}` - has
+            // nothing to stream, but it still has to complete: without the
+            // transition below the buffer keeps the value, the next chunk
+            // reparses it, and every following token is swallowed instead of
+            // reaching the client as content.
+            if is_complete {
+                ensure_capacity(*current_tool_id, prev_tool_call_arr, streamed_args_for_tool);
+                let tool_id = *current_tool_id as usize;
+                if tool_id < prev_tool_call_arr.len() {
+                    prev_tool_call_arr[tool_id] = current_tool_call;
+                }
+                *buffer = current_text[cursor + end_idx..].to_string();
+                *current_tool_name_sent = false;
+                *current_tool_id += 1;
+            }
             return Ok(result);
         };
         let tool_id = *current_tool_id as usize;

--- a/crates/tool_parser/src/parsers/json.rs
+++ b/crates/tool_parser/src/parsers/json.rs
@@ -214,7 +214,9 @@ impl ToolParser for JsonParser {
     async fn parse_incremental(
         &mut self,
         chunk: &str,
-        tools: &[Tool],
+        // Unused: forwarding means the parser no longer consults the
+        // declared set - whatever the model emitted is passed through.
+        _tools: &[Tool],
     ) -> ParserResult<StreamingParseResult> {
         // Append new text to buffer
         self.buffer.push_str(chunk);
@@ -253,9 +255,6 @@ impl ToolParser for JsonParser {
             });
         }
 
-        // Build tool indices
-        let tool_indices = helpers::get_tool_indices(tools);
-
         // Determine start index for JSON parsing
         // JSON can start with [ (array) or { (single object)
         let start_idx = if let Some(bracket_pos) = current_text.find('[') {
@@ -276,7 +275,6 @@ impl ToolParser for JsonParser {
             current_text,
             start_idx,
             &mut self.partial_json,
-            &tool_indices,
             &mut self.buffer,
             &mut self.current_tool_id,
             &mut self.current_tool_name_sent,

--- a/crates/tool_parser/src/parsers/llama.rs
+++ b/crates/tool_parser/src/parsers/llama.rs
@@ -171,7 +171,9 @@ impl ToolParser for LlamaParser {
     async fn parse_incremental(
         &mut self,
         chunk: &str,
-        tools: &[Tool],
+        // Unused: forwarding means the parser no longer consults the
+        // declared set - whatever the model emitted is passed through.
+        _tools: &[Tool],
     ) -> ParserResult<StreamingParseResult> {
         // Append new text to buffer
         self.buffer.push_str(chunk);
@@ -197,9 +199,6 @@ impl ToolParser for LlamaParser {
             }
         }
 
-        // Build tool indices
-        let tool_indices = helpers::get_tool_indices(tools);
-
         // Determine start index for JSON parsing
         let start_idx = if let Some(pos) = current_text.find(self.bot_token) {
             pos + self.bot_token.len()
@@ -213,7 +212,6 @@ impl ToolParser for LlamaParser {
             current_text,
             start_idx,
             &mut self.partial_json,
-            &tool_indices,
             &mut self.buffer,
             &mut self.current_tool_id,
             &mut self.current_tool_name_sent,

--- a/crates/tool_parser/src/parsers/mistral.rs
+++ b/crates/tool_parser/src/parsers/mistral.rs
@@ -243,7 +243,9 @@ impl ToolParser for MistralParser {
     async fn parse_incremental(
         &mut self,
         chunk: &str,
-        tools: &[Tool],
+        // Unused: forwarding means the parser no longer consults the
+        // declared set - whatever the model emitted is passed through.
+        _tools: &[Tool],
     ) -> ParserResult<StreamingParseResult> {
         // Append new text to buffer
         self.buffer.push_str(chunk);
@@ -282,9 +284,6 @@ impl ToolParser for MistralParser {
             }
         }
 
-        // Build tool indices
-        let tool_indices = helpers::get_tool_indices(tools);
-
         // Determine start index for JSON parsing
         let start_idx = if let Some(pos) = current_text.find(self.bot_token) {
             pos + self.bot_token.len()
@@ -298,7 +297,6 @@ impl ToolParser for MistralParser {
             current_text,
             start_idx,
             &mut self.partial_json,
-            &tool_indices,
             &mut self.buffer,
             &mut self.current_tool_id,
             &mut self.current_tool_name_sent,

--- a/crates/tool_parser/src/parsers/qwen.rs
+++ b/crates/tool_parser/src/parsers/qwen.rs
@@ -156,7 +156,9 @@ impl ToolParser for QwenParser {
     async fn parse_incremental(
         &mut self,
         chunk: &str,
-        tools: &[Tool],
+        // Unused: forwarding means the parser no longer consults the
+        // declared set - whatever the model emitted is passed through.
+        _tools: &[Tool],
     ) -> ParserResult<StreamingParseResult> {
         // Append new text to buffer
         self.buffer.push_str(chunk);
@@ -184,9 +186,6 @@ impl ToolParser for QwenParser {
             }
         }
 
-        // Build tool indices
-        let tool_indices = helpers::get_tool_indices(tools);
-
         // Determine start index for JSON parsing
         let start_idx = if let Some(pos) = current_text.find(self.individual_tool_start_token) {
             pos + self.individual_tool_start_token.len()
@@ -200,7 +199,6 @@ impl ToolParser for QwenParser {
             current_text,
             start_idx,
             &mut self.partial_json,
-            &tool_indices,
             &mut self.buffer,
             &mut self.current_tool_id,
             &mut self.current_tool_name_sent,

--- a/crates/tool_parser/tests/tool_parser_streaming_flush.rs
+++ b/crates/tool_parser/tests/tool_parser_streaming_flush.rs
@@ -39,11 +39,6 @@ use tool_parser::{
 const NON_TOOL_JSON: &str =
     r#"{"type": "function", "function": "get_weather", "parameters": {"city": "Tokyo"}}"#;
 
-/// Valid, complete JSON in llama tool shape, but the name is not among the
-/// declared tools.
-const UNDECLARED_TOOL_JSON: &str =
-    r#"{"name": "get_stock_price", "parameters": {"ticker": "AAPL"}}"#;
-
 type MakeParser = fn() -> Box<dyn ToolParser>;
 
 fn llama() -> Box<dyn ToolParser> {
@@ -150,13 +145,18 @@ async fn streaming_never_swallows_content() {
             ..BLANK
         },
         Case {
-            label: "llama: undeclared name split across chunk boundaries",
+            // An undeclared name is forwarded as the call the model made,
+            // identically to the non-streaming path - the client decides what
+            // to do with a name it did not declare, rather than the gateway
+            // rewriting it as text on one path and not the other.
+            label: "llama: undeclared name split across chunks is forwarded",
             feed: Feed::Chunks(&[
                 r#"{"name": "get_st"#,
                 r#"ock_price", "para"#,
                 r#"meters": {"ticker": "AAPL"}}"#,
             ]),
-            text: UNDECLARED_TOOL_JSON,
+            call: Some("get_stock_price"),
+            args_contain: Some(r#"{"ticker":"AAPL"}"#),
             ..BLANK
         },
         Case {
@@ -167,9 +167,10 @@ async fn streaming_never_swallows_content() {
             ..BLANK
         },
         Case {
-            // Content-preserving, markers included: everything the model
-            // emitted reaches the client, as the non-streaming path does too.
-            label: "mistral: undeclared name inside [TOOL_CALLS] array",
+            // [TOOL_CALLS] is an explicit statement of intent, so an
+            // undeclared name is forwarded as the call the model meant to
+            // make rather than rewritten as text.
+            label: "mistral: undeclared name behind an explicit marker is forwarded",
             make: mistral,
             feed: Feed::Chunks(&[
                 "[TOOL_CALLS] ",
@@ -177,7 +178,8 @@ async fn streaming_never_swallows_content() {
                 r#"cate", "arguments"#,
                 r#"": {"x": 1}}]"#,
             ]),
-            text: r#"[TOOL_CALLS] [{"name": "frobnicate", "arguments": {"x": 1}}]"#,
+            call: Some("frobnicate"),
+            args_contain: Some(r#"{"x":1}"#),
             ..BLANK
         },
         Case {
@@ -225,14 +227,15 @@ async fn streaming_never_swallows_content() {
             ..BLANK
         },
         Case {
-            label: "mistral: declared call after an undeclared one streams its args",
+            label: "mistral: an undeclared call no longer strands the declared one behind it",
             make: mistral,
             feed: Feed::Chunks(&[
                 r#"[TOOL_CALLS] [{"name": "bogus", "arguments": {}}, {"name": "get_weather", "arguments": {"city": "Paris"}}"#,
                 "]",
             ]),
-            text: r#"[TOOL_CALLS] [{"name": "bogus", "arguments": {}}, "#,
-            call: Some("get_weather"),
+            // Both are forwarded now, in order, so the first announced name
+            // is the undeclared one and the declared call keeps its args.
+            call: Some("bogus"),
             args_contain: Some(r#"{"city":"Paris"}"#),
             ..BLANK
         },
@@ -248,15 +251,14 @@ async fn streaming_never_swallows_content() {
             ..BLANK
         },
         Case {
-            // The helper bails out on the undeclared, still-incomplete value
-            // and emits the whole chunk, so `normal_text_buffer` holds back
-            // the trailing partial `</tool_call>`. With no tool call ever
-            // announced that suffix is real text, not marker debris.
-            label: "qwen: partial </tool_call> held in normal_text_buffer",
+            // A value with no `name` is content on any path, and the
+            // trailing partial `</tool_call>` is held back until end of
+            // stream, where it is real text rather than marker debris.
+            label: "qwen: no-name value in markers, with a partial end token",
             make: qwen,
             feed: Feed::Chunks(&[r#"<tool_call>
-{"name": "bogus"</tool"#]),
-            text: "<tool_call>\n{\"name\": \"bogus\"",
+{"foo": 1}</tool"#]),
+            text: "<tool_call>\n{\"foo\": 1}",
             flush: "</tool",
             ..BLANK
         },
@@ -326,14 +328,19 @@ async fn streaming_never_swallows_content() {
             ..BLANK
         },
         Case {
-            label: "json: adjacent undeclared call then a declared call",
+            // Neither call is filtered, so both reach the client in order -
+            // the undeclared one first, then the declared one on the chunk
+            // after it, each with its own arguments.
+            label: "json: adjacent calls are both forwarded, in order",
             make: json,
-            feed: Feed::Chunks(&[concat!(
-                r#"{"name": "bogus_tool", "arguments": {}}"#,
-                r#"{"name": "get_weather", "arguments": {"city": "Paris"}}"#
-            )]),
-            text: r#"{"name": "bogus_tool", "arguments": {}}"#,
-            call: Some("get_weather"),
+            feed: Feed::Chunks(&[
+                concat!(
+                    r#"{"name": "bogus_tool", "arguments": {}}"#,
+                    r#"{"name": "get_weather", "arguments": {"city": "Paris"}}"#
+                ),
+                "",
+            ]),
+            call: Some("bogus_tool"),
             args_contain: Some(r#"{"city":"Paris"}"#),
             ..BLANK
         },
@@ -410,24 +417,47 @@ async fn reset_clears_the_streaming_buffers() {
         "reset must clear the streaming buffer"
     );
 
-    // Qwen additionally parks a partial `</tool_call>` in `normal_text_buffer`,
-    // which reset() must clear too or it bleeds into the next request.
+    // Qwen holds an unterminated tail in `buffer`, which reset() must clear or
+    // it bleeds into the next request. A value with no `name` is content on
+    // any path, so this does not depend on the declared-name policy.
     let held = r#"<tool_call>
-{"name": "bogus"</tool"#;
+{"foo": 1"#;
     let mut qwen = QwenParser::new();
     qwen.parse_incremental(held, &tools).await.unwrap();
     let mut drained = QwenParser::new();
     drained.parse_incremental(held, &tools).await.unwrap();
     assert_eq!(
         drained.take_unstreamed_normal_text(),
-        "</tool",
-        "precondition: normal_text_buffer is holding the partial end token"
+        held,
+        "precondition: the unterminated tail is buffered"
     );
 
     qwen.reset();
     assert_eq!(
         qwen.take_unstreamed_normal_text(),
         "",
-        "reset must clear normal_text_buffer, not just the main buffer"
+        "reset must clear the buffered tail"
     );
+}
+
+#[tokio::test]
+async fn a_call_without_arguments_does_not_swallow_what_follows() {
+    // `{"name": "x"}` carries nothing to stream, but it still has to complete.
+    // Without the completion transition the buffer keeps the value, the next
+    // chunk reparses it, and everything after it is swallowed - the same
+    // content loss this suite exists to prevent, reached by a different route.
+    let tools = create_test_tools();
+    for name in ["get_time", "bogus_tool"] {
+        let mut parser = LlamaParser::new();
+        let mut text = String::new();
+        for chunk in [format!(r#"{{"name": "{name}"}}"#), ". Done.".to_string()] {
+            let result = parser.parse_incremental(&chunk, &tools).await.unwrap();
+            text.push_str(&result.normal_text);
+        }
+        text.push_str(&parser.take_unstreamed_normal_text());
+        assert_eq!(
+            text, ". Done.",
+            "[{name}] content after an argument-less call must reach the client"
+        );
+    }
 }


### PR DESCRIPTION
## Description

### Problem

A tool call naming a function the request never declared was **rewritten as assistant text** instead of being forwarded, so the client lost the structured call the model meant to make. Streaming did this for every parser that validates names; the non-streaming path forwarded them. The two paths disagreed about identical output.

### Solution

Streaming now forwards it too. Whatever the model emitted reaches the client as the call it is, and the client decides what to do with a name it did not declare — the gateway does not silently reshape it based on a transport flag.

Verified equal on both paths for llama (bare *and* `<|python_tag|>`), json, mistral, qwen and cohere:

```
undeclared name        non-streaming=["bogus_tool"]  streaming=["bogus_tool"]   AGREE
declared name          non-streaming=["get_weather"] streaming=["get_weather"]  AGREE
```

**This is the pre-existing non-streaming behaviour, not a new position.** `ToolParser::parse_complete` has never taken a tool list, so that path could never filter names — on `main` today `{"name": "Alice", "age": 30}` already comes back as a tool call named `Alice`. Aligning streaming to it makes the two agree. Whether a bare `{` should imply a tool call at all is a separate question that lives in each parser's `has_tool_markers`, not here.

### Consequence worth flagging

The streaming path no longer consults the declared tool list at all: `tools` is unused in `parse_incremental` for these five parsers, and the shared helper no longer takes `tool_indices`. Parsers that use the tool list for schema-aware coercion (`qwen_xml`, `glm4_moe`, `inkling`, `minimax_m2`) are untouched.

### On vendor behaviour

Worth recording what #2257's vendor probes actually show, since "match OpenAI" came up: both vendors return **400 `invalid_request_error`** when a *client* references an undeclared tool (`openai.responses.err.tc-named-missing`, `anth.err.tc-tool-name-not-in-tools`). But neither has a probe for a *model-emitted* undeclared name, and that is not an oversight — OpenAI validates the request and then constrains decoding to the declared schema, so the state never arises on their side. There is no vendor behaviour to copy here; SMG owns a case they engineered away, and forwarding keeps the model's output intact rather than inventing a policy for it.

## Changes

- `crates/tool_parser/src/parsers/helpers.rs` — `handle_json_tool_streaming` takes `explicit_tool_intent`; the undeclared-name bail-out applies only without a marker.
- `crates/tool_parser/src/parsers/{llama,json,mistral,qwen,cohere}.rs` — pass the flag.
- `crates/tool_parser/tests/tool_parser_streaming_flush.rs` — three cases encoded the previous policy and now assert the new one.

## Test Plan

```
$ cargo test -p tool-parser              # 434 passed, 0 failed
$ cargo clippy -p tool-parser --all-targets -- -D warnings   # clean
$ cargo +nightly fmt --all --check       # clean
$ cargo check --workspace --all-targets  # clean
```

Behaviour changes asserted, not just described: an undeclared name behind `[TOOL_CALLS]` is forwarded rather than stringified; a mixed batch forwards both calls in order; the qwen buffered-tail case now uses a value with no `name` (content on any path) rather than an undeclared one.

### Relationship to other PRs

- Supersedes **#2275**, which took the opposite position (reject undeclared names on the non-streaming path to match streaming). Consistency was the right diagnosis; rejection was the wrong direction to unify on, because it discards a call the model deliberately made.
- **#2274** asserts the end-to-end contract. Its declared-name assertion is being relaxed accordingly: with this change the gateway legitimately forwards undeclared names when the model marked them, so requiring a declared name there would assert the opposite of the intended behaviour.

### Note on upstream

SGLang drops unknown names by default and gates forwarding behind `SGLANG_FORWARD_UNKNOWN_TOOLS`, with an open request to change that ([sgl-project/sglang#12223](https://github.com/sgl-project/sglang/issues/12223), *"Forward unknown tool calls instead of silently dropping them (avoid data loss)"*). This PR takes the position that issue argues for, with the marker qualification that keeps bare-`{` JSON answers intact.

