### PR TITLE
chore(release): bump versions for v1.10.0

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+SGLang |
   ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.18' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.18') }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.9.0'
+        default: 'v1.10.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.9.0-sglang-v0.5.18)'
+        description: 'Override image tag (e.g. v1.10.0-sglang-v0.5.18)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.sglang_repo }}
       engine_commit: ${{ inputs.sglang_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/smg-project/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+TRTLLM |
   ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24') }} |
   engine=${{ inputs.trtllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.9.0'
+        default: 'v1.10.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.9.0-trtllm-1.3.0)'
+        description: 'Override image tag (e.g. v1.10.0-trtllm-1.3.0)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/smg-project/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }}
       tag: ${{ inputs.tag }}
       source_build_repo: ${{ inputs.trtllm_repo }}
       source_build_ref: ${{ inputs.trtllm_commit || 'latest' }}

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+vLLM |
   ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.27.1') }} |
   engine=${{ inputs.vllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.9.0'
+        default: 'v1.10.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.9.0-vllm-v0.26.0)'
+        description: 'Override image tag (e.g. v1.10.0-vllm-v0.26.0)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.vllm_repo }}
       engine_commit: ${{ inputs.vllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/smg-project/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "data-connector"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "kv-index"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "bincode",
  "blake3",
@@ -3868,7 +3868,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llm-multimodal"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "llm-tokenizer"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "openai-protocol"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "axum",
  "bitflags 2.13.1",
@@ -6238,7 +6238,7 @@ dependencies = [
 
 [[package]]
 name = "reasoning-parser"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "parking_lot",
  "regex",
@@ -7384,7 +7384,7 @@ dependencies = [
 
 [[package]]
 name = "smg"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7497,7 +7497,7 @@ dependencies = [
 
 [[package]]
 name = "smg-auth"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "axum",
  "chrono",
@@ -7518,7 +7518,7 @@ dependencies = [
 
 [[package]]
 name = "smg-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "futures",
@@ -7535,7 +7535,7 @@ dependencies = [
 
 [[package]]
 name = "smg-golang"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -7557,7 +7557,7 @@ dependencies = [
 
 [[package]]
 name = "smg-grpc-client"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "futures",
  "hyper-util",
@@ -7581,7 +7581,7 @@ dependencies = [
 
 [[package]]
 name = "smg-mcp"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -7609,7 +7609,7 @@ dependencies = [
 
 [[package]]
 name = "smg-mesh"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7650,7 +7650,7 @@ dependencies = [
 
 [[package]]
 name = "smg-mm-rdma"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dashmap",
  "nixl-sys",
@@ -7660,7 +7660,7 @@ dependencies = [
 
 [[package]]
 name = "smg-python"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "once_cell",
  "pyo3",
@@ -7677,7 +7677,7 @@ dependencies = [
 
 [[package]]
 name = "smg-wasm"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -8643,7 +8643,7 @@ dependencies = [
 
 [[package]]
 name = "tool-parser"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "num-traits",
@@ -9807,7 +9807,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wfaas"
-version = "1.0.5"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,20 +4,20 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.11.0", path = "crates/protocols" }
-smg-mm-rdma = { version = "0.1.0", path = "crates/mm_rdma" }
-reasoning-parser = { version = "1.6.0", path = "crates/reasoning_parser" }
-tool-parser = { version = "1.6.0", path = "crates/tool_parser" }
-wfaas = { version = "1.0.5", path = "crates/workflow" }
-llm-tokenizer = { version = "1.6.0", path = "crates/tokenizer" }
-smg-auth = { version = "1.2.2", path = "crates/auth" }
-smg-mcp = { version = "2.3.2", path = "crates/mcp" }
-kv-index = { version = "1.3.2", path = "crates/kv_index" }
-smg-data-connector = { version = "2.3.3", path = "crates/data_connector", package = "data-connector" }
-llm-multimodal = { version = "1.9.0", path = "crates/multimodal" }
-smg-wasm = { version = "1.1.3", path = "crates/wasm", package = "smg-wasm" }
-smg-mesh = { version = "1.4.2", path = "crates/mesh", package = "smg-mesh" }
-smg-grpc-client = { version = "1.10.0", path = "crates/grpc_client" }
+openai-protocol = { version = "1.12.0", path = "crates/protocols" }
+smg-mm-rdma = { version = "0.1.1", path = "crates/mm_rdma" }
+reasoning-parser = { version = "1.7.0", path = "crates/reasoning_parser" }
+tool-parser = { version = "1.7.0", path = "crates/tool_parser" }
+wfaas = { version = "1.1.0", path = "crates/workflow" }
+llm-tokenizer = { version = "1.7.0", path = "crates/tokenizer" }
+smg-auth = { version = "1.2.3", path = "crates/auth" }
+smg-mcp = { version = "2.3.3", path = "crates/mcp" }
+kv-index = { version = "1.4.0", path = "crates/kv_index" }
+smg-data-connector = { version = "2.3.4", path = "crates/data_connector", package = "data-connector" }
+llm-multimodal = { version = "1.10.0", path = "crates/multimodal" }
+smg-wasm = { version = "1.1.4", path = "crates/wasm", package = "smg-wasm" }
+smg-mesh = { version = "1.4.3", path = "crates/mesh", package = "smg-mesh" }
+smg-grpc-client = { version = "1.11.0", path = "crates/grpc_client" }
 engine-zmq-client = { version = "0.1.0", path = "crates/engine_zmq_client" }
 
 # Shared dependencies

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-golang"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "1.9.0"
+version = "1.10.0"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Rust HTTP client for SMG (Shepherd Model Gateway)"
 license = "Apache-2.0"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-auth"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 description = "Authentication and authorization for control plane APIs"
 license = "Apache-2.0"

--- a/crates/data_connector/Cargo.toml
+++ b/crates/data_connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-connector"
-version = "2.3.3"
+version = "2.3.4"
 edition = "2021"
 description = "Storage backends for conversations and responses"
 license = "Apache-2.0"

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-grpc-client"
-version = "1.10.0"
+version = "1.11.0"
 edition = "2021"
 description = "gRPC clients for vLLM, TensorRT-LLM, MLX, TokenSpeed, and SGLang backends"
 license = "Apache-2.0"

--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.4.14"
+version = "0.4.15"
 description = "SMG gRPC proto definitions for vLLM, TRT-LLM, MLX, TokenSpeed, and SGLang"
 requires-python = ">=3.10"
 dependencies = [

--- a/crates/kv_index/Cargo.toml
+++ b/crates/kv_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kv-index"
-version = "1.3.2"
+version = "1.4.0"
 edition = "2021"
 description = "Radix tree implementations for prefix matching and cache-aware routing"
 license = "Apache-2.0"

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mcp"
-version = "2.3.2"
+version = "2.3.3"
 edition = "2021"
 description = "Model Context Protocol (MCP) client implementation"
 license = "Apache-2.0"

--- a/crates/mcp/src/core/pool.rs
+++ b/crates/mcp/src/core/pool.rs
@@ -289,6 +289,17 @@ impl McpConnectionPool {
             },
         }
     }
+
+    /// Look up a connection by URL when exactly one pooled identity matches.
+    #[deprecated(
+        note = "use get() with a full PoolKey; URL-only lookup fails closed when ambiguous"
+    )]
+    pub fn get_by_url(&self, url: &str) -> Option<Arc<McpClient>> {
+        match self.get_unique_by_url(url) {
+            UrlLookup::Found(client) => Some(client),
+            UrlLookup::NotFound | UrlLookup::Ambiguous => None,
+        }
+    }
 }
 
 impl Default for McpConnectionPool {
@@ -538,6 +549,13 @@ mod tests {
             pool.get_unique_by_url("http://localhost:3000"),
             UrlLookup::NotFound
         ));
+    }
+
+    #[test]
+    #[expect(deprecated, reason = "verifies the source-compatibility wrapper")]
+    fn deprecated_get_by_url_fails_closed_on_empty_pool() {
+        let pool = McpConnectionPool::new();
+        assert!(pool.get_by_url("http://localhost:3000").is_none());
     }
 
     #[test]

--- a/crates/mesh/Cargo.toml
+++ b/crates/mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mesh"
-version = "1.4.2"
+version = "1.4.3"
 edition = "2021"
 description = "Mesh gossip protocol and distributed state synchronization for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/crates/mm_rdma/Cargo.toml
+++ b/crates/mm_rdma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mm-rdma"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Multimodal pixel RDMA (NIXL) transport for the SMG gateway"
 license = "Apache-2.0"

--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-multimodal"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 description = "Multimodal processing for vision and other modalities"
 license = "Apache-2.0"

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/crates/reasoning_parser/Cargo.toml
+++ b/crates/reasoning_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasoning-parser"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 description = "Parser for AI model reasoning/thinking outputs (chain-of-thought, etc.)"
 license = "Apache-2.0"

--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-tokenizer"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 description = "LLM tokenizer library with caching and chat template support"
 license = "Apache-2.0"

--- a/crates/tool_parser/Cargo.toml
+++ b/crates/tool_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tool-parser"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 description = "Tool/function call parser for LLM model outputs"
 license = "Apache-2.0"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-wasm"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2021"
 description = "WebAssembly runtime and module management for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/crates/workflow/Cargo.toml
+++ b/crates/workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wfaas"
-version = "1.0.5"
+version = "1.1.0"
 edition = "2021"
 description = "Workflow-as-a-Service engine for managing multi-step operations"
 license = "Apache-2.0"

--- a/deploy/helm/smg/Chart.yaml
+++ b/deploy/helm/smg/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: smg
 description: "Shepherd Model Gateway - high-performance inference router for LLM deployments"
 type: application
-version: 1.9.0
-appVersion: "1.9.0"
+version: 1.10.0
+appVersion: "1.10.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/smg-project/smg
 sources:

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-servicer"
-version = "0.8.0"
+version = "0.9.0"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, MLX, TokenSpeed, SGLang)"
 requires-python = ">=3.10"
 dependencies = [

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description

### Problem

Prepare v1.10.0 by versioning packages changed since v1.9.0 and synchronizing every release surface.

### Solution

- Apply the make check-versions recommendations for 16 Rust crates and 2 Python packages.
- Sync SMG v1.10.0 across Rust, Python, and Go bindings, the Helm chart, and backend image release workflows.
- Refresh Cargo.lock workspace package versions.
- Bump smg-grpc-servicer to v0.9.0 instead of the proposed v0.8.1 because its minimum SGLang version moves from 0.5.16 to 0.5.18. This follows the compatibility convention established in the v1.9.0 release PR.
- Restore deprecated McpConnectionPool::get_by_url as a fail-closed wrapper so smg-mcp v2.3.3 remains source-compatible while ambiguous credential or tenant matches return None.

## Test Plan

- [x] make check-versions
- [x] cargo +nightly fmt --all
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test
- [x] cargo test -p smg-mcp
- [x] make python-dev

## Checklist

- [x] I have performed a self-review of the complete diff.
- [x] All version references and release artifacts are synchronized.
- [x] New and existing tests pass locally.
- [x] The changes introduce no new compiler or clippy warnings.