### PR TITLE
ci(workflows): pin third-party actions to commit SHAs, and guard the pin

### DIFF
--- a/.github/actions/publish-crate/action.yml
+++ b/.github/actions/publish-crate/action.yml
@@ -42,11 +42,15 @@ runs:
 
     - name: Setup Rust
       if: steps.check.outputs.changed == 'true'
-      uses: dtolnay/rust-toolchain@1.98.0
+      # The toolchain must be an explicit input once the ref is a commit pin:
+      # this action otherwise derives the toolchain from its own ref name.
+      uses: dtolnay/rust-toolchain@f8be11a05b1d4f3fcebe6410cc16743212b999b0 # 1.98.0
+      with:
+        toolchain: "1.98.0"
 
     - name: Install protoc
       if: steps.check.outputs.changed == 'true'
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
         repo-token: ${{ github.token }}
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -19,13 +19,13 @@ runs:
       run: cargo metadata --locked --no-deps --format-version 1 > /dev/null
 
     - name: Configure sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       with:
         version: ${{ inputs.sccache-version }}
         disable_annotations: true
 
     - name: Rust cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       with:
         workspaces: .
         # The Go FFI build (bindings/golang/Makefile) overrides CARGO_TARGET_DIR

--- a/.github/workflows/_build-engine-image.yml
+++ b/.github/workflows/_build-engine-image.yml
@@ -93,7 +93,7 @@ jobs:
           echo "| source_build_ref | \`${SOURCE_BUILD_REF}\` |" >> $GITHUB_STEP_SUMMARY
 
       - name: Checkout SMG
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate inputs
         env:
@@ -136,7 +136,7 @@ jobs:
 
       - name: Checkout source build repo
         if: inputs.engine == 'trtllm' && inputs.base_image_ref == '' && inputs.source_build_repo != ''
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ steps.source-ref.outputs.repo }}
           ref: ${{ steps.source-ref.outputs.ref }}
@@ -149,13 +149,13 @@ jobs:
       # ── Docker setup ─────────────────────────────────────────────────────────
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           driver: docker
 
       - name: Login to GitHub Container Registry
         if: ${{ !inputs.dry_run }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -217,7 +217,7 @@ jobs:
       # ── Build engine image ───────────────────────────────────────────────────
 
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/engine.Dockerfile

--- a/.github/workflows/benchmark-manual-policy.yml
+++ b/.github/workflows/benchmark-manual-policy.yml
@@ -38,7 +38,7 @@ jobs:
     if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 100
 
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: manual-policy-results-${{ github.sha }}
           path: |

--- a/.github/workflows/benchmark-radix-tree.yml
+++ b/.github/workflows/benchmark-radix-tree.yml
@@ -41,7 +41,7 @@ jobs:
     # for GPU runners.
     runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 100
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: radix-tree-results-${{ github.sha }}
           path: |

--- a/.github/workflows/benchmark-request-processing.yml
+++ b/.github/workflows/benchmark-request-processing.yml
@@ -42,7 +42,7 @@ jobs:
     if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 100
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: request-processing-results-${{ github.sha }}
           path: |

--- a/.github/workflows/benchmark-tokenizer.yml
+++ b/.github/workflows/benchmark-tokenizer.yml
@@ -38,7 +38,7 @@ jobs:
     if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 100
 
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tokenizer-results-${{ github.sha }}
           path: |

--- a/.github/workflows/benchmark-tool-parser.yml
+++ b/.github/workflows/benchmark-tool-parser.yml
@@ -38,7 +38,7 @@ jobs:
     if: github.repository == 'smg-project/smg' || vars.SMG_RUN_BENCHMARKS == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 100
 
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tool-parser-results-${{ github.sha }}
           path: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
         id: run-start
         run: echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1.0.206
         id: claude-review
         continue-on-error: true
         with:
@@ -310,7 +310,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -329,7 +329,7 @@ jobs:
             echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           fi
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1.0.206
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           claude_args: |

--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -87,7 +87,7 @@ jobs:
       ROUTER_LOCAL_MODEL_PATH: /models
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Engine-specific setup
       - name: Setup SGLang backend
@@ -108,20 +108,20 @@ jobs:
 
       # Artifact downloads
       - name: Download wheel artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: wheel/
 
       - name: Download WASM test fixtures
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: wasm-test-fixtures
           path: crates/wasm/tests/fixtures/
         continue-on-error: true
 
       - name: Download Python client types
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-client-types
           path: clients/python/smg_client/types/
@@ -198,7 +198,7 @@ jobs:
 
       - name: Upload worker logs
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.log-snapshot.outputs.artifact }}
           path: e2e-logs/

