### PR TITLE
ci(workflows): install smg plugin for Claude review and raise effort to xhigh

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -192,10 +192,13 @@ jobs:
                full reviews have enough context to approve.
           claude_args: |
             --model claude-opus-5
+            --effort xhigh
             --max-turns 50
             --allowedTools "Read,Glob,Grep,Bash,Agent,Skill,ToolSearch,TaskCreate,TaskUpdate,TaskGet,mcp__github_inline_comment__create_inline_comment"
           show_full_output: true
-          plugins: "pr-review-toolkit@claude-plugins-official"
+          plugins: |
+            pr-review-toolkit@claude-plugins-official
+            smg@smg-dev-guide
           plugin_marketplaces: |
             https://github.com/anthropics/claude-plugins-official.git
             https://github.com/smg-project/smg-dev-guide.git
@@ -333,7 +336,9 @@ jobs:
             --model claude-opus-5
             --max-turns 30
             --allowedTools "Read,Glob,Grep,Bash,Agent,Skill,ToolSearch,TaskCreate,TaskUpdate,TaskGet,mcp__github_inline_comment__create_inline_comment"
-          plugins: "pr-review-toolkit@claude-plugins-official"
+          plugins: |
+            pr-review-toolkit@claude-plugins-official
+            smg@smg-dev-guide
           plugin_marketplaces: |
             https://github.com/anthropics/claude-plugins-official.git
             https://github.com/smg-project/smg-dev-guide.git


### PR DESCRIPTION
## Description

### Problem

`REVIEW.md` step 1 instructs the reviewer to use `/smg:review-pr`, but the workflow never installs it: `plugins:` lists only `pr-review-toolkit@claude-plugins-official`, and registering the `smg-dev-guide` *marketplace* alone installs nothing. Review sessions therefore run without the SMG subsystem checklist and recipes. The effect is visible in the history: claude[bot] posted zero inline comments across the last nine PRs while every run completed successfully (no turn-limit annotations), i.e. the reviews are shallow, not broken.

The review job also runs at default effort even though review quality matters more than latency there.

### Solution

- Install `smg@smg-dev-guide` in both jobs (plugin name verified against the marketplace manifest; the action's `plugins` input takes a newline-separated list per its `action.yml`).
- Add `--effort xhigh` to the auto-review job's `claude_args` — supported by `claude-opus-5` (confirmed via the org key's `/v1/models` capabilities; note Opus 4.6 did not support `xhigh`, so this lands after #2331). The `respond` job stays at default effort so `@claude` mention replies stay quick.

## Changes

- `.github/workflows/claude-code-review.yml`: newline-list `plugins` with `smg@smg-dev-guide` added in the `review` and `respond` jobs; `--effort xhigh` added to the `review` job only.

## Test Plan

Workflow-config-only change; validated statically:

- `smg` plugin name and `smg-dev-guide` marketplace name read from `smg-project/smg-dev-guide` `.claude-plugin/marketplace.json`
- `plugins` input format (newline-separated `name@marketplace`) read from `anthropics/claude-code-action` `action.yml`
- `xhigh` effort support on `claude-opus-5` confirmed from the live `/v1/models` capabilities listing for the org's key
- Effect check after merge: next PR review run should show the smg skills loaded and inline comments following the REVIEW.md severity format
