### PR TITLE
ci(workflows): read self-hosted runner labels from repository variables

### DIFF
--- a/.github/workflows/_build-engine-image.yml
+++ b/.github/workflows/_build-engine-image.yml
@@ -62,7 +62,7 @@ on:
 jobs:
   build-and-push:
     if: github.repository == 'smg-project/smg'
-    runs-on: ["cpu-e5"]
+    runs-on: ${{ vars.SMG_RUNNER_DOCKER || 'cpu-e5' }}
     steps:
       - name: Print inputs to summary
         env:

--- a/.github/workflows/benchmark-radix-tree.yml
+++ b/.github/workflows/benchmark-radix-tree.yml
@@ -39,7 +39,7 @@ jobs:
     # CPU-only criterion/throughput benchmarks of the kv-index radix tree —
     # no GPU needed, so it runs on the CPU runner pool rather than competing
     # for GPU runners.
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
       && github.repository == 'smg-project/smg'
       && github.actor != 'dependabot[bot]'
       && !github.event.pull_request.head.repo.fork
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     timeout-minutes: 30
     concurrency:
       group: claude-review-${{ github.event.pull_request.number }}
@@ -300,7 +300,7 @@ jobs:
       (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment')
       && contains(github.event.comment.body, '@claude')
       && github.repository == 'smg-project/smg'
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     timeout-minutes: 30
     concurrency:
       group: claude-respond-${{ github.event.issue.number || github.event.pull_request.number }}

--- a/.github/workflows/engine-version-watch.yml
+++ b/.github/workflows/engine-version-watch.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   detect:
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -85,7 +85,7 @@ jobs:
   research-and-file:
     needs: detect
     if: needs.detect.outputs.has_pending == 'true'
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   labeler:
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     steps:
       - name: Label PR based on changed files
         uses: actions/labeler@v7

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -41,7 +41,7 @@ jobs:
     # reaped it, which reports as `cancelled` and took the whole run with it.
     # pr-test-rust.yml's build-wheel already builds the same wheel on the CPU
     # pool; match it.
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
       contents: read
     steps:
@@ -117,7 +117,7 @@ jobs:
     name: "${{ matrix.model.id }} / single-${{ matrix.variant.id }}"
     needs: build-wheel
     if: ${{ !cancelled() }}
-    runs-on: 4-gpu-h100
+    runs-on: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
     timeout-minutes: 1440
     strategy:
       fail-fast: false
@@ -233,7 +233,7 @@ jobs:
     name: "${{ matrix.model.id }} / multi-${{ matrix.variant.id }}"
     needs: build-wheel
     if: ${{ !cancelled() }}
-    runs-on: 4-gpu-h100
+    runs-on: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
     timeout-minutes: 1440
     strategy:
       fail-fast: false
@@ -347,7 +347,7 @@ jobs:
     name: "${{ matrix.model.id }} / single-${{ matrix.variant.id }}"
     needs: build-wheel
     if: ${{ !cancelled() }}
-    runs-on: ["8-gpu-h200"]
+    runs-on: ${{ vars.SMG_RUNNER_GPU_8 || '8-gpu-h200' }}
     timeout-minutes: 1440
     strategy:
       fail-fast: false
@@ -466,7 +466,7 @@ jobs:
   #   name: "${{ matrix.model.id }} / multi-${{ matrix.variant.id }}"
   #   needs: build-wheel
   #   if: ${{ !cancelled() }}
-  #   runs-on: ["8-gpu-h200"]
+  #   runs-on: ${{ vars.SMG_RUNNER_GPU_8 || '8-gpu-h200' }}
   #   timeout-minutes: 1440
   #   strategy:
   #     fail-fast: false

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -70,7 +70,7 @@ jobs:
   # Build the smg wheel once (mirrors nightly-benchmark.yml build-wheel + cache).
   # CPU-only work (Rust/maturin compile) — no GPU needed, so don't occupy a GPU runner.
   build-wheel:
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -33,7 +33,7 @@ jobs:
   build-and-push:
     name: Build nightly Docker image
     if: github.repository == 'smg-project/smg'
-    runs-on: ${{ inputs.runner || 'cpu-e5' }}
+    runs-on: ${{ inputs.runner || vars.SMG_RUNNER_DOCKER || 'cpu-e5' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -89,7 +89,7 @@ env:
 jobs:
   # Build the smg wheel once (CPU-only Rust/maturin compile — no GPU needed).
   build-wheel:
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/nightly-triage.yml
+++ b/.github/workflows/nightly-triage.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   collect:
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     timeout-minutes: 10
     permissions:
       actions: read
@@ -69,7 +69,7 @@ jobs:
   triage:
     needs: collect
     if: needs.collect.outputs.has_failures == 'true'
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     timeout-minutes: 45
     permissions:
       contents: read

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   pre-commit:
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
       contents: read
     steps:
@@ -50,7 +50,7 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure
 
   python-lint:
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
       contents: read
     steps:
@@ -77,7 +77,7 @@ jobs:
         run: mypy bindings/python/ --config-file mypy.ini
 
   grpc-proto-build-check:
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
       contents: read
     steps:
@@ -119,7 +119,7 @@ jobs:
     # runner pool (which also tolerates the nvidia.com/gpu taint, so it can use
     # the abundant stranded CPU on GPU nodes) instead of competing for scarce
     # GPU runners.
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
       contents: read
     steps:
@@ -212,7 +212,7 @@ jobs:
 
   python-unit-tests:
     needs: build-wheel
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
       contents: read
     steps:
@@ -268,7 +268,7 @@ jobs:
         github.event_name != 'pull_request'
         || needs.detect-changes.outputs.rust-ci == 'true'
       )
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
       contents: read
     steps:
@@ -344,7 +344,7 @@ jobs:
 
   benchmarks:
     needs: build-wheel
-    runs-on: 4-gpu-h100
+    runs-on: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
     timeout-minutes: 36
     permissions:
       contents: read
@@ -565,7 +565,7 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       gpu_tier: "1"
-      runner: 1-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
       timeout: ${{ matrix.timeout }}
       test_timeout: ${{ matrix.test_timeout }}
       test_dirs: ${{ matrix.test_dirs || 'e2e_test/chat_completions' }}
@@ -606,7 +606,7 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       gpu_tier: "1"
-      runner: 1-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
       timeout: ${{ matrix.timeout }}
       test_timeout: ${{ matrix.test_timeout }}
       test_dirs: e2e_test/chat_completions
@@ -652,7 +652,7 @@ jobs:
       # tier-1 chat suite; the second GPU serves the second engine of the
       # group, not 2-GPU-marked tests.
       gpu_tier: "1"
-      runner: 2-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_2 || '2-gpu-h100' }}
       timeout: ${{ matrix.timeout }}
       test_timeout: 40
       test_dirs: e2e_test/chat_completions
