### PR TITLE
fix(bfcl): grade dotted function names the way the tools were sent

### DIFF
--- a/scripts/bfcl/register_bfcl_model.py
+++ b/scripts/bfcl/register_bfcl_model.py
@@ -39,6 +39,26 @@ def find_model_config() -> Path:
     return Path(spec.origin)
 
 
+# Handlers whose tool payload rewrites "." to "_" in function names, per
+# bfcl_eval.model_handler.utils.convert_to_tool. For these the checker must
+# apply the same rewrite to the expected name, which is what `underscore_to_dot`
+# switches on — its own docstring says it "only matters for checker". Setting it
+# False alongside one of these handlers is internally inconsistent: the model is
+# asked for `math_factorial` and then graded against `math.factorial`, so every
+# dotted-name case is scored wrong no matter what the model or the frontend did.
+DOT_SANITIZING_HANDLERS = {
+    "OpenAICompletionsHandler",
+    "OpenAIResponsesHandler",
+    "MistralHandler",
+    "GoogleHandler",
+    "OSSHandler",
+    "AnthropicHandler",
+    "CohereHandler",
+    "AmazonHandler",
+    "NovitaHandler",
+}
+
+
 def build_entry(model_id: str, handler: str) -> str:
     return (
         f'    "{model_id}-FC": ModelConfig(\n'
@@ -51,7 +71,7 @@ def build_entry(model_id: str, handler: str) -> str:
         f"        input_price=None,\n"
         f"        output_price=None,\n"
         f"        is_fc_model=True,\n"
-        f"        underscore_to_dot=False,\n"
+        f"        underscore_to_dot={handler in DOT_SANITIZING_HANDLERS},\n"
         f"    ),\n"
     )
 

--- a/scripts/tests/test_register_bfcl_model.py
+++ b/scripts/tests/test_register_bfcl_model.py
@@ -1,0 +1,68 @@
+"""Tests for scripts/bfcl/register_bfcl_model.py.
+
+The entry this script writes decides how BFCL grades a model. One field in it,
+``underscore_to_dot``, is easy to get wrong and fails silently: nothing errors,
+the run completes, and the score is simply too low.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "bfcl" / "register_bfcl_model.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("register_bfcl_model", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["register_bfcl_model"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _field(entry: str, name: str) -> str:
+    for line in entry.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(f"{name}="):
+            return stripped.rstrip(",").split("=", 1)[1]
+    raise AssertionError(f"{name} missing from entry:\n{entry}")
+
+
+@pytest.mark.parametrize(
+    "handler",
+    ["OpenAICompletionsHandler", "OpenAIResponsesHandler", "AnthropicHandler"],
+)
+def test_dot_sanitizing_handlers_enable_underscore_to_dot(handler: str) -> None:
+    """A handler that rewrites dots must grade against rewritten names.
+
+    ``convert_to_tool`` replaces "." with "_" in function names for these
+    styles, so the model is only ever offered ``math_factorial``. The checker
+    applies the same rewrite to the expected name only when this flag is set;
+    without it every dotted-name case is marked wrong_func_name regardless of
+    what the model or the frontend did.
+    """
+    entry = _load().build_entry("org/Some-Model", handler)
+    assert _field(entry, "underscore_to_dot") == "True"
+
+
+def test_non_sanitizing_handler_leaves_names_alone() -> None:
+    """A handler that passes dotted names through must not rewrite expectations."""
+    entry = _load().build_entry("org/Some-Model", "SomeLocalFCHandler")
+    assert _field(entry, "underscore_to_dot") == "False"
+
+
+def test_entry_shape_is_registerable() -> None:
+    """The generated entry must be a syntactically valid mapping member."""
+    module = _load()
+    entry = module.build_entry("meta-models/Muse-Glimmer-30B", "OpenAICompletionsHandler")
+
+    assert entry.lstrip().startswith('"meta-models/Muse-Glimmer-30B-FC": ModelConfig(')
+    assert _field(entry, "model_name") == '"meta-models/Muse-Glimmer-30B"'
+    assert _field(entry, "is_fc_model") == "True"
+    # Parses as Python once the ModelConfig call is stubbed out.
+    compile(f"ModelConfig = dict\nx = {{\n{entry}}}\n", "<entry>", "exec")


### PR DESCRIPTION
## Description

### Problem

Every model registered by `scripts/bfcl/register_bfcl_model.py` has been scored against function names it was never offered.

`bfcl_eval.model_handler.utils.convert_to_tool` rewrites `.` to `_` in function names for OpenAI-style handlers:

```python
# OAI does not support "." in the function name so we replace it with "_".
item["name"] = re.sub(r"\.", "_", item["name"])
```

So the model is offered `math_factorial` and correctly answers `math_factorial`. The checker applies the same rewrite to the *expected* name only when the model config sets `underscore_to_dot`:

```python
if MODEL_CONFIG_MAPPING[model_name_escaped].underscore_to_dot:
    return re.sub(r"\.", "_", function_name)
```

Our script hardcoded `underscore_to_dot=False` while registering `OpenAICompletionsHandler` — one of the handlers that does the rewrite. The config is internally inconsistent, so every dotted-name case is marked `wrong_func_name` regardless of what the model or the frontend produced. Upstream's own docstring notes the flag "only matters for checker".

Nothing errors and the run completes, so this shows up as a mediocre score rather than a broken harness — which is why it has gone unnoticed.

**Measured impact.** On a Muse-Glimmer `simple_python` run this was **167 of 191 failures**, holding the score at 52.25%. Samples:

| returned | graded against |
| :-- | :-- |
| `math_factorial` | `math.factorial` |
| `algebra_quadratic_roots` | `algebra.quadratic_roots` |
| `geometry_area_circle` | `geometry.area_circle` |

The frontend returned exactly the name it was given in every one of those.

This affects **all** script-registered legs — any model `bfcl-eval` does not ship a handler for, which is the reason the script exists. Their historical `simple_python` / `multiple` / `parallel` numbers are understated by roughly the share of dotted-name cases in each category.

### Solution

Derive the flag from the handler rather than hardcoding it, against the same handler list `convert_to_tool` keys on. A handler that rewrites dots gets `underscore_to_dot=True`; one that passes names through keeps `False`.

## Changes

- `scripts/bfcl/register_bfcl_model.py` — add `DOT_SANITIZING_HANDLERS` and set `underscore_to_dot` from the handler, with a comment recording why the two must agree.
- `scripts/tests/test_register_bfcl_model.py` (new) — the script had no tests. Covers both branches and asserts the generated entry is a syntactically valid mapping member, since a malformed entry is another silent-failure mode.

## Test Plan

- `pytest scripts/tests/test_register_bfcl_model.py` — 4 tests. (pytest is unavailable in my local environment, so I executed the same assertions directly; CI runs them properly under `python-unit-tests`.)
- Traced the behaviour end to end against the installed `bfcl_eval` sources — `convert_to_tool` for the rewrite, `convert_func_name` for the checker side — rather than inferring it from the score.
- Re-running the Muse-Glimmer leg on top of this is the confirmation: `simple_python` should move up by roughly the dotted-name share if the diagnosis is right, and I will report the before/after rather than assume it.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>