### PR TITLE
fix(grpc): correct minimum ping interval option

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/mlx/server.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/server.py
@@ -144,7 +144,7 @@ async def serve_grpc(args):
         options=[
             ("grpc.max_send_message_length", 1024 * 1024 * 256),
             ("grpc.max_receive_message_length", 1024 * 1024 * 256),
-            ("grpc.http2.min_recv_ping_interval_without_data_ms", 10000),
+            ("grpc.http2.min_ping_interval_without_data_ms", 10000),
             ("grpc.keepalive_permit_without_calls", True),
         ],
     )

--- a/grpc_servicer/smg_grpc_servicer/sglang/server.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/server.py
@@ -156,7 +156,7 @@ async def serve_grpc(
             # Without this, the gRPC C-core default (300s minimum) causes
             # GOAWAY when clients send pings more frequently during long
             # requests (e.g. prefill) where no DATA frames flow.
-            ("grpc.http2.min_recv_ping_interval_without_data_ms", 10000),
+            ("grpc.http2.min_ping_interval_without_data_ms", 10000),
             ("grpc.keepalive_permit_without_calls", True),
         ],
     )

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/server.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/server.py
@@ -70,7 +70,7 @@ def _grpc_server_options(max_message_bytes: int) -> list[tuple[str, int]]:
         ("grpc.max_receive_message_length", max_message_bytes),
         # Long EPD requests can spend minutes without sending DATA frames while
         # the Rust client still sends HTTP/2 keepalive pings.
-        ("grpc.http2.min_recv_ping_interval_without_data_ms", 10000),
+        ("grpc.http2.min_ping_interval_without_data_ms", 10000),
         ("grpc.http2.max_pings_without_data", 0),
         ("grpc.http2.max_ping_strikes", 0),
         ("grpc.keepalive_permit_without_calls", True),


### PR DESCRIPTION
## Description

### Problem

The gRPC servicers configure `grpc.http2.min_recv_ping_interval_without_data_ms`, but gRPC Core defines the actual channel argument key as `grpc.http2.min_ping_interval_without_data_ms`. As a result, the intended 10-second minimum receive ping interval is not applied.

### Solution

Use the channel argument key recognized by gRPC Core.

## Changes

- Correct the HTTP/2 minimum ping interval option in the MLX gRPC server.
- Correct the same option in the SGLang gRPC server.
- Correct the same option in the TokenSpeed gRPC server.

## Test Plan

- `ruff check grpc_servicer/smg_grpc_servicer/{mlx,sglang,tokenspeed}/server.py`
- `ruff format --check grpc_servicer/smg_grpc_servicer/{mlx,sglang,tokenspeed}/server.py`
- Parse all three modified files with Python's `ast.parse`.
- `git diff --check`
- Verify the obsolete `grpc.http2.min_recv_ping_interval_without_data_ms` key no longer appears in the repository.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` not applicable (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` not applicable (no Rust changes)
- [x] Documentation not required for this channel argument correction

</details>