### PR TITLE
ci(workflows): switch Claude code review to Opus 5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -191,7 +191,7 @@ jobs:
                Do NOT approve on "synchronize" (incremental) reviews — only
                full reviews have enough context to approve.
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --max-turns 50
             --allowedTools "Read,Glob,Grep,Bash,Agent,Skill,ToolSearch,TaskCreate,TaskUpdate,TaskGet,mcp__github_inline_comment__create_inline_comment"
           show_full_output: true
@@ -330,7 +330,7 @@ jobs:
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --max-turns 30
             --allowedTools "Read,Glob,Grep,Bash,Agent,Skill,ToolSearch,TaskCreate,TaskUpdate,TaskGet,mcp__github_inline_comment__create_inline_comment"
           plugins: "pr-review-toolkit@claude-plugins-official"


### PR DESCRIPTION
## Description

### Problem

Both jobs in the Claude code review workflow (auto-review and the `@claude` mention responder) pin `--model claude-opus-4-6`, two generations behind the newest model the org's API key can use.

### Solution

Switch both jobs to `claude-opus-5` — same $5/$25 per MTok pricing as Opus 4.6, 1M context, and the strongest reviewer available to this key today. (`claude-fable-5` was evaluated first but is not enabled for the org: the API returns `not_found_error` for it and it is absent from the key's `/v1/models` listing — enabling it is an Anthropic Console/support conversation, and it would also double per-token cost.)

## Changes

- `.github/workflows/claude-code-review.yml`: `--model claude-opus-4-6` → `--model claude-opus-5` in the `review` and `respond` jobs.

## Test Plan

Verified with the live credential from inside a `k8s-runner-cpu` runner pod (the same env the workflow exports its key from):

- `GET /v1/models` → `claude-opus-5` is the newest model visible to the key (`req` evidence available)
- `POST /v1/messages` with `model: claude-opus-5` → HTTP 200, valid completion
- `POST /v1/messages` with `model: claude-fable-5` → HTTP 404 `not_found_error` (org not enabled), confirming the Opus 5 choice
