### PR TITLE
docs(governance): define API stability policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,6 @@
 
 # Main source code (model_gateway)
 /model_gateway/src/config @slin1237 @CatherineSue
-/model_gateway/src/core @slin1237 @CatherineSue
 /model_gateway/src/policies @slin1237
 /model_gateway/src/routers @CatherineSue @key4ng @slin1237
 
@@ -47,3 +46,16 @@
 
 # Examples
 /examples/wasm @tonyluj @slin1237
+
+# API stability and generated client contracts
+/docs/api-stability.md @slin1237 @CatherineSue @key4ng
+/docs/api-stability-ci.md @slin1237 @CatherineSue @key4ng
+/docs/api-surface-inventory.md @slin1237 @CatherineSue @key4ng
+/governance @slin1237 @CatherineSue @key4ng
+/clients/openapi-gen @slin1237 @CatherineSue @key4ng
+/clients/openapi @slin1237 @CatherineSue @key4ng
+/clients/python @slin1237 @CatherineSue @key4ng
+/clients/rust @slin1237 @CatherineSue @key4ng
+/clients/java @slin1237 @CatherineSue @key4ng
+/crates/grpc_client/proto @njhill @CatherineSue @slin1237
+/crates/mesh/src/proto @tonyluj @llfl @slin1237

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,10 +48,7 @@
 /examples/wasm @tonyluj @slin1237
 
 # API stability and generated client contracts
-/docs/api-stability.md @slin1237 @CatherineSue @key4ng
-/docs/api-stability-ci.md @slin1237 @CatherineSue @key4ng
-/docs/api-surface-inventory.md @slin1237 @CatherineSue @key4ng
-/governance @slin1237 @CatherineSue @key4ng
+/governance/ @slin1237 @CatherineSue @key4ng
 /clients/openapi-gen @slin1237 @CatherineSue @key4ng
 /clients/openapi @slin1237 @CatherineSue @key4ng
 /clients/python @slin1237 @CatherineSue @key4ng

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,11 +101,11 @@ Signed-off-by: Your Name <your.email@example.com>
   Example: `Fixed in abc1234 — capped total_chunks at 1024 before allocation`.
   Silence or "Fixed!" makes reviewers re-hunt your work.
 
