### PR TITLE
ci(workflows): let forks supply a container image for the GPU jobs

### DIFF
--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -73,6 +73,7 @@ on:
 jobs:
   run:
     runs-on: ${{ inputs.runner }}
+    container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
     timeout-minutes: ${{ inputs.timeout }}
     permissions:
       contents: read

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -345,6 +345,7 @@ jobs:
   benchmarks:
     needs: build-wheel
     runs-on: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
+    container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
     timeout-minutes: 36
     permissions:
       contents: read
@@ -1056,6 +1057,7 @@ jobs:
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.go-bindings == 'true')))
     runs-on: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
+    container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -1127,6 +1129,7 @@ jobs:
     needs: build-wheel
     if: false  # Disabled
     runs-on: ${{ vars.SMG_RUNNER_GPU || 'k8s-runner-gpu' }}
+    container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
     timeout-minutes: 32
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,21 @@ Only the GPU jobs carry it: they are the ones that need a CUDA toolchain, and
 keeping the seam narrow keeps the blast radius small. It can be extended to the
 CPU jobs if someone needs it.
 
+**What the image has to provide.** When the variable is set, the GPU job's steps
+run *inside* the image, so it is not enough for it to be CUDA-capable:
+
+| requirement | needed by |
+| --- | --- |
+| `bash`, `pip`, `pytest` | all four GPU jobs |
+| `python3` | `go-bindings-benchmark` |
+| a usable `docker` client with daemon access | `benchmarks`, `go-bindings-benchmark` |
+| CUDA runtime matching the engine under test | all four |
+
+A slim CUDA base image will fail during setup rather than at test time. Pin the
+image **by digest** (`repo/image@sha256:...`) rather than by tag: the value is
+read at job start, so a mutable tag silently changes the CI environment with no
+workflow change to review.
+
 ---
 
 ## Reporting security issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,24 @@ edits, so upstream syncs stay conflict-free.
 GitHub-hosted labels (`ubuntu-latest`, `macos-latest`) are left as-is — every
 fork already has those.
 
+### Container-mode GPU runners
+
+The GPU jobs declare their container image through a variable:
+
+```yaml
+container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
+```
+
+Unset, the expression is the empty string and the job runs directly on the runner
+— what upstream does today. Forks whose GPU runners are container-only (an
+Actions Runner Controller scale set with `containerMode: kubernetes` refuses jobs
+without a `container:`) set it to a CUDA-capable image and the same jobs run
+unchanged.
+
+Only the GPU jobs carry it: they are the ones that need a CUDA toolchain, and
+keeping the seam narrow keeps the blast radius small. It can be extended to the
+CPU jobs if someone needs it.
+
 ---
 
 ## Reporting security issues


### PR DESCRIPTION
## Description

### Problem

The GPU jobs run containerless. That is fine on this repository's runners, but an
[Actions Runner Controller](https://github.com/actions/actions-runner-controller)
scale set installed with `containerMode: kubernetes` refuses such jobs outright:

```
Runner name: 'self-hosted-h100-2gpu-cu131-knf42-runner-kwr9h'
##[error]Jobs without a job container are forbidden on this runner,
         please add a 'container:' to your job
```

So a fork on container-mode GPU runners has to add a `container:` block to every
GPU job, and re-resolve those blocks on every sync from upstream. Unlike a runner
label this cannot be worked around locally in a cheap way: `container:` accepts
no `if:`, so the block cannot be made conditional.

### Solution

Source the image from a repository variable:

```yaml
container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
```

Unset, the expression is the empty string and Actions starts **no** job container
— the job runs directly on the runner, exactly as today. Set, the job runs in that
image. Same shape as #2323: upstream default preserved, fork opts in with a
variable and touches no workflow file.

## Changes

Four jobs, one line each — the ones that land on a GPU runner:

| workflow | job | note |
| --- | --- | --- |
| `e2e-gpu-job.yml` | `run` | the reusable GPU job, shared by every GPU e2e lane |
| `pr-test-rust.yml` | `benchmarks` | |
| `pr-test-rust.yml` | `go-bindings-e2e` | |
| `pr-test-rust.yml` | `go-bindings-benchmark` | |

Plus a "Container-mode GPU runners" subsection in `CONTRIBUTING.md`.

The CPU jobs are deliberately left alone: they need no CUDA toolchain, and a
narrow seam keeps the blast radius small. It can be extended later if someone
needs it.

## Test Plan

The load-bearing question is whether an empty `container:` expression means "no
container" or is an error — that is what makes this a no-op here. Rather than
assume, I ran both halves in one workflow on a fork, on the same runner pool, with
one variable set and one deliberately unset:

```yaml
unset_var:
  container: ${{ vars.SMG_CI_CONTAINER_IMAGE }}   # never defined
set_var:
  container: ${{ vars.SMG_CI_CONTAINER_TEST }}    # = ubuntu:24.04
```

Result — run `32909847529`, both jobs `success`:

```
════ unset_var
    case=unset  var=[]
    dockerenv=absent
    PRETTY_NAME="Ubuntu 22.04.5 LTS"          <- the runner's own OS
    (no "Starting job container" step in the log at all)

════ set_var
    ##[group]Starting job container
    ##[command]/usr/bin/docker create --name ..._ubuntu2404_690ce4 --workdir /__w/...
    case=set  var=[ubuntu:24.04]
    dockerenv=present
    PRETTY_NAME="Ubuntu 24.04.4 LTS"          <- the container's OS
```

So with the variable unset the job is containerless and indistinguishable from
today's behaviour; with it set the container is created and used. The `##[error]`
quoted in the Problem section is also real output, from that same fork's ARC GPU
scale set rejecting a containerless job.

YAML parse plus the resolved `container` value for each changed job:

```
$ python3 -c "import yaml; ..."
  e2e-gpu-job.yml      run                      container='${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}'
  pr-test-rust.yml     benchmarks               container='${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}'
  pr-test-rust.yml     go-bindings-e2e          container='${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}'
  pr-test-rust.yml     go-bindings-benchmark    container='${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}'
yaml OK
```

This PR's own CI is the end-to-end check: with no `SMG_CI_GPU_CONTAINER_IMAGE`
set on this repository, the GPU lanes must run containerless and pass as usual.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes — n/a, no Rust changed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes — n/a, no Rust changed
- [x] (Optional) Documentation updated — new "Container-mode GPU runners" subsection in `CONTRIBUTING.md`

</details>