@@ -686,7 +686,7 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       gpu_tier: "1"
-      runner: 1-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/completions
       min_selected: ${{ matrix.min_selected }}
@@ -717,7 +717,7 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       gpu_tier: "1"
-      runner: 1-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/embeddings
       extra_deps: "sentence-transformers"
@@ -738,7 +738,7 @@ jobs:
     with:
       engine: vllm
       gpu_tier: "1"
-      runner: 1-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
       timeout: 25
       test_timeout: 20
       test_dirs: e2e_test/realtime
@@ -770,7 +770,7 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       gpu_tier: "1"
-      runner: 1-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/router
       test_filter: "--ignore=e2e_test/router/test_pd_mmlu.py"
@@ -796,7 +796,7 @@ jobs:
     with:
       engine: sglang
       gpu_tier: "1"
-      runner: 1-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
       timeout: 28
       test_timeout: 20
       test_dirs: e2e_test/responses
@@ -833,7 +833,7 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       gpu_tier: "2"
-      runner: 2-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_2 || '2-gpu-h100' }}
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/router
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
@@ -862,7 +862,7 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       gpu_tier: "4"
-      runner: 4-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/chat_completions
       min_selected: ${{ matrix.min_selected }}
@@ -875,7 +875,7 @@ jobs:
     with:
       engine: sglang
       gpu_tier: "4"
-      runner: 4-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
       timeout: 25
       test_dirs: e2e_test/router
       test_filter: "-k TestIGWMixedWorkerClassification"
@@ -888,7 +888,7 @@ jobs:
     with:
       engine: tokenspeed
       gpu_tier: "4"
