### PR TITLE
fix(ci): unbreak the tau2 nightly's vLLM install on Python 3.10

### DIFF
--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -29,6 +29,30 @@ echo "Using uv version: $(uv --version)"
 echo "Installing vLLM..."
 uv pip install "vllm==0.27.1" --torch-backend=auto
 
+# vLLM 0.27.1 hard-pins flashinfer-python==0.6.16.post3, which cannot be
+# imported on Python < 3.12. Its flashinfer/comm/fd_exchange.py:55 declares
+#
+#     def _fd_ancillary(fd: int) -> tuple[tuple[int, int, array.array[int]]]:
+#
+# with no `from __future__ import annotations`, so the annotation is evaluated
+# at import time; `array.array` only gained __class_getitem__ in CPython 3.12,
+# and everything below it dies with "TypeError: 'type' object is not
+# subscriptable". vLLM imports flashinfer.comm eagerly from
+# distributed/device_communicators/flashinfer_all_reduce.py, so every worker
+# fails to start.
+#
+# This only bites where the venv is built on an older interpreter: the
+# bare-metal GPU runners resolve `python3` to 3.10, while the containerised
+# pools get 3.12+ and are unaffected. That asymmetry is why the blackwell legs
+# of the tau2 nightly failed for five consecutive runs while the h100 legs
+# stayed green.
+#
+# 0.6.16.post4 is the same release with `from __future__ import annotations`
+# added, so the annotation is never evaluated. --no-deps because vLLM's pin is
+# exact and would otherwise drag post3 back in.
+echo "Patching flashinfer-python (post3 is unimportable on Python < 3.12)..."
+uv pip install --no-deps "flashinfer-python==0.6.16.post4"
+
 # vLLM >=0.25 eagerly imports torchcodec, which dlopens the FFmpeg shared
 # libraries (libavutil/libavcodec/libavformat/...) at import time. The runner
 # image ships none, so every worker dies importing vllm. Install distro FFmpeg
@@ -106,5 +130,19 @@ uv pip install "flashinfer-jit-cache==${FLASHINFER_VERSION}" \
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."
 uv pip install -e crates/grpc_client/python/
 uv pip install -e grpc_servicer/
+
+# Import canary: fail here (not 40 minutes later on a GPU) if flashinfer.comm
+# is unimportable. This runs LAST on purpose. The post4 override above leaves
+# the environment contradicting vLLM's exact post3 pin, and several uv installs
+# follow it -- any one of them could "repair" the environment back to post3 and
+# silently reinstate the TypeError. Importing the actual failing module is the
+# only check that cannot be fooled: a version string can look right while the
+# import still dies.
+echo "Checking flashinfer imports..."
+python3 -c "
+import importlib.metadata as m
+import flashinfer.comm  # noqa: F401  - the import IS the assertion
+print('flashinfer-python', m.version('flashinfer-python'), 'imports OK')
+"
 
 echo "vLLM installation complete"


### PR DESCRIPTION
## Description

### Problem

Every **blackwell** leg of the tau2 nightly has failed for five consecutive scheduled runs — 08-13, 08-15, 08-18, 08-20, 08-22 — while both **4-gpu-h100** legs passed every time:

```
failure  tau2-ab deepseek-ai/DeepSeek-V4-Flash-0731 (blackwell TP4)
failure  tau2-ab MiniMaxAI/MiniMax-M2.7            (blackwell TP4)
failure  tau2-ab moonshotai/Kimi-K2.6              (blackwell TP4)
failure  tau2-ab zai-org/GLM-5.2-FP8               (blackwell TP8)
success  tau2-ab openai/gpt-oss-120b               (4-gpu-h100 TP2)
success  tau2-ab Qwen/Qwen3.6-27B                  (4-gpu-h100 TP2)
```

This is not infrastructure — the Blackwell runner is healthy. It is an upstream defect that only fires on older interpreters, frozen in place by our version pin.

`ci_install_vllm.sh:30` installs `vllm==0.27.1`, which hard-pins `flashinfer-python==0.6.16.post3`. That release declares, at `flashinfer/comm/fd_exchange.py:55`:

```python
def _fd_ancillary(fd: int) -> tuple[tuple[int, int, array.array[int]]]:
```

with **no** `from __future__ import annotations`, so the annotation is evaluated eagerly at import. `array.array` only gained `__class_getitem__` in CPython 3.12. vLLM imports `flashinfer.comm` eagerly from `distributed/device_communicators/flashinfer_all_reduce.py`, so every worker dies at startup (run 32560568837):

```
File ".../python3.10/site-packages/flashinfer/comm/mnnvl.py", line 54, in <module>
    from .fd_exchange import broadcast_fd, exchange_fds
File ".../python3.10/site-packages/flashinfer/comm/fd_exchange.py", line 55, in <module>
    def _fd_ancillary(fd: int) -> tuple[tuple[int, int, array.array[int]]]:
TypeError: 'type' object is not subscriptable
```

**The h100/blackwell split is the interpreter.** `ci_setup_python_venv.sh:16` builds the venv with a bare `python3` — that resolves to 3.10 on the bare-metal GPU runners and 3.12+ in the containerised pools. Same script, same pin, different Python.

### Solution

Install `0.6.16.post4` over the pin. It is the same release with the missing `from __future__ import annotations` added.

I verified that by diffing the two wheels rather than trusting the changelog:

| version | `from __future__ import annotations` | `_fd_ancillary` |
| --- | --- | --- |
| `0.6.16.post3` | **absent** | line 55 |
| `0.6.16.post4` | **present** | line 59 |

`--no-deps` because vLLM's pin is exact and would otherwise drag post3 straight back in.

## Changes

- `scripts/ci_install_vllm.sh` — install `flashinfer-python==0.6.16.post4` immediately after vLLM, with the mechanism recorded in a comment.
- `scripts/ci_install_vllm.sh` — add a `flashinfer.comm` import canary as the **final** step of the script.

The canary is the part I would push back on removing. The override deliberately leaves the environment contradicting vLLM's exact pin, and four more `uv pip install` invocations run after it — nixl, mooncake, and two editable installs. Any one of them could resolve the environment "back into compliance" and silently reinstate post3. A version-string assertion would not catch every form of that; importing the module that actually fails cannot be fooled. It also moves the failure from 40 minutes into a GPU job to a few seconds into setup.

## Test Plan

Root cause confirmed from the failing run's own logs (32560568837), quoted above — not inferred: the traceback names the file, the line, the declaration, and the interpreter version.

The fix verified against the published artifacts:

```
# post4 exists
0.6.16* releases: ['0.6.16', '.post1', '.post2', '.post3', '.post4', 'rc3', 'rc4', 'rc5']

# and post4 really is the fix (wheels downloaded and diffed)
0.6.16.post3  from __future__ import annotations: False
0.6.16.post4  from __future__ import annotations: True
```

Checked the second-order effect too — `ci_install_vllm.sh:92` derives `FLASHINFER_VERSION` from the *installed* package and feeds it to the jit-cache install, so bumping to post4 demands a matching jit-cache wheel. It exists:

```
$ curl -s https://flashinfer.ai/whl/cu130/flashinfer-jit-cache/ | grep -c '0\.6\.16\.post4'
2      # x86_64 + aarch64
```

`bash -n scripts/ci_install_vllm.sh` passes.

**Not yet confirmed on hardware.** The proof that this fixes the nightly is one blackwell run, which I have not burned GPU time on unprompted — happy to dispatch it if you want that before merge.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes — n/a, shell script only
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes — n/a, shell script only
- [x] (Optional) Documentation updated — mechanism recorded inline
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
