### PR TITLE
fix(ci): stop pinning the benchmark wheel build to a decommissioned runner

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -34,7 +34,14 @@ jobs:
   # ---------------------------------------------------------------------------
 
   build-wheel:
-    runs-on: k8s-runner-gpu
+    # CPU-only work: a Rust/maturin compile plus openapi-gen and
+    # datamodel-codegen. It never needed a GPU, and the label it asked for
+    # ('k8s-runner-gpu') no longer has any runners behind it, so the job was
+    # never claimed -- it sat queued for 24h until GitHub's self-hosted limit
+    # reaped it, which reports as `cancelled` and took the whole run with it.
+    # pr-test-rust.yml's build-wheel already builds the same wheel on the CPU
+    # pool; match it.
+    runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Description

### Problem

`nightly-benchmark` has reported `cancelled` on every scheduled run since 2026-08-02 (08-02, 08-09, 08-16, and the 08-23 run now queued).

`build-wheel` is pinned to `runs-on: k8s-runner-gpu`. That scale set was decommissioned on **2026-07-31** (#2009 moved its values file into `archived/` and dropped the `helm install k8s-runner-gpu` block), and **no runner advertises that label today**. The job was therefore never claimed — empty `runner_name`, zero steps executed — and sat queued until GitHub's 24-hour self-hosted queue limit reaped it, to the second:

```
run 31933733328 (08-16)  build-wheel
  conclusion=cancelled  runner_name=""  steps=0
  2026-08-16T07:22:58Z -> 2026-08-17T07:22:59Z   = 24h00m01s
```

A reaped queue entry reports `cancelled`, not `failure` — which is why this read as throttling rather than breakage and sat unexamined for three weeks.

### Solution

Move it to `k8s-runner-cpu`. The job is CPU-only — a Rust/maturin compile plus `openapi-gen` and `datamodel-codegen` — and never needed a GPU. `pr-test-rust.yml`'s `build-wheel` already builds the same wheel on the CPU pool.

## Changes

- `.github/workflows/nightly-benchmark.yml:37` — `k8s-runner-gpu` → `k8s-runner-cpu`, with the reason recorded inline.

## Test Plan

Runner inventory, from the Actions API:

```
k8s-runner-gpu   -> 0 runners   (decommissioned 2026-07-31, #2009)
8-gpu-h200       -> 0 runners
k8s-runner-cpu   -> 5 runners, online
4-gpu-h100       -> 2+ runners, online
```

Workflow parses; job targets resolve as:

```
build-wheel           -> k8s-runner-cpu     (was k8s-runner-gpu)
single-worker         -> 4-gpu-h100         alive
multi-worker          -> 4-gpu-h100         alive
single-worker-h200    -> ['8-gpu-h200']     DEAD
summarize-benchmarks  -> ubuntu-latest
```

### This does not make the nightly green, and should not be read as if it does

`single-worker-h200` requests `8-gpu-h200`, which **also has zero registered runners** and will keep being reaped at 24h exactly as `build-wheel` was. So the run will still conclude `cancelled` after this lands.

That part needs hardware, not a config change — I am not going to retarget an 8-GPU H200 benchmark onto 4×H100, because that silently changes what is being measured and makes the published numbers incomparable to history. That is a benchmarking decision, not a CI fix.

Landing this is still worth it on its own terms: `k8s-runner-gpu` is genuinely dead, the fix is one line, and it stops burning a 24-hour queue slot every week for a job that has no reason to want a GPU.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes — n/a, CI config only
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes — n/a, CI config only
- [x] (Optional) Documentation updated — rationale recorded inline
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