-      runner: 4-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
       timeout: 75
       test_timeout: 65
       test_dirs: e2e_test/chat_completions/test_epd_multimodal.py
@@ -938,7 +938,7 @@ jobs:
             timeout: 15
             setup_agentic_deps: true
 
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     timeout-minutes: ${{ matrix.timeout }}
     env:
       E2E_VENDOR: ${{ matrix.vendor }}
@@ -1007,7 +1007,7 @@ jobs:
   go-unit-tests:
     name: go-unit-tests
     needs: build-wheel
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -1055,7 +1055,7 @@ jobs:
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.go-bindings == 'true')))
-    runs-on: 1-gpu-h100
+    runs-on: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -1126,7 +1126,7 @@ jobs:
     name: go-bindings-benchmark
     needs: build-wheel
     if: false  # Disabled
-    runs-on: k8s-runner-gpu
+    runs-on: ${{ vars.SMG_RUNNER_GPU || 'k8s-runner-gpu' }}
     timeout-minutes: 32
     permissions:
       contents: read
@@ -1189,7 +1189,7 @@ jobs:
   finish:
     needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-chat-zmq, e2e-2gpu-chat-zmq-dp, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-realtime, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-vendor, go-unit-tests, go-bindings-e2e]
     if: always()
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
       contents: read
     steps:
@@ -1268,7 +1268,7 @@ jobs:
 
   summarize-benchmarks:
     needs: [benchmarks]
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     if: success()
     permissions:
       contents: read

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -24,7 +24,7 @@ jobs:
   build-and-push:
     name: Build and push Docker image
     if: github.repository == 'smg-project/smg'
-    runs-on: ["cpu-e5"]
+    runs-on: ${{ vars.SMG_RUNNER_DOCKER || 'cpu-e5' }}
     permissions:
       contents: read
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,35 @@ Agents are welcome and useful. Three ground rules:
 
 ---
 
+## Running CI on your own runners
+
+Every self-hosted `runs-on` label in `.github/workflows/` reads from a repository
+variable with the upstream label as its fallback, e.g.
+
+```yaml
+runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
+```
+
+Upstream sets none of these variables, so CI keeps using the labels above with no
+change. A fork that runs CI on its own runners only has to set the variables it
+needs (**Settings → Secrets and variables → Actions → Variables**) — no workflow
+edits, so upstream syncs stay conflict-free.
+
+| Variable | Upstream fallback | Used for |
+| --- | --- | --- |
+| `SMG_RUNNER_CPU` | `k8s-runner-cpu` | lint, build, unit tests, summaries |
+| `SMG_RUNNER_DOCKER` | `cpu-e5` | docker / engine image build and push |
+| `SMG_RUNNER_GPU` | `k8s-runner-gpu` | GPU jobs with no fixed GPU count |
+| `SMG_RUNNER_GPU_1` | `1-gpu-h100` | 1-GPU e2e jobs |
+| `SMG_RUNNER_GPU_2` | `2-gpu-h100` | 2-GPU e2e jobs |
+| `SMG_RUNNER_GPU_4` | `4-gpu-h100` | 4-GPU e2e and benchmark jobs |
+| `SMG_RUNNER_GPU_8` | `8-gpu-h200` | 8-GPU benchmark jobs |
+
+GitHub-hosted labels (`ubuntu-latest`, `macos-latest`) are left as-is — every
+fork already has those.
+
+---
+
 ## Reporting security issues
 
 Please do **not** open a public issue for security vulnerabilities. Contact the


### PR DESCRIPTION
## Description

### Problem

Every self-hosted `runs-on` label in `.github/workflows/` is hardcoded, and so
are the 13 `runner:` inputs `pr-test-rust.yml` passes to `e2e-gpu-job.yml`. Any
fork that runs CI on its own runners has to edit those workflow files, and then
re-resolve the same edits on every sync from upstream — the workflow files become
a permanent conflict surface for something that is pure deployment configuration.

### Solution

Move each label behind a repository variable with the current label as the
fallback, extending the pattern `nightly-docker.yml` already uses for
`inputs.runner`:

```yaml
runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
```

Upstream sets none of these variables, so `vars.*` evaluates to the empty string
and the `||` falls through to the literal — **every job lands on exactly the
runner it does today.** A fork sets only the variables it needs and touches no
workflow file.

