### PR TITLE
fix(responses): terminal-fail streams on mid-stream backend errors

### DIFF
--- a/crates/protocols/src/event_types.rs
+++ b/crates/protocols/src/event_types.rs
@@ -6,18 +6,28 @@ pub enum ResponseEvent {
     Created,
     InProgress,
     Completed,
+    /// Terminal: the response stopped early (e.g. a tool-call budget); partial
+    /// output is attached.
+    Incomplete,
+    /// Terminal: the backend failed mid-stream; the response carries an error
+    /// object and whatever output had accumulated.
+    Failed,
 }
 
 impl ResponseEvent {
     pub const CREATED: &'static str = "response.created";
     pub const IN_PROGRESS: &'static str = "response.in_progress";
     pub const COMPLETED: &'static str = "response.completed";
+    pub const INCOMPLETE: &'static str = "response.incomplete";
+    pub const FAILED: &'static str = "response.failed";
 
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Created => Self::CREATED,
             Self::InProgress => Self::IN_PROGRESS,
             Self::Completed => Self::COMPLETED,
+            Self::Incomplete => Self::INCOMPLETE,
+            Self::Failed => Self::FAILED,
         }
     }
 }
@@ -637,7 +647,11 @@ impl fmt::Display for RealtimeServerEvent {
 pub fn is_response_event(event_type: &str) -> bool {
     matches!(
         event_type,
-        ResponseEvent::CREATED | ResponseEvent::IN_PROGRESS | ResponseEvent::COMPLETED
+        ResponseEvent::CREATED
+            | ResponseEvent::IN_PROGRESS
+            | ResponseEvent::COMPLETED
+            | ResponseEvent::INCOMPLETE
+            | ResponseEvent::FAILED
     )
 }
 

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -986,6 +986,23 @@ impl Metrics {
         .increment(1);
     }
 
+    /// Record a Responses-surface mid-stream terminal failure.
+    ///
+    /// The HTTP status was already 200 when the stream opened, so without this
+    /// counter a backend failure after first byte is indistinguishable from a
+    /// successful request (or from a client disconnect) in every other metric.
+    /// `reason` is a small static set — "backend_error" | "read_error" —
+    /// never a raw upstream string, to keep cardinality bounded.
+    pub fn record_responses_stream_failure(model_id: &str, reason: &'static str) {
+        let model = intern_model_label(model_id);
+        counter!(
+            "smg_responses_stream_failures_total",
+            "model" => model,
+            "reason" => reason
+        )
+        .increment(1);
+    }
+
     /// Record pipeline stage duration (gRPC only).
     /// All labels are static, so this is very fast.
     pub fn record_router_stage_duration(

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -493,6 +493,10 @@ pub(crate) fn init_metrics() {
         "smg_mcp_tool_iterations_total",
         "Tool loop iterations in Responses API by model"
     );
+    describe_counter!(
+        "smg_responses_stream_failures_total",
+        "Responses-surface mid-stream terminal failures by model and reason (backend_error/read_error)"
+    );
 
     // Layer 6: Database metrics
     describe_counter!(

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -321,50 +321,144 @@ impl ResponseStreamEventEmitter {
             response_obj["usage"] = usage_val.clone();
         }
 
-        // Add all original request fields if available
-        if let Some(ref req) = self.original_request {
-            Self::add_optional_field(&mut response_obj, "instructions", req.instructions.as_ref());
-            Self::add_optional_field(
-                &mut response_obj,
-                "max_output_tokens",
-                req.max_output_tokens.as_ref(),
-            );
-            Self::add_optional_field(
-                &mut response_obj,
-                "max_tool_calls",
-                req.max_tool_calls.as_ref(),
-            );
-            Self::add_optional_field(
-                &mut response_obj,
-                "previous_response_id",
-                req.previous_response_id.as_ref(),
-            );
-            Self::add_optional_field(&mut response_obj, "reasoning", req.reasoning.as_ref());
-            Self::add_optional_field(&mut response_obj, "temperature", req.temperature.as_ref());
-            Self::add_optional_field(&mut response_obj, "top_p", req.top_p.as_ref());
-            Self::add_optional_field(&mut response_obj, "truncation", req.truncation.as_ref());
-            Self::add_optional_field(&mut response_obj, "user", req.user.as_ref());
-
-            response_obj["parallel_tool_calls"] = json!(req.parallel_tool_calls.unwrap_or(true));
-            response_obj["store"] = json!(req.store.unwrap_or(true));
-            let empty_tools = vec![];
-            let empty_metadata = Default::default();
-            response_obj["tools"] = json!(req.tools.as_ref().unwrap_or(&empty_tools));
-            response_obj["metadata"] = json!(req.metadata.as_ref().unwrap_or(&empty_metadata));
-
-            // tool_choice: serialize if present, otherwise use "auto"
-            if let Some(ref tc) = req.tool_choice {
-                response_obj["tool_choice"] = json!(tc);
-            } else {
-                response_obj["tool_choice"] = json!("auto");
-            }
-        }
+        self.apply_request_echo_fields(&mut response_obj);
 
         json!({
             "type": ResponseEvent::COMPLETED,
             "sequence_number": self.next_sequence(),
             "response": response_obj
         })
+    }
+
+    /// Echo the original request's fields onto a terminal response object,
+    /// as OpenAI does on every response lifecycle terminal.
+    fn apply_request_echo_fields(&self, response_obj: &mut serde_json::Value) {
+        let Some(ref req) = self.original_request else {
+            return;
+        };
+        Self::add_optional_field(response_obj, "instructions", req.instructions.as_ref());
+        Self::add_optional_field(
+            response_obj,
+            "max_output_tokens",
+            req.max_output_tokens.as_ref(),
+        );
+        Self::add_optional_field(response_obj, "max_tool_calls", req.max_tool_calls.as_ref());
+        Self::add_optional_field(
+            response_obj,
+            "previous_response_id",
+            req.previous_response_id.as_ref(),
+        );
+        Self::add_optional_field(response_obj, "reasoning", req.reasoning.as_ref());
+        Self::add_optional_field(response_obj, "temperature", req.temperature.as_ref());
+        Self::add_optional_field(response_obj, "top_p", req.top_p.as_ref());
+        Self::add_optional_field(response_obj, "truncation", req.truncation.as_ref());
+        Self::add_optional_field(response_obj, "user", req.user.as_ref());
+
+        response_obj["parallel_tool_calls"] = json!(req.parallel_tool_calls.unwrap_or(true));
+        response_obj["store"] = json!(req.store.unwrap_or(true));
+        let empty_tools = vec![];
+        let empty_metadata = Default::default();
+        response_obj["tools"] = json!(req.tools.as_ref().unwrap_or(&empty_tools));
+        response_obj["metadata"] = json!(req.metadata.as_ref().unwrap_or(&empty_metadata));
+
+        // tool_choice: serialize if present, otherwise use "auto"
+        if let Some(ref tc) = req.tool_choice {
+            response_obj["tool_choice"] = json!(tc);
+        } else {
+            response_obj["tool_choice"] = json!("auto");
+        }
+    }
+
+    /// Close the in-progress message item as incomplete, if one is open.
+    ///
+    /// Mid-stream-failure counterpart of the `finish_reason` closers in
+    /// [`Self::process_chunk`]: the same done-event ladder, but the item is
+    /// stamped `"status": "incomplete"` and kept for the terminal response's
+    /// output — the partial text is the point. Events are sent best-effort:
+    /// this runs on a path that may already have lost the client.
+    async fn close_open_message_as_incomplete(&mut self, tx: &SseSender) {
+        let (Some(output_index), Some(item_id)) = (
+            self.current_message_output_index,
+            self.current_item_id.clone(),
+        ) else {
+            return;
+        };
+        let content_index = 0;
+
+        if self.has_emitted_content_part_added {
+            let event = self.emit_text_done(output_index, &item_id, content_index);
+            self.send_event_best_effort(&event, tx).await;
+            let event = self.emit_content_part_done(output_index, &item_id, content_index);
+            self.send_event_best_effort(&event, tx).await;
+        }
+        if self.has_emitted_output_item_added {
+            let item = json!({
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "incomplete",
+                "content": [{
+                    "type": "output_text",
+                    "text": std::mem::take(&mut self.accumulated_text)
+                }]
+            });
+            // Stores the item data; the item is deliberately NOT marked
+            // completed, so emit_failed includes it as the incomplete tail.
+            let event = self.emit_output_item_done(output_index, &item);
+            self.send_event_best_effort(&event, tx).await;
+        }
+        self.current_message_output_index = None;
+        self.current_item_id = None;
+    }
+
+    /// Terminal failure: close any open message item as incomplete, then emit
+    /// `response.failed` carrying a typed error and every item that produced
+    /// output — completed and incomplete alike. Counterpart of
+    /// [`Self::emit_completed`] for the mid-stream failure path.
+    ///
+    /// Returns the failed response object so callers can persist exactly what
+    /// the client was shown.
+    ///
+    /// INVARIANT: terminal — drains internal state via `take()` and must only
+    /// be called once per emitter lifetime (and never after `emit_completed`).
+    pub async fn emit_failed(
+        &mut self,
+        code: &str,
+        message: &str,
+        usage: Option<&serde_json::Value>,
+        tx: &SseSender,
+    ) -> serde_json::Value {
+        self.close_open_message_as_incomplete(tx).await;
+
+        // Unlike emit_completed, incomplete items are included: dropping the
+        // partial output is exactly the failure mode this event exists to fix.
+        let output: Vec<serde_json::Value> = self
+            .output_items
+            .iter_mut()
+            .filter_map(|item| item.item_data.take())
+            .collect();
+
+        let mut response_obj = json!({
+            "id": self.response_id,
+            "object": "response",
+            "created_at": self.created_at,
+            "status": "failed",
+            "model": self.model,
+            "error": {"code": code, "message": message},
+            "output": output
+        });
+        if let Some(usage_val) = usage {
+            response_obj["usage"] = usage_val.clone();
+        }
+        self.apply_request_echo_fields(&mut response_obj);
+
+        let event = json!({
+            "type": ResponseEvent::FAILED,
+            "sequence_number": self.next_sequence(),
+            "response": response_obj.clone()
+        });
+        self.send_event_best_effort(&event, tx).await;
+        response_obj
     }
 
     /// Convert tool entries to JSON values using the shared bridge builder.
@@ -1012,6 +1106,7 @@ pub(crate) fn attach_mcp_server_label(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::routers::common::sse::sse_channel;
 
     #[test]
     fn finalized_streaming_response_serializes_responses_api_usage() {
@@ -1038,5 +1133,102 @@ mod tests {
         );
         assert!(usage.get("prompt_tokens").is_none());
         assert!(usage.get("completion_tokens").is_none());
+    }
+
+    fn chunk_with_content(text: &str) -> ChatCompletionStreamResponse {
+        serde_json::from_value(json!({
+            "id": "chatcmpl_test",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "test-model",
+            "choices": [{"index": 0, "delta": {"content": text}}]
+        }))
+        .expect("valid chunk")
+    }
+
+    /// Collect every `data:` payload the emitter sent; call after dropping tx.
+    async fn drain_frames(rx: &mut SseReceiver) -> Vec<serde_json::Value> {
+        let mut out = Vec::new();
+        while let Some(Ok(bytes)) = rx.recv().await {
+            let text = String::from_utf8_lossy(bytes.as_ref());
+            for line in text.lines() {
+                if let Some(data) = line.strip_prefix("data: ") {
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(data) {
+                        out.push(value);
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn emit_failed_closes_open_message_and_attaches_partials() {
+        let (tx, mut rx) = sse_channel();
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_f".to_string(), "test-model".to_string(), 1);
+        emitter
+            .process_chunk(&chunk_with_content("partial tex"), &tx)
+            .await
+            .expect("delta events send");
+
+        let failed_obj = emitter
+            .emit_failed("processing_error", "backend died", None, &tx)
+            .await;
+        drop(tx);
+
+        let events = drain_frames(&mut rx).await;
+        let types: Vec<&str> = events
+            .iter()
+            .filter_map(|e| e.get("type").and_then(|t| t.as_str()))
+            .collect();
+        // The open message item is closed with the full done ladder before the
+        // terminal event...
+        assert!(types.contains(&OutputTextEvent::DONE));
+        assert!(types.contains(&ContentPartEvent::DONE));
+        assert!(types.contains(&OutputItemEvent::DONE));
+        // ...and response.failed is terminal.
+        assert_eq!(types.last(), Some(&ResponseEvent::FAILED));
+
+        let failed = events.last().expect("terminal event present");
+        let response = failed.get("response").expect("carries the response");
+        assert_eq!(response.pointer("/status"), Some(&json!("failed")));
+        assert_eq!(
+            response.pointer("/error/code"),
+            Some(&json!("processing_error"))
+        );
+        assert_eq!(
+            response.pointer("/error/message"),
+            Some(&json!("backend died"))
+        );
+        // The partial output is attached, stamped incomplete — not dropped.
+        assert_eq!(
+            response.pointer("/output/0/status"),
+            Some(&json!("incomplete"))
+        );
+        assert_eq!(
+            response.pointer("/output/0/content/0/text"),
+            Some(&json!("partial tex"))
+        );
+        // What the caller persists is exactly what the client was shown.
+        assert_eq!(&failed_obj, response);
+    }
+
+    #[tokio::test]
+    async fn emit_failed_without_output_still_carries_the_error() {
+        let (tx, mut rx) = sse_channel();
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_f2".to_string(), "m".to_string(), 1);
+        emitter
+            .emit_failed("stream_read_error", "boom", None, &tx)
+            .await;
+        drop(tx);
+
+        let events = drain_frames(&mut rx).await;
+        assert_eq!(events.len(), 1);
+        let response = events[0].get("response").expect("carries the response");
+        assert_eq!(response.pointer("/status"), Some(&json!("failed")));
+        assert_eq!(response.pointer("/output"), Some(&json!([])));
+        assert_eq!(response.pointer("/error/message"), Some(&json!("boom")));
     }
 }

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -297,6 +297,7 @@ impl ResponseStreamEventEmitter {
                 "id": std::mem::take(&mut self.message_id),
                 "type": "message",
                 "role": "assistant",
+                "status": "completed",
                 "content": [{
                     "type": "output_text",
                     "text": std::mem::take(&mut self.accumulated_text)
@@ -383,6 +384,16 @@ impl ResponseStreamEventEmitter {
         ) else {
             return;
         };
+        // A message that already completed normally keeps its text; only an
+        // item still in progress is closed as incomplete.
+        let already_completed = self
+            .output_items
+            .iter()
+            .any(|i| i.output_index == output_index && i.status == ItemStatus::Completed);
+        if already_completed {
+            self.forget_current_message();
+            return;
+        }
         let content_index = 0;
 
         if self.has_emitted_content_part_added {
@@ -407,8 +418,7 @@ impl ResponseStreamEventEmitter {
             let event = self.emit_output_item_done(output_index, &item);
             self.send_event_best_effort(&event, tx).await;
         }
-        self.current_message_output_index = None;
-        self.current_item_id = None;
+        self.forget_current_message();
     }
 
     /// Terminal failure: close any open message item as incomplete, then emit
@@ -416,49 +426,61 @@ impl ResponseStreamEventEmitter {
     /// output — completed and incomplete alike. Counterpart of
     /// [`Self::emit_completed`] for the mid-stream failure path.
     ///
-    /// Returns the failed response object so callers can persist exactly what
-    /// the client was shown.
+    /// Returns the typed failed response; the event payload is its
+    /// serialization, so what a caller persists is exactly what the client was
+    /// shown — including the response identity when the failure precedes the
+    /// first backend chunk.
     ///
-    /// INVARIANT: terminal — drains internal state via `take()` and must only
-    /// be called once per emitter lifetime (and never after `emit_completed`).
+    /// INVARIANT: terminal — drains internal state and must only be called once
+    /// per emitter lifetime (and never after `emit_completed`).
     pub async fn emit_failed(
         &mut self,
         code: &str,
         message: &str,
-        usage: Option<&serde_json::Value>,
+        usage: Option<Usage>,
         tx: &SseSender,
-    ) -> serde_json::Value {
+    ) -> ResponsesResponse {
         self.close_open_message_as_incomplete(tx).await;
 
         // Unlike emit_completed, incomplete items are included: dropping the
         // partial output is exactly the failure mode this event exists to fix.
-        let output: Vec<serde_json::Value> = self
-            .output_items
-            .iter_mut()
-            .filter_map(|item| item.item_data.take())
-            .collect();
-
-        let mut response_obj = json!({
-            "id": self.response_id,
-            "object": "response",
-            "created_at": self.created_at,
-            "status": "failed",
-            "model": self.model,
-            "error": {"code": code, "message": message},
-            "output": output
-        });
-        if let Some(usage_val) = usage {
-            response_obj["usage"] = usage_val.clone();
+        let failed = self.finalize_failed(code, message, usage);
+        for item in &mut self.output_items {
+            item.item_data = None;
         }
-        self.apply_request_echo_fields(&mut response_obj);
 
+        let response_obj = serde_json::to_value(&failed).unwrap_or_else(|e| {
+            warn!("Failed to serialize response.failed payload: {e}");
+            json!({
+                "id": failed.id,
+                "object": "response",
+                "status": "failed",
+                "model": failed.model,
+                "error": {"code": code, "message": message},
+                "output": []
+            })
+        });
         let event = json!({
             "type": ResponseEvent::FAILED,
             "sequence_number": self.next_sequence(),
-            "response": response_obj.clone()
+            "response": response_obj
         });
         self.send_event_best_effort(&event, tx).await;
-        response_obj
+        failed
+    }
+
+    /// Typed failed response built from the tracked items without draining
+    /// them: status `failed`, the error object, request echo fields and usage.
+    /// [`Self::emit_failed`] both emits and returns this.
+    pub fn finalize_failed(
+        &self,
+        code: &str,
+        message: &str,
+        usage: Option<Usage>,
+    ) -> ResponsesResponse {
+        let mut response = self.finalize_with_status(ResponseStatus::Failed, usage);
+        response.error = Some(json!({"code": code, "message": message}));
+        response
     }
 
     /// Convert tool entries to JSON values using the shared bridge builder.
@@ -747,6 +769,10 @@ impl ResponseStreamEventEmitter {
     }
 
     /// Mark output item as completed and store its data
+    ///
+    /// Completing the tracked message item also forgets it as the current
+    /// message, so a later terminal failure cannot re-close a finished item
+    /// with an empty incomplete replacement.
     pub fn complete_output_item(&mut self, output_index: usize) {
         if let Some(item) = self
             .output_items
@@ -755,6 +781,27 @@ impl ResponseStreamEventEmitter {
         {
             item.status = ItemStatus::Completed;
         }
+        if self.current_message_output_index == Some(output_index) {
+            self.forget_current_message();
+        }
+    }
+
+    /// Register a message item that an external streaming processor opened via
+    /// [`Self::emit_output_item_added`], so a mid-stream failure can close it
+    /// as incomplete with the text accumulated through
+    /// [`Self::emit_text_delta`]. [`Self::complete_output_item`] clears it.
+    pub fn track_open_message(&mut self, output_index: usize, item_id: &str) {
+        self.current_message_output_index = Some(output_index);
+        self.current_item_id = Some(item_id.to_string());
+        self.has_emitted_output_item_added = true;
+    }
+
+    fn forget_current_message(&mut self) {
+        self.current_message_output_index = None;
+        self.current_item_id = None;
+        self.has_emitted_output_item_added = false;
+        self.has_emitted_content_part_added = false;
+        self.accumulated_text.clear();
     }
 
     /// Store output item data when emitting output_item.done
@@ -774,14 +821,33 @@ impl ResponseStreamEventEmitter {
     /// for persistence. Should be called after streaming is complete.
     /// Reads non-destructively so `emit_completed()` can still drain state afterwards.
     pub fn finalize(&self, usage: Option<Usage>) -> ResponsesResponse {
-        // Build output array from tracked items (clone — emit_completed drains later)
+        self.finalize_with_status(ResponseStatus::Completed, usage)
+    }
+
+    fn finalize_with_status(
+        &self,
+        status: ResponseStatus,
+        usage: Option<Usage>,
+    ) -> ResponsesResponse {
+        // Build output array from tracked items (clone — emit_completed drains later).
+        // An item that does not type-check is dropped from the persisted record,
+        // loudly: silent drops here hid a missing `status` on message items.
         let output: Vec<ResponseOutputItem> = self
             .output_items
             .iter()
             .filter_map(|item| {
-                item.item_data
-                    .as_ref()
-                    .and_then(|data| serde_json::from_value(data.clone()).ok())
+                let data = item.item_data.as_ref()?;
+                match serde_json::from_value::<ResponseOutputItem>(data.clone()) {
+                    Ok(typed) => Some(typed),
+                    Err(e) => {
+                        warn!(
+                            output_index = item.output_index,
+                            error = %e,
+                            "Output item could not be typed for persistence; dropping it"
+                        );
+                        None
+                    }
+                }
             })
             .collect();
 
@@ -803,7 +869,7 @@ impl ResponseStreamEventEmitter {
         // Build response using builder
         ResponsesResponse::builder(&self.response_id, &self.model)
             .created_at(self.created_at as i64)
-            .status(ResponseStatus::Completed)
+            .status(status)
             .output(output)
             .maybe_copy_from_request(self.original_request.as_ref())
             .maybe_usage(responses_usage)
@@ -922,11 +988,14 @@ impl ResponseStreamEventEmitter {
                         }
 
                         if self.has_emitted_output_item_added {
-                            // Build complete message item for output_item.done
+                            // Build complete message item for output_item.done.
+                            // `status` is part of the wire shape and what lets the
+                            // item round-trip into the typed persisted response.
                             let item = json!({
                                 "id": item_id,
                                 "type": "message",
                                 "role": "assistant",
+                                "status": "completed",
                                 "content": [{
                                     "type": "output_text",
                                     "text": std::mem::take(&mut self.accumulated_text)
@@ -1211,7 +1280,112 @@ mod tests {
             Some(&json!("partial tex"))
         );
         // What the caller persists is exactly what the client was shown.
-        assert_eq!(&failed_obj, response);
+        assert_eq!(&serde_json::to_value(&failed_obj).unwrap(), response);
+    }
+
+    fn chunk_with_finish(reason: &str) -> ChatCompletionStreamResponse {
+        serde_json::from_value(json!({
+            "id": "chatcmpl_test",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "test-model",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": reason}]
+        }))
+        .expect("valid chunk")
+    }
+
+    #[tokio::test]
+    async fn emit_failed_after_normal_completion_keeps_the_completed_message() {
+        let (tx, mut rx) = sse_channel();
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_c".to_string(), "test-model".to_string(), 1);
+        emitter
+            .process_chunk(&chunk_with_content("full answer"), &tx)
+            .await
+            .expect("delta events send");
+        emitter
+            .process_chunk(&chunk_with_finish("stop"), &tx)
+            .await
+            .expect("finish events send");
+
+        let failed = emitter
+            .emit_failed("stream_read_error", "socket closed", None, &tx)
+            .await;
+        drop(tx);
+
+        let events = drain_frames(&mut rx).await;
+        let done_ladders = events
+            .iter()
+            .filter(|e| e.get("type").and_then(|t| t.as_str()) == Some(OutputItemEvent::DONE))
+            .count();
+        // The finished message is closed exactly once — no second, empty ladder.
+        assert_eq!(done_ladders, 1);
+        let response = events.last().unwrap().get("response").unwrap();
+        assert_eq!(response.pointer("/status"), Some(&json!("failed")));
+        assert_eq!(
+            response.pointer("/output/0/status"),
+            Some(&json!("completed"))
+        );
+        assert_eq!(
+            response.pointer("/output/0/content/0/text"),
+            Some(&json!("full answer"))
+        );
+        assert_eq!(failed.output.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn emit_failed_closes_a_message_tracked_by_an_external_processor() {
+        // Mirrors the Harmony processor: it allocates and streams the message
+        // item itself and only registers it with the emitter.
+        let (tx, mut rx) = sse_channel();
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_h".to_string(), "test-model".to_string(), 1);
+        let (output_index, item_id) = emitter.allocate_output_index(OutputItemKind::Message);
+        let item = json!({"id": item_id, "type": "message", "role": "assistant", "content": []});
+        let event = emitter.emit_output_item_added(output_index, &item);
+        emitter.send_event_best_effort(&event, &tx).await;
+        emitter.track_open_message(output_index, &item_id);
+        let event = emitter.emit_content_part_added(output_index, &item_id, 0);
+        emitter.send_event_best_effort(&event, &tx).await;
+        let event = emitter.emit_text_delta("partial fin", output_index, &item_id, 0);
+        emitter.send_event_best_effort(&event, &tx).await;
+
+        let failed = emitter
+            .emit_failed("processing_error", "decode died", None, &tx)
+            .await;
+        drop(tx);
+
+        let events = drain_frames(&mut rx).await;
+        let response = events.last().unwrap().get("response").unwrap();
+        assert_eq!(
+            response.pointer("/output/0/status"),
+            Some(&json!("incomplete"))
+        );
+        assert_eq!(
+            response.pointer("/output/0/content/0/text"),
+            Some(&json!("partial fin"))
+        );
+        assert!(matches!(failed.status, ResponseStatus::Failed));
+    }
+
+    #[tokio::test]
+    async fn emit_failed_before_any_chunk_keeps_the_response_identity() {
+        let (tx, _rx) = sse_channel();
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_id".to_string(), "test-model".to_string(), 7);
+        let failed = emitter
+            .emit_failed("stream_read_error", "boom", None, &tx)
+            .await;
+        // The persisted record carries the emitter's identity rather than empty
+        // placeholders from an accumulator that never saw a chunk.
+        assert_eq!(failed.id, "resp_id");
+        assert_eq!(failed.model, "test-model");
+        assert_eq!(failed.created_at, 7);
+        assert!(matches!(failed.status, ResponseStatus::Failed));
+        assert_eq!(
+            failed.error.as_ref().and_then(|e| e.get("code")),
+            Some(&json!("stream_read_error"))
+        );
     }
 
     #[tokio::test]

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -235,10 +235,12 @@ async fn execute_mcp_tool_loop_streaming(
         {
             Ok(result) => result,
             Err(err_response) => {
+                Metrics::record_responses_stream_failure(&current_request.model, "backend_error");
                 emitter
-                    .emit_error(
+                    .emit_failed(
+                        "pipeline_error",
                         &format!("Pipeline execution failed: {err_response:?}"),
-                        Some("pipeline_error"),
+                        None,
                         tx,
                     )
                     .await;
@@ -258,8 +260,11 @@ async fn execute_mcp_tool_loop_streaming(
         {
             Ok(result) => result,
             Err(err_msg) => {
+                // Mid-stream backend death: terminal-fail with the partial
+                // output attached rather than a bare error frame.
+                Metrics::record_responses_stream_failure(&current_request.model, "backend_error");
                 emitter
-                    .emit_error(&err_msg, Some("processing_error"), tx)
+                    .emit_failed("processing_error", &err_msg, None, tx)
                     .await;
                 return;
             }
@@ -457,10 +462,12 @@ async fn execute_without_mcp_streaming(
     {
         Ok(result) => result,
         Err(err_response) => {
+            Metrics::record_responses_stream_failure(&current_request.model, "backend_error");
             emitter
-                .emit_error(
+                .emit_failed(
+                    "pipeline_error",
                     &format!("Pipeline execution failed: {err_response:?}"),
-                    Some("pipeline_error"),
+                    None,
                     tx,
                 )
                 .await;
@@ -480,8 +487,11 @@ async fn execute_without_mcp_streaming(
     {
         Ok(result) => result,
         Err(err_msg) => {
+            // Mid-stream backend death: terminal-fail with the partial output
+            // attached rather than a bare error frame.
+            Metrics::record_responses_stream_failure(&current_request.model, "backend_error");
             emitter
-                .emit_error(&err_msg, Some("processing_error"), tx)
+                .emit_failed("processing_error", &err_msg, None, tx)
                 .await;
             return;
         }

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -848,6 +848,9 @@ impl HarmonyStreamingProcessor {
                                     // Emit output_item.added
                                     let event = emitter.emit_output_item_added(output_index, &item);
                                     emitter.send_event_best_effort(&event, tx).await;
+                                    // Registered so a mid-stream failure can close
+                                    // this item with its partial text (emit_failed).
+                                    emitter.track_open_message(output_index, &item_id);
                                 }
 
                                 let Some(output_index) = message_output_index else {
@@ -1135,6 +1138,7 @@ impl HarmonyStreamingProcessor {
                             "id": item_id,
                             "type": "message",
                             "role": "assistant",
+                            "status": "completed",
                             "content": [{
                                 "type": "output_text",
                                 "text": accumulated_final_text.clone()

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -180,9 +180,24 @@ async fn process_and_transform_sse_stream(
     // Convert body to data stream
     let mut stream = body.into_data_stream();
 
+    // A mid-stream backend failure must terminal-fail the response — close
+    // open items, attach the error and the partial output — never fall through
+    // to response.completed. Captured here, handled after the loop where the
+    // accumulator can be consumed.
+    let mut failure: Option<(String, String)> = None;
+
     // Process stream chunks (each chunk is a complete SSE event)
     while let Some(chunk_result) = stream.next().await {
-        let chunk = chunk_result.map_err(|e| format!("Stream read error: {e}"))?;
+        let chunk = match chunk_result {
+            Ok(chunk) => chunk,
+            Err(e) => {
+                failure = Some((
+                    "stream_read_error".to_string(),
+                    format!("Stream read error: {e}"),
+                ));
+                break;
+            }
+        };
 
         // Convert chunk to string
         let event_str = String::from_utf8_lossy(&chunk);
@@ -207,6 +222,13 @@ async fn process_and_transform_sse_stream(
                     event_emitter.process_chunk(&chat_chunk, &tx).await?;
                 }
                 Err(_) => {
+                    // The chat layer reports a mid-stream backend failure as an
+                    // error frame; relaying it and then completing would tell
+                    // the client the response succeeded. Fail terminally.
+                    if let Some(frame_error) = parse_error_frame(json_str) {
+                        failure = Some(frame_error);
+                        break;
+                    }
                     // Not a valid chat chunk - might be error event, pass through
                     debug!("Non-chunk SSE event, passing through: {}", event);
                     if tx
@@ -221,25 +243,37 @@ async fn process_and_transform_sse_stream(
         }
     }
 
+    let usage_json = build_usage_json(accumulator.usage.as_ref());
+
+    if let Some((code, message)) = failure {
+        // Terminal failure: response.failed carries the typed error and the
+        // partial output, and what gets persisted is exactly what the client
+        // was shown — a failed response with its partials, not a completed one.
+        Metrics::record_responses_stream_failure(
+            &original_request.model,
+            if code == "stream_read_error" {
+                "read_error"
+            } else {
+                "backend_error"
+            },
+        );
+        event_emitter
+            .emit_failed(&code, &message, usage_json.as_ref(), &tx)
+            .await;
+        let failed_response = accumulator.finalize_failed(&code, &message);
+        persist_response_if_needed(
+            conversation_storage,
+            conversation_item_storage,
+            response_storage,
+            &failed_response,
+            &original_request,
+            request_context,
+        )
+        .await;
+        return Ok(());
+    }
+
     // Emit final response.completed event with accumulated usage
-    let usage_json = accumulator.usage.as_ref().map(|u| {
-        let mut usage_obj = json!({
-            "input_tokens": u.prompt_tokens,
-            "output_tokens": u.completion_tokens,
-            "total_tokens": u.total_tokens
-        });
-
-        // Include reasoning_tokens if present
-        if let Some(details) = &u.completion_tokens_details {
-            if let Some(reasoning_tokens) = details.reasoning_tokens {
-                usage_obj["output_tokens_details"] =
-                    json!({ "reasoning_tokens": reasoning_tokens });
-            }
-        }
-
-        usage_obj
-    });
-
     let completed_event = event_emitter.emit_completed(usage_json.as_ref());
     event_emitter.send_event(&completed_event, &tx).await?;
 
@@ -369,6 +403,26 @@ impl StreamingResponseAccumulator {
     }
 
     fn finalize(self) -> ResponsesResponse {
+        self.finalize_with_item_status("completed", None)
+    }
+
+    /// Finalize after a mid-stream failure: partial content survives with
+    /// `"incomplete"` item status, the response status is `failed`, and the
+    /// typed error rides the response — matching the terminal
+    /// `response.failed` event the client was shown.
+    fn finalize_failed(mut self, code: &str, message: &str) -> ResponsesResponse {
+        self.finish_reason = Some("failed".to_string());
+        self.finalize_with_item_status(
+            "incomplete",
+            Some(json!({"code": code, "message": message})),
+        )
+    }
+
+    fn finalize_with_item_status(
+        self,
+        item_status: &str,
+        error: Option<Value>,
+    ) -> ResponsesResponse {
         let mut output: Vec<ResponseOutputItem> = Vec::new();
 
         // Add message content if present
@@ -381,7 +435,7 @@ impl StreamingResponseAccumulator {
                     annotations: vec![],
                     logprobs: None,
                 }],
-                status: "completed".to_string(),
+                status: item_status.to_string(),
                 phase: None,
             });
         }
@@ -394,7 +448,7 @@ impl StreamingResponseAccumulator {
                 vec![ResponseReasoningContent::ReasoningText {
                     text: self.reasoning_buffer,
                 }],
-                Some("completed".to_string()),
+                Some(item_status.to_string()),
             ));
         }
 
@@ -424,14 +478,58 @@ impl StreamingResponseAccumulator {
             ResponsesUsage::Modern(usage_info.to_response_usage())
         });
 
-        ResponsesResponse::builder(&self.response_id, &self.model)
+        let mut response = ResponsesResponse::builder(&self.response_id, &self.model)
             .copy_from_request(&self.original_request)
             .created_at(self.created_at)
             .status(status)
             .output(output)
             .maybe_usage(usage)
-            .build()
+            .build();
+        if error.is_some() {
+            response.error = error;
+        }
+        response
     }
+}
+
+/// A mid-stream failure frame from the chat layer (`data: {"error": {...}}`).
+/// Returns `(code, message)`; `None` for frames that are not error objects.
+fn parse_error_frame(json_str: &str) -> Option<(String, String)> {
+    let value: Value = serde_json::from_str(json_str).ok()?;
+    let error = value.get("error")?.as_object()?;
+    let message = error
+        .get("message")
+        .and_then(|m| m.as_str())
+        .unwrap_or("backend stream error")
+        .to_string();
+    let code = error
+        .get("code")
+        .and_then(|c| c.as_str())
+        .or_else(|| error.get("type").and_then(|t| t.as_str()))
+        .unwrap_or("stream_error")
+        .to_string();
+    Some((code, message))
+}
+
+/// The responses-shaped usage object for terminal events.
+fn build_usage_json(usage: Option<&Usage>) -> Option<Value> {
+    usage.map(|u| {
+        let mut usage_obj = json!({
+            "input_tokens": u.prompt_tokens,
+            "output_tokens": u.completion_tokens,
+            "total_tokens": u.total_tokens
+        });
+
+        // Include reasoning_tokens if present
+        if let Some(details) = &u.completion_tokens_details {
+            if let Some(reasoning_tokens) = details.reasoning_tokens {
+                usage_obj["output_tokens_details"] =
+                    json!({ "reasoning_tokens": reasoning_tokens });
+            }
+        }
+
+        usage_obj
+    })
 }
 
 // ============================================================================
@@ -606,7 +704,20 @@ async fn execute_tool_loop_streaming_internal(
         // Convert chat stream to Responses API events while accumulating for tool call detection
         // Stream text naturally - it only appears on final iteration (tool iterations have empty content)
         let accumulated_response =
-            convert_and_accumulate_stream(response.into_body(), &mut emitter, &tx).await?;
+            match convert_and_accumulate_stream(response.into_body(), &mut emitter, &tx).await? {
+                StreamOutcome::Complete(response) => response,
+                StreamOutcome::Failed(code, message) => {
+                    // Terminal failure: close open items and attach the error
+                    // plus whatever output (mcp_list_tools, prior tool calls,
+                    // partial text) had accumulated across iterations.
+                    Metrics::record_responses_stream_failure(
+                        &current_request.model,
+                        "backend_error",
+                    );
+                    emitter.emit_failed(&code, &message, None, &tx).await;
+                    return Ok(());
+                }
+            };
 
         // Check for tool calls (extract all of them for parallel execution)
         let tool_calls = extract_all_tool_calls_from_chat(&accumulated_response);
@@ -948,17 +1059,32 @@ async fn execute_tool_loop_streaming_internal(
     Ok(())
 }
 
+/// Outcome of draining one chat stream iteration.
+enum StreamOutcome {
+    Complete(ChatCompletionResponse),
+    /// The chat layer failed mid-stream: `(code, message)`.
+    Failed(String, String),
+}
+
 /// Convert chat stream to Responses API events while accumulating for tool call detection
 async fn convert_and_accumulate_stream(
     body: Body,
     emitter: &mut ResponseStreamEventEmitter,
     tx: &SseSender,
-) -> Result<ChatCompletionResponse, String> {
+) -> Result<StreamOutcome, String> {
     let mut accumulator = ChatResponseAccumulator::new();
     let mut stream = body.into_data_stream();
 
     while let Some(chunk_result) = stream.next().await {
-        let chunk = chunk_result.map_err(|e| format!("Stream read error: {e}"))?;
+        let chunk = match chunk_result {
+            Ok(chunk) => chunk,
+            Err(e) => {
+                return Ok(StreamOutcome::Failed(
+                    "stream_read_error".to_string(),
+                    format!("Stream read error: {e}"),
+                ));
+            }
+        };
 
         // Parse chunk
         let event_str = String::from_utf8_lossy(&chunk);
@@ -970,17 +1096,27 @@ async fn convert_and_accumulate_stream(
 
         if let Some(json_str) = event.strip_prefix("data: ") {
             let json_str = json_str.trim();
-            if let Ok(chat_chunk) = serde_json::from_str::<ChatCompletionStreamResponse>(json_str) {
-                // Convert chat chunk to Responses API events and emit
-                emitter.process_chunk(&chat_chunk, tx).await?;
+            match serde_json::from_str::<ChatCompletionStreamResponse>(json_str) {
+                Ok(chat_chunk) => {
+                    // Convert chat chunk to Responses API events and emit
+                    emitter.process_chunk(&chat_chunk, tx).await?;
 
-                // Accumulate for tool call detection
-                accumulator.process_chunk(&chat_chunk);
+                    // Accumulate for tool call detection
+                    accumulator.process_chunk(&chat_chunk);
+                }
+                Err(_) => {
+                    // A mid-stream backend failure arrives as an error frame.
+                    // Dropping it silently would let the loop fall through to
+                    // response.completed over truncated output.
+                    if let Some((code, message)) = parse_error_frame(json_str) {
+                        return Ok(StreamOutcome::Failed(code, message));
+                    }
+                }
             }
         }
     }
 
-    Ok(accumulator.finalize())
+    Ok(StreamOutcome::Complete(accumulator.finalize()))
 }
 
 /// Accumulates chat streaming chunks into complete ChatCompletionResponse
@@ -1155,5 +1291,43 @@ mod tests {
             }
             other => panic!("expected function tool call, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn error_frames_are_recognized_and_typed() {
+        assert_eq!(
+            parse_error_frame(r#"{"error":{"message":"worker died","type":"stream_error"}}"#),
+            Some(("stream_error".to_string(), "worker died".to_string()))
+        );
+        // An explicit code beats the type when both are present.
+        assert_eq!(
+            parse_error_frame(r#"{"error":{"message":"m","type":"t","code":"c"}}"#),
+            Some(("c".to_string(), "m".to_string()))
+        );
+        // Ordinary chunks and non-error frames are not misread as failures.
+        assert_eq!(
+            parse_error_frame(r#"{"id":"x","object":"chat.completion.chunk"}"#),
+            None
+        );
+        assert_eq!(parse_error_frame("not json"), None);
+    }
+
+    #[test]
+    fn finalize_failed_preserves_partials_as_incomplete() {
+        let request = ResponsesRequest::default();
+        let mut accumulator = StreamingResponseAccumulator::new(&request);
+        accumulator.content_buffer.push_str("partial answer");
+
+        let response = accumulator.finalize_failed("stream_error", "worker died");
+
+        assert!(matches!(response.status, ResponseStatus::Failed));
+        let wire = serde_json::to_value(&response).expect("serializes");
+        assert_eq!(wire.pointer("/status"), Some(&json!("failed")));
+        assert_eq!(wire.pointer("/error/code"), Some(&json!("stream_error")));
+        assert_eq!(wire.pointer("/output/0/status"), Some(&json!("incomplete")));
+        assert_eq!(
+            wire.pointer("/output/0/content/0/text"),
+            Some(&json!("partial answer"))
+        );
     }
 }

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -184,7 +184,7 @@ async fn process_and_transform_sse_stream(
     // open items, attach the error and the partial output — never fall through
     // to response.completed. Captured here, handled after the loop where the
     // accumulator can be consumed.
-    let mut failure: Option<(String, String)> = None;
+    let mut failure: Option<(StreamFailureReason, String, String)> = None;
 
     // Process stream chunks (each chunk is a complete SSE event)
     while let Some(chunk_result) = stream.next().await {
@@ -192,6 +192,7 @@ async fn process_and_transform_sse_stream(
             Ok(chunk) => chunk,
             Err(e) => {
                 failure = Some((
+                    StreamFailureReason::ReadError,
                     "stream_read_error".to_string(),
                     format!("Stream read error: {e}"),
                 ));
@@ -225,8 +226,8 @@ async fn process_and_transform_sse_stream(
                     // The chat layer reports a mid-stream backend failure as an
                     // error frame; relaying it and then completing would tell
                     // the client the response succeeded. Fail terminally.
-                    if let Some(frame_error) = parse_error_frame(json_str) {
-                        failure = Some(frame_error);
+                    if let Some((code, message)) = parse_error_frame(json_str) {
+                        failure = Some((StreamFailureReason::BackendError, code, message));
                         break;
                     }
                     // Not a valid chat chunk - might be error event, pass through
@@ -245,22 +246,15 @@ async fn process_and_transform_sse_stream(
 
     let usage_json = build_usage_json(accumulator.usage.as_ref());
 
-    if let Some((code, message)) = failure {
+    if let Some((reason, code, message)) = failure {
         // Terminal failure: response.failed carries the typed error and the
-        // partial output, and what gets persisted is exactly what the client
-        // was shown — a failed response with its partials, not a completed one.
-        Metrics::record_responses_stream_failure(
-            &original_request.model,
-            if code == "stream_read_error" {
-                "read_error"
-            } else {
-                "backend_error"
-            },
-        );
-        event_emitter
-            .emit_failed(&code, &message, usage_json.as_ref(), &tx)
+        // partial output, and what gets persisted is the very response the
+        // client was shown — a failed response with its partials, not a
+        // completed one.
+        Metrics::record_responses_stream_failure(&original_request.model, reason.label());
+        let failed_response = event_emitter
+            .emit_failed(&code, &message, accumulator.usage.clone(), &tx)
             .await;
-        let failed_response = accumulator.finalize_failed(&code, &message);
         persist_response_if_needed(
             conversation_storage,
             conversation_item_storage,
@@ -403,26 +397,7 @@ impl StreamingResponseAccumulator {
     }
 
     fn finalize(self) -> ResponsesResponse {
-        self.finalize_with_item_status("completed", None)
-    }
-
-    /// Finalize after a mid-stream failure: partial content survives with
-    /// `"incomplete"` item status, the response status is `failed`, and the
-    /// typed error rides the response — matching the terminal
-    /// `response.failed` event the client was shown.
-    fn finalize_failed(mut self, code: &str, message: &str) -> ResponsesResponse {
-        self.finish_reason = Some("failed".to_string());
-        self.finalize_with_item_status(
-            "incomplete",
-            Some(json!({"code": code, "message": message})),
-        )
-    }
-
-    fn finalize_with_item_status(
-        self,
-        item_status: &str,
-        error: Option<Value>,
-    ) -> ResponsesResponse {
+        let item_status = "completed";
         let mut output: Vec<ResponseOutputItem> = Vec::new();
 
         // Add message content if present
@@ -478,17 +453,13 @@ impl StreamingResponseAccumulator {
             ResponsesUsage::Modern(usage_info.to_response_usage())
         });
 
-        let mut response = ResponsesResponse::builder(&self.response_id, &self.model)
+        ResponsesResponse::builder(&self.response_id, &self.model)
             .copy_from_request(&self.original_request)
             .created_at(self.created_at)
             .status(status)
             .output(output)
             .maybe_usage(usage)
-            .build();
-        if error.is_some() {
-            response.error = error;
-        }
-        response
+            .build()
     }
 }
 
@@ -706,13 +677,17 @@ async fn execute_tool_loop_streaming_internal(
         let accumulated_response =
             match convert_and_accumulate_stream(response.into_body(), &mut emitter, &tx).await? {
                 StreamOutcome::Complete(response) => response,
-                StreamOutcome::Failed(code, message) => {
+                StreamOutcome::Failed {
+                    reason,
+                    code,
+                    message,
+                } => {
                     // Terminal failure: close open items and attach the error
                     // plus whatever output (mcp_list_tools, prior tool calls,
                     // partial text) had accumulated across iterations.
                     Metrics::record_responses_stream_failure(
                         &current_request.model,
-                        "backend_error",
+                        reason.label(),
                     );
                     emitter.emit_failed(&code, &message, None, &tx).await;
                     return Ok(());
@@ -1059,11 +1034,35 @@ async fn execute_tool_loop_streaming_internal(
     Ok(())
 }
 
+/// Why a chat stream terminated early — the closed label set of the
+/// `smg_responses_stream_failures_total{reason}` counter. Decided where the
+/// failure is observed, never recovered from an upstream-controlled code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StreamFailureReason {
+    /// The response body could not be read (transport/read error).
+    ReadError,
+    /// The chat layer delivered an error frame mid-stream.
+    BackendError,
+}
+
+impl StreamFailureReason {
+    fn label(self) -> &'static str {
+        match self {
+            StreamFailureReason::ReadError => "read_error",
+            StreamFailureReason::BackendError => "backend_error",
+        }
+    }
+}
+
 /// Outcome of draining one chat stream iteration.
 enum StreamOutcome {
     Complete(ChatCompletionResponse),
-    /// The chat layer failed mid-stream: `(code, message)`.
-    Failed(String, String),
+    /// The chat layer failed mid-stream.
+    Failed {
+        reason: StreamFailureReason,
+        code: String,
+        message: String,
+    },
 }
 
 /// Convert chat stream to Responses API events while accumulating for tool call detection
@@ -1079,10 +1078,11 @@ async fn convert_and_accumulate_stream(
         let chunk = match chunk_result {
             Ok(chunk) => chunk,
             Err(e) => {
-                return Ok(StreamOutcome::Failed(
-                    "stream_read_error".to_string(),
-                    format!("Stream read error: {e}"),
-                ));
+                return Ok(StreamOutcome::Failed {
+                    reason: StreamFailureReason::ReadError,
+                    code: "stream_read_error".to_string(),
+                    message: format!("Stream read error: {e}"),
+                });
             }
         };
 
@@ -1109,7 +1109,11 @@ async fn convert_and_accumulate_stream(
                     // Dropping it silently would let the loop fall through to
                     // response.completed over truncated output.
                     if let Some((code, message)) = parse_error_frame(json_str) {
-                        return Ok(StreamOutcome::Failed(code, message));
+                        return Ok(StreamOutcome::Failed {
+                            reason: StreamFailureReason::BackendError,
+                            code,
+                            message,
+                        });
                     }
                 }
             }
@@ -1313,21 +1317,8 @@ mod tests {
     }
 
     #[test]
-    fn finalize_failed_preserves_partials_as_incomplete() {
-        let request = ResponsesRequest::default();
-        let mut accumulator = StreamingResponseAccumulator::new(&request);
-        accumulator.content_buffer.push_str("partial answer");
-
-        let response = accumulator.finalize_failed("stream_error", "worker died");
-
-        assert!(matches!(response.status, ResponseStatus::Failed));
-        let wire = serde_json::to_value(&response).expect("serializes");
-        assert_eq!(wire.pointer("/status"), Some(&json!("failed")));
-        assert_eq!(wire.pointer("/error/code"), Some(&json!("stream_error")));
-        assert_eq!(wire.pointer("/output/0/status"), Some(&json!("incomplete")));
-        assert_eq!(
-            wire.pointer("/output/0/content/0/text"),
-            Some(&json!("partial answer"))
-        );
+    fn failure_reason_labels_are_the_closed_metric_set() {
+        assert_eq!(StreamFailureReason::ReadError.label(), "read_error");
+        assert_eq!(StreamFailureReason::BackendError.label(), "backend_error");
     }
 }


### PR DESCRIPTION
## Description

### Problem

A backend failure after the first byte of a `/v1/responses` stream never becomes a terminal event — on any gRPC-native path:

- **Regular streaming**: the chat layer's mid-stream error frame fails to parse as a chunk, gets relayed verbatim as an anonymous frame, and the loop then emits `response.completed` — and **persists the truncated response as completed**.
- **MCP tool loop**: the error frame is silently dropped (parse-miss with no else arm), so the client sees a clean-looking `response.completed` over truncated output with **no error signal whatsoever**.
- **Harmony**: pipeline/processing failures emit a bare `data:`-only error frame — no SSE event name, no item closure, and open items are dropped from any subsequent output.

`response.failed` / `response.incomplete` did not exist in the codebase — the lifecycle enum could not represent them — even though the wire model (`ResponseStatus::Failed`, `error`, `incomplete_details`) exists and non-streaming uses it correctly. And because the HTTP status was already 200 when the stream opened, these failures land in `http_responses{status="200"}`: **a backend death after first byte is metrically indistinguishable from success — or from a client disconnect.**

### Solution

One terminal-failure contract, applied to all three gRPC paths:

- `ResponseEvent::{Failed, Incomplete}` join the lifecycle enum (`crates/protocols/src/event_types.rs`) with `is_response_event` coverage.
- The shared emitter gains `emit_failed(code, message, usage, tx)`: it closes an open message item with the standard done ladder (`output_text.done` → `content_part.done` → `output_item.done`) stamped `"status": "incomplete"`, then emits `response.failed` (a named SSE event) whose response object carries `status: failed`, a typed `{code, message}` error, and **every item that produced output — completed and incomplete alike**. Dropping the partials is exactly the failure mode this event exists to fix. It returns the response object so callers persist exactly what the client was shown.
- **Regular path**: recognizes the chat layer's error frame (`parse_error_frame`) and read errors, terminal-fails instead of completing, and persists via a new `finalize_failed` (status `failed`, error attached, partial items stamped `incomplete`) instead of storing a truncated "completed" response.
- **MCP loop**: `convert_and_accumulate_stream` returns a typed `StreamOutcome::{Complete, Failed}`; an error frame aborts the loop into `emit_failed`, with accumulated `mcp_list_tools`/tool-call items riding along in the output.
- **Harmony**: the four pipeline/processing failure sites route through `emit_failed` instead of the bare error frame.
- **Metrics**: `smg_responses_stream_failures_total{model, reason}` — the only signal that a 200-established stream died on the backend. `reason` is a closed set (`backend_error` | `read_error`), never a raw upstream string, keeping cardinality bounded.

Deliberately out of scope (follow-ups, same defect class): the provider-proxying `openai` router path (separate subsystem and accumulator; it additionally overwrites an upstream `response.failed` with a synthetic `completed`), the `max_tool_calls`/`max_iterations` limit semantics on harmony (behavior-design questions, not backend failures), and mock-worker mid-stream fault injection for e2e coverage.

## Changes

- `crates/protocols/src/event_types.rs` — `Failed`/`Incomplete` lifecycle events.
- `model_gateway/src/routers/grpc/common/responses/streaming.rs` — `emit_failed`, `close_open_message_as_incomplete`, request-echo fields factored to be shared by both terminals.
- `model_gateway/src/routers/grpc/regular/responses/streaming.rs` — error-frame recognition, failure capture, `finalize_failed` persistence, `StreamOutcome` for the MCP loop.
- `model_gateway/src/routers/grpc/harmony/responses/streaming.rs` — failure sites use the terminal contract.
- `model_gateway/src/observability/metrics.rs` — the failure counter.

## Test Plan

- New unit tests:
  - `emit_failed_closes_open_message_and_attaches_partials` — full done ladder before the terminal, item stamped incomplete with the partial text, `response.failed` last, error object shape, and the returned (persisted) object identical to the emitted one.
  - `emit_failed_without_output_still_carries_the_error` — bare failure shape.
  - `error_frames_are_recognized_and_typed` — code-beats-type, chunks and junk not misread.
  - `finalize_failed_preserves_partials_as_incomplete` — persisted wire JSON: `status: failed`, typed error, incomplete partial item (asserted on `serde_json::to_value`, per the wire-contract-test practice).
- `cargo test -p smg --lib` passes; `cargo test -p smg --test api_tests` and `--test spec_test` pass (responses API integration surface).
- `cargo clippy -p smg --all-targets -- -D warnings` and `cargo +nightly fmt --all` clean.
- Behavior on healthy streams is unchanged: the completed path is untouched except for the factored-out request-echo helper (same output, shared by both terminals).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes — run as `-p smg --all-targets`; the full-workspace `--all-features` matrix needs the opencv toolchain not present locally, CI owns it
- [ ] (Optional) Documentation updated — contract documented on the emitter methods
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
