### PR TITLE
fix(protocols): accept replayed response items without ids

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1577,6 +1577,7 @@ pub enum MessagePhase {
 pub enum ResponseInputOutputItem {
     #[serde(rename = "message")]
     Message {
+        #[serde(default)]
         id: String,
         role: String,
         content: Vec<ResponseContentPart>,
@@ -1590,6 +1591,7 @@ pub enum ResponseInputOutputItem {
     #[serde(rename = "reasoning")]
     #[non_exhaustive]
     Reasoning {
+        #[serde(default)]
         id: String,
         #[serde(default)]
         summary: Vec<SummaryTextContent>,

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -743,6 +743,37 @@ fn function_call_items_accept_missing_optional_id() {
 }
 
 #[test]
+fn message_and_reasoning_items_accept_missing_id() {
+    let input: ResponseInput = serde_json::from_value(json!([
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "ok"}]
+        },
+        {
+            "type": "reasoning",
+            "summary": []
+        }
+    ]))
+    .expect("replayed input items without server-generated ids should deserialize");
+
+    match input {
+        ResponseInput::Items(items) => {
+            assert_eq!(items.len(), 2);
+            match &items[0] {
+                ResponseInputOutputItem::Message { id, .. } => assert!(id.is_empty()),
+                other => panic!("expected Message, got {other:?}"),
+            }
+            match &items[1] {
+                ResponseInputOutputItem::Reasoning { id, .. } => assert!(id.is_empty()),
+                other => panic!("expected Reasoning, got {other:?}"),
+            }
+        }
+        other => panic!("expected item-list input, got {other:?}"),
+    }
+}
+
+#[test]
 fn content_part_unknown_type_fails_fast() {
     // Previously `#[serde(other)] Unknown` silently swallowed unknown
     // types; P1 removes that arm so spec-invalid payloads fail cleanly.


### PR DESCRIPTION
## Summary

Allow Responses API `message` and `reasoning` input items to omit server-generated IDs when clients replay conversation history. This keeps deserialization compatible with valid replay payloads and lets downstream projects use the published protocol crate instead of maintaining a vendored fork.

## Changes

- Add `#[serde(default)]` to `ResponseInputOutputItem::Message.id` and `Reasoning.id`.
- Add a regression test covering a mixed `ResponseInput::Items` payload with both IDs omitted.
- Keep the existing public field types unchanged.

## Test plan

- `cargo test -p openai-protocol --test responses` (129 passed)

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (Codex)