### PR TITLE
refactor(grpc): replace PD runtime-identity checks with a protocol table

### DIFF
--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -11,6 +11,7 @@ use smg_grpc_client::{
 };
 use tracing::{debug, warn};
 
+use super::pd_protocol::{DpPlacement, PdProtocol, PdRendezvous};
 use crate::{
     middleware::{RequestId, TenantRequestMeta},
     rate_limit::{ReservationAttachment, SharedReservationHandle},
@@ -19,8 +20,8 @@ use crate::{
         proto_wrapper::ProtoGenerateRequest,
     },
     worker::{
-        sampling_defaults::SamplingDefaults, AttachedBody, RuntimeType, Worker,
-        DEFAULT_BOOTSTRAP_PORT, DEFAULT_SAMPLING_PARAMS_LABEL,
+        sampling_defaults::SamplingDefaults, AttachedBody, Worker, DEFAULT_BOOTSTRAP_PORT,
+        DEFAULT_SAMPLING_PARAMS_LABEL,
     },
 };
 
@@ -434,9 +435,9 @@ pub(crate) fn resolve_string_stops(
     Vec::new()
 }
 
-/// Inject PD bootstrap metadata for SGLang if needed.
+/// Inject PD bootstrap metadata when the runtime's rendezvous travels as
+/// SGLang-style `DisaggregatedParams` (bootstrap host/port/room).
 ///