--- a/.github/workflows/e2e-kind-discovery.yml
+++ b/.github/workflows/e2e-kind-discovery.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/engine-version-watch.yml
+++ b/.github/workflows/engine-version-watch.yml
@@ -28,7 +28,7 @@ jobs:
       has_pending: ${{ steps.dedup.outputs.has_pending }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -93,7 +93,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -119,7 +119,7 @@ jobs:
             echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           fi
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1.0.206
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     steps:
       - name: Label PR based on changed files
-        uses: actions/labeler@v7
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -46,11 +46,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache wheel artifacts
         id: cache-wheel
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             bindings/python/dist/*.whl
@@ -92,14 +92,14 @@ jobs:
           sed -i 's/class \(.*\)(Enum):/class \1(str, Enum):/' clients/python/smg_client/types/_generated.py
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smg-wheel
           path: bindings/python/dist/*.whl
           retention-days: 7
 
       - name: Upload Python client types
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-client-types
           path: clients/python/smg_client/types/_generated.py
@@ -152,7 +152,7 @@ jobs:
 
       - name: Checkout code
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup vLLM backend
         if: steps.filter.outputs.skip != 'true' && matrix.variant.setup_vllm
@@ -168,14 +168,14 @@ jobs:
 
       - name: Download wheel artifact
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: wheel/
 
       - name: Download Python client types
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-client-types
           path: clients/python/smg_client/types/
@@ -215,7 +215,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always() && steps.filter.outputs.skip != 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-${{ matrix.model.slug }}-single-${{ matrix.variant.id }}-${{ github.run_id }}
           path: nightly_*/
@@ -265,7 +265,7 @@ jobs:
 
       - name: Checkout code
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup vLLM backend
         if: steps.filter.outputs.skip != 'true' && matrix.variant.setup_vllm
@@ -281,14 +281,14 @@ jobs:
 
       - name: Download wheel artifact
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: wheel/
 
       - name: Download Python client types
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-client-types
           path: clients/python/smg_client/types/
@@ -328,7 +328,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always() && steps.filter.outputs.skip != 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-${{ matrix.model.slug }}-multi-${{ matrix.variant.id }}-${{ github.run_id }}
           path: nightly_*/
@@ -378,11 +378,11 @@ jobs:
 
       - name: Checkout code
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Python
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -400,14 +400,14 @@ jobs:
 
       - name: Download wheel artifact
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: wheel/
 
       - name: Download Python client types
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-client-types
           path: clients/python/smg_client/types/
@@ -448,7 +448,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always() && steps.filter.outputs.skip != 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-${{ matrix.model.slug }}-single-${{ matrix.variant.id }}-${{ github.run_id }}
           path: nightly_*/
@@ -491,10 +491,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download all benchmark results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: nightly-*
           merge-multiple: true
@@ -507,7 +507,7 @@ jobs:
 
       - name: Upload comparison charts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-comparison-charts-${{ github.run_id }}
           path: nightly_charts/

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -74,10 +74,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cache wheel artifacts
         id: cache-wheel
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             bindings/python/dist/*.whl
@@ -94,7 +94,7 @@ jobs:
         if: steps.cache-wheel.outputs.cache-hit != 'true'
         run: bash scripts/ci_build_wheel.sh
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smg-wheel
           path: bindings/python/dist/*.whl
@@ -247,8 +247,8 @@ jobs:
       # PR = quick non-live sanity subset; schedule/dispatch = non_live + live + multi_turn.
       CATEGORIES: ${{ github.event.inputs.categories || (github.event_name == 'pull_request' && 'simple_python,irrelevance' || 'simple_python,simple_java,simple_javascript,multiple,parallel,parallel_multiple,irrelevance,live_simple,live_multiple,live_parallel,live_parallel_multiple,live_irrelevance,live_relevance,multi_turn_base,multi_turn_miss_func,multi_turn_miss_param,multi_turn_long_context') }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: wheel
@@ -417,7 +417,7 @@ jobs:
           fi
       - name: Upload results (summary + per-case scores + transcripts)
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bfcl-ab-${{ matrix.name }}-${{ github.run_id }}
           # Summary + per-category score files (which list each failed case for
@@ -431,7 +431,7 @@ jobs:
           retention-days: 30
       - name: Upload arm logs (failure only)
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bfcl-ab-${{ matrix.name }}-logs-${{ github.run_id }}
           # vLLM/SMG logs — only useful on crash/timeout; noise on success.

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -38,17 +38,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up QEMU
         if: env.EXPRESS != 'true'
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -80,7 +80,7 @@ jobs:
           fi
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/nightly-mlx-bench.yml
+++ b/.github/workflows/nightly-mlx-bench.yml
@@ -77,21 +77,25 @@ jobs:
       PYTHONUNBUFFERED: "1"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.98.0
+        # The toolchain must be an explicit input once the ref is a commit pin:
+        # this action otherwise derives the toolchain from its own ref name.
+        uses: dtolnay/rust-toolchain@f8be11a05b1d4f3fcebe6410cc16743212b999b0 # 1.98.0
+        with:
+          toolchain: "1.98.0"
 
       - name: Install protoc
         run: brew install protobuf
 
       - name: Cache Cargo registry and target
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: mlx-bench
           cache-on-failure: true
@@ -156,7 +160,7 @@ jobs:
 
       - name: Upload raw genai-bench output
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-mlx-bench-${{ github.run_id }}
           path: bench-results/
@@ -164,7 +168,7 @@ jobs:
 
       - name: Upload server logs on failure
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-mlx-bench-logs-${{ github.run_id }}
           path: |

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -93,10 +93,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cache wheel artifacts
         id: cache-wheel
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             bindings/python/dist/*.whl
@@ -113,7 +113,7 @@ jobs:
         if: steps.cache-wheel.outputs.cache-hit != 'true'
         run: bash scripts/ci_build_wheel.sh
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smg-wheel
           path: bindings/python/dist/*.whl
@@ -250,8 +250,8 @@ jobs:
       REQUEST_TIMEOUT: ${{ github.event.inputs.request_timeout || '300' }}
       RUN_TIMEOUT: ${{ github.event.inputs.run_timeout || matrix.run_timeout }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: wheel
@@ -416,7 +416,7 @@ jobs:
           fi
       - name: Upload results (summary + scores + transcripts)
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tau2-ab-${{ matrix.name }}-${{ github.run_id }}
           path: |
@@ -427,7 +427,7 @@ jobs:
           retention-days: 30
       - name: Upload arm logs (failure only)
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tau2-ab-${{ matrix.name }}-logs-${{ github.run_id }}
           path: ${{ runner.temp }}/tau2_run/*.log

--- a/.github/workflows/nightly-triage.yml
+++ b/.github/workflows/nightly-triage.yml
@@ -78,7 +78,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -111,7 +111,7 @@ jobs:
           gh label create nightly-triage --repo "$GITHUB_REPOSITORY" \
             --description "Automated nightly failure triage" --color d93f0b --force
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1.0.206
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -91,7 +91,7 @@ jobs:
 
           echo "✅ PR title is valid: '$PR_TITLE'"
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -55,22 +55,26 @@ jobs:
       PYTHONUNBUFFERED: "1"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.98.0
+        # The toolchain must be an explicit input once the ref is a commit pin:
+        # this action otherwise derives the toolchain from its own ref name.
+        uses: dtolnay/rust-toolchain@f8be11a05b1d4f3fcebe6410cc16743212b999b0 # 1.98.0
+        with:
+          toolchain: "1.98.0"
 
       - name: Install protoc
         run: brew install protobuf
 
       - name: Cache Cargo registry and target
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: mlx-pr-test
           cache-on-failure: true
@@ -123,7 +127,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-mlx-logs
           path: e2e-logs/

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -34,10 +34,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 
@@ -54,10 +54,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 
@@ -81,10 +81,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -123,7 +123,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # No wheel-output cache here. It was keyed on a hash of every crate's
       # source, so it missed on essentially every code PR (all-or-nothing), and
@@ -166,28 +166,28 @@ jobs:
           bash crates/wasm/tests/fixtures/build_fixtures.sh
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smg-wheel
           path: bindings/python/dist/*.whl
           retention-days: 1
 
       - name: Upload Go FFI library artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: go-ffi-library
           path: bindings/golang/target/release/libsmg_go.*
           retention-days: 1
 
       - name: Upload Python client types
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-client-types
           path: clients/python/smg_client/types/_generated.py
           retention-days: 1
 
       - name: Upload WASM test fixtures
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wasm-test-fixtures
           path: crates/wasm/tests/fixtures/*.wasm
@@ -199,7 +199,7 @@ jobs:
         run: sccache --show-stats
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -216,15 +216,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: dist/
@@ -272,10 +272,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 
@@ -351,26 +351,26 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup SGLang backend
         uses: ./.github/actions/setup-sglang
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: wheel/
 
       - name: Download WASM test fixtures
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: wasm-test-fixtures
           path: crates/wasm/tests/fixtures/
         continue-on-error: true
 
       - name: Download Python client types
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-client-types
           path: clients/python/smg_client/types/
@@ -399,7 +399,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: genai-bench-results-all-policies
           path: benchmark_**/
@@ -410,7 +410,7 @@ jobs:
 
       - name: Upload worker logs
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-worker-logs
           path: benchmark-logs/
@@ -432,8 +432,8 @@ jobs:
       go-bindings: ${{ steps.filter.outputs.go-bindings }}
       rust-ci: ${{ steps.filter.outputs.rust-ci }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |
@@ -947,10 +947,10 @@ jobs:
       SHOW_ROUTER_LOGS: "1"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 
@@ -959,20 +959,20 @@ jobs:
         run: bash scripts/ci_agentic_svc_deps.sh check --oracle oracle-db --brave brave-search-mcp
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: wheel/
 
       - name: Download WASM test fixtures
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: wasm-test-fixtures
           path: crates/wasm/tests/fixtures/
         continue-on-error: true
 
       - name: Download Python client types
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-client-types
           path: clients/python/smg_client/types/
@@ -1014,10 +1014,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.24'
           cache: true
@@ -1029,7 +1029,7 @@ jobs:
           sudo apt-get install -y build-essential
 
       - name: Download Go FFI library
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: go-ffi-library
           path: bindings/golang/target/release/
@@ -1063,20 +1063,20 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup SGLang backend
         uses: ./.github/actions/setup-sglang
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.24'
           cache: true
           cache-dependency-path: bindings/golang/go.sum
 
       - name: Download Go FFI library
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: go-ffi-library
           path: bindings/golang/target/release/
@@ -1085,13 +1085,13 @@ jobs:
         run: ls -la bindings/golang/target/release/libsmg_go.*
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: wheel/
 
       - name: Download Python client types
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-client-types
           path: clients/python/smg_client/types/
@@ -1117,7 +1117,7 @@ jobs:
 
       - name: Upload worker logs
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-worker-logs-go-bindings
           path: e2e-logs/
@@ -1135,20 +1135,20 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup SGLang backend
         uses: ./.github/actions/setup-sglang
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.24'
           cache: true
           cache-dependency-path: bindings/golang/go.sum
 
       - name: Download Go FFI library
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: go-ffi-library
           path: bindings/golang/target/release/
@@ -1157,7 +1157,7 @@ jobs:
         run: ls -la bindings/golang/target/release/libsmg_go.*
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smg-wheel
           path: wheel/
@@ -1184,7 +1184,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: genai-bench-results-go-bindings
           path: benchmark_go_bindings/
@@ -1197,7 +1197,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Self-check: every e2e-* job defined in this workflow must gate merge
       # via finish.needs AND the failure check below. Keeps a new (or
@@ -1277,15 +1277,15 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.13"
 
     - name: Download gateway benchmark results
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: genai-bench-results-all-policies
 

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -42,7 +42,7 @@ jobs:
           - crate: engine-zmq-client
             path: crates/engine_zmq_client
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/publish-crate
         with:
           crate: ${{ matrix.crate }}
@@ -70,7 +70,7 @@ jobs:
           - crate: llm-tokenizer
             path: crates/tokenizer
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/publish-crate
         with:
           crate: ${{ matrix.crate }}
@@ -82,7 +82,7 @@ jobs:
     needs: tier2
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/publish-crate
         with:
           crate: llm-multimodal
@@ -94,7 +94,7 @@ jobs:
     needs: tier3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/publish-crate
         with:
           crate: smg

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -73,21 +73,21 @@ jobs:
           echo "Will push: ${PUSH}"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to Docker Hub
         if: steps.should-push.outputs.push == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -29,17 +29,17 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25'
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ github.token }}
 

