### PR TITLE
ci(workflows): let forks opt into the benchmark workflows

### DIFF
--- a/.github/workflows/benchmark-manual-policy.yml
+++ b/.github/workflows/benchmark-manual-policy.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   benchmark:
     name: Manual Policy (Sticky Sessions)
-    if: github.repository == 'smg-project/smg'
+    if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/benchmark-radix-tree.yml
+++ b/.github/workflows/benchmark-radix-tree.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   benchmark:
     name: Radix Tree (Cache-Aware Routing)
-    if: github.repository == 'smg-project/smg'
+    if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
     # CPU-only criterion/throughput benchmarks of the kv-index radix tree —
     # no GPU needed, so it runs on the CPU runner pool rather than competing
     # for GPU runners.

--- a/.github/workflows/benchmark-request-processing.yml
+++ b/.github/workflows/benchmark-request-processing.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   benchmark:
     name: Request Processing
-    if: github.repository == 'smg-project/smg'
+    if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/benchmark-tokenizer.yml
+++ b/.github/workflows/benchmark-tokenizer.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   benchmark:
     name: Tokenizer
-    if: github.repository == 'smg-project/smg'
+    if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/benchmark-tool-parser.yml
+++ b/.github/workflows/benchmark-tool-parser.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   benchmark:
     name: Tool Parser
-    if: github.repository == 'smg-project/smg'
+    if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,22 @@ image **by digest** (`repo/image@sha256:...`) rather than by tag: the value is
 read at job start, so a mutable tag silently changes the CI environment with no
 workflow change to review.
 
+### Benchmark workflows
+
+The `benchmark-*` workflows are gated so a fork does not silently burn its
+runners on them:
+
+```yaml
+if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
+```
+
+They stay off in a fork until you set `SMG_RUN_BENCHMARKS` to `true`. Only
+`benchmark-radix-tree` runs on the self-hosted CPU pool, so it also needs
+`SMG_RUNNER_CPU`; the other four are on `ubuntu-latest` and need nothing else.
+
+The `release-*`, `nightly-*` and `stale` workflows are deliberately **not**
+opt-in — a fork should not publish artifacts or manage upstream's issues.
+
 ---
 
 ## Reporting security issues


### PR DESCRIPTION
## Description

### Problem

The five `benchmark-*` workflows gate their only job on the repository name:

```yaml
if: github.repository == 'smg-project/smg'
```

In a fork that job is therefore permanently skipped, with no way to turn it on.
The default is right — a fork should not silently burn its runners on scheduled
benchmarks — but the absence of an escape hatch has a cost: a fork that *does*
want benchmark coverage has to patch the guard, and then re-resolve that patch on
every sync from upstream. It also fails quietly: the workflow shows up in the
Actions tab, gets dispatched, and reports `skipped` with no explanation, so it is
easy to keep maintaining a workflow that has never executed.

### Solution

Add an opt-in alongside the existing check:

```yaml
if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
```

With the variable unset, `vars.SMG_RUN_BENCHMARKS` is the empty string, `'' ==
'true'` is false, and the guard reduces to the repository check — **no behaviour
change for this repository, or for any fork that does not set it.**

Same shape as #2323: upstream default preserved in the expression, fork opts in
with a repository variable and touches no workflow file.

## Changes

- `benchmark-manual-policy.yml`, `benchmark-radix-tree.yml`,
  `benchmark-request-processing.yml`, `benchmark-tokenizer.yml`,
  `benchmark-tool-parser.yml` — one line each.
- `CONTRIBUTING.md` — a "Benchmark workflows" subsection under the
  "Running CI on your own runners" section added by #2323.

Deliberately **not** changed: `release-*`, `nightly-*` and `stale`. A fork should
not publish artifacts or manage this repository's issues, and unlike the
benchmarks there is no legitimate fork use case for them.

## Test Plan

No source code is touched — five workflow lines and one Markdown subsection, so
`cargo fmt` / `clippy` / `cargo test` have nothing to act on. What actually needs
proving is that the guard still evaluates false without the variable and true with
it. I ran both halves on a fork (`togethercomputer/together-smg`, whose name
matches neither the old nor the new repository check):

**Before** — old guard, `SMG_RUN_BENCHMARKS` unset. `workflow_dispatch` of
`benchmark-radix-tree.yml`:

```
run=32905934159  status=completed  conclusion=skipped
  job "Radix Tree (Cache-Aware Routing)"  conclusion=skipped  runnerName=null
```

**After** — this commit's guard, `SMG_RUN_BENCHMARKS=true`, same dispatch:

```
run=32906808531  status=in_progress
  job "Radix Tree (Cache-Aware Routing)"  status=in_progress
  runnerName=ubuntu-22.04-64core-1003039476  labels=["ubuntu-22.04-64core"]
```

The job is no longer skipped, it is scheduled and running. I cancelled it after
confirming it had a runner rather than let the full ~2.5 h criterion +
throughput suite complete:

```
run=32906808531  status=completed  conclusion=cancelled
```

The "no behaviour change upstream" half is the `before` case above: that fork's
name does not match the repository check, and with the variable unset the job was
skipped exactly as it is today. On this repository the left operand is true, so
the `||` short-circuits and nothing changes regardless of the variable.

YAML parse check on the five changed files:

```
$ python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/benchmark-*.yml')]; print('yaml OK')"
yaml OK
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes — n/a, no Rust changed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes — n/a, no Rust changed
- [x] (Optional) Documentation updated — new "Benchmark workflows" subsection in `CONTRIBUTING.md`

</details>
