### PR TITLE
fix: unblock worker removal during cache cleanup

### DIFF
--- a/crates/kv_index/src/event_tree.rs
+++ b/crates/kv_index/src/event_tree.rs
@@ -683,9 +683,10 @@ impl PositionalIndexer {
     /// Remove a worker entirely — takes ownership of blocks, cleans index, worker is gone.
     ///
     /// `worker_id`: internal ID from [`intern_worker`].
-    /// `worker_blocks`: caller-owned reverse lookup — consumed.
+    /// `worker_blocks`: caller-owned reverse lookup — consumed. Removal is
+    /// proportional to this worker's blocks, not to the total index size.
     pub fn remove_worker(&self, worker_id: u32, worker_blocks: WorkerBlockMap) {
-        for &(position, content_hash, prefix_hash) in worker_blocks.values() {
+        for (position, content_hash, prefix_hash) in worker_blocks.into_values() {
             if let Entry::Occupied(mut occ) = self.index.entry((position, content_hash)) {
                 let (_, now_empty) = occ.get_mut().seq.remove(prefix_hash, worker_id);
                 if now_empty {
@@ -1397,6 +1398,31 @@ mod tests {
         let scores = indexer.find_matches(&hashes(&[10, 20, 30]), false);
         assert!(scores.scores.is_empty());
         assert_eq!(indexer.current_size(), 0);
+    }
+
+    #[test]
+    fn test_remove_worker_uses_reverse_map_and_preserves_unrelated_entries() {
+        let indexer = PositionalIndexer::new(64);
+        let removed = indexer.intern_worker("http://removed:8000").unwrap();
+        let survivor = indexer.intern_worker("http://survivor:8000").unwrap();
+        let mut removed_blocks = WorkerBlockMap::default();
+        let mut survivor_blocks = WorkerBlockMap::default();
+
+        indexer
+            .apply_stored(removed, &make_blocks(&[1]), None, &mut removed_blocks)
+            .unwrap();
+        for value in 10_000..11_000 {
+            indexer
+                .apply_stored(survivor, &make_blocks(&[value]), None, &mut survivor_blocks)
+                .unwrap();
+        }
+
+        indexer.remove_worker(removed, removed_blocks);
+
+        assert_eq!(indexer.current_size(), survivor_blocks.len());
+        let scores = indexer.find_matches(&hashes(&[10_999]), false);
+        assert_eq!(scores.scores.get(&survivor), Some(&1));
+        assert!(!scores.scores.contains_key(&removed));
     }
 
     #[test]

--- a/crates/kv_index/src/string_tree.rs
+++ b/crates/kv_index/src/string_tree.rs
@@ -1193,18 +1193,58 @@ impl Tree {
     /// Used for mesh eviction propagation and worker removal — size-based
     /// eviction never fires for a tenant whose count no longer grows.
     pub fn remove_tenant_all(&self, tenant_id: &TenantId) {
+        let expected_chars = self.tenant_char_size(tenant_id);
+
         // collect_tenant_nodes skips root (root is never LRU-evicted),
         // but global removal must include it.
         self.remove_tenant_from_node(&self.root, tenant_id);
+        if expected_chars == 0 {
+            self.tenant_char_count.remove(tenant_id);
+            return;
+        }
 
         let mut nodes: Vec<(NodeRef, u64)> = Vec::new();
-        self.collect_tenant_nodes(&self.root, tenant_id, &mut nodes);
+        self.collect_tenant_nodes_pruned(&self.root, tenant_id, &mut nodes);
+
+        // Normal inserts attach a tenant to every ancestor, allowing the
+        // pruned walk above to skip unrelated subtrees. Older snapshots and
+        // targeted eviction may not preserve that prefix-closed invariant;
+        // the maintained byte count detects that shape and falls back to the
+        // complete walk for correctness.
+        let collected_chars: usize = nodes
+            .iter()
+            .map(|(node, _)| node.text.read().char_count())
+            .sum();
+        if collected_chars != expected_chars {
+            nodes.clear();
+            self.collect_tenant_nodes(&self.root, tenant_id, &mut nodes);
+        }
         for (node, _) in &nodes {
             self.remove_tenant_from_node(node, tenant_id);
             Self::detach_empty_ancestors(node);
         }
         if let Some((_, count)) = self.tenant_char_count.remove(tenant_id) {
             self.total_char_count.fetch_sub(count, Ordering::Relaxed);
+        }
+    }
+
+    /// Fast tenant walk for the common prefix-closed ownership shape. If a
+    /// child does not contain the tenant, none of its descendants can contain
+    /// it either, so the entire unrelated subtree can be skipped.
+    fn collect_tenant_nodes_pruned(
+        &self,
+        node: &NodeRef,
+        tenant_id: &TenantId,
+        result: &mut Vec<(NodeRef, u64)>,
+    ) {
+        for child in &node.children {
+            let child = child.value();
+            let Some(ts) = child.tenant_last_access_time.get(tenant_id) else {
+                continue;
+            };
+            result.push((Arc::clone(child), *ts));
+            drop(ts);
+            self.collect_tenant_nodes_pruned(child, tenant_id, result);
         }
     }
 
@@ -3696,6 +3736,50 @@ mod tests {
         let r = tree.match_prefix_with_counts("hello there");
         assert_eq!(r.matched_char_count, "hello there".chars().count());
         assert_eq!(r.tenant.as_ref(), "tenant2");
+    }
+
+    #[test]
+    fn test_remove_tenant_all_prunes_unrelated_subtrees() {
+        let tree = Tree::new();
+        tree.insert_text("a-target", "target");
+        for depth in 1..=64 {
+            tree.insert_text(&format!("z{}", "x".repeat(depth)), "other");
+        }
+
+        let tenant = Arc::from("target");
+        let mut nodes = Vec::new();
+        tree.collect_tenant_nodes_pruned(&tree.root, &tenant, &mut nodes);
+
+        assert_eq!(nodes.len(), 1);
+
+        tree.remove_tenant_all(&tenant);
+        assert!(!tree.get_tenant_char_count().contains_key("target"));
+        assert_eq!(
+            tree.match_prefix_with_counts(&format!("z{}", "x".repeat(64)))
+                .matched_char_count,
+            65
+        );
+    }
+
+    #[test]
+    fn test_remove_tenant_all_falls_back_after_non_prefix_closed_eviction() {
+        let tree = Tree::new();
+        tree.insert_text("apple", "tenant1");
+        tree.insert_text("application", "tenant2");
+
+        // Targeted string eviction can remove an older ancestor before a
+        // newer descendant. The optimized purge must detect that shape and
+        // fall back to a complete walk.
+        tree.evict_by_tenant(&Arc::from("tenant1"), 3);
+        tree.remove_tenant_all(&Arc::from("tenant1"));
+
+        assert!(!tree.get_tenant_char_count().contains_key("tenant1"));
+        assert!(!tree.get_used_size_per_tenant().contains_key("tenant1"));
+        assert_eq!(
+            tree.match_prefix_with_counts("application")
+                .matched_char_count,
+            "application".chars().count()
+        );
     }
 
     #[test]

--- a/crates/kv_index/src/token_tree.rs
+++ b/crates/kv_index/src/token_tree.rs
@@ -1632,15 +1632,52 @@ impl TokenTree {
     /// Size-based eviction never fires for a tenant whose count no longer
     /// grows, so removed workers must be purged eagerly.
     pub fn remove_tenant_all(&self, tenant_id: &TenantId) {
+        let expected_tokens = self.tenant_token_size(tenant_id);
         self.root.tenant_last_access_time.remove(tenant_id.as_ref());
+        if expected_tokens == 0 {
+            self.tenant_token_count.remove(tenant_id.as_ref());
+            return;
+        }
 
         let mut nodes: Vec<NodeRef> = Vec::new();
-        self.collect_tenant_nodes(&self.root, tenant_id, &mut nodes);
+        self.collect_tenant_nodes_pruned(&self.root, tenant_id, &mut nodes);
+
+        // Inserts and leaf-first eviction keep tenant ownership prefix-closed,
+        // so the pruned walk normally sees exactly the maintained token count.
+        // Fall back to a complete walk if imported or concurrently-mutated
+        // state violates that invariant.
+        let collected_tokens: usize = nodes.iter().map(|node| node.tokens.read().len()).sum();
+        if collected_tokens != expected_tokens {
+            nodes.clear();
+            self.collect_tenant_nodes(&self.root, tenant_id, &mut nodes);
+        }
         for node in &nodes {
             self.remove_tenant_and_cleanup(node, tenant_id);
         }
         if let Some((_, count)) = self.tenant_token_count.remove(tenant_id.as_ref()) {
             self.total_token_count.fetch_sub(count, Ordering::Relaxed);
+        }
+    }
+
+    /// Fast tenant walk for the common prefix-closed ownership shape. If a
+    /// child does not contain the tenant, none of its descendants can contain
+    /// it either, so the entire unrelated subtree can be skipped.
+    fn collect_tenant_nodes_pruned(
+        &self,
+        node: &NodeRef,
+        tenant_id: &TenantId,
+        result: &mut Vec<NodeRef>,
+    ) {
+        for child in &node.children {
+            let child = child.value();
+            if !child
+                .tenant_last_access_time
+                .contains_key(tenant_id.as_ref())
+            {
+                continue;
+            }
+            result.push(Arc::clone(child));
+            self.collect_tenant_nodes_pruned(child, tenant_id, result);
         }
     }
 
@@ -3896,6 +3933,33 @@ mod tests {
         let r = tree.match_prefix_with_counts(&tokens2);
         assert_eq!(r.matched_token_count, 2 * PAGE_SIZE);
         assert_eq!(r.tenant.as_ref(), "tenant2");
+    }
+
+    #[test]
+    fn test_remove_tenant_all_prunes_unrelated_subtrees() {
+        let tree = TokenTree::new();
+        let target = make_tokens(1, 2);
+        tree.insert_tokens(&target, "target");
+
+        let mut unrelated = make_tokens(10_000, 1);
+        for page in 1..=64 {
+            unrelated.extend(make_tokens(10_000 + page * 100, 1));
+            tree.insert_tokens(&unrelated, "other");
+        }
+
+        let tenant = Arc::from("target");
+        let mut nodes = Vec::new();
+        tree.collect_tenant_nodes_pruned(&tree.root, &tenant, &mut nodes);
+
+        assert_eq!(nodes.len(), 1);
+
+        tree.remove_tenant_all(&tenant);
+        assert!(!tree.get_tenant_token_counts().contains_key("target"));
+        assert_eq!(
+            tree.match_prefix_with_counts(&unrelated)
+                .matched_token_count,
+            unrelated.len()
+        );
     }
 
     #[test]

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -54,7 +54,7 @@
 */
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -632,6 +632,44 @@ impl CacheAwarePolicy {
         for placements in placement_maps {
             placements.retain(|_, holders| {
                 holders.retain(|h| h.worker_url != url);
+                !holders.is_empty()
+            });
+        }
+    }
+
+    /// Remove several workers from one model. Tree cleanup remains precise per
+    /// tenant, while hash-placement state is scanned only once for the batch.
+    pub(crate) fn remove_workers_from_model(&self, model_id: &str, worker_urls: &HashSet<String>) {
+        let model_id = normalize_model_key(model_id);
+        let tenants: Vec<TenantId> = worker_urls
+            .iter()
+            .map(|worker_url| TenantId::from(worker_url.as_str()))
+            .collect();
+        let string_tree = self
+            .string_trees
+            .get(model_id)
+            .map(|entry| Arc::clone(entry.value()));
+        if let Some(tree) = string_tree {
+            for tenant in &tenants {
+                tree.remove_tenant_all(tenant);
+            }
+        }
+        let token_tree = self
+            .token_trees
+            .get(model_id)
+            .map(|entry| Arc::clone(entry.value()));
+        if let Some(tree) = token_tree {
+            for tenant in &tenants {
+                tree.remove_tenant_all(tenant);
+            }
+        }
+        let placements = self
+            .placement_index
+            .get(model_id)
+            .map(|entry| Arc::clone(entry.value()));
+        if let Some(placements) = placements {
+            placements.retain(|_, holders| {
+                holders.retain(|holder| !worker_urls.contains(&holder.worker_url));
                 !holders.is_empty()
             });
         }
@@ -2694,6 +2732,59 @@ mod tests {
         policy.remove_worker_by_url("http://w2:8000");
         assert!(string_tree.get_tenant_char_count().is_empty());
         assert!(token_tree.get_tenant_token_counts().is_empty());
+    }
+
+    #[test]
+    fn test_remove_workers_from_model_does_not_mutate_other_models() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            cache_boundaries: vec![16],
+            ..Default::default()
+        });
+        let worker_url = "http://shared-url:8000";
+        let tokens: Vec<u32> = (0..32).collect();
+
+        for model_id in ["retired-model", "active-model"] {
+            let string_tree = Arc::new(Tree::new());
+            string_tree.insert_text("shared prefix", worker_url);
+            policy
+                .string_trees
+                .insert(model_id.to_string(), string_tree);
+
+            let token_tree = Arc::new(policy.new_token_tree());
+            token_tree.insert_tokens(&tokens, worker_url);
+            policy.token_trees.insert(model_id.to_string(), token_tree);
+
+            policy.record_placement(model_id, &tokens, &[16], worker_url, Instant::now());
+        }
+
+        policy.remove_workers_from_model("retired-model", &HashSet::from([worker_url.to_string()]));
+
+        let retired_string = policy.string_trees.get("retired-model").unwrap();
+        let retired_token = policy.token_trees.get("retired-model").unwrap();
+        assert!(!retired_string
+            .get_tenant_char_count()
+            .contains_key(worker_url));
+        assert!(!retired_token
+            .get_tenant_token_counts()
+            .contains_key(worker_url));
+        assert!(policy
+            .placement_index
+            .get("retired-model")
+            .is_some_and(|placements| placements.is_empty()));
+
+        let active_string = policy.string_trees.get("active-model").unwrap();
+        let active_token = policy.token_trees.get("active-model").unwrap();
+        assert!(active_string
+            .get_tenant_char_count()
+            .contains_key(worker_url));
+        assert!(active_token
+            .get_tenant_token_counts()
+            .contains_key(worker_url));
+        assert!(policy
+            .placement_index
+            .get("active-model")
+            .is_some_and(|placements| !placements.is_empty()));
     }
 
     #[test]

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, OnceLock},
 };
 
@@ -845,6 +845,30 @@ impl PolicyRegistry {
                             worker_url, worker_type
                         );
                     }
+                }
+            }
+        }
+    }
+
+    /// Remove a batch of workers from every cache-aware policy that may route
+    /// the model. Shared policies are deduplicated by Arc identity.
+    pub(crate) fn remove_workers_from_cache_aware(
+        &self,
+        model_id: &str,
+        worker_urls: &HashSet<String>,
+    ) {
+        // A model can route through its explicit, default, or PD/EPD policy.
+        // `policies_for_model` deduplicates shared policy instances so each
+        // tree is cleaned at most once.
+        for policy in self.policies_for_model(model_id) {
+            if policy.name() == "cache_aware" {
+                if let Some(cache_aware) = policy.as_any().downcast_ref::<CacheAwarePolicy>() {
+                    cache_aware.remove_workers_from_model(model_id, worker_urls);
+                    debug!(
+                        "Removed {} workers from cache-aware policy for model {}",
+                        worker_urls.len(),
+                        model_id
+                    );
                 }
             }
         }

--- a/model_gateway/src/worker/kv_event_monitor.rs
+++ b/model_gateway/src/worker/kv_event_monitor.rs
@@ -21,7 +21,7 @@ use smg_grpc_client::common_proto::{
     kv_cache_event, KvBlock, KvBlocksRemoved, KvBlocksStored, KvCacheEvent, KvEventBatch,
 };
 use tokio::{
-    sync::{oneshot, Mutex},
+    sync::{oneshot, Mutex, Semaphore},
     task::JoinHandle,
 };
 use tracing::{debug, error, info, warn};
@@ -44,6 +44,11 @@ const INITIAL_RECONNECT_DELAY_MS: u64 = 100;
 
 /// Maximum reconnection delay (caps exponential backoff).
 const MAX_RECONNECT_DELAY_MS: u64 = 30_000;
+
+/// Positional-index cleanup is CPU-bound and can touch many blocks. Keep it
+/// off Tokio workers and bound concurrent purges during fleet-wide drains.
+const MAX_CONCURRENT_INDEX_REMOVALS: usize = 4;
+static INDEX_REMOVAL_PERMITS: Semaphore = Semaphore::const_new(MAX_CONCURRENT_INDEX_REMOVALS);
 
 /// Manages per-worker KV cache event subscriptions.
 ///
@@ -190,7 +195,6 @@ impl KvEventMonitor {
             .entry(model_id.clone())
             .or_insert_with(|| Arc::new(PositionalIndexer::new(self.jump_size)))
             .clone();
-
         // Seed block_size provisionally from WorkerSpec. The event stream will
         // overwrite this with the backend's actual page size once received.
         if let Some(bs) = worker.metadata().spec.kv_block_size {
@@ -263,8 +267,10 @@ impl KvEventMonitor {
 
     /// Stop the KV event subscription for a worker.
     ///
-    /// Sends a graceful shutdown signal — the task cleans up its own
-    /// `WorkerBlockMap` in the indexer before exiting.
+    /// Sends a graceful shutdown signal. The subscription task cleans up its
+    /// own `WorkerBlockMap` using the indexer's per-worker reverse map; that
+    /// CPU-bound cleanup runs on the bounded blocking pool rather than a Tokio
+    /// runtime worker.
     pub async fn on_worker_removed(&self, worker_url: &str) {
         let subscription = {
             let mut handles = self.worker_handles.lock().await;
@@ -274,7 +280,6 @@ impl KvEventMonitor {
         let Some(sub) = subscription else {
             return;
         };
-
         info!(worker_url = %worker_url, "Stopping KV event subscription");
         // Signal graceful shutdown — task cleans up its worker_blocks in the indexer.
         let _ = sub.shutdown_tx.send(());
@@ -411,6 +416,26 @@ impl KvEventMonitor {
     ///
     /// Owns the `WorkerBlockMap` for this worker and cleans it up on exit.
     /// Exits when `shutdown_rx` fires or the backend returns `Unimplemented`.
+    async fn remove_indexer_worker(
+        indexer: Arc<PositionalIndexer>,
+        worker_id: u32,
+        worker_blocks: WorkerBlockMap,
+    ) {
+        let Ok(permit) = INDEX_REMOVAL_PERMITS.acquire().await else {
+            error!(worker_id, "Positional-index cleanup semaphore closed");
+            return;
+        };
+        let result = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            indexer.remove_worker(worker_id, worker_blocks);
+        })
+        .await;
+
+        if let Err(error) = result {
+            error!(worker_id, %error, "Positional-index worker cleanup task failed");
+        }
+    }
+
     async fn subscription_loop(
         worker: Arc<dyn Worker>,
         worker_url: String,
@@ -463,7 +488,8 @@ impl KvEventMonitor {
                         Duration::from_millis(reconnect_delay_ms),
                         &mut shutdown_rx
                     ) {
-                        indexer.remove_worker(worker_id, worker_blocks);
+                        Self::remove_indexer_worker(Arc::clone(&indexer), worker_id, worker_blocks)
+                            .await;
                         return;
                     }
                     reconnect_delay_ms = (reconnect_delay_ms * 2).min(MAX_RECONNECT_DELAY_MS);
@@ -480,7 +506,8 @@ impl KvEventMonitor {
                         Duration::from_millis(reconnect_delay_ms),
                         &mut shutdown_rx
                     ) {
-                        indexer.remove_worker(worker_id, worker_blocks);
+                        Self::remove_indexer_worker(Arc::clone(&indexer), worker_id, worker_blocks)
+                            .await;
                         return;
                     }
                     reconnect_delay_ms = (reconnect_delay_ms * 2).min(MAX_RECONNECT_DELAY_MS);
@@ -507,7 +534,8 @@ impl KvEventMonitor {
                             "Backend does not implement SubscribeKvEvents, \
                              disabling KV event subscription for this worker"
                         );
-                        indexer.remove_worker(worker_id, worker_blocks);
+                        Self::remove_indexer_worker(Arc::clone(&indexer), worker_id, worker_blocks)
+                            .await;
                         return;
                     }
                     if e.code() == tonic::Code::OutOfRange {
@@ -531,7 +559,8 @@ impl KvEventMonitor {
                         Duration::from_millis(reconnect_delay_ms),
                         &mut shutdown_rx
                     ) {
-                        indexer.remove_worker(worker_id, worker_blocks);
+                        Self::remove_indexer_worker(Arc::clone(&indexer), worker_id, worker_blocks)
+                            .await;
                         return;
                     }
                     reconnect_delay_ms = (reconnect_delay_ms * 2).min(MAX_RECONNECT_DELAY_MS);
@@ -548,7 +577,12 @@ impl KvEventMonitor {
                     &mut worker_blocks, &mut last_seq, on_batch,
                 ) => result,
                 _ = &mut shutdown_rx => {
-                    indexer.remove_worker(worker_id, worker_blocks);
+                    Self::remove_indexer_worker(
+                        Arc::clone(&indexer),
+                        worker_id,
+                        worker_blocks,
+                    )
+                    .await;
                     return;
                 }
             };
@@ -567,7 +601,8 @@ impl KvEventMonitor {
                         Duration::from_millis(reconnect_delay_ms),
                         &mut shutdown_rx
                     ) {
-                        indexer.remove_worker(worker_id, worker_blocks);
+                        Self::remove_indexer_worker(Arc::clone(&indexer), worker_id, worker_blocks)
+                            .await;
                         return;
                     }
                     reconnect_delay_ms = (reconnect_delay_ms * 2).min(MAX_RECONNECT_DELAY_MS);
@@ -596,7 +631,8 @@ impl KvEventMonitor {
                         Duration::from_millis(reconnect_delay_ms),
                         &mut shutdown_rx
                     ) {
-                        indexer.remove_worker(worker_id, worker_blocks);
+                        Self::remove_indexer_worker(Arc::clone(&indexer), worker_id, worker_blocks)
+                            .await;
                         return;
                     }
                     reconnect_delay_ms = (reconnect_delay_ms * 2).min(MAX_RECONNECT_DELAY_MS);
@@ -1096,6 +1132,28 @@ mod tests {
     async fn test_on_worker_removed_nonexistent() {
         let monitor = KvEventMonitor::new(None);
         monitor.on_worker_removed("http://nonexistent:8000").await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_indexer_worker_runs_cleanup_off_runtime() {
+        let indexer = Arc::new(PositionalIndexer::new(64));
+        let worker_id = indexer.intern_worker("http://w1:8000").unwrap();
+        let mut worker_blocks = WorkerBlockMap::default();
+        indexer
+            .apply_stored(
+                worker_id,
+                &[StoredBlock {
+                    seq_hash: SequenceHash(1),
+                    content_hash: compute_content_hash(&[1, 2, 3]),
+                }],
+                None,
+                &mut worker_blocks,
+            )
+            .unwrap();
+
+        KvEventMonitor::remove_indexer_worker(Arc::clone(&indexer), worker_id, worker_blocks).await;
+
+        assert_eq!(indexer.current_size(), 0);
     }
 
     // -----------------------------------------------------------------------

--- a/model_gateway/src/workflow/steps/local/mod.rs
+++ b/model_gateway/src/workflow/steps/local/mod.rs
@@ -73,12 +73,12 @@ pub(crate) fn find_workers_by_url(
 ///              │
 ///         drain_workers
 ///              │
-///     remove_from_policy_registry
-///              │
 ///     remove_from_worker_registry
 ///              │
-///     update_remaining_policies
+///     remove_from_policy_registry
 /// ```
+/// Cache cleanup removes only departed tenants, so surviving workers do not
+/// need the previous full-policy reinitialization pass.
 pub fn create_worker_removal_workflow() -> WorkflowDefinition<WorkerRemovalWorkflowData> {
     WorkflowDefinition::new("worker_removal", "Remove worker from router")
         .add_step(
@@ -114,9 +114,9 @@ pub fn create_worker_removal_workflow() -> WorkflowDefinition<WorkerRemovalWorkf
         )
         .add_step(
             StepDefinition::new(
-                "remove_from_policy_registry",
-                "Remove workers from policy registry",
-                Arc::new(RemoveFromPolicyRegistryStep),
+                "remove_from_worker_registry",
+                "Remove workers from worker registry",
+                Arc::new(RemoveFromWorkerRegistryStep),
             )
             .with_timeout(Duration::from_secs(10))
             .with_retry(RetryPolicy {
@@ -127,24 +127,12 @@ pub fn create_worker_removal_workflow() -> WorkflowDefinition<WorkerRemovalWorkf
         )
         .add_step(
             StepDefinition::new(
-                "remove_from_worker_registry",
-                "Remove workers from worker registry",
-                Arc::new(RemoveFromWorkerRegistryStep),
+                "remove_from_policy_registry",
+                "Remove workers from policy registry",
+                Arc::new(RemoveFromPolicyRegistryStep),
             )
-            .with_timeout(Duration::from_secs(10))
-            .with_retry(RetryPolicy {
-                max_attempts: 1,
-                backoff: BackoffStrategy::Fixed(Duration::from_secs(0)),
-            })
-            .depends_on(&["remove_from_policy_registry"]),
-        )
-        .add_step(
-            StepDefinition::new(
-                "update_remaining_policies",
-                "Update cache-aware policies for remaining workers",
-                Arc::new(UpdateRemainingPoliciesStep),
-            )
-            .with_timeout(Duration::from_secs(10))
+            // The old 10s override was too short for large cache cleanup.
+            // Inherit the workflow default after the worker is deregistered.
             .with_retry(RetryPolicy {
                 max_attempts: 1,
                 backoff: BackoffStrategy::Fixed(Duration::from_secs(0)),
@@ -241,5 +229,38 @@ pub fn create_worker_update_workflow_data(
         app_context: Some(app_context),
         workers_to_update: None,
         updated_workers: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wfaas::StepId;
+
+    use super::*;
+
+    #[test]
+    fn worker_removal_deregisters_before_policy_cleanup() {
+        let workflow = create_worker_removal_workflow();
+        let registry_step = workflow
+            .steps
+            .iter()
+            .find(|step| step.id == StepId::new("remove_from_worker_registry"))
+            .unwrap();
+        let policy_step = workflow
+            .steps
+            .iter()
+            .find(|step| step.id == StepId::new("remove_from_policy_registry"))
+            .unwrap();
+
+        assert_eq!(registry_step.depends_on, vec![StepId::new("drain_workers")]);
+        assert_eq!(
+            policy_step.depends_on,
+            vec![StepId::new("remove_from_worker_registry")]
+        );
+        assert_eq!(policy_step.timeout, None);
+        assert!(workflow
+            .steps
+            .iter()
+            .all(|step| step.id != StepId::new("update_remaining_policies")));
     }
 }

--- a/model_gateway/src/workflow/steps/local/remove_from_policy_registry.rs
+++ b/model_gateway/src/workflow/steps/local/remove_from_policy_registry.rs
@@ -1,16 +1,55 @@
 //! Step to remove workers from policy registry.
 
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
 use async_trait::async_trait;
-use tracing::debug;
+use tokio::sync::Semaphore;
+use tracing::{debug, error};
 use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
-use crate::workflow::data::WorkerRemovalWorkflowData;
+use crate::{
+    policies::PolicyRegistry, worker::WorkerRegistry, workflow::data::WorkerRemovalWorkflowData,
+};
+
+/// Bound CPU-heavy radix-tree purges during a fleet-wide scale-down. The
+/// worker has already left the routing registry before any task waits here.
+const MAX_CONCURRENT_CACHE_REMOVALS: usize = 4;
+static CACHE_REMOVAL_PERMITS: Semaphore = Semaphore::const_new(MAX_CONCURRENT_CACHE_REMOVALS);
 
 /// Step to remove workers from the policy registry.
 ///
 /// Removes each worker from cache-aware policies and notifies
 /// the policy registry of worker removal.
 pub struct RemoveFromPolicyRegistryStep;
+
+impl RemoveFromPolicyRegistryStep {
+    async fn remove_cache_state(
+        policy_registry: Arc<PolicyRegistry>,
+        removals: HashMap<String, HashSet<String>>,
+    ) {
+        if removals.is_empty() {
+            return;
+        }
+        let Ok(permit) = CACHE_REMOVAL_PERMITS.acquire().await else {
+            error!("Cache-removal semaphore closed");
+            return;
+        };
+        let result = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            for (model_id, worker_urls) in removals {
+                policy_registry.remove_workers_from_cache_aware(&model_id, &worker_urls);
+            }
+        })
+        .await;
+
+        if let Err(error) = result {
+            error!(%error, "Cache-aware worker cleanup task failed");
+        }
+    }
+}
 
 #[async_trait]
 impl StepExecutor<WorkerRemovalWorkflowData> for RemoveFromPolicyRegistryStep {
@@ -35,30 +74,33 @@ impl StepExecutor<WorkerRemovalWorkflowData> for RemoveFromPolicyRegistryStep {
         );
 
         for worker in workers_to_remove {
-            let model_id = worker.model_id().to_string();
-            let worker_url = worker.url();
-
             // Remove from KV event monitor (stops subscription, removes from indexer)
             if let Some(ref monitor) = app_context.kv_event_monitor {
-                monitor.on_worker_removed(worker_url).await;
+                monitor.on_worker_removed(worker.url()).await;
             }
-
-            // Remove from cache-aware policy
-            app_context
-                .policy_registry
-                .remove_worker_from_cache_aware(&model_id, worker_url);
-            app_context
-                .policy_registry
-                .remove_worker_from_pd_cache_aware(worker_url);
 
             // Drop the worker's cached load report from load-aware policies
             // (power_of_two, least_load) so their caches don't leak under churn.
             app_context
                 .policy_registry
-                .remove_worker_from_load_aware(worker_url);
+                .remove_worker_from_load_aware(worker.url());
+        }
 
-            // Notify policy registry
-            app_context.policy_registry.on_worker_removed(&model_id);
+        let mut cache_removals: HashMap<String, HashSet<String>> = HashMap::new();
+        for worker in workers_to_remove {
+            for model_id in WorkerRegistry::worker_model_ids(worker) {
+                cache_removals
+                    .entry(model_id)
+                    .or_default()
+                    .insert(worker.url().to_string());
+            }
+        }
+        Self::remove_cache_state(Arc::clone(&app_context.policy_registry), cache_removals).await;
+
+        for worker in workers_to_remove {
+            app_context
+                .policy_registry
+                .on_worker_removed(worker.model_id());
         }
 
         debug!(


### PR DESCRIPTION
## Summary

- remove workers from the routing registry before expensive policy cleanup so cleanup latency cannot strand draining workers
- batch cache-aware cleanup by model and prune unrelated string and token radix branches
- move radix and KV-event cleanup to bounded blocking workers, with permits held through blocking work
- drop the explicit 10-second policy cleanup override and avoid rebuilding all remaining policies after each removal

## Testing

- cargo +nightly fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test