### PR TITLE
fix(ci): build the nightly Docker image on a runner that exists

### DIFF
--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -11,9 +11,9 @@ on:
         type: boolean
         default: false
       runner:
-        description: 'Runner label to build on (default self-hosted cpu-e5; any self-hosted label or a GitHub-hosted size works, x86_64 assumed)'
+        description: 'Runner label to build on (default self-hosted b200; any self-hosted label or a GitHub-hosted size works, x86_64 assumed)'
         type: string
-        default: 'cpu-e5'
+        default: 'b200'
 
 concurrency:
   # Express builds run in their own lane so a fast one-off never cancels
@@ -33,13 +33,29 @@ jobs:
   build-and-push:
     name: Build nightly Docker image
     if: github.repository == 'smg-project/smg'
-    runs-on: ${{ inputs.runner || 'cpu-e5' }}
+    # `inputs` is empty on a schedule event, so this falls back to the literal
+    # below — which is what the nightly actually builds on. It read 'cpu-e5'
+    # until that label stopped existing: the host behind it was re-provisioned
+    # and re-registered as 'cpu-e5-test', leaving nothing claiming 'cpu-e5'.
+    # Scheduled runs then sat queued until GitHub reaped them at its 24h
+    # self-hosted limit, which reports as `cancelled` rather than as a failure —
+    # so the nightly image silently stopped being published without ever going
+    # red. Manual runs kept working only because whoever ran them typed a live
+    # label into the input.
+    runs-on: ${{ inputs.runner || 'b200' }}
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v7
 
+      # The one step b200 has not yet exercised. Both manual builds that ran
+      # there were express, so QEMU was skipped and only the amd64 half was
+      # proven; binfmt registration for the arm64 half is unverified on that
+      # host. Left as the full build anyway, because the failure modes are not
+      # comparable: if binfmt is missing this dies here in under a minute with a
+      # clear error, whereas the status quo hangs for 24h and reports
+      # `cancelled`. A loud, fast failure is strictly better than a silent one.
       - name: Set up QEMU
         if: env.EXPRESS != 'true'
         uses: docker/setup-qemu-action@v4


### PR DESCRIPTION
## Description

### Problem

The nightly Docker image stopped being published on **2026-08-20**, and nothing surfaced it.

`runs-on` is `${{ inputs.runner || 'cpu-e5' }}`. On a `schedule` event the `inputs` context is empty, so it falls through to the literal `cpu-e5` — and **nothing claims that label any more**. The host behind it was re-provisioned and re-registered as `cpu-e5-test`; zero runners advertise `cpu-e5` today.

Scheduled runs therefore never reached a machine at all:

| run | event | labels | runner_name | steps | outcome |
| --- | --- | --- | --- | --- | --- |
| 32622971133 | schedule | `["cpu-e5"]` | *(empty)* | 0 | cancelled |
| 32556951335 | schedule | `["cpu-e5"]` | *(empty)* | 0 | cancelled |
| 32454815729 | schedule | `["cpu-e5"]` | *(empty)* | 0 | cancelled |
| 32444001281 | dispatch | `["b200"]` | `moirai-b200` | all | **success** |

They sat queued until GitHub reaped them at its 24-hour self-hosted queue limit — measurable to the second (`06:25:57Z → 06:25:58Z` the next day, 24h00m01s).

**The reporting is what made this invisible.** A reaped queue entry reports `cancelled`, not `failure`. A cancelled workflow reads as throttled or superseded rather than broken, so three consecutive nights of missing images produced no red signal and no alert.

Manual dispatches kept working only because the operator typed a live label into the `runner` input — those runs went to b200, never to cpu-e5. That escape hatch was added in #2241 on 2026-08-20, the same day the label died.

### Solution

Point the default at `b200`, which is online, idle, and **has already built and pushed this exact image twice** (runs 32411899449 and 32444001281).

**Why not retarget to `cpu-e5-test`,** which is the same physical box and is online: it has no Docker daemon running. PR #2281 tried exactly this and its CI proves the outcome — the job reached the host in 16 seconds and then died at `Set up Docker Buildx` with `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`. That swaps a 24-hour hang for an immediate failure without producing an image. (That PR is a teammate's, marked **[DO NOT MERGE]**, and this change does not conflict with it.)

## Changes

- `.github/workflows/nightly-docker.yml`: `runner` input default and the `runs-on` fallback both move `cpu-e5` → `b200`, with a comment recording why the old label died and why the failure presented as `cancelled`.

## Test Plan

Verified from the Actions API rather than by inference:

```
# nothing claims cpu-e5
gh api --paginate '/repos/smg-project/smg/actions/runners?per_page=100' \
  --jq '[.runners[] | select([.labels[].name] | index("cpu-e5"))] | length'
-> 0

# b200 is alive and idle
moirai-b200      | online | busy=false | [self-hosted, Linux, X64, blackwell, b200]
moirai-e5-runner | online | busy=false | [self-hosted, Linux, X64, cpu-e5-test]
```

`nightly-docker.yml` parses, and `build-and-push.runs-on` resolves to `${{ inputs.runner || 'b200' }}`.

### One thing this does not prove

**The arm64 half is unverified on b200.** Both prior b200 builds were `express`, so `Set up QEMU` was *skipped* — only the amd64 path is proven there. binfmt registration for the emulated arm64 leg has never run on that host.

I left the scheduled build as the full multi-arch build rather than quietly narrowing it to amd64, because the two failure modes are not comparable: if binfmt is missing, this now dies at `Set up QEMU` in under a minute with a clear error, where the status quo hangs for 24 hours and reports `cancelled`. A loud, fast failure is strictly better than a silent one, and it is the only way to learn the answer.

Settling it needs one dispatch with `express=false` on b200 — which publishes a nightly image, so I have not run it unprompted. Say the word and I will.

### Related but deliberately out of scope

`nightly-engine-docker` and `release-docker` are broken by the *same* dead label via `_build-engine-image.yml:65` (`runs-on: ["cpu-e5"]`, hard-coded). I left them alone: that file is shared with the release path, so changing its runner is a release-infrastructure decision rather than a nightly one, and it deserves its own review.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes — n/a, CI config only
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes — n/a, CI config only
- [x] (Optional) Documentation updated — rationale recorded inline in the workflow
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