-/// SGLang uses DisaggregatedParams with bootstrap host/port/room.
 /// vLLM kv_transfer_params are handled in the request_execution stage.
 pub(crate) fn maybe_inject_pd_metadata(
     request: &mut ProtoGenerateRequest,
@@ -448,7 +449,8 @@ pub(crate) fn maybe_inject_pd_metadata(
         ..
     } = workers
     {
-        if *runtime_type == RuntimeType::Sglang {
+        let rendezvous = PdProtocol::for_runtime(*runtime_type).map(|p| p.rendezvous);
+        if rendezvous == Some(PdRendezvous::SglangBootstrap) {
             inject_sglang_bootstrap_metadata(request, prefill);
         }
     }
@@ -507,36 +509,52 @@ pub(crate) fn maybe_inject_pd_rendezvous(
         } => (prefill, runtime_type),
         WorkerSelection::Single { .. } => return,
     };
-    if *runtime_type == RuntimeType::TokenSpeed {
-        let metadata = prefill.metadata();
-        let hostname = metadata.bootstrap_host();
-        let bootstrap_port = metadata.bootstrap_port().unwrap_or(DEFAULT_BOOTSTRAP_PORT);
-        // 63-bit room: no dedup, keep the space wide so the birthday collision
-        // rate stays negligible. See the proto field doc.
-        //
-        // When the prefill worker is a dp-aware virtual worker, mint the room
-        // congruent to its rank: TokenSpeed disaggregation engines dispatch by
-        // `room % dp_size` (the pin field is ignored there), so the residue is
-        // the placement carrier. The low bits therefore carry structure — do
-        // not shard on them elsewhere. Under round_robin the decode side
-        // follows the same residue and deliberately inherits the prefill
-        // placement (decode prefix reuse shrinks the KV transfer).
-        let room_id = match (prefill.dp_rank(), prefill.dp_size()) {
-            (Some(rank), Some(dp)) if dp > 1 && rank < dp => {
-                let dp = dp as i64;
-                let base = rand::rng().random_range(0..i64::MAX - dp);
-                base - (base % dp) + rank as i64
-            }
-            _ => rand::rng().random_range(0..i64::MAX),
-        };
-
-        request.set_kv_bootstrap_info(hostname.to_string(), bootstrap_port as i32, room_id);
-
-        debug!(
-            "Injected PD rendezvous: host={}, port={}, room={}",
-            hostname, bootstrap_port, room_id
-        );
+    let Some(protocol) = PdProtocol::for_runtime(*runtime_type) else {
+        return;
+    };
+    if protocol.rendezvous == PdRendezvous::KvBootstrapRoom {
+        inject_kv_bootstrap_room(request, prefill, protocol.dp_placement);
     }
+}
+
+/// Inject the KV bootstrap host/port/room into a generate request.
+fn inject_kv_bootstrap_room(
+    request: &mut ProtoGenerateRequest,
+    prefill_worker: &Arc<dyn Worker>,
+    dp_placement: DpPlacement,
+) {
+    let metadata = prefill_worker.metadata();
+    let hostname = metadata.bootstrap_host();
+    let bootstrap_port = metadata.bootstrap_port().unwrap_or(DEFAULT_BOOTSTRAP_PORT);
+    // 63-bit room: no dedup, keep the space wide so the birthday collision
+    // rate stays negligible. See the proto field doc.
+    //
+    // Under `DpPlacement::RoomResidue`, mint the room congruent to the
+    // dp-aware prefill worker's rank: the engine dispatches by
+    // `room % dp_size`, so the residue is the placement carrier. The low
+    // bits therefore carry structure — do not shard on them elsewhere. Under
+    // round_robin the decode side follows the same residue and deliberately
+    // inherits the prefill placement (decode prefix reuse shrinks the KV
+    // transfer).
+    let room_id = match (
+        dp_placement,
+        prefill_worker.dp_rank(),
+        prefill_worker.dp_size(),
+    ) {
+        (DpPlacement::RoomResidue, Some(rank), Some(dp)) if dp > 1 && rank < dp => {
+            let dp = dp as i64;
+            let base = rand::rng().random_range(0..i64::MAX - dp);
+            base - (base % dp) + rank as i64
+        }
+        _ => rand::rng().random_range(0..i64::MAX),
+    };
+
+    request.set_kv_bootstrap_info(hostname.to_string(), bootstrap_port as i32, room_id);
+
+    debug!(
+        "Injected PD rendezvous: host={}, port={}, room={}",
+        hostname, bootstrap_port, room_id
+    );
 }
 
 #[cfg(test)]
@@ -799,8 +817,8 @@ mod stop_resolution_tests {
 
     #[test]
     fn pd_bootstrap_injection_skips_non_sglang_requests() {
-        use super::{RuntimeType, Worker, WorkerSelection};
-        use crate::worker::{BasicWorkerBuilder, WorkerType};
+        use super::{Worker, WorkerSelection};
+        use crate::worker::{BasicWorkerBuilder, RuntimeType, WorkerType};
 
         // An SGLang-runtime worker selection paired with a non-SGLang proto
         // (e.g. a misreporting backend) must skip injection, not panic.

--- a/model_gateway/src/routers/grpc/common/stages/mod.rs
+++ b/model_gateway/src/routers/grpc/common/stages/mod.rs
@@ -43,6 +43,7 @@ mod client_acquisition;
 mod dispatch_metadata;
 pub(crate) mod encode;
 pub(crate) mod helpers;
+pub(crate) mod pd_protocol;
 mod rate_limit;
 mod request_execution;
 mod worker_selection;

--- a/model_gateway/src/routers/grpc/common/stages/pd_protocol.rs
+++ b/model_gateway/src/routers/grpc/common/stages/pd_protocol.rs
@@ -1,0 +1,123 @@
+//! Per-runtime PD (prefill/decode) disaggregation protocol descriptors.
+//!
+//! Every way one runtime's PD implementation differs from another's is a row
+//! in [`PdProtocol::for_runtime`]: dispatch shape, rendezvous carrier, and DP
+//! placement carrier. Stage code branches on these semantic axes, never on
+//! `RuntimeType` identity, so teaching the router a new runtime's PD protocol
+//! means deciding the three axes in one place — the exhaustive match below
+//! turns a skipped decision into a compile error instead of an audit of
+//! scattered `== RuntimeType::X` checks.
+
+use crate::worker::RuntimeType;
+
+/// Shape of the disaggregated dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PdDispatch {
+    /// Prefill runs to completion first, then decode: the router relays the
+    /// KV handoff state between the legs (vLLM `kv_transfer_params`).
+    Sequential,
+    /// Prefill and decode dispatch together and rendezvous on bootstrap info
+    /// carried in the request itself.
+    Parallel,
+}
+
+/// How the prefill/decode rendezvous travels to the engines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PdRendezvous {
+    /// SGLang-style `DisaggregatedParams` bootstrap metadata (host, port,
+    /// room), injected by `helpers::maybe_inject_pd_metadata`.
+    SglangBootstrap,
+    /// KV bootstrap host/port/room fields on the generate request
+    /// (TokenSpeed), injected by `helpers::maybe_inject_pd_rendezvous`.
+    KvBootstrapRoom,
+    /// No in-request rendezvous: the sequential dispatch path relays the
+    /// handoff state between the legs instead.
+    None,
+}
+
+/// How a disaggregated engine learns each leg's data-parallel placement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DpPlacement {
+    /// The engine honors the per-request `data_parallel_rank` pin field, set
+    /// on each leg from its selected dp-aware virtual worker.
+    PinField,
+    /// The engine dispatches both legs by `bootstrap_room % dp_size` and
+    /// ignores the pin field (TokenSpeed — a mismatched decode-leg pin spams
+    /// conflict warnings there). The rendezvous room is minted congruent to
+    /// the prefill worker's rank, so the room residue, not the pin, is the
+    /// placement carrier.
+    RoomResidue,
+}
+
+/// PD disaggregation protocol for one runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PdProtocol {
+    pub dispatch: PdDispatch,
+    pub rendezvous: PdRendezvous,
+    pub dp_placement: DpPlacement,
+}
+
+impl PdProtocol {
+    /// The PD protocol table. `None` means the runtime does not support PD
+    /// disaggregated mode.
+    pub(crate) fn for_runtime(runtime: RuntimeType) -> Option<Self> {
+        match runtime {
+            RuntimeType::Sglang => Some(Self {
+                dispatch: PdDispatch::Parallel,
+                rendezvous: PdRendezvous::SglangBootstrap,
+                dp_placement: DpPlacement::PinField,
+            }),
+            RuntimeType::Vllm => Some(Self {
+                dispatch: PdDispatch::Sequential,
+                rendezvous: PdRendezvous::None,
+                dp_placement: DpPlacement::PinField,
+            }),
+            RuntimeType::TokenSpeed => Some(Self {
+                dispatch: PdDispatch::Parallel,
+                rendezvous: PdRendezvous::KvBootstrapRoom,
+                dp_placement: DpPlacement::RoomResidue,
+            }),
+            RuntimeType::Trtllm
+            | RuntimeType::Mlx
+            | RuntimeType::Generic
+            | RuntimeType::External
+            | RuntimeType::Unspecified => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pd_protocol_table_rows() {
+        let sglang = PdProtocol::for_runtime(RuntimeType::Sglang).unwrap();
+        assert_eq!(sglang.dispatch, PdDispatch::Parallel);
+        assert_eq!(sglang.rendezvous, PdRendezvous::SglangBootstrap);
+        assert_eq!(sglang.dp_placement, DpPlacement::PinField);
+
+        let vllm = PdProtocol::for_runtime(RuntimeType::Vllm).unwrap();
+        assert_eq!(vllm.dispatch, PdDispatch::Sequential);
+        assert_eq!(vllm.rendezvous, PdRendezvous::None);
+        assert_eq!(vllm.dp_placement, DpPlacement::PinField);
+
+        let tokenspeed = PdProtocol::for_runtime(RuntimeType::TokenSpeed).unwrap();
+        assert_eq!(tokenspeed.dispatch, PdDispatch::Parallel);
+        assert_eq!(tokenspeed.rendezvous, PdRendezvous::KvBootstrapRoom);
+        assert_eq!(tokenspeed.dp_placement, DpPlacement::RoomResidue);
+
+        for runtime in [
+            RuntimeType::Trtllm,
+            RuntimeType::Mlx,
+            RuntimeType::Generic,
+            RuntimeType::External,
+            RuntimeType::Unspecified,
+        ] {
+            assert!(
+                PdProtocol::for_runtime(runtime).is_none(),
+                "{runtime} must not claim PD support"
+            );
+        }
+    }
+}

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -7,7 +7,10 @@ use axum::response::Response;
 use futures::future::{join_all, try_join_all};
 use tracing::{debug, error, info_span, Instrument};
 
-use super::PipelineStage;
+use super::{
+    pd_protocol::{DpPlacement, PdDispatch, PdProtocol},
+    PipelineStage,
+};
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
@@ -29,7 +32,7 @@ use crate::{
             utils::tonic_ext::{TonicResultExt, TonicStatusExt},
         },
     },
-    worker::{ConnectionModeExt, RuntimeType},
+    worker::ConnectionModeExt,
 };
 
 type StreamResult = Result<ProtoStream, tonic::Status>;
