### PR TITLE
fix(discovery): drain workers for unready pods

### DIFF
--- a/.github/workflows/e2e-kind-discovery.yml
+++ b/.github/workflows/e2e-kind-discovery.yml
@@ -1,13 +1,15 @@
 name: E2E Kind Discovery
 
-# Manual-only while runner Docker support (dind on the k8s runner pool) is
-# unconfirmed; GitHub-hosted ubuntu-latest works out of the box. Builds smg
-# in-job: pr-test-rust publishes no server binary artifact (and its
-# artifacts expire after a day), and its self-hosted runner image is not
-# glibc-matched to ubuntu-latest — sccache keeps rebuilds cheap instead.
-# Once dind on k8s-runner-cpu is confirmed, set the runner input and
-# artifact reuse becomes safe.
+# Run automatically for service-discovery code and test-infrastructure
+# changes. GitHub-hosted ubuntu-latest provides Docker for the kind node;
+# manual dispatch keeps the runner selectable for ad-hoc validation.
 on:
+  pull_request:
+    paths:
+      - model_gateway/src/service_discovery.rs
+      - model_gateway/tests/k8s_discovery_test.rs
+      - e2e_test/kind_discovery/**
+      - .github/workflows/e2e-kind-discovery.yml
   workflow_dispatch:
     inputs:
       runner:

--- a/e2e_test/kind_discovery/test_kind_discovery.py
+++ b/e2e_test/kind_discovery/test_kind_discovery.py
@@ -16,6 +16,7 @@ import time
 from pathlib import Path
 
 import pytest
+import requests
 
 HERE = Path(__file__).parent
 
@@ -121,7 +122,7 @@ class TestKindDiscovery:
         )
         gateway.wait_for_count(5, "workers restored for re-added ports")
 
-    def test_readiness_flip_keeps_workers(self, gateway):
+    def test_readiness_flip_removes_and_restores_workers(self, gateway):
         toggle_engine_health("multi-engine-0", 28080, "down")
         kubectl(
             "wait",
@@ -129,9 +130,44 @@ class TestKindDiscovery:
             "pod/multi-engine-0",
             "--timeout=60s",
         )
-        for _ in range(3):
-            time.sleep(2)
-            assert gateway.worker_count() == 5, "unready pod lost workers"
+        drain_deadline = time.monotonic() + 30
+        while True:
+            multi = [
+                worker
+                for worker in gateway.workers()
+                if worker.get("labels", {}).get("smg.ai/pod-name") == "multi-engine-0"
+            ]
+            if not any(worker.get("status") == "ready" for worker in multi):
+                break
+            assert time.monotonic() < drain_deadline, (
+                f"unready pod workers remained routable: {multi}"
+            )
+            time.sleep(0.25)
+
+        response = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            json={
+                "model": "kind-e2e-model",
+                "messages": [{"role": "user", "content": "drain probe"}],
+            },
+            timeout=10,
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["choices"][0]["message"]["content"] == "served-by-28090"
+
+        gateway.wait_for_count(1, "four workers removed while their pod is unready")
+        remaining = gateway.workers()
+        assert len(remaining) == 1
+        assert remaining[0].get("labels", {}).get("smg.ai/pod-name") == "single-engine-0"
+
+        deletion_timestamp = kubectl(
+            "get",
+            "pod/multi-engine-0",
+            "-o",
+            "jsonpath={.metadata.deletionTimestamp}",
+        ).stdout
+        assert not deletion_timestamp, "unready pod must still exist"
+
         toggle_engine_health("multi-engine-0", 28080, "up")
         kubectl(
             "wait",
@@ -139,7 +175,7 @@ class TestKindDiscovery:
             "pod/multi-engine-0",
             "--timeout=60s",
         )
-        gateway.wait_for_count(5, "workers intact after readiness recovery")
+        gateway.wait_for_count(5, "workers restored after readiness recovery")
 
     def test_gateway_restart_rebuilds_registry(self, gateway):
         gateway.restart()
@@ -164,8 +200,6 @@ class TestKindDiscovery:
         )
 
     def test_completions_route_to_discovered_workers(self, gateway):
-        import requests
-
         gateway.wait_for_count(5, "baseline before data-plane check")
         # Health promotion lags registration; wait for the first 200 before
         # asserting fan-out.

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -667,12 +667,11 @@ struct DesiredWorker {
 /// Desired view of the cluster derived from the store snapshot.
 #[derive(Debug, Default)]
 struct DesiredState {
-    /// Owning pod uid per worker URL, for all live, non-terminating pods
-    /// (any readiness). Registered workers whose URL is absent — or owned by
-    /// a different pod uid — are removed; unready pods keep their own
-    /// workers (the health checker owns readiness flaps).
+    /// Owning pod uid per worker URL for Ready, non-terminating Pods.
+    /// Registered workers whose URL is absent — or owned by a different Pod
+    /// uid — enter the existing drain/remove workflow.
     uid_by_url: HashMap<String, String>,
-    /// Workers on healthy pods — registration candidates.
+    /// Workers on Running, Ready Pods — registration candidates.
     addable: Vec<DesiredWorker>,
 }
 
@@ -703,6 +702,13 @@ fn compute_desired_state(pods: &[Arc<Pod>], config: &ServiceDiscoveryConfig) -> 
         let Some(info) = PodInfo::from_pod(pod, Some(config)) else {
             continue;
         };
+        // Pod readiness is Kubernetes' standard traffic-admission signal.
+        // Controllers can drive it through readiness gates; direct Pod-IP
+        // routing must honor the aggregate Ready condition just like a
+        // Service/EndpointSlice consumer would.
+        if !info.is_ready {
+            continue;
+        }
         for (index, port) in info.ports.iter().enumerate() {
             let url = format!("{}:{}", info.ip, port);
             if state.uid_by_url.contains_key(&url) {
@@ -892,7 +898,10 @@ async fn reconcile_workers(
     );
 
     for worker in removals {
-        info!("Removing worker {}: pod gone or terminating", worker.url);
+        info!(
+            "Removing worker {}: pod unready, gone, terminating, or replaced",
+            worker.url
+        );
         let job = Job::RemoveWorker {
             url: worker.url.clone(),
             expected_revision: Some(worker.revision),
@@ -1624,9 +1633,9 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_desired_state_unready_pod_present_but_not_addable() {
+    fn test_compute_desired_state_unready_pod_excluded() {
         let config = make_regular_config();
-        let mut pod = make_labeled_pod("w", "10.0.0.1", &[("app", "sglang")]);
+        let mut pod = pod_with_annotations("w", &[("smg.ai/worker-ports", "8080,8081")]);
         if let Some(status) = pod.status.as_mut() {
             status.conditions = Some(vec![PodCondition {
                 type_: "Ready".to_string(),
@@ -1639,7 +1648,27 @@ mod tests {
             }]);
         }
         let desired = compute_desired_state(&store_snapshot(vec![pod]), &config);
-        assert!(desired.uid_by_url.contains_key("10.0.0.1:8000"));
+        assert!(desired.uid_by_url.is_empty());
+        assert!(desired.addable.is_empty());
+    }
+
+    #[test]
+    fn test_compute_desired_state_unknown_readiness_excluded() {
+        let config = make_regular_config();
+        let mut pod = make_labeled_pod("w", "10.0.0.1", &[("app", "sglang")]);
+        if let Some(status) = pod.status.as_mut() {
+            status.conditions = Some(vec![PodCondition {
+                type_: "Ready".to_string(),
+                status: "Unknown".to_string(),
+                last_probe_time: None,
+                last_transition_time: None,
+                message: None,
+                reason: None,
+                observed_generation: None,
+            }]);
+        }
+        let desired = compute_desired_state(&store_snapshot(vec![pod]), &config);
+        assert!(desired.uid_by_url.is_empty());
         assert!(desired.addable.is_empty());
     }
 
@@ -1727,18 +1756,13 @@ mod tests {
         }
     }
 
-    fn desired_state_of(workers: &[DesiredWorker], present_only: &[(&str, &str)]) -> DesiredState {
+    fn desired_state_of(workers: &[DesiredWorker]) -> DesiredState {
         let mut state = DesiredState::default();
         for worker in workers {
             state
                 .uid_by_url
                 .insert(worker.url.clone(), worker.pod_uid.clone());
             state.addable.push(worker.clone());
-        }
-        for (url, uid) in present_only {
-            state
-                .uid_by_url
-                .insert((*url).to_string(), (*uid).to_string());
         }
         state
     }
@@ -1753,13 +1777,10 @@ mod tests {
 
     #[test]
     fn test_compute_actions_adds_missing_workers() {
-        let desired = desired_state_of(
-            &[
-                desired_worker("10.0.0.1:8080", "u1"),
-                desired_worker("10.0.0.1:8081", "u1"),
-            ],
-            &[],
-        );
+        let desired = desired_state_of(&[
+            desired_worker("10.0.0.1:8080", "u1"),
+            desired_worker("10.0.0.1:8081", "u1"),
+        ]);
         let actions = compute_actions(&desired, &[]);
         assert_eq!(actions.add.len(), 2);
         assert!(actions.remove.is_empty());
@@ -1767,7 +1788,7 @@ mod tests {
 
     #[test]
     fn test_compute_actions_noop_when_converged() {
-        let desired = desired_state_of(&[desired_worker("10.0.0.1:8080", "u1")], &[]);
+        let desired = desired_state_of(&[desired_worker("10.0.0.1:8080", "u1")]);
         let registered = [owned("10.0.0.1:8080", "u1")];
         let actions = compute_actions(&desired, &registered);
         assert!(actions.add.is_empty());
@@ -1776,7 +1797,7 @@ mod tests {
 
     #[test]
     fn test_compute_actions_removes_workers_for_gone_pods() {
-        let desired = desired_state_of(&[desired_worker("10.0.0.1:8080", "u1")], &[]);
+        let desired = desired_state_of(&[desired_worker("10.0.0.1:8080", "u1")]);
         let registered = [owned("10.0.0.1:8080", "u1"), owned("10.0.0.2:8080", "u2")];
         let actions = compute_actions(&desired, &registered);
         assert!(actions.add.is_empty());
@@ -1789,7 +1810,7 @@ mod tests {
         // Same-IP pod restart (hostNetwork / stable IP): URL unchanged but
         // uid differs → the stale worker is removed (covers a scheme-flipped
         // sibling the Upsert cannot replace) and the new one registered.
-        let desired = desired_state_of(&[desired_worker("10.0.0.1:8080", "uid-new")], &[]);
+        let desired = desired_state_of(&[desired_worker("10.0.0.1:8080", "uid-new")]);
         let registered = [owned("10.0.0.1:8080", "uid-old")];
         let actions = compute_actions(&desired, &registered);
         assert_eq!(actions.add.len(), 1);
@@ -1799,15 +1820,30 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_actions_removes_stale_worker_behind_unready_replacement() {
-        // Pod A was deleted; unready replacement B holds the same URL. A's
-        // worker must go now — B registers only once it turns healthy.
-        let desired = desired_state_of(&[], &[("10.0.0.1:8080", "uid-b")]);
-        let registered = [owned("10.0.0.1:8080", "uid-a")];
+    fn test_compute_actions_unready_pod_removes_registered_workers() {
+        let config = make_regular_config();
+        let mut pod = pod_with_annotations("w", &[("smg.ai/worker-ports", "8080,8081")]);
+        if let Some(status) = pod.status.as_mut() {
+            status.conditions = Some(vec![PodCondition {
+                type_: "Ready".to_string(),
+                status: "False".to_string(),
+                last_probe_time: None,
+                last_transition_time: None,
+                message: None,
+                reason: None,
+                observed_generation: None,
+            }]);
+        }
+        let desired = compute_desired_state(&store_snapshot(vec![pod]), &config);
+        let registered = [
+            owned("10.0.0.1:8080", "uid-w"),
+            owned("10.0.0.1:8081", "uid-w"),
+        ];
         let actions = compute_actions(&desired, &registered);
         assert!(actions.add.is_empty());
-        assert_eq!(actions.remove.len(), 1);
-        assert_eq!(actions.remove[0].pod_uid, "uid-a");
+        assert_eq!(actions.remove.len(), 2);
+        assert_eq!(actions.remove[0].pod_uid, "uid-w");
+        assert_eq!(actions.remove[1].pod_uid, "uid-w");
     }
 
     #[test]
@@ -1818,17 +1854,6 @@ mod tests {
         assert_eq!(actions.remove[0].url, "10.0.0.1:8080");
         assert_eq!(actions.remove[0].revision, 1);
         assert!(actions.add.is_empty());
-    }
-
-    #[test]
-    fn test_compute_actions_unready_pod_keeps_registered_worker() {
-        // URL present (pod exists, unready → not addable) and registered:
-        // neither added nor removed — the health checker owns readiness.
-        let desired = desired_state_of(&[], &[("10.0.0.1:8080", "u1")]);
-        let registered = [owned("10.0.0.1:8080", "u1")];
-        let actions = compute_actions(&desired, &registered);
-        assert!(actions.add.is_empty());
-        assert!(actions.remove.is_empty());
     }
 
     #[test]

--- a/model_gateway/tests/k8s_discovery_test.rs
+++ b/model_gateway/tests/k8s_discovery_test.rs
@@ -473,6 +473,8 @@ async fn watch_interruption_relists_and_converges() {
 
 #[tokio::test]
 async fn drain_window_is_honored_despite_reconcile_passes() {
+    use openai_protocol::worker::WorkerStatus;
+
     let fake = FakeK8s::start().await;
     let app_context = test_context_with_drain(2).await;
     let (_engine, port) = start_mock_engine().await;
@@ -500,7 +502,6 @@ async fn drain_window_is_honored_despite_reconcile_passes() {
 
     // The drain path only settles Ready workers; promote if the registration
     // left it in another state (no health-check loop runs in tests).
-    use openai_protocol::worker::WorkerStatus;
     let registry = &app_context.worker_registry;
     let worker = registry
         .get_all()
@@ -517,10 +518,16 @@ async fn drain_window_is_honored_despite_reconcile_passes() {
         "worker must be Ready to exercise the drain path"
     );
 
-    // The 300ms check_interval guarantees several reconcile passes during
-    // the 2s drain; none of them may cut it short. Anchor on the observed
-    // Draining transition so discovery latency doesn't pad the measurement.
-    fake.delete_pod("drain-0");
+    // Ready=False must enter the same drain workflow as deletion. The 300ms
+    // check interval guarantees several reconcile passes during the 2s drain;
+    // none may cut it short. Anchor on the observed Draining transition so
+    // discovery latency does not pad the measurement.
+    fake.apply_pod(worker_pod(
+        "drain-0",
+        "uid-drain-0",
+        &port.to_string(),
+        false,
+    ));
     let url = worker.url().to_string();
     let drain_started = {
         let deadline = std::time::Instant::now() + Duration::from_secs(15);
@@ -551,6 +558,10 @@ async fn drain_window_is_honored_despite_reconcile_passes() {
         drained_for >= Duration::from_millis(1800),
         "drain window collapsed: worker removed {drained_for:?} after draining began (settle is 2s)"
     );
+    assert!(
+        fake.state.pods.lock().unwrap().contains_key("drain-0"),
+        "Ready=False must drain workers while the Pod still exists"
+    );
 
     handle.abort();
 }
@@ -561,6 +572,33 @@ async fn wait_for_pod_uid(app_context: &AppContext, port: u16, uid: &str, what: 
     loop {
         let found = app_context.worker_registry.get_all().into_iter().any(|w| {
             w.url().ends_with(&format!(":{port}"))
+                && w.metadata()
+                    .spec
+                    .labels
+                    .get(POD_UID_LABEL)
+                    .map(String::as_str)
+                    == Some(uid)
+        });
+        if found {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for {what}; registry: {:?}",
+            app_context.worker_registry.get_all_urls()
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn wait_for_ready_pod_uid(app_context: &AppContext, port: u16, uid: &str, what: &str) {
+    use openai_protocol::worker::WorkerStatus;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        let found = app_context.worker_registry.get_all().into_iter().any(|w| {
+            w.url().ends_with(&format!(":{port}"))
+                && w.status() == WorkerStatus::Ready
                 && w.metadata()
                     .spec
                     .labels
@@ -656,6 +694,81 @@ async fn pod_added_after_start_registers_only_once_ready() {
         "worker registered after pod became Ready",
         Duration::from_secs(15),
         |urls| has_url(urls, port),
+    )
+    .await;
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn ready_pod_becoming_unready_removes_all_workers_and_recovers() {
+    let fake = FakeK8s::start().await;
+    let app_context = test_context().await;
+    let (_engine_a, port_a) = start_mock_engine().await;
+    let (_engine_b, port_b) = start_mock_engine().await;
+    let ports = format!("{port_a},{port_b}");
+
+    fake.apply_pod(worker_pod("ready-flip-0", "uid-ready-flip-0", &ports, true));
+    let handle = start_service_discovery_with_client(
+        fake.client(),
+        discovery_config(),
+        Arc::clone(&app_context),
+        None,
+        None,
+    );
+    wait_for_ready_pod_uid(
+        &app_context,
+        port_a,
+        "uid-ready-flip-0",
+        "first worker routable before readiness change",
+    )
+    .await;
+    wait_for_ready_pod_uid(
+        &app_context,
+        port_b,
+        "uid-ready-flip-0",
+        "second worker routable before readiness change",
+    )
+    .await;
+
+    fake.apply_pod(worker_pod(
+        "ready-flip-0",
+        "uid-ready-flip-0",
+        &ports,
+        false,
+    ));
+    wait_for(
+        &app_context,
+        "all workers removed while pod remains unready",
+        Duration::from_secs(15),
+        |urls| !has_url(urls, port_a) && !has_url(urls, port_b),
+    )
+    .await;
+    assert!(
+        fake.state.pods.lock().unwrap().contains_key("ready-flip-0"),
+        "unready pod should still exist after its workers are removed"
+    );
+
+    fake.apply_pod(worker_pod("ready-flip-0", "uid-ready-flip-0", &ports, true));
+    wait_for(
+        &app_context,
+        "all workers re-registered after readiness recovery",
+        Duration::from_secs(15),
+        |urls| has_url(urls, port_a) && has_url(urls, port_b),
+    )
+    .await;
+    wait_for_ready_pod_uid(
+        &app_context,
+        port_a,
+        "uid-ready-flip-0",
+        "first recovered worker routable",
+    )
+    .await;
+    wait_for_ready_pod_uid(
+        &app_context,
+        port_b,
+        "uid-ready-flip-0",
+        "second recovered worker routable",
     )
     .await;
 


### PR DESCRIPTION
## Description

### Problem

SMG discovers workers from Pods and routes directly to Pod IPs. Existing workers remained registered when the aggregate Kubernetes Pod Ready condition became False, so controllers could withdraw an endpoint and terminate the Pod while SMG continued selecting its workers until deletion was observed.

### Solution

Treat Ready != True as absent from the Kubernetes discovery desired set. Existing discovery-owned workers then use the current RemoveWorker workflow: they stop receiving new traffic in Draining, honor the configured drain-settle window, and are removed. A later Ready=True event registers them again.

This uses only the standard Pod Ready condition already present in the Pod watch. It adds no controller-specific condition, annotation, or EndpointSlice watcher.

Scope note: if Ready returns while RemoveWorker is still inside the settle window, re-registration can wait for the existing periodic reconciliation. This patch intentionally does not add cross-workflow retry or registry-event state for that uncommon recovery race.

## Changes

- Exclude Ready=False and Ready=Unknown Pods from the desired worker set.
- Route readiness withdrawal through the existing drain/remove workflow for every annotated worker port.
- Replace the old unit expectations that retained unready workers.
- Add fake-Kubernetes lifecycle coverage for Ready -> unready -> removed -> Ready recovery.
- Update the kind test to verify unready workers stop routing, are removed while the Pod still exists, and return after readiness recovery.

## Test Plan

- `cargo +nightly fmt --all`
- `cargo clippy -p smg --lib --test k8s_discovery_test -- -D warnings`
- `cargo test -p smg --lib service_discovery::tests` (79 passed)
- `cargo test -p smg --test k8s_discovery_test -- --nocapture` (21 passed)
- `uv run --project e2e_test --extra dev ruff check e2e_test/kind_discovery/test_kind_discovery.py`
- [Remote E2E Kind Discovery](https://github.com/slin1237/smg/actions/runs/32786378388) (16 passed)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] Changed Rust targets pass Clippy with warnings denied
- [x] Focused unit and fake-Kubernetes integration tests pass
- [x] Remote kind discovery workflow passes

</details>