-For a public-contract change, identify the affected Rust package, HTTP/OpenAPI,
-protobuf, CLI/config, generated-client, or release surface in the PR description.
-State whether the change is additive, deprecated-compatible, or breaking; include
-the version decision and migration note when required by
-[`docs/api-stability.md`](docs/api-stability.md).
+For any change governed by the [API Stability Policy](docs/api-stability.md), identify
+every affected contract in the PR description and classify the change as additive,
+deprecated-compatible, or breaking. Record any version or deprecation action and
+migration note required by the policy. An intentional break must also follow the
+[label, release-note, and approval requirements](docs/api-stability.md#intentional-breaking-changes).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,12 @@ Signed-off-by: Your Name <your.email@example.com>
   Example: `Fixed in abc1234 — capped total_chunks at 1024 before allocation`.
   Silence or "Fixed!" makes reviewers re-hunt your work.
 
+For a public-contract change, identify the affected Rust package, HTTP/OpenAPI,
+protobuf, CLI/config, generated-client, or release surface in the PR description.
+State whether the change is additive, deprecated-compatible, or breaking; include
+the version decision and migration note when required by
+[`docs/api-stability.md`](docs/api-stability.md).
+
 ---
 
 ## Using code agents (Claude Code, Cursor, Copilot, etc.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,11 +101,11 @@ Signed-off-by: Your Name <your.email@example.com>
   Example: `Fixed in abc1234 — capped total_chunks at 1024 before allocation`.
   Silence or "Fixed!" makes reviewers re-hunt your work.
 
-For any change governed by the [API Stability Policy](docs/api-stability.md), identify
+For any change governed by the [API Stability Policy](governance/api-stability.md), identify
 every affected contract in the PR description and classify the change as additive,
 deprecated-compatible, or breaking. Record any version or deprecation action and
 migration note required by the policy. An intentional break must also follow the
-[label, release-note, and approval requirements](docs/api-stability.md#intentional-breaking-changes).
+[label, release-note, and approval requirements](governance/api-stability.md#intentional-breaking-changes).
 
 ---
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -37,7 +37,7 @@ crates, release planning, deprecations — are proposed as a GitHub issue or
 design discussion and decided by consensus among the core maintainers.
 
 Public contract changes additionally follow the [API Stability
-Policy](docs/api-stability.md). That policy defines compatibility categories,
+Policy](governance/api-stability.md). That policy defines compatibility categories,
 deprecation windows, version decisions, migration requirements, and the owner path
 for intentional breaking changes.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -36,6 +36,11 @@ Significant changes — new architecture, breaking API changes, new workspace
 crates, release planning, deprecations — are proposed as a GitHub issue or
 design discussion and decided by consensus among the core maintainers.
 
+Public contract changes additionally follow the [API Stability
+Policy](docs/api-stability.md). That policy defines compatibility categories,
+deprecation windows, version decisions, migration requirements, and the owner path
+for intentional breaking changes.
+
 If consensus cannot be reached in a reasonable time, the final decision
 rests with the core maintainers. Disagreements are expected to be resolved
 through discussion in the open, on GitHub.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -1,0 +1,209 @@
+# API Stability Policy
+
+SMG treats compatibility as a property of every externally consumed contract, not
+only its network protocols. The required end state applies strict formatting,
+linting, testing, and standards-drift rules to every package under `crates/`.
+Published libraries and other public surfaces receive the additional compatibility
+guarantees defined below. Policy decisions and review requirements apply immediately;
+mechanical blocking is activated in stages as described under Enforcement commands.
+
+## Contract categories
+
+| Category | Surface | Compatibility promise |
+| --- | --- | --- |
+| `published-library` | The 15 publishable libraries under `crates/` | Rust public-API compatibility under the package's version and supported feature profiles |
+| `quality-only` | `crates/mock_worker` (package `mock-worker`, with `publish = false`) | Strict workspace quality gates, but no independent public Rust API promise |
+| `public-sdk` | `clients/rust` (package `smg-client`) | Independent Rust SemVer and a declared supported endpoint surface |
+| `external-application` | `model_gateway` | Compatibility for HTTP/OpenAPI, CLI, configuration, released binary and image behavior, and documented operational behavior; no Rust module-level SemVer promise |
+| `version-locked-binding` | `bindings/python` and `bindings/golang` | Quality and integration compatibility while version-locked to core; no independent Rust API promise |
+
+The engine and mesh protobuf definitions are stable wire contracts. Generated
+clients, stable HTTP endpoints, and supported CLI and configuration interfaces are
+also contracts even though they are not Rust packages. Public WIT worlds and
+versioned data schemas remain explicit contracts; their versioned compatibility
+fixtures and upgrade-test enforcement activate only after the Rust, protobuf,
+HTTP/OpenAPI, and all-crates quality gates are blocking and the combined exit audit
+passes.
+
+Every governed change uses one of three compatibility classifications:
+
+- **Additive** adds a capability while preserving compilation, import, wire,
+  request/response, generated-client, CLI, configuration, and operational behavior
+  for every supported consumer.
+- **Deprecated-compatible** introduces a documented replacement while retaining the
+  old contract and its observable behavior for the full deprecation window.
+- **Breaking** removes, restricts, reinterprets, or observably changes a supported
+  contract, or causes a supported consumer to fail to compile, import, send, parse,
+  or operate as before.
+
+## Rust package compatibility
+
+The following publishable `crates/` packages are SemVer-governed until an explicit
+manifest change reclassifies them:
+
+1. `data-connector`
+2. `engine-zmq-client`
+3. `kv-index`
+4. `llm-multimodal`
+5. `llm-tokenizer`
+6. `openai-protocol`
+7. `reasoning-parser`
+8. `smg-auth`
+9. `smg-grpc-client`
+10. `smg-mcp`
+11. `smg-mesh`
+12. `smg-mm-rdma`
+13. `smg-wasm`
+14. `tool-parser`
+15. `wfaas`
+
+For packages at `1.0.0` or later, an incompatible public-API change requires a
+major-version release. For `0.y.z` packages, patch releases remain compatible; an
+incompatible change increments `y` and resets `z` to zero. Compatibility covers the
+public API emitted by rustdoc for every documented supported feature profile.
+
+For a published Rust library or the public Rust SDK, a change is additive only when
+all supported feature profiles remain SemVer-compatible and the SDK's declared
+endpoint surface remains compatible. Keeping the old item or endpoint usable while
+marking it deprecated and documenting its replacement is deprecated-compatible. A
+SemVer-incompatible item change, supported-feature removal, incompatible SDK API, or
+endpoint change is breaking; adding a required trait item or exhaustively matched
+enum variant is not additive merely because it adds syntax.
+
+Under the GOV-02 inventory gate, a publishable package cannot silently escape
+governance. Adding a package or changing its publication state requires updating the
+authoritative API-surface inventory, release registry, ownership, and compatibility
+checks in the same change.
+
+## Protobuf wire compatibility
+
+The protobuf definitions under `crates/grpc_client/proto` and
+`crates/mesh/src/proto` are stable wire contracts. Once the protobuf lane is
+activated, lint and breaking-change checks compare them with the pull request's merge
+base.
+
+- Existing field numbers and meanings are immutable within a supported package.
+- Removed fields and enum values reserve both their numbers and names.
+- An RPC cannot be removed or changed incompatibly in place; introduce a versioned
+  replacement instead.
+- Additive optional fields, messages, enum values, and RPCs are permitted when
+  generated consumers continue to compile or import.
+
+An addition is additive only under that generated-consumer condition. Marking and
+retaining an existing field, enum value, or RPC while a replacement is available is
+deprecated-compatible. Reusing or changing a field number or meaning, removing a
+field or enum value before its support window ends, changing an RPC in place, or
+breaking a generated consumer is breaking. Any later field or enum removal still
+reserves its number and name.
+
+## HTTP and OpenAPI compatibility
+
+Stable routes, methods, required inputs, response schemas, error behavior, streaming
+media types, and authentication behavior form the HTTP contract. Preview and internal
+routes must be explicitly classified; omission from the generated OpenAPI document is
+not itself a classification.
+
+The required mechanical end state uses the generated OpenAPI document as the
+canonical description of the declared HTTP surface. In that state, generated clients
+remain synchronized with it, and the activated compatibility lane assesses changes
+against the pull request's merge base.
+
+A new route, method, or optional input is additive only when existing requests,
+responses, and generated clients remain compatible. A response field or enum value
+is additive only when supported consumers accept it; it is breaking when strict or
+generated consumers cannot parse or compile against it. Retaining an old route,
+schema, authentication behavior, and generated-client interface while documenting a
+replacement is deprecated-compatible. Removing or renaming a stable operation,
+making an input required, narrowing accepted values, or incompatibly changing a
+schema, error, streaming media type, authentication behavior, or generated-client
+interface is breaking.
+
+## CLI and configuration compatibility
+
+Supported flags, configuration keys, defaults, exit behavior, and machine-consumed
+output remain compatible for their documented support window. Renames provide an
+alias or migration path for the normal deprecation window. A default change that
+alters observable behavior requires explicit release notes and compatibility review.
+
+A new optional flag or key is additive only when its default preserves existing
+behavior and machine-consumed output remains parseable. A rename is
+deprecated-compatible only while the old flag or key remains as an alias or a
+behavior-preserving migration for the full window. Removing an interface, adding a
+required setting, changing a default or exit behavior, or incompatibly changing
+machine-consumed output is breaking.
+
+Application internals may change without a compatibility process when none of these
+external behaviors change.
+
+## Deprecation and removal
+
+A public item must be deprecated before normal removal. The default removal window is
+two published minor releases and at least 90 days, whichever is later. Documentation
+must identify the replacement and migration path when deprecation begins.
+
+Removal or another incompatible change requires a migration note and the version
+decision appropriate to the affected contract. An emergency security change may
+shorten the window, but its pull request must record the reason, approvers, affected
+versions, and replacement path.
+
+## Intentional breaking changes
+
+An intentional break must be visible and reviewable. Its pull request must include:
+
+- the `api-break-approved` label;
+- the affected contract and compatibility classification;
+- the major or pre-1.0 minor version decision, where applicable;
+- release notes and a concrete migration path; and
+- approval from an applicable CODEOWNER and a Core Maintainer acting as release owner.
+
+Compatibility and lint exceptions must be narrow, documented, owned, and expire no
+more than 90 days after approval. A repository-local weakening of a shared rule or a
+silent gate waiver is not an acceptable exception.
+
+## Ownership and review
+
+`.github/CODEOWNERS` identifies the reviewers for policy, inventory, SDK, OpenAPI, and
+protobuf changes. Significant public-contract changes are proposed through a GitHub
+issue or design discussion in accordance with `GOVERNANCE.md`.
+
+The author must identify every affected contract in the pull request and classify the
+change as additive, deprecated-compatible, or breaking. A release owner is a current
+Core Maintainer listed in `GOVERNANCE.md`. Request and record both approvals on the
+pull request. If one person is both the applicable CODEOWNER and release owner, a
+second Core Maintainer must approve so every intentional break has two distinct human
+approvers.
+
+## Enforcement commands
+
+The policy's classifications, deprecation rules, migration requirements, and approval
+path are normative now. At publication, the repository's existing formatting,
+Clippy, test, and pre-commit checks are the active mechanical checks, with coverage
+defined by the current workflows and manifests. Full strict-rule coverage for all 16
+`crates/` packages and the compatibility blockers below are staged work, not current
+blocking claims.
+
+The required all-crates end state runs:
+
+```bash
+cargo +nightly fmt --all
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test
+```
+
+[GOV-02 (#2289)](https://github.com/smg-project/smg/issues/2289) tracks creation of
+the authoritative package inventory and this checker:
+
+```bash
+python3 scripts/check_api_governance.py --check
+```
+
+The command is not available until its implementation lands and is not a blocking
+gate until the rollout status marks it blocking.
+
+[GOV-03 (#2288)](https://github.com/smg-project/smg/issues/2288) tracks
+`docs/api-stability-ci.md`, which defines the pinned tools, exact CI job contracts,
+merge-base selection, artifacts, rollout status, and exception mechanics. The
+required compatibility lanes use `cargo-semver-checks` for governed Rust packages,
+Buf lint and breaking checks for protobuf contracts, and canonical generation and
+diff checks for OpenAPI and generated clients. A job becomes blocking only after its
+implementation exists and the GOV-03 rollout status marks it blocking.

--- a/governance/api-stability.md
+++ b/governance/api-stability.md
@@ -1,189 +1,59 @@
 # API Stability Policy
 
-SMG treats compatibility as a property of every externally consumed contract, not
-only its network protocols. The required end state applies strict formatting,
-linting, testing, and standards-drift rules to every package under `crates/`.
-Published libraries and other public surfaces receive the additional compatibility
-guarantees defined below. Policy decisions and review requirements apply immediately;
-mechanical blocking is activated in stages as described under Enforcement commands.
+SMG protects externally consumed contracts. Every regular package under
+`crates/**` must remain a workspace member, inherit workspace lints, and pass the
+repository's existing workspace formatting, Clippy, and test jobs. The machine
+inventory in `governance/api-surfaces.toml` is the authoritative package
+classification.
 
-## Contract categories
+## Public boundary
 
-| Category | Surface | Compatibility promise |
-| --- | --- | --- |
-| `published-library` | The 15 publishable libraries under `crates/` | Rust public-API compatibility under the package's version and supported feature profiles |
-| `quality-only` | `crates/mock_worker` (package `mock-worker`, with `publish = false`) | Strict workspace quality gates, but no independent public Rust API promise |
-| `public-sdk` | `clients/rust` (package `smg-client`) | Independent Rust SemVer and a declared supported endpoint surface |
-| `external-application` | `model_gateway` | Compatibility for HTTP/OpenAPI, CLI, configuration, released binary and image behavior, and documented operational behavior; no Rust module-level SemVer promise |
-| `version-locked-binding` | `bindings/python` and `bindings/golang` | Quality and integration compatibility while version-locked to core; no independent Rust API promise |
+| Category | Boundary |
+| --- | --- |
+| Published crate | Rust public API is SemVer-compatible for its documented public feature profiles. |
+| `smg-client` | Public Rust SDK and declared endpoint surface are SemVer-compatible. |
+| `mock-worker` | Quality-controlled infrastructure; no independent public Rust API promise. |
+| `model_gateway` | HTTP/OpenAPI, CLI, configuration, released artifacts, and documented operational behavior; not internal Rust modules. |
+| Python and Go bindings | Quality and integration compatibility while version-locked to core; no independent Rust API promise. |
+| Engine and mesh protobuf | Stable wire contracts, including supported generated consumers. |
 
-The engine and mesh protobuf definitions are stable wire contracts. Generated
-clients, stable HTTP endpoints, and supported CLI and configuration interfaces are
-also contracts even though they are not Rust packages. Public WIT worlds and
-versioned data schemas remain explicit contracts; their versioned compatibility
-fixtures and upgrade-test enforcement activate only after the Rust, protobuf,
-HTTP/OpenAPI, and all-crates quality gates are blocking and the combined exit audit
-passes.
+Stable HTTP routes, methods, required inputs, responses, errors, streaming media
+types, and authentication behavior are part of the public boundary. Preview and
+internal routes must be explicitly classified. Supported CLI flags, configuration
+keys, defaults, exit behavior, and machine-consumed output are also contracts.
 
-Every governed change uses one of three compatibility classifications:
+## Compatibility
 
-- **Additive** adds a capability while preserving compilation, import, wire,
-  request/response, generated-client, CLI, configuration, and operational behavior
-  for every supported consumer.
-- **Deprecated-compatible** introduces a documented replacement while retaining the
-  old contract and its observable behavior for the full deprecation window.
+- **Additive** preserves existing supported consumers while adding capability.
+- **Deprecated-compatible** provides a documented replacement while retaining the
+  old behavior for the full deprecation window.
 - **Breaking** removes, restricts, reinterprets, or observably changes a supported
-  contract, or causes a supported consumer to fail to compile, import, send, parse,
-  or operate as before.
+  contract, including a failure to compile, import, send, parse, or operate as
+  before.
 
-## Rust package compatibility
+For Rust crates at 1.0 or later, a breaking public API change requires a major
+release. Before 1.0, patch releases remain compatible and a breaking change requires
+the next minor release. Protobuf field numbers and meanings remain immutable; removed
+field and enum names and numbers remain reserved, and an incompatible RPC change
+requires a versioned replacement.
 
-The following publishable `crates/` packages are SemVer-governed until an explicit
-manifest change reclassifies them:
+## Deprecation and intentional breaks
 
-1. `data-connector`
-2. `engine-zmq-client`
-3. `kv-index`
-4. `llm-multimodal`
-5. `llm-tokenizer`
-6. `openai-protocol`
-7. `reasoning-parser`
-8. `smg-auth`
-9. `smg-grpc-client`
-10. `smg-mcp`
-11. `smg-mesh`
-12. `smg-mm-rdma`
-13. `smg-wasm`
-14. `tool-parser`
-15. `wfaas`
+Normal removal follows deprecation for at least two published minor releases and 90
+days, whichever is later. The deprecation documentation identifies the replacement
+and migration path. An emergency security change may shorten the window only when its
+pull request records the reason, affected versions, approvers, and replacement path.
 
-For packages at `1.0.0` or later, an incompatible public-API change requires a
-major-version release. For `0.y.z` packages, patch releases remain compatible; an
-incompatible change increments `y` and resets `z` to zero. Compatibility covers the
-public API emitted by rustdoc for every documented supported feature profile.
+An intentional break requires the `api-break-approved` label, the affected contract
+and classification, the applicable major or pre-1.0 minor version decision, release
+notes, a concrete migration path, and approval from the applicable CODEOWNER and a
+Core Maintainer acting as release owner. If one person fills both roles, a second Core
+Maintainer approves. Exceptions must be narrow, documented, owned, and expire within
+90 days; silent waivers and broad local weakenings are not exceptions.
 
-For a published Rust library or the public Rust SDK, a change is additive only when
-all supported feature profiles remain SemVer-compatible and the SDK's declared
-endpoint surface remains compatible. Keeping the old item or endpoint usable while
-marking it deprecated and documenting its replacement is deprecated-compatible. A
-SemVer-incompatible item change, supported-feature removal, incompatible SDK API, or
-endpoint change is breaking; adding a required trait item or exhaustively matched
-enum variant is not additive merely because it adds syntax.
+## Enforcement
 
-Under the GOV-02 inventory gate, a publishable package cannot silently escape
-governance. Adding a package or changing its publication state requires updating the
-authoritative API-surface inventory, release registry, ownership, and compatibility
-checks in the same change.
-
-## Protobuf wire compatibility
-
-The protobuf definitions under `crates/grpc_client/proto` and
-`crates/mesh/src/proto` are stable wire contracts. Once the protobuf lane is
-activated, lint and breaking-change checks compare them with the pull request's merge
-base.
-
-- Existing field numbers and meanings are immutable within a supported package.
-- Removed fields and enum values reserve both their numbers and names.
-- An RPC cannot be removed or changed incompatibly in place; introduce a versioned
-  replacement instead.
-- Additive optional fields, messages, enum values, and RPCs are permitted only when
-  supported generated consumers continue to compile or import, parse the expanded
-  contract, and operate correctly with the additions.
-
-An addition is additive only under that generated-consumer condition. Marking and
-retaining an existing field, enum value, or RPC while a replacement is available is
-deprecated-compatible. Reusing or changing a field number or meaning, removing a
-field or enum value before its support window ends, changing an RPC in place, or
-breaking a generated consumer is breaking. Any later field or enum removal still
-reserves its number and name.
-
-## HTTP and OpenAPI compatibility
-
-Stable routes, methods, required inputs, response schemas, error behavior, streaming
-media types, and authentication behavior form the HTTP contract. Preview and internal
-routes must be explicitly classified; omission from the generated OpenAPI document is
-not itself a classification.
-
-The required mechanical end state uses the generated OpenAPI document as the
-canonical description of the declared HTTP surface. In that state, generated clients
-remain synchronized with it, and the activated compatibility lane assesses changes
-against the pull request's merge base.
-
-A new route, method, or optional input is additive only when existing requests,
-responses, and generated clients remain compatible. A response field or enum value
-is additive only when supported consumers accept it; it is breaking when strict or
-generated consumers cannot parse or compile against it. Retaining an old route,
-schema, authentication behavior, and generated-client interface while documenting a
-replacement is deprecated-compatible. Removing or renaming a stable operation,
-making an input required, narrowing accepted values, or incompatibly changing a
-schema, error, streaming media type, authentication behavior, or generated-client
-interface is breaking.
-
-## CLI and configuration compatibility
-
-Supported flags, configuration keys, defaults, exit behavior, and machine-consumed
-output remain compatible for their documented support window. Renames provide an
-alias or migration path for the normal deprecation window. A default change that
-alters observable behavior requires explicit release notes and compatibility review.
-
-A new optional flag or key is additive only when its default preserves existing
-behavior and machine-consumed output remains parseable. A rename is
-deprecated-compatible only while the old flag or key remains as an alias or a
-behavior-preserving migration for the full window. Removing an interface, adding a
-required setting, changing a default or exit behavior, or incompatibly changing
-machine-consumed output is breaking.
-
-Application internals may change without a compatibility process when none of these
-external behaviors change.
-
-## Deprecation and removal
-
-A public item must be deprecated before normal removal. The default removal window is
-two published minor releases and at least 90 days, whichever is later. Documentation
-must identify the replacement and migration path when deprecation begins.
-
-Removal or another incompatible change requires a migration note and the version
-decision appropriate to the affected contract. An emergency security change may
-shorten the window, but its pull request must record the reason, approvers, affected
-versions, and replacement path.
-
-## Intentional breaking changes
-
-An intentional break must be visible and reviewable. Its pull request must include:
-
-- the `api-break-approved` label;
-- the affected contract and compatibility classification;
-- the major or pre-1.0 minor version decision, where applicable;
-- release notes and a concrete migration path; and
-- approval from an applicable CODEOWNER and a Core Maintainer acting as release owner.
-
-Compatibility and lint exceptions must be narrow, documented, owned, and expire no
-more than 90 days after approval. A repository-local weakening of a shared rule or a
-silent gate waiver is not an acceptable exception.
-
-## Ownership and review
-
-`.github/CODEOWNERS` identifies the reviewers for policy, inventory, SDK, OpenAPI, and
-protobuf changes. Significant public-contract changes are proposed through a GitHub
-issue or design discussion in accordance with `GOVERNANCE.md`.
-
-The author must identify every affected contract in the pull request and classify the
-change as additive, deprecated-compatible, or breaking. A release owner is a current
-Core Maintainer listed in `GOVERNANCE.md`. Request and record both approvals on the
-pull request. If one person is both the applicable CODEOWNER and release owner, a
-second Core Maintainer must approve so every intentional break has two distinct human
-approvers.
-
-## Enforcement commands
-
-The policy's classifications, deprecation rules, migration requirements, and approval
-path are normative now. At publication, the repository's existing formatting,
-Clippy, test, and pre-commit checks are the active mechanical checks, with coverage
-defined by the current workflows and manifests. Full strict-rule coverage for all 16
-`crates/` packages and the compatibility blockers below are staged work, not current
-blocking claims.
-
-The required all-crates end state runs:
+The repository's existing workspace checks enforce package quality:
 
 ```bash
 cargo +nightly fmt --all
@@ -191,20 +61,12 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test
 ```
 
-[GOV-02 (#2289)](https://github.com/smg-project/smg/issues/2289) tracks creation of
-the authoritative package inventory and this checker:
+The inventory checker confirms all `crates/**` manifests remain covered and that
+release and version registries agree with governed packages:
 
 ```bash
 python3 scripts/check_api_governance.py --check
 ```
 
-The command is not available until its implementation lands and is not a blocking
-gate until the rollout status marks it blocking.
-
-[GOV-03 (#2288)](https://github.com/smg-project/smg/issues/2288) tracks
-`governance/api-stability-ci.md`, which defines the pinned tools, exact CI job contracts,
-merge-base selection, artifacts, rollout status, and exception mechanics. The
-required compatibility lanes use `cargo-semver-checks` for governed Rust packages,
-Buf lint and breaking checks for protobuf contracts, and canonical generation and
-diff checks for OpenAPI and generated clients. A job becomes blocking only after its
-implementation exists and the GOV-03 rollout status marks it blocking.
+Dedicated compatibility checks enforce the published Rust/SDK, protobuf, and
+HTTP/OpenAPI boundaries directly in the existing pull-request workflow.

--- a/governance/api-stability.md
+++ b/governance/api-stability.md
@@ -86,8 +86,9 @@ base.
 - Removed fields and enum values reserve both their numbers and names.
 - An RPC cannot be removed or changed incompatibly in place; introduce a versioned
   replacement instead.
-- Additive optional fields, messages, enum values, and RPCs are permitted when
-  generated consumers continue to compile or import.
+- Additive optional fields, messages, enum values, and RPCs are permitted only when
+  supported generated consumers continue to compile or import, parse the expanded
+  contract, and operate correctly with the additions.
 
 An addition is additive only under that generated-consumer condition. Marking and
 retaining an existing field, enum value, or RPC while a replacement is available is

--- a/governance/api-stability.md
+++ b/governance/api-stability.md
@@ -31,6 +31,15 @@ keys, defaults, exit behavior, and machine-consumed output are also contracts.
   contract, including a failure to compile, import, send, parse, or operate as
   before.
 
+For HTTP/OpenAPI, a new route or optional input or response field is additive only
+when existing supported clients continue to send, parse, and operate correctly.
+Removing a route or method, making an input required, narrowing accepted input, or
+changing response, error, streaming media type, or authentication semantics is
+breaking. For CLI and configuration, a new optional flag or key is additive only
+when its default preserves behavior and output. Removing, renaming, retyping, making
+required, narrowing accepted values, or changing the meaning of a flag or key is
+breaking, as is changing a default, exit behavior, or machine-consumed output.
+
 For Rust crates at 1.0 or later, a breaking public API change requires a major
 release. Before 1.0, patch releases remain compatible and a breaking change requires
 the next minor release. Protobuf field numbers and meanings remain immutable; removed
@@ -39,34 +48,38 @@ requires a versioned replacement.
 
 ## Deprecation and intentional breaks
 
-Normal removal follows deprecation for at least two published minor releases and 90
-days, whichever is later. The deprecation documentation identifies the replacement
-and migration path. An emergency security change may shorten the window only when its
-pull request records the reason, affected versions, approvers, and replacement path.
+For published Rust crates, normal removal follows deprecation for at least two minor
+releases and 90 days, whichever is later. Other stable contracts retain the old
+behavior for a documented, contract-appropriate window of at least 90 days and use
+their established version or release mechanism. The deprecation documentation
+identifies the replacement and migration path. An emergency security change may
+shorten the window only when its pull request records the reason, affected versions,
+approvers, and replacement path.
 
 An intentional break requires the `api-break-approved` label, the affected contract
-and classification, the applicable major or pre-1.0 minor version decision, release
-notes, a concrete migration path, and approval from the applicable CODEOWNER and a
-Core Maintainer acting as release owner. If one person fills both roles, a second Core
-Maintainer approves. Exceptions must be narrow, documented, owned, and expire within
-90 days; silent waivers and broad local weakenings are not exceptions.
+and classification, and the version, versioned-replacement, or release action
+required for that surface. The change also requires release notes, a concrete
+migration path, and approval from the applicable CODEOWNER and a Core Maintainer
+acting as release owner. If one person fills both roles, a second Core Maintainer
+approves. Exceptions must be narrow, documented, owned, and expire within 90 days;
+silent waivers and broad local weakenings are not exceptions.
 
 ## Enforcement
 
 The repository's existing workspace checks enforce package quality:
 
 ```bash
-cargo +nightly fmt --all
-cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo +nightly fmt -- --check
+cargo clippy --all-targets --all-features -- -D warnings
 cargo test
 ```
 
-The inventory checker confirms all `crates/**` manifests remain covered and that
-release and version registries agree with governed packages:
+The inventory gate must fail when a regular `crates/**` package is missing from
+the authoritative inventory or workspace, does not inherit workspace lints, or
+disagrees with governed release and version metadata. The maintained checker and
+its focused tests live with the inventory implementation.
 
-```bash
-python3 scripts/check_api_governance.py --check
-```
-
-Dedicated compatibility checks enforce the published Rust/SDK, protobuf, and
-HTTP/OpenAPI boundaries directly in the existing pull-request workflow.
+Today, `grpc-proto-build-check` builds and imports the generated Python gRPC package,
+while `build-wheel` generates the OpenAPI document and Python client. The separately
+tracked inventory, Rust/SDK SemVer, protobuf compatibility, and HTTP/OpenAPI contract
+jobs become enforced only when they feed the existing pull-request `finish` job.

--- a/governance/api-stability.md
+++ b/governance/api-stability.md
@@ -201,7 +201,7 @@ The command is not available until its implementation lands and is not a blockin
 gate until the rollout status marks it blocking.
 
 [GOV-03 (#2288)](https://github.com/smg-project/smg/issues/2288) tracks
-`docs/api-stability-ci.md`, which defines the pinned tools, exact CI job contracts,
+`governance/api-stability-ci.md`, which defines the pinned tools, exact CI job contracts,
 merge-base selection, artifacts, rollout status, and exception mechanics. The
 required compatibility lanes use `cargo-semver-checks` for governed Rust packages,
 Buf lint and breaking checks for protobuf contracts, and canonical generation and


### PR DESCRIPTION
## Description

### Problem

SMG does not define which repository surfaces are compatibility contracts, how
changes to them are classified, or who approves an intentional break.

### Solution

Define one repository-wide API stability policy under `governance/`. The policy
covers every regular package under `crates/**`, the Rust SDK, protobuf services,
HTTP/OpenAPI, CLI, configuration, released artifacts, and documented operational
behavior while keeping `model_gateway` internal Rust modules outside SemVer scope.

## Changes

- Add `governance/api-stability.md` with public boundaries and additive,
  deprecated-compatible, and breaking classifications.
- Define contract-specific Rust, protobuf, HTTP/OpenAPI, CLI, and configuration
  compatibility rules.
- Define deprecation windows, migration requirements, and the two-person approval
  path for intentional breaking changes.
- Link the policy from contribution and governance guidance and assign the relevant
  CODEOWNERS.
- Distinguish checks enforced today from direct compatibility gates delivered by
  the follow-up workstreams.

This is a policy-only change; it does not change runtime behavior or release
artifacts.

## Test Plan

- `cargo +nightly fmt --all -- --check`
- `PKG_CONFIG_PATH=/opt/homebrew/opt/opencv@4/lib/pkgconfig cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `PKG_CONFIG_PATH=/opt/homebrew/opt/opencv@4/lib/pkgconfig cargo test`
- `git diff --check`
- Independent whole-branch and scoped bot-feedback reviews

Closes #2290
Refs #2287
