### PR TITLE
fix: gate stale ZMQ socket cleanup on Unix

### DIFF
--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -340,6 +340,7 @@ async fn ensure_ipc_socket_dir(base_url: &str) -> Result<(), String> {
 /// Remove a stale ipc socket file left by a previous gateway process, if any.
 /// Only ever unlinks sockets (never a regular file at the path), inside the
 /// owner-verified socket dir.
+#[cfg(unix)]
 async fn unlink_stale_socket(address: &str) -> Result<(), String> {
     let Some(path) = address.strip_prefix("ipc://") else {
         return Ok(());
@@ -383,8 +384,11 @@ pub(crate) async fn connect_for_worker(
     // The dir is verified owner-only above, and a live gateway can't leave
     // these behind (each worker URL is bound by at most one process), so any
     // existing socket file here is stale by construction.
-    unlink_stale_socket(&input).await?;
-    unlink_stale_socket(&output).await?;
+    #[cfg(unix)]
+    {
+        unlink_stale_socket(&input).await?;
+        unlink_stale_socket(&output).await?;
+    }
     // The engine can't stop at EOS on its own (it has no tokenizer or model
     // config); resolve the EOS ids from the local model dir so every request
     // carries them.
@@ -1628,6 +1632,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn unlink_stale_socket_removes_sockets_and_refuses_files() {
         use std::os::unix::net::UnixListener;


### PR DESCRIPTION
## Summary

- compile stale IPC socket inspection only on Unix platforms
- skip the Unix-only cleanup calls on Windows, preserving the behavior before PR #2076
- gate the UnixListener regression test with the same platform condition

Fixes the Windows wheel failure in https://github.com/smg-project/smg/actions/runs/32875023923/job/97890781170.

## Testing

- cargo +nightly fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test
- focused stale-socket cleanup test

A local Windows cross-check progressed past Rust target setup but was blocked by missing Windows SDK headers on macOS; the release Windows runner is the authoritative cross-platform check.