### PR TITLE
feat(multimodal): add qwen4_exp vision support

### DIFF
--- a/crates/multimodal/src/registry/qwen3_vl.rs
+++ b/crates/multimodal/src/registry/qwen3_vl.rs
@@ -148,7 +148,8 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
         let is_qwen3_5 = id.contains("qwen3.5")
             || id.contains("qwen3.6")
             || model_type.is_some_and(|mt| mt == "qwen3_5" || mt == "qwen3_5_moe");
-        is_qwen3_vl || is_qwen3_5
+        let is_qwen4_exp = model_type.is_some_and(|mt| mt == "qwen4_exp");
+        is_qwen3_vl || is_qwen3_5 || is_qwen4_exp
     }
 
     fn placeholder_token(&self, metadata: &ModelMetadata) -> RegistryResult<String> {
@@ -512,6 +513,25 @@ mod tests {
         let spec = registry
             .lookup(&metadata)
             .expect("should match qwen3.5 alias");
+        assert_eq!(spec.name(), "qwen3_vl");
+    }
+
+    #[test]
+    fn qwen4_exp_matches_alias_via_model_type() {
+        let tokenizer = TestTokenizer::new(&[("<|image_pad|>", 151655)]);
+        let config = json!({
+            "model_type": "qwen4_exp",
+            "image_token_id": 151655,
+        });
+        let metadata = ModelMetadata {
+            model_id: "custom-model",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry
+            .lookup(&metadata)
+            .expect("should match qwen4_exp alias");
         assert_eq!(spec.name(), "qwen3_vl");
     }
 }

--- a/crates/multimodal/src/vision/processor.rs
+++ b/crates/multimodal/src/vision/processor.rs
@@ -203,6 +203,7 @@ impl VisionProcessorRegistry {
     /// - `qwen2.5-vl` -> Qwen2VLProcessor (same preprocessing as Qwen2-VL)
     /// - `qwen3-vl` -> Qwen3VLProcessor (patch_size=16, [0.5,0.5,0.5] normalization)
     /// - `qwen3.5` / `qwen3_5` -> Qwen3VLProcessor (Qwen3.5 reuses Qwen3-VL preprocessing)
+    /// - `qwen4_exp` / `qwen4-exp` -> Qwen3VLProcessor (same vision tower as Qwen3.5)
     /// - `phi-3-vision` -> Phi3VisionProcessor (HD transform with 336x336 tiles)
     pub fn with_defaults() -> Self {
         let mut registry = Self::new();
@@ -269,6 +270,16 @@ impl VisionProcessorRegistry {
         );
         registry.register(
             "qwen3_6",
+            Box::new(super::processors::Qwen3VLProcessor::new()),
+        );
+
+        // Qwen4-Exp: same vision tower as Qwen3.5
+        registry.register(
+            "qwen4_exp",
+            Box::new(super::processors::Qwen3VLProcessor::new()),
+        );
+        registry.register(
+            "qwen4-exp",
             Box::new(super::processors::Qwen3VLProcessor::new()),
         );
 
@@ -470,5 +481,15 @@ mod tests {
             .find("custom-model", Some("phi3_v"))
             .expect("phi3 processor by model_type");
         assert_eq!(processor.model_name(), "phi3-vision");
+    }
+
+    #[test]
+    fn test_registry_find_qwen4_exp_model_type_fallback() {
+        let registry = VisionProcessorRegistry::with_defaults();
+
+        let processor = registry
+            .find("custom-model", Some("qwen4_exp"))
+            .expect("qwen3 processor by qwen4_exp model_type");
+        assert_eq!(processor.model_name(), "qwen3-vl");
     }
 }


### PR DESCRIPTION
## Description
### Problem
Qwen4-Exp checkpoints fail multimodal lookup: no `ModelProcessorSpec` claims them, and `VisionProcessorRegistry` has no matching pattern, so image requests are rejected even though the model ships the Qwen3-VL vision tower.

### Solution 
Route the family to the existing `Qwen3VLProcessor` / `Qwen3VLVisionSpec` rather than adding a processor. Preprocessing is identical to Qwen3.5 (`patch_size=16`, `[0.5, 0.5, 0.5]` normalization), so no new code path is needed.

## Changes
- `registry/qwen3_vl.rs`: `Qwen3VLVisionSpec::matches` also accepts `model_type == "qwen4_exp"`.
- `vision/processor.rs`: register `qwen4_exp` / `qwen4-exp` → `Qwen3VLProcessor`, covering both the `model_type` (underscore) and `model_id` (hyphen) spellings that `find()` tries.
- Two unit tests, one per registry.

## Test Plan
- `cargo test -p llm-multimodal --lib` — 290 passed, including the two new tests `qwen4_exp_matches_alias_via_model_type` and `test_registry_find_qwen4_exp_model_type_fallback`.
- **Before**: an OpenAI-compatible `image_url` request is rejected, no vision processor found.
- **After**: the same request returns a correct description of the image (`prompt_tokens: 213`).

<details>
  <summary>Checklist</summary>

  - [x] `cargo +nightly fmt` passes
  - [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
  - [ ] (Optional) Documentation updated
  - [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>