### PR TITLE
chore(ci): temporarily switch Docker build runner label to cpu-e5-test

### DIFF
--- a/.github/workflows/_build-engine-image.yml
+++ b/.github/workflows/_build-engine-image.yml
@@ -62,7 +62,7 @@ on:
 jobs:
   build-and-push:
     if: github.repository == 'smg-project/smg'
-    runs-on: ["cpu-e5"]
+    runs-on: ["cpu-e5-test"]
     steps:
       - name: Print inputs to summary
         env:

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -11,9 +11,9 @@ on:
         type: boolean
         default: false
       runner:
-        description: 'Runner label to build on (default self-hosted cpu-e5; any self-hosted label or a GitHub-hosted size works, x86_64 assumed)'
+        description: 'Runner label to build on (default self-hosted cpu-e5-test; any self-hosted label or a GitHub-hosted size works, x86_64 assumed)'
         type: string
-        default: 'cpu-e5'
+        default: 'cpu-e5-test'
 
 concurrency:
   # Express builds run in their own lane so a fast one-off never cancels
@@ -33,7 +33,7 @@ jobs:
   build-and-push:
     name: Build nightly Docker image
     if: github.repository == 'smg-project/smg'
-    runs-on: ${{ inputs.runner || 'cpu-e5' }}
+    runs-on: ${{ inputs.runner || 'cpu-e5-test' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -24,7 +24,7 @@ jobs:
   build-and-push:
     name: Build and push Docker image
     if: github.repository == 'smg-project/smg'
-    runs-on: ["cpu-e5"]
+    runs-on: ["cpu-e5-test"]
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Description

### Problem

We need to validate the new `cpu-e5-test` self-hosted runner pool before pointing production Docker build workflows at it permanently.

### Solution

**Temporary change for testing** — switch the runner label from `cpu-e5` to `cpu-e5-test` in the Docker build workflows so the next runs land on the test runner pool. This will be reverted (or made permanent) once testing is done.

## Changes

- `.github/workflows/_build-engine-image.yml`: `runs-on` label `cpu-e5` → `cpu-e5-test`
- `.github/workflows/release-docker.yml`: `runs-on` label `cpu-e5` → `cpu-e5-test`
- `.github/workflows/nightly-docker.yml`: default `runner` input, its description, and the `runs-on` fallback `cpu-e5` → `cpu-e5-test`

## Test Plan

- `pre-commit run --all-files` passes locally (includes `check-yaml` on the edited workflow files and a clean `rustfmt` run; the clippy hook could not run on this machine because `pkg-config` is unavailable — no Rust code is touched by this PR, so CI clippy is the authoritative check).
- `grep -rn cpu-e5` confirms no bare `cpu-e5` reference remains; all 5 occurrences across the 3 workflows now read `cpu-e5-test`.
- Once the PR is open, trigger a `workflow_dispatch` of the nightly Docker build (express mode) and confirm the job is picked up by a `cpu-e5-test` runner.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