@@ -171,45 +174,39 @@ impl RequestExecutionStage {
         workers: &WorkerSelection,
         model: &str,
     ) -> Result<ExecutionResult, Response> {
-        // Dispatch based on runtime type:
-        // - SGLang: parallel prefill/decode dispatch with bootstrap metadata
-        // - vLLM: sequential prefill-then-decode with kv_transfer_params relay
-        let runtime_type = workers.disaggregated_runtime_type();
-        match runtime_type {
-            Some(RuntimeType::Vllm) => {
+        let Some(runtime_type) = workers.disaggregated_runtime_type() else {
+            error!(
+                function = "RequestExecutionStage::execute",
+                "PD mode requires disaggregated worker selection"
+            );
+            return Err(error::internal_error(
+                "pd_mode_requires_disaggregated_workers",
+                "PD mode requires disaggregated worker selection",
+            ));
+        };
+        let Some(protocol) = PdProtocol::for_runtime(*runtime_type) else {
+            error!(
+                function = "RequestExecutionStage::execute",
+                runtime_type = ?runtime_type,
+                "Runtime does not support PD disaggregated mode"
+            );
+            return Err(error::bad_request(
+                "runtime_pd_not_supported",
+                "This runtime does not support PD disaggregated mode",
+            ));
+        };
+        // Dispatch shape comes from the per-runtime PD protocol table (see
+        // `PdProtocol::for_runtime`): sequential legs relay the KV handoff
+        // through the router, parallel legs rendezvous on bootstrap info
+        // carried in the request.
+        match protocol.dispatch {
+            PdDispatch::Sequential => {
                 self.execute_sequential_pd(proto_request, clients, workers, model)
                     .await
             }
-            Some(RuntimeType::Sglang) | Some(RuntimeType::TokenSpeed) => {
-                // These runtimes carry bootstrap rendezvous in the request
-                // and use parallel prefill/decode dispatch.
-                self.execute_parallel_pd(proto_request, clients, workers)
+            PdDispatch::Parallel => {
+                self.execute_parallel_pd(proto_request, clients, workers, protocol)
                     .await
-            }
-            Some(RuntimeType::Trtllm)
-            | Some(RuntimeType::Mlx)
-            | Some(RuntimeType::Generic)
-            | Some(RuntimeType::External)
-            | Some(RuntimeType::Unspecified) => {
-                error!(
-                    function = "RequestExecutionStage::execute",
-                    runtime_type = ?runtime_type,
-                    "Runtime does not support PD disaggregated mode"
-                );
-                Err(error::bad_request(
-                    "runtime_pd_not_supported",
-                    "This runtime does not support PD disaggregated mode",
-                ))
-            }
-            None => {
-                error!(
-                    function = "RequestExecutionStage::execute",
-                    "PD mode requires disaggregated worker selection"
-                );
-                Err(error::internal_error(
-                    "pd_mode_requires_disaggregated_workers",
-                    "PD mode requires disaggregated worker selection",
-                ))
             }
         }
     }
@@ -376,6 +373,7 @@ impl RequestExecutionStage {
         proto_request: ProtoGenerateRequest,
         clients: &mut ClientSelection,
         workers: &WorkerSelection,
+        protocol: PdProtocol,
     ) -> Result<ExecutionResult, Response> {
         let runtime = workers
             .disaggregated_runtime_type()
@@ -400,11 +398,11 @@ impl RequestExecutionStage {
         let mut prefill_request = proto_request;
         let mut decode_request = prefill_request.clone_without_mm_pixels();
         decode_request.clear_encode_bootstrap_info();
-        // TokenSpeed disaggregation engines route both sides by
-        // `bootstrap_room % dp_size` (minted residue-aligned in
-        // maybe_inject_pd_rendezvous); a pin is ignored there, and a
-        // mismatched decode-leg pin would spam conflict warnings.
-        if workers.disaggregated_runtime_type().copied() != Some(RuntimeType::TokenSpeed) {
+        // Pin each leg's DP rank only when the engine reads placement from
+        // the request field; `RoomResidue` engines take it from the bootstrap
+        // room minted in maybe_inject_pd_rendezvous, ignore the pin, and spam
+        // conflict warnings on a mismatched decode-leg pin.
+        if protocol.dp_placement == DpPlacement::PinField {
             if let Some(rank) = workers.prefill_worker().and_then(|w| w.dp_rank()) {
                 prefill_request.set_data_parallel_rank(rank as i32);
             }
@@ -751,7 +749,7 @@ mod tests {
     use smg_grpc_client::{tokenspeed_proto as ts, vllm_proto as vllm};
 
     use super::*;
-    use crate::worker::{BasicWorkerBuilder, ConnectionMode, Worker, WorkerType};
+    use crate::worker::{BasicWorkerBuilder, ConnectionMode, RuntimeType, Worker, WorkerType};
 
     #[test]
     fn pd_leg_labels_reflect_each_legs_transport() {


### PR DESCRIPTION
## Description

### Problem

The gRPC router's shared stage code decides per-runtime PD disaggregation behavior by branching on `RuntimeType` identity, in four places: dispatch shape in `execute_pd_dispatch`, the SGLang bootstrap metadata and TokenSpeed KV bootstrap room injectors in `stages/helpers.rs`, and — since #2326 — the DP-rank pin suppression in `execute_parallel_pd`. The last two are two halves of one fact (TokenSpeed carries DP placement in the room residue, not the pin field), kept in sync only by comments.

### Solution

Convert identity checks to a capability table: a per-runtime `PdProtocol` descriptor (dispatch shape, rendezvous carrier, DP placement carrier) resolved in one exhaustive match, following the same pattern as `multimodal/capability.rs` and the ZMQ dialect mapping. Stage code branches on the semantic axes, never on `RuntimeType`, and adding a runtime forces one compile-checked decision about all three axes instead of an audit of scattered `== RuntimeType::X` checks. No behavior change.

## Changes

- New `routers/grpc/common/stages/pd_protocol.rs`: `PdProtocol { dispatch, rendezvous, dp_placement }` plus `PdProtocol::for_runtime` (exhaustive match, no wildcard arm) and a table unit test.
- `execute_pd_dispatch` matches `protocol.dispatch`; the unsupported-runtime error falls out of the table's `None` row.
- The #2326 pin gate becomes `protocol.dp_placement == DpPlacement::PinField`, with the protocol threaded into `execute_parallel_pd`.
- `maybe_inject_pd_metadata` / `maybe_inject_pd_rendezvous` key on `protocol.rendezvous`; the TokenSpeed body moved to `inject_kv_bootstrap_room`, whose residue-aligned room minting is keyed by the same `DpPlacement` value that suppresses the pin — the room/pin coupling is now explicit in one struct instead of cross-referenced comments. The harmony pipeline's metadata-only injection call is preserved as-is.

Out of scope (different axis, candidate follow-up): the EPD encode-adapter checks in `worker_selection.rs` / `encode.rs`, which belong to a `supports_epd_encode`-style capability in the `multimodal/capability.rs` family.

## Test Plan

Behavior-preserving refactor; the existing PD stage, helpers, and proto_wrapper tests are the safety net.

- `cargo test -p smg --lib` — 1831 passed, 0 failed (includes the new `pd_protocol_table_rows` test)
- `cargo +nightly fmt --all --check` — clean
- `cargo clippy -p smg --lib --tests -- -D warnings` — clean (full `--all-features` clippy left to CI; this machine cannot build the opencv feature set)
