### PR TITLE
refactor(multimodal): own the tokenizer seam with a local three-method trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,7 +3882,6 @@ dependencies = [
  "http",
  "image",
  "libloading",
- "llm-tokenizer",
  "ndarray",
  "npyz",
  "once_cell",

--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -48,7 +48,6 @@ tracing.workspace = true
 url = "2.5.8"
 
 # Workspace crates
-llm-tokenizer.workspace = true
 anyhow.workspace = true
 blake3.workspace = true
 

--- a/crates/multimodal/src/lib.rs
+++ b/crates/multimodal/src/lib.rs
@@ -18,7 +18,7 @@ pub use error::{MediaConnectorError, MultiModalError, MultiModalResult, Transfor
 pub use media::{
     ImageFetchConfig, MediaConnector, MediaConnectorConfig, MediaSource, VideoFetchConfig,
 };
-pub use registry::{MediaPartOrder, ModelMetadata, ModelProcessorSpec, ModelRegistry};
+pub use registry::{MediaPartOrder, ModelMetadata, ModelProcessorSpec, ModelRegistry, Tokenizer};
 pub use tracker::{AsyncMultiModalTracker, TrackerOutput};
 pub use types::{
     AudioClip, AudioSource, EncoderFieldLayouts, FieldLayout, ImageDetail, ImageFrame, ImageSize,

--- a/crates/multimodal/src/registry/kimi_k3.rs
+++ b/crates/multimodal/src/registry/kimi_k3.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use llm_tokenizer::Encoding;
 use serde_json::{json, Value};
 
 use crate::{
@@ -45,18 +44,13 @@ impl KimiK3VisionSpec {
     /// segment boundaries for the encoder, so encoding it alone yields the same
     /// ids as the reference's one-shot encoding of the whole block.
     fn encode_plain_text(metadata: &ModelMetadata, text: &str) -> RegistryResult<Vec<TokenId>> {
-        let encoding = metadata.tokenizer.encode(text, false).map_err(|_| {
+        let ids = metadata.tokenizer.encode_text(text).ok_or_else(|| {
             ModelRegistryError::TextEncodingFailed {
                 spec: "kimi_k3",
                 text: text.to_string(),
             }
         })?;
-        Ok(match encoding {
-            Encoding::Hf(inner) => inner.get_ids().iter().map(|&id| id as TokenId).collect(),
-            Encoding::Plain(ids) | Encoding::Tiktoken(ids) => {
-                ids.into_iter().map(|id| id as TokenId).collect()
-            }
-        })
+        Ok(ids.into_iter().map(|id| id as TokenId).collect())
     }
 }
 

--- a/crates/multimodal/src/registry/mod.rs
+++ b/crates/multimodal/src/registry/mod.rs
@@ -24,6 +24,7 @@ use qwen_vl::QwenVLVisionSpec;
 // Re-export public API from traits.
 pub use traits::{
     MediaPartOrder, ModelMetadata, ModelProcessorSpec, ModelRegistryError, RegistryResult,
+    Tokenizer,
 };
 
 pub struct ModelRegistry {
@@ -90,9 +91,6 @@ impl LazySpec {
 pub(super) mod test_helpers {
     use std::collections::HashMap;
 
-    use llm_tokenizer::{Decoder, Encoder, Encoding, SpecialTokens, TokenizerTrait};
-    use once_cell::sync::Lazy;
-
     use crate::{
         encoder_inputs::{ModelSpecificValue, PreprocessedEncoderInputs},
         types::ImageSize,
@@ -126,53 +124,7 @@ pub(super) mod test_helpers {
         }
     }
 
-    impl Encoder for TestTokenizer {
-        fn encode(&self, input: &str, _add_special_tokens: bool) -> anyhow::Result<Encoding> {
-            let Some(base) = self.text_base else {
-                return Ok(Encoding::Plain(Vec::new()));
-            };
-            Ok(Encoding::Plain(
-                input.bytes().map(|b| base + u32::from(b)).collect(),
-            ))
-        }
-
-        fn encode_batch(
-            &self,
-            inputs: &[&str],
-            add_special_tokens: bool,
-        ) -> anyhow::Result<Vec<Encoding>> {
-            inputs
-                .iter()
-                .map(|input| self.encode(input, add_special_tokens))
-                .collect()
-        }
-    }
-
-    impl Decoder for TestTokenizer {
-        fn decode(&self, _token_ids: &[u32], _skip_special_tokens: bool) -> anyhow::Result<String> {
-            Ok(String::new())
-        }
-    }
-
-    impl TokenizerTrait for TestTokenizer {
-        fn vocab_size(&self) -> usize {
-            self.vocab.len()
-        }
-
-        fn get_special_tokens(&self) -> &SpecialTokens {
-            static TOKENS: Lazy<SpecialTokens> = Lazy::new(|| SpecialTokens {
-                bos_token: None,
-                eos_token: None,
-                unk_token: None,
-                sep_token: None,
-                pad_token: None,
-                cls_token: None,
-                mask_token: None,
-                additional_special_tokens: vec![],
-            });
-            &TOKENS
-        }
-
+    impl crate::registry::Tokenizer for TestTokenizer {
         fn token_to_id(&self, token: &str) -> Option<u32> {
             self.vocab.get(token).copied()
         }
@@ -184,8 +136,13 @@ pub(super) mod test_helpers {
                 .map(|(k, _)| k.clone())
         }
 
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
+        fn encode_text(&self, text: &str) -> Option<Vec<u32>> {
+            // Mirrors the pre-seam stub behavior: without a byte encoder the
+            // stub encodes everything to nothing rather than failing.
+            Some(match self.text_base {
+                Some(base) => text.bytes().map(|b| base + u32::from(b)).collect(),
+                None => Vec::new(),
+            })
         }
     }
 

--- a/crates/multimodal/src/registry/qwen3_vl.rs
+++ b/crates/multimodal/src/registry/qwen3_vl.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use llm_tokenizer::Encoding;
 use serde_json::{json, Value};
 
 use crate::{
@@ -69,18 +68,8 @@ impl Qwen3VLVisionSpec {
     fn encode_plain_text(metadata: &ModelMetadata, text: &str) -> Vec<TokenId> {
         metadata
             .tokenizer
-            .encode(text, false)
-            .ok()
-            .map(|encoding| match encoding {
-                Encoding::Hf(inner) => inner
-                    .get_ids()
-                    .iter()
-                    .map(|&id| id as TokenId)
-                    .collect::<Vec<_>>(),
-                Encoding::Plain(ids) | Encoding::Tiktoken(ids) => {
-                    ids.into_iter().map(|id| id as TokenId).collect()
-                }
-            })
+            .encode_text(text)
+            .map(|ids| ids.into_iter().map(|id| id as TokenId).collect())
             .unwrap_or_default()
     }
 

--- a/crates/multimodal/src/registry/traits.rs
+++ b/crates/multimodal/src/registry/traits.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, sync::OnceLock};
 
-use llm_tokenizer::TokenizerTrait;
 use serde_json::Value;
 use thiserror::Error;
 
@@ -112,10 +111,28 @@ pub enum MediaPartOrder {
     Authored,
 }
 
+/// The tokenizer surface the registry needs: resolving placeholder and
+/// structural token ids, and encoding the short text fragments some families
+/// splice into their media wrappers (e.g. an `image {W}x{H}` header).
+///
+/// Deliberately local: callers adapt whatever tokenizer they hold to this
+/// trait, and this crate stays free of any tokenizer crate's dependency tree.
+pub trait Tokenizer: Send + Sync {
+    /// The token id for a token string, if the vocabulary knows it.
+    fn token_to_id(&self, token: &str) -> Option<u32>;
+
+    /// The token string for a token id, if the vocabulary knows it.
+    fn id_to_token(&self, id: u32) -> Option<String>;
+
+    /// Encode plain text (no special tokens) into token ids; `None` when the
+    /// text cannot be encoded.
+    fn encode_text(&self, text: &str) -> Option<Vec<u32>>;
+}
+
 /// Metadata about the current model used to derive tokenizer/config dependent fields.
 pub struct ModelMetadata<'a> {
     pub model_id: &'a str,
-    pub tokenizer: &'a dyn TokenizerTrait,
+    pub tokenizer: &'a dyn Tokenizer,
     pub config: &'a Value,
 }
 

--- a/model_gateway/src/routers/grpc/multimodal/mod.rs
+++ b/model_gateway/src/routers/grpc/multimodal/mod.rs
@@ -22,6 +22,29 @@ use llm_multimodal::{
     AudioClip, EncoderFieldLayouts, ImageFrame, Modality, PlaceholderRange,
     PreprocessedEncoderInputs, VideoClip,
 };
+use llm_tokenizer::{Encoding, TokenizerTrait};
+
+/// Bridges the gateway's tokenizer to the model registry's local tokenizer
+/// seam: `llm-multimodal` deliberately depends on no tokenizer crate, so the
+/// flattening from [`Encoding`] to plain ids lives here, on the caller side.
+pub(crate) struct RegistryTokenizer<'a>(pub(crate) &'a dyn TokenizerTrait);
+
+impl llm_multimodal::Tokenizer for RegistryTokenizer<'_> {
+    fn token_to_id(&self, token: &str) -> Option<u32> {
+        self.0.token_to_id(token)
+    }
+
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        self.0.id_to_token(id)
+    }
+
+    fn encode_text(&self, text: &str) -> Option<Vec<u32>> {
+        Some(match self.0.encode(text, false).ok()? {
+            Encoding::Hf(inner) => inner.get_ids().to_vec(),
+            Encoding::Plain(ids) | Encoding::Tiktoken(ids) => ids,
+        })
+    }
+}
 
 mod assemble;
 mod capability;

--- a/model_gateway/src/routers/grpc/multimodal/plan.rs
+++ b/model_gateway/src/routers/grpc/multimodal/plan.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use llm_multimodal::{MediaContentPart, MediaPartOrder, Modality, ModelMetadata};
 use llm_tokenizer::TokenizerTrait;
 
-use super::config::MultimodalComponents;
+use super::{config::MultimodalComponents, RegistryTokenizer};
 
 /// Ordered media extracted from an API request.
 ///
@@ -105,9 +105,10 @@ pub(crate) async fn prepare_placeholder_tokens(
         .config_registry
         .get_or_load(tokenizer_id, tokenizer_source)
         .await?;
+    let registry_tokenizer = RegistryTokenizer(tokenizer);
     let metadata = ModelMetadata {
         model_id,
-        tokenizer,
+        tokenizer: &registry_tokenizer,
         config: &model_config.config,
     };
     let spec = components
@@ -161,9 +162,10 @@ pub(crate) async fn resolve_media_part_order(
         Ok(config) => config,
         Err(_) => return MediaPartOrder::MediaFirst,
     };
+    let registry_tokenizer = RegistryTokenizer(tokenizer);
     let metadata = ModelMetadata {
         model_id,
-        tokenizer,
+        tokenizer: &registry_tokenizer,
         config: &model_config.config,
     };
     components

--- a/model_gateway/src/routers/grpc/multimodal/process.rs
+++ b/model_gateway/src/routers/grpc/multimodal/process.rs
@@ -22,7 +22,7 @@ use super::{
     pixel_cache::{config_fingerprint, CachedPreprocessedItem, PixelCache, PixelCacheKey},
     plan::MediaPlan,
     MediaBatch, MultimodalIntermediate, MultimodalOutput, PrecomputedMultimodalIntermediate,
-    PromptBinding,
+    PromptBinding, RegistryTokenizer,
 };
 
 struct PreparedMultimodalPart {
@@ -171,9 +171,10 @@ pub(crate) async fn process_multimodal_plan(
         .config
         .get("model_type")
         .and_then(|v| v.as_str());
+    let registry_tokenizer = RegistryTokenizer(tokenizer);
     let metadata = ModelMetadata {
         model_id,
-        tokenizer,
+        tokenizer: &registry_tokenizer,
         config: &model_config.config,
     };
     let spec = components


### PR DESCRIPTION
## Description

### Problem

`llm-multimodal` depends on `llm-tokenizer` for exactly three calls — token string → id, id → token string, and encoding the short text fragments some families splice into their media wrappers (Kimi-K3's `image {W}x{H}` header). That single edge drags the full tokenizer stack (HF `tokenizers` and its transitive tree) into every consumer of the crate, and leaks the `Encoding` enum into registry code that immediately flattens it to plain ids — the registry never cares whether ids came from HF, tiktoken, or a plain vector.

The standalone export of this crate has shipped the decoupled shape since extraction (a local three-method trait, no tokenizer dependency); the in-tree crate never adopted it.

### Solution

Define the three-method surface as a local trait and invert the dependency:

```rust
pub trait Tokenizer: Send + Sync {
    fn token_to_id(&self, token: &str) -> Option<u32>;
    fn id_to_token(&self, id: u32) -> Option<String>;
    fn encode_text(&self, text: &str) -> Option<Vec<u32>>;
}
```

`ModelMetadata.tokenizer` becomes `&dyn Tokenizer`, and `llm-tokenizer` leaves the crate's Cargo.toml entirely. Callers adapt whatever tokenizer they hold: the gateway's `RegistryTokenizer` adapter is fifteen lines and owns the `Encoding` flattening, which was caller-side knowledge all along. The test stub sheds the full `TokenizerTrait`/`Encoder`/`Decoder` surface (including the `SpecialTokens` boilerplate) for the same three methods.

Note for release: the next publish of `llm-multimodal` is API-breaking for `ModelMetadata` constructors — the version is deliberately left for the release train to bump.

## Changes

- `crates/multimodal/src/registry/traits.rs` — local `Tokenizer` trait; `ModelMetadata.tokenizer` retyped.
- `crates/multimodal/src/registry/{kimi_k3,qwen3_vl}.rs` — `encode(text, false)` + `Encoding` match → `encode_text`.
- `crates/multimodal/src/registry/mod.rs` — test stub reimplements the local trait (behavior-identical, including empty-encode without a byte encoder); re-export.
- `crates/multimodal/Cargo.toml` — drop `llm-tokenizer`.
- `model_gateway/src/routers/grpc/multimodal/{mod,plan,process}.rs` — `RegistryTokenizer` adapter wrapping the gateway's `&dyn TokenizerTrait` at the three `ModelMetadata` construction sites.

## Test Plan

- `cargo test -p llm-multimodal` — 382 tests across 10 targets pass (the registry suites exercise the stub through the new trait: K3 wrapper encoding, Qwen3-VL video timestamps, placeholder resolution).
- `cargo test -p smg --lib` — passes (gateway multimodal module tests included).
- `cargo clippy -p llm-multimodal -p smg --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all` — clean.
- `grep -r llm_tokenizer crates/multimodal/` — zero references remain.
- Behavior parity: the adapter encodes with `add_special_tokens=false`, exactly what the one previous call site passed; the stub's no-byte-encoder case still encodes to empty rather than failing.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes — run as `-p llm-multimodal -p smg --all-targets`; full-workspace `--all-features` requires the opencv toolchain not present locally, CI owns that matrix
- [ ] (Optional) Documentation updated — trait doc comments carry the rationale
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