## Changes

43 sites across 12 workflow files, plus a CONTRIBUTING.md section. Deduplicated,
the entire diff is 8 shapes:

```diff
-    runs-on: k8s-runner-cpu
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
-    runs-on: k8s-runner-gpu
+    runs-on: ${{ vars.SMG_RUNNER_GPU || 'k8s-runner-gpu' }}
-    runs-on: 1-gpu-h100
+    runs-on: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
-    runs-on: 4-gpu-h100
+    runs-on: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
-    runs-on: ["8-gpu-h200"]
+    runs-on: ${{ vars.SMG_RUNNER_GPU_8 || '8-gpu-h200' }}
-    runs-on: ["cpu-e5"]
+    runs-on: ${{ vars.SMG_RUNNER_DOCKER || 'cpu-e5' }}
-    runs-on: ${{ inputs.runner || 'cpu-e5' }}
+    runs-on: ${{ inputs.runner || vars.SMG_RUNNER_DOCKER || 'cpu-e5' }}
-      runner: 1-gpu-h100
+      runner: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
```

| Variable | Fallback | Used for |
| --- | --- | --- |
| `SMG_RUNNER_CPU` | `k8s-runner-cpu` | lint, build, unit tests, summaries (21 sites) |
| `SMG_RUNNER_DOCKER` | `cpu-e5` | docker / engine image build and push (3) |
| `SMG_RUNNER_GPU` | `k8s-runner-gpu` | GPU jobs with no fixed GPU count (1) |
| `SMG_RUNNER_GPU_1` | `1-gpu-h100` | 1-GPU e2e (8) |
| `SMG_RUNNER_GPU_2` | `2-gpu-h100` | 2-GPU e2e (2) |
| `SMG_RUNNER_GPU_4` | `4-gpu-h100` | 4-GPU e2e and benchmarks (6) |
| `SMG_RUNNER_GPU_8` | `8-gpu-h200` | 8-GPU benchmarks (2) |

Deliberately **not** changed:

- `ubuntu-latest` / `macos-latest` (34 sites) — every fork already has
  GitHub-hosted runners, parameterising them would only inflate the diff.
- `e2e-gpu-job.yml` / `e2e-kind-discovery.yml` `runs-on: ${{ inputs.runner }}` —
  the caller now supplies the variable-resolved value.

`nightly-benchmark.yml:469` is a commented-out job; its `runs-on` was converted
too so it does not reintroduce a hardcoded label when re-enabled.

## Test Plan

No Rust, Python, or Go source is touched — this PR is workflow YAML plus one
Markdown section, so `cargo fmt` / `clippy` / `cargo test` have nothing to act on.
The meaningful gates for a change of this shape are that the YAML still parses,
that no label is left hardcoded, and that every fallback literal is byte-identical
to the label it replaced (which is what makes this a no-op upstream). All three
were checked mechanically over the actual commit:

```
$ python3 verify.py
fallback-equals-original: 43 sites OK, 0 mismatched
yaml.safe_load: 49 files parsed, 0 errors
remaining hardcoded self-hosted labels: 0
lines touching ubuntu-latest/macos-latest: 0
```

Resolved `runs-on` for every job in `pr-test-rust.yml`, parsed from the committed
YAML — note `detect-changes` is untouched and the rest carry their original label
as the fallback:

```
pre-commit                 "${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}"
python-lint                "${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}"
grpc-proto-build-check     "${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}"
build-wheel                "${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}"
python-unit-tests          "${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}"
unit-tests                 "${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}"
benchmarks                 "${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}"
detect-changes             'ubuntu-latest'
e2e-vendor                 "${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}"
go-unit-tests              "${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}"
go-bindings-e2e            "${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}"
go-bindings-benchmark      "${{ vars.SMG_RUNNER_GPU || 'k8s-runner-gpu' }}"
finish                     "${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}"
summarize-benchmarks       "${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}"
```

The real end-to-end check is this PR's own CI run: with no variables set on this
repository, every job must schedule onto the same runner as on `main`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes — n/a, no Rust changed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes — n/a, no Rust changed
- [x] (Optional) Documentation updated — new "Running CI on your own runners" section in `CONTRIBUTING.md`

</details>
