### PR TITLE
fix: publish engine ZMQ client before SMG

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -39,6 +39,8 @@ jobs:
             path: crates/mcp
           - crate: smg-mm-rdma
             path: crates/mm_rdma
+          - crate: engine-zmq-client
+            path: crates/engine_zmq_client
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/publish-crate

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -60,6 +60,7 @@ escape_version() {
 CRATES=(
     "openai-protocol|crates/protocols|openai-protocol"
     "smg-mm-rdma|crates/mm_rdma|smg-mm-rdma"
+    "engine-zmq-client|crates/engine_zmq_client|engine-zmq-client"
     "reasoning-parser|crates/reasoning_parser|reasoning-parser"
     "tool-parser|crates/tool_parser|tool-parser"
     "wfaas|crates/workflow|wfaas"


### PR DESCRIPTION
## Summary
- publish engine-zmq-client in tier 1 before the main SMG crate
- include it in the release version inventory
- unblock publishing smg 1.10.0 after the partial release

Fixes the crates release failure in https://github.com/smg-project/smg/actions/runs/32875023741/job/97911333952.

## Testing
- cargo publish --dry-run --manifest-path crates/engine_zmq_client/Cargo.toml
- ./scripts/check_release_versions.sh v1.9.0
- cargo +nightly fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test (passed through the SMG unit suite; stopped afterward because this PR only changes release metadata)