--- a/.github/workflows/release-grpc.yml
+++ b/.github/workflows/release-grpc.yml
@@ -21,7 +21,7 @@ jobs:
       proto: ${{ steps.changes.outputs.proto }}
       servicer: ${{ steps.changes.outputs.servicer }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -48,10 +48,10 @@ jobs:
     if: needs.detect.outputs.proto == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -70,7 +70,7 @@ jobs:
       - name: Check package
         run: twine check --strict crates/grpc_client/python/dist/*
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grpc-proto-dist
           path: crates/grpc_client/python/dist/
@@ -81,13 +81,13 @@ jobs:
     needs: [build-proto]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: grpc-proto-dist
           path: dist
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -116,10 +116,10 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -132,7 +132,7 @@ jobs:
       - name: Check package
         run: twine check --strict grpc_servicer/dist/*
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grpc-servicer-dist
           path: grpc_servicer/dist/
@@ -146,13 +146,13 @@ jobs:
       && needs.build-servicer.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: grpc-servicer-dist
           path: dist
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Determine version
         id: version
@@ -47,7 +47,7 @@ jobs:
           grep -E '^(version|appVersion):' deploy/helm/smg/Chart.yaml
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.17.0
 

--- a/.github/workflows/release-pypi-dev.yml
+++ b/.github/workflows/release-pypi-dev.yml
@@ -40,7 +40,7 @@ jobs:
       servicer_version: ${{ steps.compute.outputs.servicer_version }}
       release_tag: ${{ steps.compute.outputs.release_tag }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - id: compute
         run: |
@@ -88,12 +88,12 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || inputs.release_smg }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: smg-repo
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 
@@ -120,7 +120,7 @@ jobs:
           echo "  model_gateway/Cargo.toml:     ${SMG_CARGO_VERSION}"
 
       - name: Build manylinux x86_64 wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: smg-repo/bindings/python
           target: x86_64
@@ -149,7 +149,7 @@ jobs:
           ls -la smg-repo/bindings/python/dist
 
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: smg-repo/bindings/python
           command: sdist
@@ -161,7 +161,7 @@ jobs:
           pip install -U twine
           twine check --strict smg-repo/bindings/python/dist/*
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smg-dev-dist
           path: smg-repo/bindings/python/dist/
@@ -173,8 +173,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || inputs.release_proto }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Install build deps
@@ -196,7 +196,7 @@ jobs:
         run: cd crates/grpc_client/python && python -m build
       - name: Check package
         run: twine check --strict crates/grpc_client/python/dist/*
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: proto-dev-dist
           path: crates/grpc_client/python/dist/
@@ -208,8 +208,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || inputs.release_servicer }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Install build deps
@@ -237,7 +237,7 @@ jobs:
         run: cd grpc_servicer && python -m build
       - name: Check package
         run: twine check --strict grpc_servicer/dist/*
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: servicer-dev-dist
           path: grpc_servicer/dist/
@@ -269,7 +269,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all dev artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           pattern: "*-dev-dist"
@@ -279,12 +279,12 @@ jobs:
         run: ls -lh dist/
 
       - name: Check out smg repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: smg-repo
 
       - name: Check out whl index repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: lightseekorg/whl
           ref: gh-pages

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -60,16 +60,16 @@ jobs:
             target: aarch64
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: smg-repo
 
       - name: Set up QEMU for aarch64 verification
         if: matrix.platform == 'linux' && matrix.target == 'aarch64' && matrix.manylinux == '2_28'
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
           architecture: ${{ matrix.python-architecture || 'x64' }}
@@ -90,7 +90,7 @@ jobs:
         run: echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: smg-repo/bindings/python
           target: ${{ matrix.target }}
@@ -139,7 +139,7 @@ jobs:
       - name: Check packages
         run: twine check --strict smg-repo/bindings/python/dist/*
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: packages-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}
           path: smg-repo/bindings/python/dist/
@@ -150,24 +150,24 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: smg-repo
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 
       - name: Build SDist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: smg-repo/bindings/python
           command: sdist
           args: --out dist
           rust-toolchain: 1.98.0
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdist
           path: smg-repo/bindings/python/dist/*.tar.gz
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
@@ -188,7 +188,7 @@ jobs:
       # runner's system packaging can't parse Metadata 2.4 (PEP 639
       # License-Expression/License-File) and rejects the wheels.
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v11
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           operations-per-run: 500
           exempt-draft-pr: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,22 @@ repos:
         stages: [commit-msg]
         always_run: true
 
+      - id: check-action-pins
+        name: Action SHA pins
+        description: Third-party GitHub Actions must be pinned to commit SHAs
+        entry: python3 scripts/check_action_pins.py
+        language: system
+        files: ^\.github/
+        pass_filenames: false
+
+      - id: check-action-pins-selftest
+        name: Action SHA pins (self-test)
+        description: Run the pin checker's case table when the checker itself changes
+        entry: python3 scripts/check_action_pins.py --test
+        language: system
+        files: ^scripts/check_action_pins\.py$
+        pass_filenames: false
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.0
     hooks:

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Enforce commit-SHA pins on third-party GitHub Actions.
+
+A `uses:` reference like `actions/checkout@v7` points at a mutable tag: whoever
+can move that tag executes code with this repository's token, on our runners.
+Every third-party reference must therefore pin the full 40-hex commit SHA and
+keep the human-readable version alongside it as a comment:
+
+    uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+The comment is load-bearing too: it is what Dependabot rewrites when it bumps a
+pinned action, and what a human reads to know what is installed. A bare major
+(`# v7`) is rejected because it cannot be checked against the SHA.
+
+Local composite actions (`./…`), reusable-workflow refs to this repo, and
+expression refs (`${{ … }}`) are exempt. Docker refs (`docker://…`) carry their
+own digest discipline and are skipped here.
+
+Usage:
+    python scripts/check_action_pins.py           # scan .github/, exit 1 on violations
+    python scripts/check_action_pins.py --test    # run the built-in case table
+"""
+
+import glob
+import re
+import sys
+
+SCAN_GLOBS = [
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml",
+    ".github/actions/*/action.yml",
+    ".github/actions/*/action.yaml",
+]
+
+# owner/repo whose refs are allowed to stay unpinned, each with a written
+# reason. Every entry here is a check this script is NOT performing — keep it
+# empty unless an action genuinely cannot be pinned.
+UNPINNED_ALLOWED: dict[str, str] = {}
+
+USES_RE = re.compile(r"^\s*(?:-\s+)?uses:\s*(.+?)\s*$")
+# 40-hex ref, then a version comment with at least two dotted numeric
+# components ("# v7.0.1", "# 1.98.0"). Suffixes like "-rc1" are accepted.
+PINNED_RE = re.compile(
+    r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[^@\s]+)?"
+    r"@[0-9a-f]{40}"
+    r"\s+#\s*v?\d+(?:\.\d+)+\S*$"
+)
+
+
+def check_line(line: str) -> str | None:
+    """Return a violation message for one line, or None if the line is fine."""
+    m = USES_RE.match(line)
+    if m is None:
+        return None
+    ref = m.group(1)
+    # A quoted scalar must not hide a tag ref: unwrap before judging.
+    if len(ref) >= 2 and ref[0] == ref[-1] and ref[0] in "\"'":
+        ref = ref[1:-1].strip()
+    if ref.startswith("./") or ref.startswith("docker://") or "${{" in ref:
+        return None
+    repo = ref.split("@", 1)[0].split("/")
+    if len(repo) >= 2 and "/".join(repo[:2]) in UNPINNED_ALLOWED:
+        return None
+    if PINNED_RE.match(ref):
+        return None
+    if "@" not in ref:
+        return f"missing a ref entirely: `{ref}`"
+    target = ref.split("@", 1)[1].split()[0]
+    if re.fullmatch(r"[0-9a-f]{40}", target):
+        return f"pinned but missing the `# vX.Y.Z` version comment: `{ref}`"
+    return f"mutable ref `{ref}` — pin the commit SHA and keep the version as a comment"
+
+
+def scan() -> int:
+    violations = []
+    for pattern in SCAN_GLOBS:
+        for path in sorted(glob.glob(pattern)):
+            with open(path, encoding="utf-8") as f:
+                for lineno, line in enumerate(f, 1):
+                    message = check_line(line)
+                    if message is not None:
+                        violations.append(f"{path}:{lineno}: {message}")
+    if violations:
+        print("\n".join(violations))
+        print(
+            "\nEvery third-party action must be pinned:"
+            "\n    uses: owner/repo@<40-hex commit sha> # vX.Y.Z"
+            "\nResolve a tag to its commit with:"
+            "\n    gh api repos/OWNER/REPO/commits/TAG --jq .sha"
+        )
+        return 1
+    return 0
+
+
+# (line, expected_ok) — every rule and every near-miss this script must catch.
+CASES: list[tuple[str, bool]] = [
+    ("      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1", True),
+    ("      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1", True),
+    ("      uses: dtolnay/rust-toolchain@f8be11a05b1d4f3fcebe6410cc16743212b999b0 # 1.98.0", True),
+    ("      uses: owner/repo/subdir@3d3c42e5aac5ba805825da76410c181273ba90b1 # v1.2.3", True),
+    ("      uses: ./.github/actions/setup-rust", True),
+    ("      uses: ./.github/workflows/e2e-gpu-job.yml", True),
+    ("      uses: ${{ matrix.action }}", True),
+    ("      uses: docker://alpine:3.20", True),
+    ("      not_a_uses_line: actions/checkout@v7", True),
+    ("      uses: actions/checkout@v7", False),
+    ('      uses: "actions/checkout@v7"', False),
+    ("      uses: 'actions/checkout@v7'", False),
+    ("      uses: actions/checkout@main", False),
+    ("      uses: actions/checkout@3d3c42e5", False),
+    ("      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", False),
+    ("      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7", False),
+    ("      uses: actions/checkout@3D3C42E5AAC5BA805825DA76410C181273BA90B1 # v7.0.1", False),
+    ("      uses: actions/checkout", False),
+]
+
+
+def self_test() -> int:
+    failures = 0
+    for line, expected_ok in CASES:
+        actual_ok = check_line(line) is None
+        if actual_ok != expected_ok:
+            failures += 1
+            print(f"case failed (expected {'ok' if expected_ok else 'violation'}): {line!r}")
+    print(f"self-test: {len(CASES) - failures}/{len(CASES)} cases passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(self_test() if "--test" in sys.argv[1:] else scan())


### PR DESCRIPTION
## Description

### Problem

Every third-party GitHub Action in this repository is referenced by a mutable tag (`actions/checkout@v7`, `Swatinem/rust-cache@v2`, …). A tag is a pointer anyone with push access to that repo can move: if any of these upstreams is compromised, the moved tag executes arbitrary code with our repository token — on the hosted pools and on the self-hosted GPU fleet. This is the actions half of the supply-chain discussion from #2285 (where the uv installer got version-pinned and checksum work was deferred to its own change).

### Solution

Pin all 20 third-party actions (186 use sites across 30 files) to the full commit SHA of the **exact version each tag already points at today** — so CI runs the same code before and after, only via an immutable name — and keep the human-readable version as a trailing comment:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
```

Two details worth reviewing:

- **`dtolnay/rust-toolchain` derives the toolchain from its own ref name** (`@1.98.0` is a branch, and the ref doubles as the version selector). A bare SHA pin would ask it to install a toolchain named after the commit. The three call sites now pass `toolchain: "1.98.0"` as an explicit input — required for the pin, and it makes future toolchain bumps a one-line edit that no longer needs a re-pin.
- **Pins decay unless something rejects the next unpinned ref.** `scripts/check_action_pins.py` (stdlib-only) enforces the shape: 40-hex ref plus a version comment, bare majors rejected as uncheckable, local/reusable/docker/expression refs exempt, and an escape-hatch dict that is deliberately empty (each entry would be a check not performed). It runs as a pre-commit hook scoped to `.github/`, with a second hook running its embedded 18-case table whenever the checker itself changes. Failure output includes the exact `gh api` command to resolve a tag.

Maintenance story: Dependabot already watches `github-actions` weekly and natively understands SHA pins — it rewrites the SHA and the version comment together, so bumps keep flowing exactly as before.

## Changes

- `.github/workflows/*.yml`, `.github/actions/*/action.yml` — all third-party `uses:` refs pinned to commit SHAs with version comments; `dtolnay/rust-toolchain` sites additionally pass the toolchain as an explicit input.
- `scripts/check_action_pins.py` — new pin checker with `--test` self-check.
- `.pre-commit-config.yaml` — `check-action-pins` (scoped to `.github/`) and `check-action-pins-selftest` (fires when the checker changes) local hooks.

## Test Plan

- Every SHA was resolved from the live GitHub API against the tag currently in use, and spot-checked through a second, independent path (`git ls-remote` peeled refs vs `gh api …/commits/<tag>`) — identical results. Version comments name the most specific tag pointing at that commit.
- `python3 scripts/check_action_pins.py` — full scan passes on the pinned tree.
- `python3 scripts/check_action_pins.py --test` — 18/18 cases (quoted refs, short SHAs, uppercase hex, missing/major-only comments, local/docker/expression exemptions).
- Negative check: appending `uses: actions/checkout@v7` to a workflow makes the scan exit 1 naming the file, line, and resolve command.
- All 30 touched YAML files parse (`yaml.safe_load_all`); `ruff check` and `ruff format --check` pass on the new script.
- Behavior neutrality: each pin is the commit its tag resolves to right now, so this PR changes *names*, not code — a green run here is the same actions CI ran yesterday.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes — n/a, no Rust changes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes — n/a, no Rust changes
- [x] (Optional) Documentation updated — rationale inline in the checker and hook descriptions
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
