### PR TITLE
feat(tokenspeed): attention-DP rank affinity (pin field, residue rooms, capability handshake)

### DIFF
--- a/crates/grpc_client/proto/tokenspeed_scheduler.proto
+++ b/crates/grpc_client/proto/tokenspeed_scheduler.proto
@@ -128,6 +128,12 @@ message GenerateRequest {
   // prefill and decode worker; they meet at (`bootstrap_host`, `bootstrap_port`)
   // keyed by `bootstrap_room`. Absent for aggregated (single-worker) requests.
   optional KvBootstrapInfo kv_bootstrap_info = 11;
+
+  // Hard-pin to a specific attention-DP rank, bypassing load balancing.
+  // Disaggregation engines ignore a conflicting pin — the bootstrap_room
+  // residue (room % dp_size) stays the authoritative rank carrier. Only
+  // forwarded when the engine advertises attention-DP support (dp_size label).
+  optional int32 data_parallel_rank = 12;
 }
 
 // EPD encode->prefill pairing handed to a prefill worker. Each multimodal item

--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.4.15"
+version = "0.4.16"
 description = "SMG gRPC proto definitions for vLLM, TRT-LLM, MLX, TokenSpeed, and SGLang"
 requires-python = ">=3.10"
 dependencies = [

--- a/crates/grpc_client/src/tokenspeed_scheduler.rs
+++ b/crates/grpc_client/src/tokenspeed_scheduler.rs
@@ -229,6 +229,9 @@ impl TokenSpeedSchedulerClient {
             // `kv_bootstrap_info` (P->D KV).
             encode_bootstrap_info: None,
             kv_bootstrap_info: None,
+            // Attention-DP pin injected later via
+            // ProtoGenerateRequest::set_data_parallel_rank, if applicable.
+            data_parallel_rank: None,
         })
     }
 

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-servicer"
-version = "0.9.0"
+version = "0.9.1"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, MLX, TokenSpeed, SGLang)"
 requires-python = ">=3.10"
 dependencies = [
-    "smg-grpc-proto>=0.4.13",
+    "smg-grpc-proto>=0.4.16",  # 0.4.16: first release with GenerateRequest.data_parallel_rank (field 12)
     "grpcio>=1.81.1",
     "grpcio-reflection>=1.81.1",
     "grpcio-health-checking>=1.81.1",

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import functools
 import hashlib
 import json
 import logging
@@ -85,6 +86,35 @@ def _lazy_generate_req_input():
     from tokenspeed.runtime.engine.io_struct import GenerateReqInput
 
     return GenerateReqInput
+
+
+@functools.cache
+def _engine_supports_dp_rank_pin() -> bool:
+    """Capability probe: can this engine honor an attention-DP hard pin?
+
+    Gates both handshake sides — the ``dp_size`` label (GetServerInfo) and
+    the proto pin forwarding (Generate). Requires the engine request schema
+    AND the installed proto stubs to carry the field.
+    """
+    try:
+        engine_has_field = any(
+            f.name == "data_parallel_rank" for f in dataclasses.fields(_lazy_generate_req_input())
+        )
+    except Exception as exc:  # noqa: BLE001 — stubbed engine surface in tests.
+        logger.warning("dp-rank-pin capability probe failed; dp affinity disabled: %s", exc)
+        return False
+    # The installed smg-grpc-proto stubs must also carry the field: a stale
+    # wheel would make HasField() raise ValueError on EVERY Generate call.
+    stub_has_field = (
+        "data_parallel_rank" in tokenspeed_scheduler_pb2.GenerateRequest.DESCRIPTOR.fields_by_name
+    )
+    if engine_has_field and not stub_has_field:
+        logger.warning(
+            "engine supports data_parallel_rank but the installed "
+            "smg-grpc-proto stubs predate it; dp affinity disabled — "
+            "upgrade smg-grpc-proto."
+        )
+    return engine_has_field and stub_has_field
 
 
 def _finish_reason_to_dict(reason: Any) -> dict | None:
@@ -534,6 +564,20 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             server_args_dict = dataclasses.asdict(self.server_args)
         else:
             server_args_dict = dict(getattr(self.server_args, "__dict__", {}))
+        # Advertise the attention-DP width ("dp_size" is the exact key the
+        # gateway's label extraction reads) only when the engine can honor a
+        # rank pin — the label doubles as the capability handshake.
+        if _engine_supports_dp_rank_pin():
+            dp_size = getattr(
+                getattr(getattr(self.server_args, "mapping", None), "attn", None),
+                "dp_size",
+                None,
+            )
+            # >= 1 (not > 1): a pin-capable engine advertises even a
+            # single-rank width, keeping label semantics = capability.
+            if isinstance(dp_size, int) and dp_size >= 1:
+                server_args_dict["dp_size"] = dp_size
+
         server_args_struct = Struct()
         server_args_struct.update(_make_json_serializable(server_args_dict))
 
@@ -998,6 +1042,15 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             bootstrap_port = dp.bootstrap_port
             bootstrap_room = dp.bootstrap_room
 
+        # Attention-DP hard pin: only pass the kwarg at all when the engine
+        # schema carries it — an unknown kwarg raises TypeError on older
+        # engines, so "absent" cannot be spelled as "None".
+        pin_kwargs = {}
+        if _engine_supports_dp_rank_pin():
+            pin_kwargs["data_parallel_rank"] = (
+                request.data_parallel_rank if request.HasField("data_parallel_rank") else None
+            )
+
         GenerateReqInput = _lazy_generate_req_input()
         obj = GenerateReqInput(
             input_ids=input_ids,
@@ -1017,6 +1070,7 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             bootstrap_host=bootstrap_host,
             bootstrap_port=bootstrap_port,
             bootstrap_room=bootstrap_room,
+            **pin_kwargs,
         )
         # ``normalize_batch_and_arguments`` asserts ``rid`` is a list when
         # n>1; expand to deterministic per-choice rids so the assert holds.

--- a/grpc_servicer/tests/test_dp_proto_fields.py
+++ b/grpc_servicer/tests/test_dp_proto_fields.py
@@ -35,3 +35,28 @@ class TestGetServerInfoResponseDataParallelSize:
         info = vllm_engine_pb2.GetServerInfoResponse(data_parallel_size=4)
         parsed = vllm_engine_pb2.GetServerInfoResponse.FromString(info.SerializeToString())
         assert parsed.data_parallel_size == 4
+
+
+class TestTokenSpeedGenerateRequestDataParallelRank:
+    """TokenSpeed mirror of the vLLM pin-field presence contract (field 12)."""
+
+    def test_unset_by_default(self):
+        from smg_grpc_proto.generated import tokenspeed_scheduler_pb2
+
+        request = tokenspeed_scheduler_pb2.GenerateRequest()
+        assert not request.HasField("data_parallel_rank")
+
+    def test_rank_zero_is_distinguishable_from_unset(self):
+        from smg_grpc_proto.generated import tokenspeed_scheduler_pb2
+
+        request = tokenspeed_scheduler_pb2.GenerateRequest(data_parallel_rank=0)
+        assert request.HasField("data_parallel_rank")
+        assert request.data_parallel_rank == 0
+
+    def test_set_rank_roundtrips(self):
+        from smg_grpc_proto.generated import tokenspeed_scheduler_pb2
+
+        request = tokenspeed_scheduler_pb2.GenerateRequest(data_parallel_rank=3)
+        parsed = tokenspeed_scheduler_pb2.GenerateRequest.FromString(request.SerializeToString())
+        assert parsed.HasField("data_parallel_rank")
+        assert parsed.data_parallel_rank == 3

--- a/grpc_servicer/tests/test_tokenspeed_dp_rank_pin.py
+++ b/grpc_servicer/tests/test_tokenspeed_dp_rank_pin.py
@@ -1,0 +1,127 @@
+"""TokenSpeed attention-DP hard-pin plumbing tests (engine-free).
+
+Covers the three servicer-side pieces of the dp-affinity handshake:
+the ``GenerateRequest.data_parallel_rank`` proto field, the
+capability-gated forwarding in ``_build_generate_req``, and the
+capability-gated ``dp_size`` advertisement in ``GetServerInfo``.
+
+Run with: pytest grpc_servicer/tests/test_tokenspeed_dp_rank_pin.py
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("smg_grpc_proto")
+pytest.importorskip("zmq")
+pytest.importorskip("msgspec")
+from smg_grpc_proto.generated import tokenspeed_scheduler_pb2  # noqa: E402
+
+if "data_parallel_rank" not in tokenspeed_scheduler_pb2.GenerateRequest.DESCRIPTOR.fields_by_name:
+    pytest.skip(
+        "smg_grpc_proto stubs predate GenerateRequest.data_parallel_rank; "
+        "regenerate from crates/grpc_client/proto",
+        allow_module_level=True,
+    )
+
+import smg_grpc_servicer.tokenspeed.servicer as servicer_mod  # noqa: E402
+from smg_grpc_servicer.tokenspeed.servicer import (  # noqa: E402
+    TokenSpeedSchedulerServicer,
+)
+
+
+class _CapturingReq:
+    """Stands in for GenerateReqInput; records constructor kwargs."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.__dict__.update(kwargs)
+
+
+def _make_servicer():
+    servicer = TokenSpeedSchedulerServicer.__new__(TokenSpeedSchedulerServicer)
+    servicer.server_args = SimpleNamespace(reasoning_parser=None)
+    return servicer
+
+
+def _request(**kwargs):
+    return tokenspeed_scheduler_pb2.GenerateRequest(
+        request_id="r1",
+        tokenized=tokenspeed_scheduler_pb2.TokenizedInput(input_ids=[1, 2, 3]),
+        sampling_params=tokenspeed_scheduler_pb2.SamplingParams(),
+        **kwargs,
+    )
+
+
+class TestBuildGenerateReqPinForwarding:
+    def test_pin_forwarded_when_engine_supports_it(self, monkeypatch):
+        monkeypatch.setattr(servicer_mod, "_lazy_generate_req_input", lambda: _CapturingReq)
+        monkeypatch.setattr(servicer_mod, "_engine_supports_dp_rank_pin", lambda: True)
+        obj = _make_servicer()._build_generate_req(_request(data_parallel_rank=5))
+        assert obj.kwargs["data_parallel_rank"] == 5
+
+    def test_rank_zero_forwarded(self, monkeypatch):
+        monkeypatch.setattr(servicer_mod, "_lazy_generate_req_input", lambda: _CapturingReq)
+        monkeypatch.setattr(servicer_mod, "_engine_supports_dp_rank_pin", lambda: True)
+        obj = _make_servicer()._build_generate_req(_request(data_parallel_rank=0))
+        assert obj.kwargs["data_parallel_rank"] == 0
+
+    def test_unset_pin_forwarded_as_none(self, monkeypatch):
+        monkeypatch.setattr(servicer_mod, "_lazy_generate_req_input", lambda: _CapturingReq)
+        monkeypatch.setattr(servicer_mod, "_engine_supports_dp_rank_pin", lambda: True)
+        obj = _make_servicer()._build_generate_req(_request())
+        assert obj.kwargs["data_parallel_rank"] is None
+
+    def test_kwarg_omitted_when_engine_lacks_field(self, monkeypatch):
+        # Older engines' GenerateReqInput has no such kwarg; passing it would
+        # raise TypeError at construction — the probe must gate the kwarg out.
+        monkeypatch.setattr(servicer_mod, "_lazy_generate_req_input", lambda: _CapturingReq)
+        monkeypatch.setattr(servicer_mod, "_engine_supports_dp_rank_pin", lambda: False)
+        obj = _make_servicer()._build_generate_req(_request(data_parallel_rank=5))
+        assert "data_parallel_rank" not in obj.kwargs
+
+
+def _make_info_servicer(dp_size):
+    servicer = TokenSpeedSchedulerServicer.__new__(TokenSpeedSchedulerServicer)
+    servicer.server_args = SimpleNamespace(
+        model="m",
+        mapping=SimpleNamespace(attn=SimpleNamespace(dp_size=dp_size)),
+    )
+    servicer.scheduler_info = {}
+    servicer.start_time = 0.0
+    servicer.async_llm = SimpleNamespace(rid_to_state={})
+    return servicer
+
+
+class TestGetServerInfoDpSizeAdvertisement:
+    def test_advertised_when_supported_and_dp_active(self, monkeypatch):
+        monkeypatch.setattr(servicer_mod, "_engine_supports_dp_rank_pin", lambda: True)
+        info = asyncio.run(
+            _make_info_servicer(8).GetServerInfo(
+                tokenspeed_scheduler_pb2.GetServerInfoRequest(), None
+            )
+        )
+        assert info.server_args["dp_size"] == 8
+
+    def test_not_advertised_without_engine_support(self, monkeypatch):
+        # The dp_size label doubles as the capability handshake: an engine that
+        # cannot honor a pin must not attract dp-aware virtual workers.
+        monkeypatch.setattr(servicer_mod, "_engine_supports_dp_rank_pin", lambda: False)
+        info = asyncio.run(
+            _make_info_servicer(8).GetServerInfo(
+                tokenspeed_scheduler_pb2.GetServerInfoRequest(), None
+            )
+        )
+        assert "dp_size" not in info.server_args
+
+    def test_dp_off_still_advertises_single_rank(self, monkeypatch):
+        # Under a dp-aware gateway a missing label is a hard registration
+        # failure, so a pin-capable engine with DP off advertises width 1.
+        monkeypatch.setattr(servicer_mod, "_engine_supports_dp_rank_pin", lambda: True)
+        info = asyncio.run(
+            _make_info_servicer(1).GetServerInfo(
+                tokenspeed_scheduler_pb2.GetServerInfoRequest(), None
+            )
+        )
+        assert info.server_args["dp_size"] == 1

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -513,7 +513,22 @@ pub(crate) fn maybe_inject_pd_rendezvous(
         let bootstrap_port = metadata.bootstrap_port().unwrap_or(DEFAULT_BOOTSTRAP_PORT);
         // 63-bit room: no dedup, keep the space wide so the birthday collision
         // rate stays negligible. See the proto field doc.
-        let room_id = rand::rng().random_range(0..i64::MAX);
+        //
+        // When the prefill worker is a dp-aware virtual worker, mint the room
+        // congruent to its rank: TokenSpeed disaggregation engines dispatch by
+        // `room % dp_size` (the pin field is ignored there), so the residue is
+        // the placement carrier. The low bits therefore carry structure — do
+        // not shard on them elsewhere. Under round_robin the decode side
+        // follows the same residue and deliberately inherits the prefill
+        // placement (decode prefix reuse shrinks the KV transfer).
+        let room_id = match (prefill.dp_rank(), prefill.dp_size()) {
+            (Some(rank), Some(dp)) if dp > 1 && rank < dp => {
+                let dp = dp as i64;
+                let base = rand::rng().random_range(0..i64::MAX - dp);
+                base - (base % dp) + rank as i64
+            }
+            _ => rand::rng().random_range(0..i64::MAX),
+        };
 
         request.set_kv_bootstrap_info(hostname.to_string(), bootstrap_port as i32, room_id);
 

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -400,11 +400,17 @@ impl RequestExecutionStage {
         let mut prefill_request = proto_request;
         let mut decode_request = prefill_request.clone_without_mm_pixels();
         decode_request.clear_encode_bootstrap_info();
-        if let Some(rank) = workers.prefill_worker().and_then(|w| w.dp_rank()) {
-            prefill_request.set_data_parallel_rank(rank as i32);
-        }
-        if let Some(rank) = workers.decode_worker().and_then(|w| w.dp_rank()) {
-            decode_request.set_data_parallel_rank(rank as i32);
+        // TokenSpeed disaggregation engines route both sides by
+        // `bootstrap_room % dp_size` (minted residue-aligned in
+        // maybe_inject_pd_rendezvous); a pin is ignored there, and a
+        // mismatched decode-leg pin would spam conflict warnings.
+        if workers.disaggregated_runtime_type().copied() != Some(RuntimeType::TokenSpeed) {
+            if let Some(rank) = workers.prefill_worker().and_then(|w| w.dp_rank()) {
+                prefill_request.set_data_parallel_rank(rank as i32);
+            }
+            if let Some(rank) = workers.decode_worker().and_then(|w| w.dp_rank()) {
+                decode_request.set_data_parallel_rank(rank as i32);
+            }
         }
 
         // `generate` only establishes the prefill stream here (SMG does not drain

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -1388,7 +1388,8 @@ impl ProtoGenerateRequest {
         match self {
             Self::Vllm(req) => req.data_parallel_rank = Some(rank),
             Self::Sglang(req) => req.data_parallel_rank = rank,
-            Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => {}
+            Self::TokenSpeed(req) => req.data_parallel_rank = Some(rank),
+            Self::Trtllm(_) | Self::Mlx(_) => {}
         }
     }
 
@@ -2433,6 +2434,13 @@ mod tests {
         assert!(matches!(
             &sglang_req,
             ProtoGenerateRequest::Sglang(req) if req.data_parallel_rank == 3
+        ));
+
+        let mut ts_req = ProtoGenerateRequest::TokenSpeed(Box::default());
+        ts_req.set_data_parallel_rank(5);
+        assert!(matches!(
+            &ts_req,
+            ProtoGenerateRequest::TokenSpeed(req) if req.data_parallel_rank == Some(5)
         ));
 
         // Engines without the proto field ignore the pin

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -225,15 +225,18 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
         let health_endpoint = &app_context.router_config.health_check.endpoint;
 
         let dp_ranks: Vec<Option<(usize, usize)>> = if app_context.router_config.dp_aware {
-            let dp_info = context
-                .data
-                .dp_info
-                .as_ref()
-                .ok_or_else(|| WorkflowError::ContextValueNotFound("dp_info".to_string()))?;
-            validate_zmq_dp(*connection_mode, dp_info.dp_size, &config.url)?;
-            (0..dp_info.dp_size)
-                .map(|r| Some((r, dp_info.dp_size)))
-                .collect()
+            // dp_info == None means the engine advertised no dp_size label
+            // (it cannot honor a rank pin): register a plain single worker
+            // instead of failing; discover_dp already logged the degradation.
+            match context.data.dp_info.as_ref() {
+                Some(dp_info) => {
+                    validate_zmq_dp(*connection_mode, dp_info.dp_size, &config.url)?;
+                    (0..dp_info.dp_size)
+                        .map(|r| Some((r, dp_info.dp_size)))
+                        .collect()
+                }
+                None => vec![None],
+            }
         } else {
             vec![None] // single worker, no DP
         };

--- a/model_gateway/src/workflow/steps/local/discover_dp.rs
+++ b/model_gateway/src/workflow/steps/local/discover_dp.rs
@@ -116,12 +116,22 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverDPInfoStep {
 
         let dp_info = match context.data.connection_mode {
             // gRPC workers report dp_size through GetServerInfo, already
-            // flattened into the discovered metadata labels
-            Some(ConnectionMode::Grpc) => dp_info_from_labels(&context.data.discovered_labels)
-                .map_err(|e| WorkflowError::StepFailed {
-                    step_id: StepId::new("discover_dp_info"),
-                    message: format!("Failed to get DP info for {}: {e}", config.url),
-                })?,
+            // flattened into the discovered metadata labels. A missing label
+            // means the engine cannot honor a rank pin — degrade to a plain
+            // single worker instead of failing registration under --dp-aware.
+            Some(ConnectionMode::Grpc) => {
+                match dp_info_from_labels(&context.data.discovered_labels) {
+                    Ok(info) => info,
+                    Err(e) => {
+                        warn!(
+                            "No DP info for {} ({e}); registering as a single \
+                         non-DP worker",
+                            config.url
+                        );
+                        return Ok(StepResult::Success);
+                    }
+                }
+            }
             // A ZMQ worker has no metadata endpoint to discover from: its DP
             // shape is the spec's own `dp_size` (a grouped worker awaiting N
             // engines on one socket set). Report it so create_worker can


### PR DESCRIPTION
## Summary

Lets the gateway keep TokenSpeed multi-turn requests on the attention-DP rank that holds their prefix cache:

- proto: `optional GenerateRequest.data_parallel_rank = 12` (`smg-grpc-proto` 0.4.16); `proto_wrapper` injects it for TokenSpeed on the colocated path.
- PD: `bootstrap_room` is minted congruent to the dp-aware prefill worker's rank (`room % dp_size` routes both engine sides), and the PD-leg pin injection is skipped for TokenSpeed — the room is authoritative engine-side.
- discovery: a missing `dp_size` label degrades to a plain single worker under `--dp-aware` instead of failing registration (legacy engines).
- servicer 0.9.1: a capability probe (engine request schema + installed proto stubs) gates both the `dp_size` label advertisement and the pin forwarding; floor `smg-grpc-proto>=0.4.16`.

Other backends are untouched — every change sits behind `RuntimeType::TokenSpeed` / dp-aware guards, and any engine–gateway–stub version combination degrades gracefully (feature off, never a fault).

Engine counterpart: lightseekorg/tokenspeed#1245.

## Validation

`cargo check` clean; 10 new servicer cases (presence semantics, rank-0, kwarg gating, label handshake) green. Engine-side E2E (DP8, 16-conversation replay): 97.6–99.9% prefix-hit, 2.1× TP8 decode throughput — details in the engine PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)