### PR TITLE
feat(router): decide stream-vs-buffer per request; deprecate --stream-request-bodies-over

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -514,7 +514,6 @@ struct Router {
     selection_temperature: f32,
     upstream_pool_idle_timeout_secs: u64,
     least_load_max_waiting_requests: u32,
-    stream_request_bodies_over: u64,
     stream_body_stall_timeout_secs: u64,
     routing_key_headers: Vec<String>,
     cache_boundaries: Vec<usize>,
@@ -526,6 +525,7 @@ struct Router {
     worker_overload_token_usage: Option<f64>,
     worker_overload_protection: bool,
     disable_load_monitoring: bool,
+    max_buffered_request_bytes: u64,
 }
 
 impl Router {
@@ -906,7 +906,7 @@ impl Router {
             .dp_aware(self.dp_aware)
             .upstream_http2(self.upstream_http2)
             .upstream_pool_idle_timeout_secs(self.upstream_pool_idle_timeout_secs)
-            .stream_request_bodies_over(self.stream_request_bodies_over)
+            .max_buffered_request_bytes(self.max_buffered_request_bytes)
             .stream_body_stall_timeout_secs(self.stream_body_stall_timeout_secs)
             .multimodal_tensor_transport(multimodal_tensor_transport)
             .multimodal_shm_min_bytes(self.multimodal_shm_min_bytes)
@@ -1071,7 +1071,6 @@ impl Router {
         selection_temperature = 0.0,
         upstream_pool_idle_timeout_secs = 3,
         least_load_max_waiting_requests = 0,
-        stream_request_bodies_over = 0,
         stream_body_stall_timeout_secs = 300,
         routing_key_headers = vec![String::from("x-smg-routing-key")],
         cache_boundaries = vec![],
@@ -1083,6 +1082,7 @@ impl Router {
         worker_overload_token_usage = None,
         worker_overload_protection = false,
         disable_load_monitoring = false,
+        max_buffered_request_bytes = 1_048_576,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1221,7 +1221,6 @@ impl Router {
         selection_temperature: f32,
         upstream_pool_idle_timeout_secs: u64,
         least_load_max_waiting_requests: u32,
-        stream_request_bodies_over: u64,
         stream_body_stall_timeout_secs: u64,
         routing_key_headers: Vec<String>,
         cache_boundaries: Vec<usize>,
@@ -1233,6 +1232,7 @@ impl Router {
         worker_overload_token_usage: Option<f64>,
         worker_overload_protection: bool,
         disable_load_monitoring: bool,
+        max_buffered_request_bytes: u64,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1385,7 +1385,6 @@ impl Router {
             selection_temperature,
             upstream_pool_idle_timeout_secs,
             least_load_max_waiting_requests,
-            stream_request_bodies_over,
             stream_body_stall_timeout_secs,
             routing_key_headers,
             cache_boundaries,
@@ -1397,6 +1396,7 @@ impl Router {
             worker_overload_token_usage,
             worker_overload_protection,
             disable_load_monitoring,
+            max_buffered_request_bytes,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -220,7 +220,6 @@ class RouterArgs:
     selection_temperature: float = 0.0
     upstream_pool_idle_timeout_secs: int = 3
     least_load_max_waiting_requests: int = 0
-    stream_request_bodies_over: int = 0
     stream_body_stall_timeout_secs: int = 300
     # Ordered header names checked for the routing key; first valid wins
     routing_key_headers: list[str] = dataclasses.field(
@@ -242,6 +241,9 @@ class RouterArgs:
     worker_overload_protection: bool = False
     # Restore the conditional load-monitor poll gate (default: poll always)
     disable_load_monitoring: bool = False
+    # Most bytes the router may buffer for a request it holds only to keep
+    # it retryable; larger eligible requests stream and forfeit router retries
+    max_buffered_request_bytes: int = 1048576
 
     @staticmethod
     def add_cli_args(
@@ -706,16 +708,17 @@ class RouterArgs:
             help="Maximum payload size in bytes",
         )
         routing_group.add_argument(
-            f"--{prefix}stream-request-bodies-over",
+            f"--{prefix}max-buffered-request-bytes",
             type=int,
-            default=RouterArgs.stream_request_bodies_over,
+            default=RouterArgs.max_buffered_request_bytes,
             help=(
-                "Forward request bodies larger than this many bytes to the"
-                " worker as a raw stream instead of buffering, when the"
-                " route's policy needs no request text and the worker applies"
-                " no body mutation. Streamed bodies cannot be replayed, so"
-                " those requests bypass router-level retries; bodies without"
-                " a Content-Length header always buffer. 0 disables"
+                "Most bytes the router may hold for a request it buffers only"
+                " to keep it retryable. Requests the router must parse buffer"
+                " regardless (bounded by max-payload-size); other eligible"
+                " requests buffer up to this many bytes when router retries"
+                " are enabled and otherwise stream to the worker verbatim,"
+                " forfeiting router-level retries. 0 never buffers for"
+                " retries"
             ),
         )
         routing_group.add_argument(
@@ -726,8 +729,8 @@ class RouterArgs:
                 "Abort a streamed request body once the upstream sender has"
                 " waited on the client for this many seconds (408). The clock"
                 " pauses while the worker applies backpressure, so a slow"
-                " worker read never trips it. Applies only to bodies streamed"
-                " via --stream-request-bodies-over. 0 disables"
+                " worker read never trips it. Applies only to streamed"
+                " request bodies. 0 disables"
             ),
         )
         routing_group.add_argument(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1389,7 +1389,6 @@ class TestRouterArgsFieldOrder:
         "selection_temperature",
         "upstream_pool_idle_timeout_secs",
         "least_load_max_waiting_requests",
-        "stream_request_bodies_over",
         "stream_body_stall_timeout_secs",
         "routing_key_headers",
         "cache_boundaries",
@@ -1401,6 +1400,7 @@ class TestRouterArgsFieldOrder:
         "worker_overload_token_usage",
         "worker_overload_protection",
         "disable_load_monitoring",
+        "max_buffered_request_bytes",
     ]
 
     def test_complete_field_sequence_is_frozen(self):
@@ -1423,7 +1423,6 @@ class TestRouterArgsFieldOrder:
             "selection_temperature",
             "upstream_pool_idle_timeout_secs",
             "least_load_max_waiting_requests",
-            "stream_request_bodies_over",
             "stream_body_stall_timeout_secs",
             "routing_key_headers",
             "cache_boundaries",
@@ -1433,6 +1432,7 @@ class TestRouterArgsFieldOrder:
             "worker_overload_token_usage",
             "worker_overload_protection",
             "disable_load_monitoring",
+            "max_buffered_request_bytes",
         ):
             assert names.index(appended) > marker, (
                 f"{appended} must be appended after worker_startup_delay to "

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -213,8 +213,8 @@ impl RouterConfigBuilder {
         self
     }
 
-    pub fn stream_request_bodies_over(mut self, bytes: u64) -> Self {
-        self.config.stream_request_bodies_over = bytes;
+    pub fn max_buffered_request_bytes(mut self, bytes: u64) -> Self {
+        self.config.max_buffered_request_bytes = bytes;
         self
     }
 

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -55,15 +55,13 @@ pub struct RouterConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_worker_threads: Option<usize>,
     pub max_payload_size: usize,
-    /// Forward request bodies larger than this many bytes to the worker as a
-    /// raw stream instead of buffering, when the route's policy needs no
-    /// request text — or the request carries a valid routing hint header
-    /// that stands in for it — and the worker applies no body mutation.
-    /// Streamed bodies cannot be replayed, so those requests bypass
-    /// router-level retries; bodies without a Content-Length header always
-    /// buffer. `0` disables.
-    #[serde(default)]
-    pub stream_request_bodies_over: u64,
+    /// Most bytes the router may hold for a request it buffers only to keep
+    /// it retryable; a larger eligible request streams to the worker verbatim
+    /// and forfeits router-level retries. `0` never buffers for retries.
+    /// Requests the router must parse buffer regardless, bounded by
+    /// `max_payload_size`.
+    #[serde(default = "default_max_buffered_request_bytes")]
+    pub max_buffered_request_bytes: u64,
     /// Abort a streamed request body once the upstream sender has waited on
     /// the client for this many seconds (408). The clock pauses while the
     /// worker applies backpressure, so a slow worker read never trips it.
@@ -793,6 +791,10 @@ fn default_stream_body_stall_timeout_secs() -> u64 {
     300
 }
 
+fn default_max_buffered_request_bytes() -> u64 {
+    1_048_576
+}
+
 fn default_prefix_hash_balance_abs_threshold() -> usize {
     10
 }
@@ -1046,7 +1048,7 @@ impl Default for RouterConfig {
             health_check_port: None,
             runtime_worker_threads: None,
             max_payload_size: 536_870_912, // 512MB
-            stream_request_bodies_over: 0,
+            max_buffered_request_bytes: default_max_buffered_request_bytes(),
             stream_body_stall_timeout_secs: default_stream_body_stall_timeout_secs(),
             request_timeout_secs: 1800, // 30 minutes
             upstream_pool_idle_timeout_secs: default_upstream_pool_idle_timeout_secs(),
@@ -1206,7 +1208,7 @@ mod tests {
         assert_eq!(config.host, "0.0.0.0");
         assert_eq!(config.port, 3001);
         assert_eq!(config.max_payload_size, 536_870_912);
-        assert_eq!(config.stream_request_bodies_over, 0);
+        assert_eq!(config.max_buffered_request_bytes, 1_048_576);
         assert_eq!(config.request_timeout_secs, 1800);
         assert_eq!(config.upstream_pool_idle_timeout_secs, 3);
         assert_eq!(config.worker_startup_timeout_secs, 1800);
@@ -1300,24 +1302,23 @@ mod tests {
     }
 
     #[test]
-    fn test_stream_request_bodies_over_serde_roundtrip_and_backward_compat() {
-        // Config files predating the field deserialize to the disabled default.
+    fn test_max_buffered_request_bytes_serde_default_and_roundtrip() {
+        // Config files predating the field deserialize to the 1MiB default.
         let mut json: serde_json::Value = serde_json::to_value(RouterConfig::default()).unwrap();
         json.as_object_mut()
             .unwrap()
-            .remove("stream_request_bodies_over")
+            .remove("max_buffered_request_bytes")
             .unwrap();
         let without: RouterConfig = serde_json::from_value(json).unwrap();
-        assert_eq!(without.stream_request_bodies_over, 0);
+        assert_eq!(without.max_buffered_request_bytes, 1_048_576);
 
-        // When set, the value round-trips.
         let config = RouterConfig::builder()
             .regular_mode(vec![])
-            .stream_request_bodies_over(4 * 1024 * 1024)
+            .max_buffered_request_bytes(8 * 1024 * 1024)
             .build_unchecked();
         let json = serde_json::to_string(&config).unwrap();
         let with: RouterConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(with.stream_request_bodies_over, 4 * 1024 * 1024);
+        assert_eq!(with.max_buffered_request_bytes, 8 * 1024 * 1024);
     }
 
     #[test]

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -774,19 +774,6 @@ impl ConfigValidator {
             }
         }
 
-        // The body-limit layer rejects payloads above max_payload_size before
-        // the streaming threshold is consulted, so a threshold at or above it
-        // could never activate.
-        if config.stream_request_bodies_over != 0
-            && config.stream_request_bodies_over >= config.max_payload_size as u64
-        {
-            return Err(ConfigError::InvalidValue {
-                field: "stream_request_bodies_over".to_string(),
-                value: config.stream_request_bodies_over.to_string(),
-                reason: format!("Must be < max_payload_size ({})", config.max_payload_size),
-            });
-        }
-
         if config.request_timeout_secs == 0 {
             return Err(ConfigError::InvalidValue {
                 field: "request_timeout_secs".to_string(),
@@ -1187,25 +1174,6 @@ impl ConfigValidator {
 mod tests {
     use super::*;
     use crate::worker::ConnectionMode;
-
-    #[test]
-    fn stream_threshold_at_or_above_payload_cap_is_rejected() {
-        let below = RouterConfig {
-            stream_request_bodies_over: 1024,
-            ..Default::default()
-        };
-        assert!(ConfigValidator::validate(&below).is_ok());
-
-        let at_cap = RouterConfig {
-            stream_request_bodies_over: RouterConfig::default().max_payload_size as u64,
-            ..Default::default()
-        };
-        assert!(matches!(
-            ConfigValidator::validate(&at_cap),
-            Err(ConfigError::InvalidValue { ref field, .. })
-                if field == "stream_request_bodies_over"
-        ));
-    }
 
     #[test]
     fn prefix_hash_policy_cache_boundaries_are_validated() {

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -677,25 +677,23 @@ struct CliArgs {
     #[arg(long, default_value_t = 536870912, help_heading = "Request Handling")]
     max_payload_size: usize,
 
-    /// Forward request bodies larger than this many bytes to the worker as a
-    /// raw stream instead of buffering, when the route's policy needs no
-    /// request text — or the request carries a valid x-smg-routing-tokens
-    /// hint, or a valid x-smg-routing-key under --routing-key-override — and
-    /// the worker applies no body mutation. Streamed bodies are forwarded
-    /// verbatim, so JSON validation and normalization defer to the worker,
-    /// and they cannot be replayed, so those requests bypass router-level
-    /// retries; bodies without a Content-Length header always buffer. WASM
-    /// OnRequest modules inspect buffered bodies, so deployments running
-    /// them keep buffering (and their own body-size cap) ahead of this.
-    /// Must be below max-payload-size. 0 disables
-    #[arg(long, default_value_t = 0, help_heading = "Request Handling")]
-    stream_request_bodies_over: u64,
+    /// Most bytes the router may hold for a request it buffers only to keep
+    /// it retryable. The router decides per request: a request it must parse
+    /// (text-routing policy without a routing hint, body-mutating worker,
+    /// WASM request hooks, missing Content-Length, PD/batch backends) always
+    /// buffers, bounded by max-payload-size; an eligible request buffers up
+    /// to this many bytes when router retries are enabled, and otherwise
+    /// streams to the worker verbatim — forfeiting router-level retries,
+    /// with JSON validation deferring to the worker. 0 never buffers for
+    /// retries
+    #[arg(long, default_value_t = 1_048_576, help_heading = "Request Handling")]
+    max_buffered_request_bytes: u64,
 
     /// Abort a streamed request body once the upstream sender has waited on
     /// the client for this many seconds (408, request_body_stalled). The
     /// clock pauses while the worker applies backpressure, so a slow worker
-    /// read never trips it. Applies only to bodies streamed via
-    /// --stream-request-bodies-over. 0 disables
+    /// read never trips it. Applies only to streamed request bodies. 0
+    /// disables
     #[arg(long, default_value_t = 300, help_heading = "Request Handling")]
     stream_body_stall_timeout_secs: u64,
 
@@ -1774,7 +1772,7 @@ impl CliArgs {
             .health_check_port(self.health_check_port)
             .runtime_worker_threads(self.runtime_worker_threads)
             .max_payload_size(self.max_payload_size)
-            .stream_request_bodies_over(self.stream_request_bodies_over)
+            .max_buffered_request_bytes(self.max_buffered_request_bytes)
             .stream_body_stall_timeout_secs(self.stream_body_stall_timeout_secs)
             .request_timeout_secs(self.request_timeout_secs)
             .upstream_pool_idle_timeout_secs(self.upstream_pool_idle_timeout_secs)
@@ -2155,6 +2153,24 @@ mod tests {
         let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
         assert_eq!(defaults.kv_indexer_ttl_secs, None);
         assert_eq!(defaults.kv_indexer_max_entries, None);
+    }
+
+    /// The retry-buffer cap must flow through both conversion paths.
+    #[test]
+    fn max_buffered_request_bytes_flows_into_both_config_paths() {
+        let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(defaults.max_buffered_request_bytes, 1_048_576);
+
+        let cli = cli_args_from(&["--max-buffered-request-bytes", "4096"]);
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(router_config.max_buffered_request_bytes, 4096);
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert_eq!(server_config.router_config.max_buffered_request_bytes, 4096);
+
+        let zeroed = cli_args_from(&["--max-buffered-request-bytes", "0"])
+            .to_router_config(vec![], vec![])
+            .unwrap();
+        assert_eq!(zeroed.max_buffered_request_bytes, 0);
     }
 
     /// Job queue sizing must flow through both conversion paths: into

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -269,6 +269,10 @@ pub(crate) fn init_metrics() {
         "smg_router_request_buffers_released_early_bytes_total",
         "Serialized size of request buffers freed at dispatch instead of response completion (retries disabled)"
     );
+    describe_counter!(
+        "smg_router_request_body_path_total",
+        "Per-request body-path decisions by path (streamed/buffered) and dominant reason"
+    );
 
     // Layer 2: Router inference metrics (gRPC only)
     describe_histogram!(
@@ -998,6 +1002,16 @@ impl Metrics {
         counter!(
             "smg_router_upstream_send_retries_total",
             "router_type" => router_type
+        )
+        .increment(1);
+    }
+
+    /// Record one per-request body-path decision with its dominant reason.
+    pub fn record_request_body_path(path: &'static str, reason: &'static str) {
+        counter!(
+            "smg_router_request_body_path_total",
+            "path" => path,
+            "reason" => reason
         )
         .increment(1);
     }

--- a/model_gateway/src/routers/common/body_policy.rs
+++ b/model_gateway/src/routers/common/body_policy.rs
@@ -1,0 +1,189 @@
+//! Request body-path capability shared by every router family: the
+//! [`BodyPolicy`] a family declares, the per-request decision matrix a
+//! forward-capable router runs, and the counter vocabulary both feed.
+
+/// How a router family treats request bodies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BodyPolicy {
+    /// May forward a raw body verbatim; the per-request buffer-vs-stream
+    /// decision applies.
+    ForwardCapable,
+    /// Must parse every body; the reason feeds the body-path counter.
+    MustBuffer(&'static str),
+}
+
+/// Per-request body-path decision with its dominant (first-match) reason.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum BodyPath {
+    Buffer(&'static str),
+    Stream(&'static str),
+}
+
+pub(crate) const BODY_PATH_STREAMED: &str = "streamed";
+pub(crate) const BODY_PATH_BUFFERED: &str = "buffered";
+
+pub(crate) const REASON_POLICY_NEEDS_TEXT: &str = "policy_needs_text";
+pub(crate) const REASON_MODEL_AMBIGUOUS: &str = "model_ambiguous";
+pub(crate) const REASON_WORKER_MUTATES_BODY: &str = "worker_mutates_body";
+pub(crate) const REASON_WASM_REQUEST_HOOK: &str = "wasm_request_hook";
+pub(crate) const REASON_NO_CONTENT_LENGTH: &str = "no_content_length";
+pub(crate) const REASON_NO_AVAILABLE_WORKER: &str = "no_available_worker";
+pub(crate) const REASON_MODEL_SELECTION: &str = "model_selection";
+pub(crate) const REASON_RETRYABLE: &str = "retryable";
+pub(crate) const REASON_RETRY_FORFEITED: &str = "retry_forfeited";
+pub(crate) const REASON_PURE_FORWARD: &str = "pure_forward";
+
+/// Per-request inputs, gathered by the caller before the body arrives.
+pub(crate) struct BodyPathInputs {
+    pub policy_needs_text: bool,
+    pub model_ambiguous: bool,
+    pub worker_mutates_body: bool,
+    pub wasm_request_hooks: bool,
+    pub content_length: Option<u64>,
+    pub retries_enabled: bool,
+    pub max_buffered_request_bytes: u64,
+}
+
+/// Decide the request body path before the body arrives. Buffer when
+/// something must read the body here: a text-routing policy without a valid
+/// hint-header waiver, a registry serving more than one model (content-blind
+/// selection could land the request on the wrong model's worker), a
+/// body-mutating worker, a WASM request hook, or a missing/invalid
+/// Content-Length. Otherwise, with router retries enabled, buffer up to
+/// `max_buffered_request_bytes` to keep the request replayable — a larger
+/// body streams and forfeits router retries. Otherwise stream, at any size.
+pub(crate) fn decide_body_path(inputs: &BodyPathInputs) -> BodyPath {
+    if inputs.policy_needs_text {
+        return BodyPath::Buffer(REASON_POLICY_NEEDS_TEXT);
+    }
+    if inputs.model_ambiguous {
+        return BodyPath::Buffer(REASON_MODEL_AMBIGUOUS);
+    }
+    if inputs.worker_mutates_body {
+        return BodyPath::Buffer(REASON_WORKER_MUTATES_BODY);
+    }
+    if inputs.wasm_request_hooks {
+        return BodyPath::Buffer(REASON_WASM_REQUEST_HOOK);
+    }
+    let Some(content_length) = inputs.content_length else {
+        return BodyPath::Buffer(REASON_NO_CONTENT_LENGTH);
+    };
+    if inputs.retries_enabled {
+        if content_length <= inputs.max_buffered_request_bytes {
+            return BodyPath::Buffer(REASON_RETRYABLE);
+        }
+        return BodyPath::Stream(REASON_RETRY_FORFEITED);
+    }
+    BodyPath::Stream(REASON_PURE_FORWARD)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn eligible(content_length: u64) -> BodyPathInputs {
+        BodyPathInputs {
+            policy_needs_text: false,
+            model_ambiguous: false,
+            worker_mutates_body: false,
+            wasm_request_hooks: false,
+            content_length: Some(content_length),
+            retries_enabled: true,
+            max_buffered_request_bytes: 1024,
+        }
+    }
+
+    #[test]
+    fn hard_buffer_reasons_apply_in_first_match_order() {
+        let all = BodyPathInputs {
+            policy_needs_text: true,
+            model_ambiguous: true,
+            worker_mutates_body: true,
+            wasm_request_hooks: true,
+            content_length: None,
+            ..eligible(0)
+        };
+        assert_eq!(
+            decide_body_path(&all),
+            BodyPath::Buffer(REASON_POLICY_NEEDS_TEXT)
+        );
+
+        for (inputs, reason) in [
+            (
+                BodyPathInputs {
+                    policy_needs_text: true,
+                    ..eligible(64)
+                },
+                REASON_POLICY_NEEDS_TEXT,
+            ),
+            (
+                BodyPathInputs {
+                    model_ambiguous: true,
+                    ..eligible(64)
+                },
+                REASON_MODEL_AMBIGUOUS,
+            ),
+            (
+                BodyPathInputs {
+                    worker_mutates_body: true,
+                    ..eligible(64)
+                },
+                REASON_WORKER_MUTATES_BODY,
+            ),
+            (
+                BodyPathInputs {
+                    wasm_request_hooks: true,
+                    ..eligible(64)
+                },
+                REASON_WASM_REQUEST_HOOK,
+            ),
+            (
+                BodyPathInputs {
+                    content_length: None,
+                    ..eligible(64)
+                },
+                REASON_NO_CONTENT_LENGTH,
+            ),
+        ] {
+            assert_eq!(decide_body_path(&inputs), BodyPath::Buffer(reason));
+        }
+    }
+
+    #[test]
+    fn retry_buffer_bound_crosses_over_exactly_at_the_cap() {
+        assert_eq!(
+            decide_body_path(&eligible(1024)),
+            BodyPath::Buffer(REASON_RETRYABLE)
+        );
+        assert_eq!(
+            decide_body_path(&eligible(1025)),
+            BodyPath::Stream(REASON_RETRY_FORFEITED)
+        );
+    }
+
+    #[test]
+    fn zero_bound_never_buffers_for_retries() {
+        let inputs = BodyPathInputs {
+            max_buffered_request_bytes: 0,
+            ..eligible(1)
+        };
+        assert_eq!(
+            decide_body_path(&inputs),
+            BodyPath::Stream(REASON_RETRY_FORFEITED)
+        );
+    }
+
+    #[test]
+    fn pure_forward_streams_at_any_size() {
+        for len in [1, 1024, u64::MAX] {
+            let inputs = BodyPathInputs {
+                retries_enabled: false,
+                ..eligible(len)
+            };
+            assert_eq!(
+                decide_body_path(&inputs),
+                BodyPath::Stream(REASON_PURE_FORWARD)
+            );
+        }
+    }
+}

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -6,6 +6,9 @@
 //! `RouterTrait` definition and the per-protocol submodules.
 //!
 //! Submodules:
+//! - [`body_policy`] — per-family [`body_policy::BodyPolicy`] capability,
+//!   the per-request buffer-vs-stream decision matrix and its counter
+//!   vocabulary
 //! - [`header_utils`] — request header parsing helpers
 //!   (`extract_routing_key`, `extract_target_worker`, etc.)
 //! - [`mcp_utils`] — Model Context Protocol tool-call orchestration
@@ -27,6 +30,7 @@
 //! - [`sse`] — shared SSE codec (encoder + decoder) for streaming
 //!   responses to clients and parsing upstream SSE byte streams
 
+pub mod body_policy;
 pub mod header_utils;
 pub(crate) mod kv_transfer;
 pub mod mcp_utils;

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -7,10 +7,7 @@ use std::{
 use axum::{
     body::{to_bytes, Body},
     extract::{Request, State},
-    http::{
-        header::{CONTENT_LENGTH, CONTENT_TYPE},
-        HeaderMap, HeaderValue, Method, StatusCode,
-    },
+    http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, Method, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
     Json,
@@ -43,7 +40,7 @@ use tracing::{error, warn};
 
 use crate::{
     app_context::AppContext,
-    config::types::{RetryConfig, RouterConfig},
+    config::types::RetryConfig,
     middleware::{scheduler::PreemptionGuard, TenantRequestMeta},
     observability::{
         events::{self, Event},
@@ -53,7 +50,13 @@ use crate::{
     policies::{PolicyRegistry, SelectWorkerInfo},
     routers::{
         common::{
-            attach_sized_body, header_utils, overload,
+            attach_sized_body,
+            body_policy::{
+                decide_body_path, BodyPath, BodyPathInputs, BODY_PATH_BUFFERED, BODY_PATH_STREAMED,
+                REASON_MODEL_AMBIGUOUS, REASON_MODEL_SELECTION, REASON_NO_AVAILABLE_WORKER,
+                REASON_WORKER_MUTATES_BODY,
+            },
+            header_utils, overload,
             realtime::{
                 rest::forward_realtime_rest, webrtc, webrtc::handle_realtime_webrtc,
                 ws::handle_realtime_ws, RealtimeLabels, RealtimeRegistry,
@@ -70,8 +73,9 @@ use crate::{
             request_stream::{CappedBodyStream, StreamProgress},
         },
         router_manager::RouterManager,
-        RouterTrait,
+        BodyPolicy, RouterTrait,
     },
+    wasm::module::{MiddlewareAttachPoint, WasmModuleAttachPoint},
     worker::{AttachedBody, ConnectionMode, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType},
 };
 
@@ -96,6 +100,10 @@ pub struct Router {
     /// Streamed-body stall watchdog: abort a dispatch once a single client
     /// wait lasts this long. `None` disables.
     stream_stall_timeout: Option<Duration>,
+    /// Cap on buffering a request only to keep it retryable; larger eligible
+    /// requests stream and forfeit router retries. `0` never buffers for
+    /// retries.
+    max_buffered_request_bytes: u64,
     realtime_registry: Arc<RealtimeRegistry>,
     webrtc_bind_addr: Option<std::net::IpAddr>,
     webrtc_stun_server: Option<String>,
@@ -164,6 +172,7 @@ impl Router {
                 0 => None,
                 secs => Some(Duration::from_secs(secs)),
             },
+            max_buffered_request_bytes: ctx.router_config.max_buffered_request_bytes,
             realtime_registry: ctx.realtime_registry.clone(),
             webrtc_bind_addr: ctx.webrtc_bind_addr,
             webrtc_stun_server: ctx.webrtc_stun_server.clone(),
@@ -1633,30 +1642,9 @@ fn convert_reqwest_error(e: reqwest::Error) -> Response {
 use async_trait::async_trait;
 
 impl Router {
-    /// Streamed pass-through: select a worker from headers alone and
-    /// forward the raw body verbatim (JSON validation and normalization
-    /// defer to the worker). `Err` hands the request back untouched —
-    /// body unconsumed — for the buffered typed path. Callers gate on
-    /// the size threshold via [`stream_large_request_bodies`].
-    pub(crate) async fn route_streaming_request(
-        &self,
-        req: Request<Body>,
-        route: &'static str,
-    ) -> Result<Response, Request<Body>> {
-        // Content-blind eligibility: the model and stream flag sit inside the
-        // unread body, so any registered policy that routes on request text
-        // (the body's model could select it) forces the buffered path unless
-        // a valid routing hint header stands in for the text. Every fallback
-        // hands the request back with its body unconsumed.
-        let model_id = crate::worker::UNKNOWN_MODEL_ID;
-        if self
-            .policy_registry
-            .any_policy_needs_request_text(Some(req.headers()))
-        {
-            return Err(req);
-        }
-        // A body-mutating worker (`prepare_request`) anywhere in the fleet
-        // forces the buffered path: the mutation needs the parsed body.
+    /// Gather this router's per-request state for the shared decision matrix
+    /// in [`crate::routers::common::body_policy`].
+    fn request_body_path(&self, headers: &HeaderMap, wasm_request_hooks: bool) -> BodyPath {
         let candidates = self.worker_registry.get_workers_filtered(
             None,
             Some(WorkerType::Regular),
@@ -1664,9 +1652,43 @@ impl Router {
             None,
             false,
         );
-        if candidates.iter().any(|w| w.mutates_request()) {
-            return Err(req);
-        }
+        decide_body_path(&BodyPathInputs {
+            policy_needs_text: self
+                .policy_registry
+                .any_policy_needs_request_text(Some(headers)),
+            model_ambiguous: self.worker_registry.model_count() > 1,
+            worker_mutates_body: candidates.iter().any(|w| w.mutates_request()),
+            wasm_request_hooks,
+            content_length: header_utils::content_length(Some(headers)).map(|len| len as u64),
+            // The model sits inside the unread body, so any per-model retry
+            // override that still allows retries must count as
+            // retries-enabled.
+            retries_enabled: self.retry_config.max_retries > 1
+                || self
+                    .worker_registry
+                    .any_model_retry_override_enables_retries(),
+            max_buffered_request_bytes: self.max_buffered_request_bytes,
+        })
+    }
+
+    /// Streamed pass-through: select a worker from headers alone and
+    /// forward the raw body verbatim (JSON validation and normalization
+    /// defer to the worker). `Err` hands the request back untouched —
+    /// body unconsumed — for the buffered typed path.
+    pub(crate) async fn route_streaming_request(
+        &self,
+        req: Request<Body>,
+        route: &'static str,
+        wasm_request_hooks: bool,
+    ) -> Result<Response, Request<Body>> {
+        let stream_reason = match self.request_body_path(req.headers(), wasm_request_hooks) {
+            BodyPath::Buffer(reason) => {
+                Metrics::record_request_body_path(BODY_PATH_BUFFERED, reason);
+                return Err(req);
+            }
+            BodyPath::Stream(reason) => reason,
+        };
+        let model_id = crate::worker::UNKNOWN_MODEL_ID;
         // Buffered-path parity: a valid tokens hint is exactly what selection
         // would have received there (text is never extracted alongside it).
         // Streamed requests have no readable body, hence no rid key; the
@@ -1679,13 +1701,22 @@ impl Router {
             Some(req.headers()),
             None,
         ) else {
+            Metrics::record_request_body_path(BODY_PATH_BUFFERED, REASON_NO_AVAILABLE_WORKER);
             return Err(req);
         };
-        // Guards a registration race: a mutating worker that joined after the
-        // fleet check above must still not receive an unmutated stream.
+        // Guard the registration races the decision left open: a mutating
+        // worker that joined after the fleet check must not receive an
+        // unmutated stream, and a second model appearing re-opens
+        // wrong-model selection.
         if worker.mutates_request() {
+            Metrics::record_request_body_path(BODY_PATH_BUFFERED, REASON_WORKER_MUTATES_BODY);
             return Err(req);
         }
+        if self.worker_registry.model_count() > 1 {
+            Metrics::record_request_body_path(BODY_PATH_BUFFERED, REASON_MODEL_AMBIGUOUS);
+            return Err(req);
+        }
+        Metrics::record_request_body_path(BODY_PATH_STREAMED, stream_reason);
 
         let start = Instant::now();
         let endpoint = route_to_endpoint(route);
@@ -1762,45 +1793,43 @@ impl Router {
     }
 }
 
-/// Whether the request qualifies for the streamed body pass-through:
-/// `--stream-request-bodies-over` is on and the declared Content-Length
-/// exceeds it. Chunked uploads carry no Content-Length and always buffer.
-fn exceeds_stream_threshold(threshold: u64, req: &Request<Body>) -> bool {
-    threshold > 0
-        && req
-            .headers()
-            .get(CONTENT_LENGTH)
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse::<u64>().ok())
-            .is_some_and(|len| len > threshold)
-}
-
-/// State for [`stream_large_request_bodies`]: the app-level router handle
-/// (the manager in production, a concrete router in tests) and the streaming
-/// threshold.
+/// State for [`stream_eligible_request_bodies`]: the app-level router handle
+/// (the manager in production, a concrete router in tests) and the app
+/// context carrying the WASM manager.
 #[derive(Clone)]
 pub struct StreamBodyState {
     router: Arc<dyn RouterTrait>,
-    threshold: u64,
+    context: Arc<AppContext>,
 }
 
 impl StreamBodyState {
-    pub fn new(router: Arc<dyn RouterTrait>, config: &RouterConfig) -> Self {
-        Self {
-            router,
-            threshold: config.stream_request_bodies_over,
-        }
+    pub fn new(router: Arc<dyn RouterTrait>, context: Arc<AppContext>) -> Self {
+        Self { router, context }
+    }
+
+    /// WASM OnRequest hooks read (and may rewrite) the buffered body, so
+    /// their presence forces the buffered path. A manager error counts as
+    /// present: never stream past a hook we could not enumerate.
+    fn wasm_request_hooks(&self) -> bool {
+        self.context.router_config.enable_wasm
+            && self.context.wasm_manager.as_ref().is_some_and(|manager| {
+                manager
+                    .get_modules_by_attach_point(WasmModuleAttachPoint::Middleware(
+                        MiddlewareAttachPoint::OnRequest,
+                    ))
+                    .map_or(true, |modules| !modules.is_empty())
+            })
     }
 }
 
-/// Route-layer middleware: a typed-JSON request whose declared Content-Length
-/// exceeds the threshold is offered to the HTTP regular router's streamed
-/// pass-through before the handler's `Json`/`ValidatedJson` extractor can
-/// buffer it. Any decline — other route, below threshold, no HTTP regular
-/// router, router-side ineligibility — falls through to the untouched
-/// handler with the body unconsumed. Sits inside the admission layer, so
-/// streamed requests hold an admission permit and race the preemption token.
-pub async fn stream_large_request_bodies(
+/// Route-layer middleware: every typed-JSON request on an eligible route is
+/// classified by the router family's [`BodyPolicy`]. A `MustBuffer` family
+/// is accounted and passed to the untouched handler; a `ForwardCapable`
+/// router then decides per request between the streamed pass-through and
+/// the handler's buffered `Json`/`ValidatedJson` path, always with the body
+/// unconsumed on decline. Sits inside the admission layer, so streamed
+/// requests hold an admission permit and race the preemption token.
+pub async fn stream_eligible_request_bodies(
     State(state): State<StreamBodyState>,
     cancel: PreemptionGuard,
     req: Request<Body>,
@@ -1815,25 +1844,34 @@ pub async fn stream_large_request_bodies(
         "/v1/classify" => "/v1/classify",
         _ => return next.run(req).await,
     };
-    if !exceeds_stream_threshold(state.threshold, &req) {
+    if let BodyPolicy::MustBuffer(reason) = state.router.request_body_policy() {
+        Metrics::record_request_body_path(BODY_PATH_BUFFERED, reason);
         return next.run(req).await;
     }
+    // ForwardCapable: resolve the concrete regular router behind an optional
+    // manager. Either arm can only fail on a registration race that turned
+    // dispatch model-addressed again.
     let resolved = match state.router.as_any().downcast_ref::<RouterManager>() {
-        // Multi-router deployments route by the model inside the body; a
-        // content-blind dispatch could pick a router that does not serve it.
-        Some(manager) if manager.router_count() > 1 => return next.run(req).await,
         Some(manager) => match manager.select_router_for_request(None) {
             Some(selected) => selected,
-            None => return next.run(req).await,
+            None => {
+                Metrics::record_request_body_path(BODY_PATH_BUFFERED, REASON_MODEL_SELECTION);
+                return next.run(req).await;
+            }
         },
         None => Arc::clone(&state.router),
     };
     let Some(http) = resolved.as_any().downcast_ref::<Router>() else {
+        Metrics::record_request_body_path(BODY_PATH_BUFFERED, REASON_MODEL_SELECTION);
         return next.run(req).await;
     };
+    let wasm_request_hooks = state.wasm_request_hooks();
     cancel
         .guard(async move {
-            match http.route_streaming_request(req, route).await {
+            match http
+                .route_streaming_request(req, route, wasm_request_hooks)
+                .await
+            {
                 Ok(response) => response,
                 Err(req) => next.run(req).await,
             }
@@ -1845,6 +1883,10 @@ pub async fn stream_large_request_bodies(
 impl RouterTrait for Router {
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn request_body_policy(&self) -> BodyPolicy {
+        BodyPolicy::ForwardCapable
     }
 
     async fn health_generate(&self, req: Request<Body>) -> Response {
@@ -2118,13 +2160,20 @@ mod tests {
         sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
     };
 
+    use axum::http::header::CONTENT_LENGTH;
     use openai_protocol::worker::HealthCheckConfig;
 
     use super::*;
     use crate::{
         config::types::{PolicyConfig, RoutingKeyOverrideConfig},
         policies::CacheAwarePolicy,
-        routers::common::request_lease::test_probe::{spawn_release_gated_stub, DropProbeRequest},
+        routers::common::{
+            body_policy::{
+                REASON_NO_CONTENT_LENGTH, REASON_POLICY_NEEDS_TEXT, REASON_RETRYABLE,
+                REASON_RETRY_FORFEITED, REASON_WASM_REQUEST_HOOK,
+            },
+            request_lease::test_probe::{spawn_release_gated_stub, DropProbeRequest},
+        },
         worker::BasicWorkerBuilder,
     };
 
@@ -2230,6 +2279,7 @@ mod tests {
             retry_config: RetryConfig::default(),
             max_payload_size: 536_870_912,
             stream_stall_timeout: Some(Duration::from_secs(60)),
+            max_buffered_request_bytes: 0,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,
@@ -2463,6 +2513,9 @@ mod tests {
             retry_config: RetryConfig::default(),
             max_payload_size,
             stream_stall_timeout: Some(Duration::from_secs(60)),
+            // Streaming tests exercise the streamed path; 0 never buffers
+            // for retries.
+            max_buffered_request_bytes: 0,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,
@@ -2509,48 +2562,155 @@ mod tests {
     }
 
     fn streamed_request(chunks: &[&'static [u8]]) -> Request<Body> {
+        let total: usize = chunks.iter().map(|c| c.len()).sum();
         let chunks: Vec<Result<Bytes, std::io::Error>> =
             chunks.iter().map(|c| Ok(Bytes::from_static(c))).collect();
         Request::builder()
             .method(Method::POST)
             .uri("/generate")
             .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .header(CONTENT_LENGTH, total)
             .body(Body::from_stream(stream::iter(chunks)))
             .unwrap()
     }
 
-    fn request_with_content_length(len: Option<&str>) -> Request<Body> {
-        let mut builder = Request::builder().method(Method::POST).uri("/generate");
+    fn headers_with_content_length(len: Option<&str>) -> HeaderMap {
+        let mut headers = HeaderMap::new();
         if let Some(len) = len {
-            builder = builder.header(CONTENT_LENGTH, len);
+            headers.insert(CONTENT_LENGTH, len.parse().unwrap());
         }
-        builder.body(Body::empty()).unwrap()
+        headers
     }
 
     #[test]
-    fn stream_threshold_requires_flag_and_larger_content_length() {
-        assert_eq!(RouterConfig::default().stream_request_bodies_over, 0);
-        assert!(!exceeds_stream_threshold(
-            0,
-            &request_with_content_length(Some("10000"))
-        ));
+    fn text_needing_policy_without_waiver_decides_buffer() {
+        let router = streaming_router(
+            cache_aware_policy(),
+            1024 * 1024,
+            vec![plain_worker("http://worker1:8080")],
+        );
+        assert_eq!(
+            router.request_body_path(&headers_with_content_length(Some("64")), false),
+            BodyPath::Buffer(REASON_POLICY_NEEDS_TEXT)
+        );
 
-        assert!(!exceeds_stream_threshold(
-            1024,
-            &request_with_content_length(None)
-        ));
-        assert!(!exceeds_stream_threshold(
-            1024,
-            &request_with_content_length(Some("1024"))
-        ));
-        assert!(!exceeds_stream_threshold(
-            1024,
-            &request_with_content_length(Some("not-a-number"))
-        ));
-        assert!(exceeds_stream_threshold(
-            1024,
-            &request_with_content_length(Some("1025"))
-        ));
+        // A valid tokens hint waives the text requirement.
+        let mut headers = headers_with_content_length(Some("64"));
+        headers.insert("x-smg-routing-tokens", "1,2,3".parse().unwrap());
+        assert_eq!(
+            router.request_body_path(&headers, false),
+            BodyPath::Stream(REASON_RETRY_FORFEITED)
+        );
+    }
+
+    #[test]
+    fn mutating_worker_decides_buffer() {
+        let worker = BasicWorkerBuilder::new("http://worker1:8080")
+            .worker_type(WorkerType::Regular)
+            .health_config(no_health_check())
+            .dp_config(3, 8)
+            .build();
+        let router = streaming_router(least_load_policy(), 1024 * 1024, vec![worker]);
+        assert_eq!(
+            router.request_body_path(&headers_with_content_length(Some("64")), false),
+            BodyPath::Buffer(REASON_WORKER_MUTATES_BODY)
+        );
+    }
+
+    #[test]
+    fn wasm_request_hook_decides_buffer() {
+        let router = streaming_router(
+            least_load_policy(),
+            1024 * 1024,
+            vec![plain_worker("http://worker1:8080")],
+        );
+        assert_eq!(
+            router.request_body_path(&headers_with_content_length(Some("64")), true),
+            BodyPath::Buffer(REASON_WASM_REQUEST_HOOK)
+        );
+    }
+
+    #[test]
+    fn missing_or_invalid_content_length_decides_buffer() {
+        let router = streaming_router(
+            least_load_policy(),
+            1024 * 1024,
+            vec![plain_worker("http://worker1:8080")],
+        );
+        for headers in [
+            headers_with_content_length(None),
+            headers_with_content_length(Some("not-a-number")),
+        ] {
+            assert_eq!(
+                router.request_body_path(&headers, false),
+                BodyPath::Buffer(REASON_NO_CONTENT_LENGTH)
+            );
+        }
+    }
+
+    /// Content-blind selection cannot tell which model's worker a streamed
+    /// request needs; two registered models force the buffered typed path.
+    #[test]
+    fn multi_model_registry_decides_buffer() {
+        let worker_for = |url: &str, model: &str| {
+            BasicWorkerBuilder::new(url)
+                .worker_type(WorkerType::Regular)
+                .health_config(no_health_check())
+                .models(vec![crate::worker::ModelCard::new(model)])
+                .build()
+        };
+        let router = streaming_router(
+            least_load_policy(),
+            1024 * 1024,
+            vec![
+                worker_for("http://worker1:8080", "model-a"),
+                worker_for("http://worker2:8080", "model-b"),
+            ],
+        );
+        assert_eq!(
+            router.request_body_path(&headers_with_content_length(Some("64")), false),
+            BodyPath::Buffer(REASON_MODEL_AMBIGUOUS)
+        );
+
+        // Two workers serving the same lone model stay streamable.
+        let router = streaming_router(
+            least_load_policy(),
+            1024 * 1024,
+            vec![
+                worker_for("http://worker1:8080", "model-a"),
+                worker_for("http://worker2:8080", "model-a"),
+            ],
+        );
+        assert_eq!(
+            router.request_body_path(&headers_with_content_length(Some("64")), false),
+            BodyPath::Stream(REASON_RETRY_FORFEITED)
+        );
+    }
+
+    #[test]
+    fn per_model_retry_override_keeps_small_bodies_buffered() {
+        let mut router = streaming_router(
+            least_load_policy(),
+            1024 * 1024,
+            vec![plain_worker("http://worker1:8080")],
+        );
+        router.retry_config = RetryConfig {
+            max_retries: 1,
+            ..Default::default()
+        };
+        router.max_buffered_request_bytes = 1024;
+        router.worker_registry.set_model_retry_config(
+            "some-model",
+            RetryConfig {
+                max_retries: 3,
+                ..Default::default()
+            },
+            true,
+        );
+        assert_eq!(
+            router.request_body_path(&headers_with_content_length(Some("64")), false),
+            BodyPath::Buffer(REASON_RETRYABLE)
+        );
     }
 
     #[tokio::test]
@@ -2562,6 +2722,7 @@ mod tests {
             .route_streaming_request(
                 streamed_request(&[b"{\"text\":\"", b"hello\"}"]),
                 "/generate",
+                false,
             )
             .await
             .unwrap();
@@ -2595,7 +2756,11 @@ mod tests {
         let router = streaming_router(least_load_policy(), 1024 * 1024, vec![plain_worker(&url)]);
 
         let response = router
-            .route_streaming_request(streamed_request(&[b"{\"stream\":true}"]), "/generate")
+            .route_streaming_request(
+                streamed_request(&[b"{\"stream\":true}"]),
+                "/generate",
+                false,
+            )
             .await
             .unwrap();
 
@@ -2617,7 +2782,7 @@ mod tests {
         let router = streaming_router(least_load_policy(), 8, vec![plain_worker(&url)]);
 
         let response = router
-            .route_streaming_request(streamed_request(&[b"12345678", b"9"]), "/generate")
+            .route_streaming_request(streamed_request(&[b"12345678", b"9"]), "/generate", false)
             .await
             .unwrap();
 
@@ -2652,11 +2817,12 @@ mod tests {
             .method(Method::POST)
             .uri("/generate")
             .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .header(CONTENT_LENGTH, 1024)
             .body(stalled_body)
             .unwrap();
 
         let response = router
-            .route_streaming_request(req, "/generate")
+            .route_streaming_request(req, "/generate", false)
             .await
             .unwrap();
 
@@ -2698,11 +2864,12 @@ mod tests {
             .method(Method::POST)
             .uri("/generate")
             .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .header(CONTENT_LENGTH, 1024)
             .body(aborted_body)
             .unwrap();
 
         let response = router
-            .route_streaming_request(req, "/generate")
+            .route_streaming_request(req, "/generate", false)
             .await
             .unwrap();
 
@@ -2720,7 +2887,11 @@ mod tests {
 
     async fn assert_falls_back_with_body_intact(router: &Router) {
         let req = router
-            .route_streaming_request(streamed_request(&[b"{\"text\":\"hello\"}"]), "/generate")
+            .route_streaming_request(
+                streamed_request(&[b"{\"text\":\"hello\"}"]),
+                "/generate",
+                false,
+            )
             .await
             .unwrap_err();
 
@@ -2745,7 +2916,7 @@ mod tests {
 
     async fn routed_worker_id(router: &Router, req: Request<Body>) -> String {
         let response = router
-            .route_streaming_request(req, "/generate")
+            .route_streaming_request(req, "/generate", false)
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
@@ -2817,7 +2988,7 @@ mod tests {
                 hint,
             );
             let req = router
-                .route_streaming_request(req, "/generate")
+                .route_streaming_request(req, "/generate", false)
                 .await
                 .unwrap_err();
             let body = to_bytes(req.into_body(), usize::MAX).await.unwrap();
@@ -2839,7 +3010,7 @@ mod tests {
             "media-1",
         );
         assert!(router
-            .route_streaming_request(req, "/generate")
+            .route_streaming_request(req, "/generate", false)
             .await
             .is_err());
 
@@ -2877,7 +3048,7 @@ mod tests {
             &"k".repeat(129),
         );
         assert!(router
-            .route_streaming_request(req, "/generate")
+            .route_streaming_request(req, "/generate", false)
             .await
             .is_err());
     }

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -42,6 +42,7 @@ pub mod responses;
 pub mod router_manager;
 pub mod tokenize;
 
+pub use common::body_policy::BodyPolicy;
 pub use factory::RouterFactory;
 // Re-export HTTP routers for convenience
 pub use http::{pd_router, pd_types, router};
@@ -54,6 +55,12 @@ pub use http::{pd_router, pd_types, router};
 pub trait RouterTrait: Send + Sync + Debug {
     /// Get a reference to self as Any for downcasting
     fn as_any(&self) -> &dyn std::any::Any;
+
+    /// Buffering is always correct and is the default; override only when
+    /// the family forwards bodies verbatim.
+    fn request_body_policy(&self) -> BodyPolicy {
+        BodyPolicy::MustBuffer(self.router_type())
+    }
 
     /// Route a health generate request
     async fn health_generate(&self, _req: Request<Body>) -> Response {

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -43,10 +43,10 @@ use crate::{
     config::RoutingMode,
     middleware::{AuthConfig, TenantRequestMeta},
     routers::{
-        common::header_utils::apply_provider_headers,
+        common::{body_policy::REASON_MODEL_SELECTION, header_utils::apply_provider_headers},
         error as route_error,
         factory::{router_ids, RouterId},
-        RouterFactory, RouterTrait,
+        BodyPolicy, RouterFactory, RouterTrait,
     },
     server::ServerConfig,
     worker::{ConnectionMode, ProviderType, RuntimeType, Worker, WorkerRegistry, WorkerType},
@@ -473,6 +473,17 @@ impl RouterManager {
 impl RouterTrait for RouterManager {
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    /// Multi-router dispatch reads the model from the body; a lone router
+    /// speaks for itself.
+    fn request_body_policy(&self) -> BodyPolicy {
+        if self.router_count() == 1 {
+            if let Some(router) = self.select_router_for_request(None) {
+                return router.request_body_policy();
+            }
+        }
+        BodyPolicy::MustBuffer(REASON_MODEL_SELECTION)
     }
 
     async fn health_generate(&self, _req: Request<Body>) -> Response {
@@ -1001,6 +1012,67 @@ mod tests {
         let manager = Arc::new(manager);
         manager.register_router(router_ids::HTTP_REGULAR, Arc::new(StubRouter));
         manager
+    }
+
+    /// A lone router speaks for itself — a forward-capable one keeps
+    /// streaming enabled, a buffering one shows its derived reason — and
+    /// more than one router makes dispatch model-addressed.
+    #[test]
+    fn body_policy_delegates_to_a_lone_router_and_buffers_multi_router() {
+        #[derive(Debug)]
+        struct ForwardStubRouter;
+
+        #[async_trait]
+        impl RouterTrait for ForwardStubRouter {
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+
+            fn request_body_policy(&self) -> BodyPolicy {
+                BodyPolicy::ForwardCapable
+            }
+
+            fn router_type(&self) -> &'static str {
+                "stub_forward"
+            }
+        }
+
+        let forward_manager = {
+            let mut m = RouterManager::new(Arc::new(WorkerRegistry::new()), reqwest::Client::new());
+            m.enable_igw = false;
+            let m = Arc::new(m);
+            m.register_router(router_ids::HTTP_REGULAR, Arc::new(ForwardStubRouter));
+            m
+        };
+        assert_eq!(
+            forward_manager.request_body_policy(),
+            BodyPolicy::ForwardCapable
+        );
+
+        let manager = test_manager(false);
+        assert_eq!(
+            manager.request_body_policy(),
+            BodyPolicy::MustBuffer("stub")
+        );
+
+        let pd_manager = {
+            let mut m = RouterManager::new(Arc::new(WorkerRegistry::new()), reqwest::Client::new());
+            m.enable_igw = false;
+            let m = Arc::new(m);
+            m.register_router(router_ids::HTTP_PD, Arc::new(PdStubRouter));
+            m
+        };
+        assert_eq!(
+            pd_manager.request_body_policy(),
+            BodyPolicy::MustBuffer("pd")
+        );
+
+        let manager = test_manager(true);
+        manager.register_router(router_ids::HTTP_PD, Arc::new(PdStubRouter));
+        assert_eq!(
+            manager.request_body_policy(),
+            BodyPolicy::MustBuffer(REASON_MODEL_SELECTION)
+        );
     }
 
     fn test_tenant_meta() -> TenantRequestMeta {

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -57,7 +57,7 @@ use crate::{
     routers::{
         common::realtime::ws::RealtimeQueryParams,
         conversations,
-        http::router::{stream_large_request_bodies, StreamBodyState},
+        http::router::{stream_eligible_request_bodies, StreamBodyState},
         parse, responses as response_handlers,
         router_manager::RouterManager,
         tokenize, RouterTrait,
@@ -841,11 +841,11 @@ pub fn build_app(
             .route("/v1/messages", post(v1_messages))
             .route("/v1/interactions", post(v1_interactions))
             .route("/v1/classify", post(v1_classify))
-            // Streamed pass-through for large typed-JSON bodies; everything
-            // else passes to the handlers untouched.
+            // Per-request buffer-vs-stream decision for typed-JSON bodies;
+            // declined requests pass to the handlers untouched.
             .route_layer(axum::middleware::from_fn_with_state(
-                StreamBodyState::new(app_state.router.clone(), &app_state.context.router_config),
-                stream_large_request_bodies,
+                StreamBodyState::new(app_state.router.clone(), app_state.context.clone()),
+                stream_eligible_request_bodies,
             ))
             // Tokenize / Detokenize endpoints
             .route("/v1/tokenize", post(v1_tokenize))

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -709,6 +709,15 @@ impl WorkerRegistry {
             .collect()
     }
 
+    /// Distinct canonical models with at least one worker serving them.
+    /// Wildcard workers carry no model and contribute nothing.
+    pub fn model_count(&self) -> usize {
+        self.model_index
+            .iter()
+            .filter(|entry| !entry.value().is_empty())
+            .count()
+    }
+
     /// Whether at least one worker serves this name, as a canonical model ID
     /// or as an alias.
     ///
@@ -844,6 +853,15 @@ impl WorkerRegistry {
         self.model_retry_configs
             .get(model_id)
             .map(|entry| entry.value().clone())
+    }
+
+    /// True when any per-model retry override still allows retries; the
+    /// content-blind streamed path cannot know the model, so it must assume
+    /// the strictest override.
+    pub fn any_model_retry_override_enables_retries(&self) -> bool {
+        self.model_retry_configs
+            .iter()
+            .any(|entry| entry.value().max_retries > 1)
     }
 
     // ───────────────────────────────────────────────────────────────────

--- a/model_gateway/tests/routing/stream_request_body_test.rs
+++ b/model_gateway/tests/routing/stream_request_body_test.rs
@@ -1,10 +1,11 @@
-//! Streamed request-body pass-through (`--stream-request-bodies-over`).
+//! Per-request body-path decision (`--max-buffered-request-bytes`).
 //!
-//! Above the threshold, with a policy that needs no request text, the raw
-//! body must flow to the worker as a chunked stream, byte-for-byte. Below the
-//! threshold, without a Content-Length, or under a text-needing policy, the
-//! buffered typed path (which re-serializes and sends a Content-Length) must
-//! be used instead.
+//! An eligible request larger than the retry-buffer cap must flow to the
+//! worker as a chunked stream, byte-for-byte; with retries disabled it must
+//! stream at any size. Under the cap with retries enabled, without a
+//! Content-Length, under a text-needing policy, or in a registry serving
+//! more than one model, the buffered typed path (which re-serializes and
+//! sends a Content-Length) must be used instead.
 
 use std::sync::Arc;
 
@@ -48,6 +49,8 @@ async fn spawn_capture_worker() -> (String, Captured) {
     let app = axum::Router::new()
         .route("/generate", axum::routing::post(capture))
         .route("/v1/chat/completions", axum::routing::post(capture))
+        // Outsize axum's 2MB default so multi-MiB streamed forwards land.
+        .layer(axum::extract::DefaultBodyLimit::max(256 * 1024 * 1024))
         .with_state(Arc::clone(&captured));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -87,27 +90,38 @@ fn cache_aware_policy() -> PolicyConfig {
     }
 }
 
-/// App wired through the real `build_app` stack with the capture stub as the
-/// only worker.
-async fn streaming_app(
-    policy: PolicyConfig,
-    threshold: u64,
-    max_payload_size: usize,
-) -> (axum::Router, Captured, AppTestContext) {
-    let (worker_url, captured) = spawn_capture_worker().await;
-
-    let mut config = RouterConfig::builder()
+fn base_config(max_payload_size: usize) -> RouterConfig {
+    RouterConfig::builder()
         .regular_mode(vec![])
         .host("127.0.0.1")
         .port(3002)
         .max_payload_size(max_payload_size)
-        .stream_request_bodies_over(threshold)
         .request_timeout_secs(600)
         .worker_startup_timeout_secs(5)
         .worker_startup_check_interval_secs(1)
         .max_concurrent_requests(64)
         .queue_timeout_secs(60)
-        .build_unchecked();
+        .build_unchecked()
+}
+
+/// App wired through the real `build_app` stack with the capture stub as the
+/// only worker.
+async fn streaming_app(
+    policy: PolicyConfig,
+    max_buffered_request_bytes: u64,
+    max_payload_size: usize,
+) -> (axum::Router, Captured, AppTestContext) {
+    let mut config = base_config(max_payload_size);
+    config.max_buffered_request_bytes = max_buffered_request_bytes;
+    streaming_app_with_config(policy, config).await
+}
+
+async fn streaming_app_with_config(
+    policy: PolicyConfig,
+    mut config: RouterConfig,
+) -> (axum::Router, Captured, AppTestContext) {
+    let (worker_url, captured) = spawn_capture_worker().await;
+
     config.policy = policy;
     config.health_check.disable_health_check = true;
 
@@ -218,7 +232,7 @@ async fn large_chat_body_streams_to_worker_chunked() {
 }
 
 #[tokio::test]
-async fn below_threshold_body_stays_buffered() {
+async fn body_under_retry_buffer_cap_stays_buffered() {
     let (app, captured, ctx) =
         streaming_app(least_load_policy(), 64 * 1024, 64 * 1024 * 1024).await;
     let payload = generate_payload(64);
@@ -232,6 +246,116 @@ async fn below_threshold_body_stays_buffered() {
     assert!(
         headers.get(CONTENT_LENGTH).is_some(),
         "the buffered path sends a fixed-length body"
+    );
+    drop(captured);
+    ctx.shutdown().await;
+}
+
+#[tokio::test]
+async fn retries_disabled_streams_a_small_body() {
+    let mut config = base_config(64 * 1024 * 1024);
+    config.disable_retries = true;
+    let (app, captured, ctx) = streaming_app_with_config(least_load_policy(), config).await;
+    let payload = generate_payload(64);
+
+    let req = chunked_json_request("/generate", payload.clone(), Some(payload.len() as u64));
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let captured = captured.lock().await;
+    let (headers, body) = captured.first().unwrap();
+    assert_eq!(body.as_ref(), payload.as_slice());
+    assert!(
+        headers.get(CONTENT_LENGTH).is_none(),
+        "a pure-forward request must stream at any size"
+    );
+    drop(captured);
+    ctx.shutdown().await;
+}
+
+#[tokio::test]
+async fn default_config_buffers_small_and_streams_past_one_mib() {
+    let (app, captured, ctx) =
+        streaming_app_with_config(least_load_policy(), base_config(64 * 1024 * 1024)).await;
+
+    let small = generate_payload(64);
+    let req = chunked_json_request("/generate", small.clone(), Some(small.len() as u64));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    {
+        let captured = captured.lock().await;
+        let (headers, _) = captured.first().unwrap();
+        assert!(
+            headers.get(CONTENT_LENGTH).is_some(),
+            "a retryable body under the 1MiB default must buffer"
+        );
+    }
+
+    let app = ctx.create_app();
+    let large = generate_payload(2 * 1024 * 1024);
+    let req = chunked_json_request("/generate", large.clone(), Some(large.len() as u64));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let captured = captured.lock().await;
+    let (headers, body) = captured.last().unwrap();
+    assert_eq!(body.as_ref(), large.as_slice());
+    assert!(
+        headers.get(CONTENT_LENGTH).is_none(),
+        "a body past the 1MiB default must stream and forfeit retries"
+    );
+    drop(captured);
+    ctx.shutdown().await;
+}
+
+/// Streamed selection is content-blind, so a second model in the registry
+/// must force the buffered typed path — which reads the model and lands the
+/// request on the right worker even past the retry-buffer cap.
+#[tokio::test]
+async fn multi_model_registry_buffers_and_routes_to_the_right_model() {
+    let (url_a, captured_a) = spawn_capture_worker().await;
+    let (url_b, captured_b) = spawn_capture_worker().await;
+
+    let mut config = base_config(64 * 1024 * 1024);
+    config.policy = least_load_policy();
+    config.health_check.disable_health_check = true;
+    let ctx = AppTestContext::new_with_config(config, vec![]).await;
+    for (url, model) in [(&url_a, "model-a"), (&url_b, "model-b")] {
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(WorkerType::Regular)
+                .models(vec![ModelCard::new(model)])
+                .health_config(openai_protocol::worker::HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        );
+        ctx.app_context.worker_registry.register(worker);
+    }
+    let app = ctx.create_app();
+
+    let payload = serde_json::to_vec(&json!({
+        "model": "model-b",
+        "messages": [{"role": "user", "content": "y".repeat(2 * 1024 * 1024)}]
+    }))
+    .unwrap();
+    let req = chunked_json_request(
+        "/v1/chat/completions",
+        payload.clone(),
+        Some(payload.len() as u64),
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    assert!(
+        captured_a.lock().await.is_empty(),
+        "model-a's worker must never see a model-b request"
+    );
+    let captured = captured_b.lock().await;
+    let (headers, _) = captured.first().unwrap();
+    assert!(
+        headers.get(CONTENT_LENGTH).is_some(),
+        "a multi-model registry must take the buffered typed path"
     );
     drop(captured);
     ctx.shutdown().await;
@@ -254,7 +378,7 @@ async fn missing_content_length_stays_buffered() {
 }
 
 #[tokio::test]
-async fn text_needing_policy_stays_buffered_above_threshold() {
+async fn text_needing_policy_stays_buffered_past_the_cap() {
     let (app, captured, ctx) = streaming_app(cache_aware_policy(), 1024, 64 * 1024 * 1024).await;
     let payload = generate_payload(16 * 1024);
 


### PR DESCRIPTION
## Description

### Problem

`--stream-request-bodies-over` made an operator pre-decide, fleet-wide and by size, whether request bodies buffer (store, parse, re-serialize, send) or stream through verbatim. That one guessed number silently coupled three unrelated questions: does anything downstream need the bytes, who validates, and how much memory one request may pin. The default (disabled) buffered everything: on the video shadow lane that was ~340GB of slow client uploads pinned per router until the flag was discovered. Operators tuning routing knobs should not inherit a memory model as a side effect - and "we only fixed router.rs" should not be possible either: whether a router family can forward bodies verbatim is a property of the family, and it should be declared, not implied by a downcast.

### Solution

Two layers, no operator input:

**Body policy is part of the router contract.** `RouterTrait` gains a non-defaulted `request_body_policy() -> BodyPolicy`: either `ForwardCapable` (the regular HTTP router) or `MustBuffer(reason)` - `per_leg_construction` (PD), `protocol_transformation` (gRPC), `pipeline_transform` (Anthropic/Gemini/OpenAI), `model_selection` (multi-router dispatch). The compiler forces every family, present and future, to declare; there is no silent default. Every request increments `smg_router_request_body_path_total{path, reason}` exactly once, so the buffered/streamed mix per lane is on a dashboard with reasons attached.

**ForwardCapable routers decide per request**, before the body arrives, from facts the router already has:
1. Buffer when someone provably needs the bytes: policy needs request text and no sticky-key/token-hint waiver applies; a candidate worker mutates requests (re-checked after selection to cover the registration race); WASM request hooks; missing/invalid Content-Length.
2. When the only reason is retryability: buffer up to `--max-buffered-request-bytes` (default 1MiB, 0 = never) to keep router retries; past the bound, stream and forfeit retries for that request, observably.
3. Otherwise stream, any size: the engine receives the client's bytes as they arrive; the router holds only in-transit chunks.

`--stream-request-bodies-over` is REMOVED, not deprecated - it never shipped in a tagged release.

### Breaking change

> ⚠️ Versus the last release, the default changes: eligible requests larger than 1MiB now stream - engines receive the client's bytes verbatim (chunked, no re-serialization normalization), those requests forfeit router-level retries, and router-side parse validation for them moves to the engine (which always re-validated). `--max-buffered-request-bytes 0` plus a text-needing policy restores buffer-everything.
>
> ⚠️ Deployment coordination: `--stream-request-bodies-over` is gone and clap rejects unknown args (verified: the binary and the Python launcher both fail at startup if it is passed). Any nightly deployment still setting it must drop the flag in the SAME change as the image bump - dropping it early reverts those routers to buffer-everything on the old image; keeping it late crash-loops the new one. Config files carrying the old key are unaffected (serde ignores unknown fields); the CLI is the hard-fail surface.

## Changes

- `BodyPolicy` in the router trait's home with a DEFAULTED `request_body_policy()`: buffering is the safe default, with the counter reason derived from the existing `router_type()` identity - zero code per family. Exactly two overrides: the regular HTTP router (`ForwardCapable`) and `RouterManager` (lone-router delegation; `model_selection` when dispatching across several). The middleware consults the capability, never a downcast
- `Router::request_body_path` per-request decision matrix (one compact doc comment); middleware renamed `stream_eligible_request_bodies`, no longer size-gated
- `--max-buffered-request-bytes` through both config paths, builder, serde default, Python bindings; old flag removed from every surface (CLI, config, validation, bindings, tests)
- `smg_router_request_body_path_total{path, reason}` counter, tiny label set

## Test Plan

- Decision matrix units: every hard-buffer reason forces buffering; retry crossover exactly at the bound (1024 buffers, 1025 streams); 0-cap semantics; pure-forward streams any size; per-model retry-override conservatism
- Capability: manager delegation pinned through derived reasons (lone stub, lone PD stub, multi-router model_selection)
- Integration: stock config buffers small and streams a 2MiB body (worker observes chunked/no-CL); retries-disabled streams small bodies; removed-flag rejection verified for both the binary and the Python launcher; all pre-existing streamed/buffered/mutating-worker fixtures pass
- Full `cargo test -p smg`: 26 binaries, zero failures (lib 1822); Python wheel rebuilt via maturin, arg-parser pytest 56 passed; smg-golang clean; clippy `--all-targets -- -D warnings` clean; fmt silent

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>