### PR TITLE
fix(tokenspeed): don't advertise or pin dp rank on width-1 engines

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -573,9 +573,11 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
                 "dp_size",
                 None,
             )
-            # >= 1 (not > 1): a pin-capable engine advertises even a
-            # single-rank width, keeping label semantics = capability.
-            if isinstance(dp_size, int) and dp_size >= 1:
+            # > 1 only: a width-1 pin has no placement to choose, yet an
+            # explicit pin still changes engine-side scheduling. Dp-aware
+            # gateways degrade a missing label to a plain worker, so
+            # single-rank engines simply stay label-free.
+            if isinstance(dp_size, int) and dp_size > 1:
                 server_args_dict["dp_size"] = dp_size
 
         server_args_struct = Struct()

--- a/grpc_servicer/tests/test_tokenspeed_dp_rank_pin.py
+++ b/grpc_servicer/tests/test_tokenspeed_dp_rank_pin.py
@@ -115,13 +115,15 @@ class TestGetServerInfoDpSizeAdvertisement:
         )
         assert "dp_size" not in info.server_args
 
-    def test_dp_off_still_advertises_single_rank(self, monkeypatch):
-        # Under a dp-aware gateway a missing label is a hard registration
-        # failure, so a pin-capable engine with DP off advertises width 1.
+    def test_single_rank_width_is_not_advertised(self, monkeypatch):
+        # A width-1 pin has no placement to choose, and an explicit pin
+        # still changes engine-side scheduling. Dp-aware gateways degrade
+        # a missing label to a plain worker, so DP-off engines stay
+        # label-free.
         monkeypatch.setattr(servicer_mod, "_engine_supports_dp_rank_pin", lambda: True)
         info = asyncio.run(
             _make_info_servicer(1).GetServerInfo(
                 tokenspeed_scheduler_pb2.GetServerInfoRequest(), None
             )
         )
-        assert info.server_args["dp_size"] == 1
+        assert "dp_size" not in info.server_args

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -11,6 +11,7 @@ use openai_protocol::{
 use tracing::{debug, warn};
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
+use super::discover_dp::DpInfo;
 use crate::{
     routers::grpc::zmq_client::zmq_handshake_address,
     worker::{
@@ -225,18 +226,7 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
         let health_endpoint = &app_context.router_config.health_check.endpoint;
 
         let dp_ranks: Vec<Option<(usize, usize)>> = if app_context.router_config.dp_aware {
-            // dp_info == None means the engine advertised no dp_size label
-            // (it cannot honor a rank pin): register a plain single worker
-            // instead of failing; discover_dp already logged the degradation.
-            match context.data.dp_info.as_ref() {
-                Some(dp_info) => {
-                    validate_zmq_dp(*connection_mode, dp_info.dp_size, &config.url)?;
-                    (0..dp_info.dp_size)
-                        .map(|r| Some((r, dp_info.dp_size)))
-                        .collect()
-                }
-                None => vec![None],
-            }
+            dp_rank_expansion(context.data.dp_info.as_ref(), *connection_mode, &config.url)?
         } else {
             vec![None] // single worker, no DP
         };
@@ -709,6 +699,28 @@ fn validate_zmq_worker_type(
 /// on the worker spec: one worker, one socket set, N engines dialing in), so
 /// reject the expansion loudly and point at the grouped form. gRPC/HTTP
 /// expansion and single-engine ZMQ are fine.
+/// Ranks to register for a dp-aware worker. A width above one expands into
+/// one dp-annotated worker per rank. A width-1 advertisement (older
+/// servicers emit it as a capability signal) and a missing one both
+/// register a plain worker: there is no placement to choose, and pinning
+/// rank 0 anyway still alters engine-side scheduling. discover_dp already
+/// logged the degradation for the missing-label case.
+fn dp_rank_expansion(
+    dp_info: Option<&DpInfo>,
+    connection_mode: ConnectionMode,
+    url: &str,
+) -> Result<Vec<Option<(usize, usize)>>, WorkflowError> {
+    match dp_info {
+        Some(dp_info) if dp_info.dp_size > 1 => {
+            validate_zmq_dp(connection_mode, dp_info.dp_size, url)?;
+            Ok((0..dp_info.dp_size)
+                .map(|r| Some((r, dp_info.dp_size)))
+                .collect())
+        }
+        Some(_) | None => Ok(vec![None]),
+    }
+}
+
 fn validate_zmq_dp(
     connection_mode: ConnectionMode,
     dp_size: usize,
@@ -729,6 +741,33 @@ fn validate_zmq_dp(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dp_expansion_pins_only_multi_rank_widths() {
+        let multi = DpInfo {
+            dp_size: 3,
+            model_id: "m".to_string(),
+        };
+        assert_eq!(
+            dp_rank_expansion(Some(&multi), ConnectionMode::Grpc, "grpc://w:1").unwrap(),
+            vec![Some((0, 3)), Some((1, 3)), Some((2, 3))]
+        );
+
+        // Width 1 is a capability-only advertisement: no placement exists,
+        // and a rank-0 pin would still alter engine scheduling.
+        let single = DpInfo {
+            dp_size: 1,
+            model_id: "m".to_string(),
+        };
+        assert_eq!(
+            dp_rank_expansion(Some(&single), ConnectionMode::Grpc, "grpc://w:1").unwrap(),
+            vec![None]
+        );
+        assert_eq!(
+            dp_rank_expansion(None, ConnectionMode::Grpc, "grpc://w:1").unwrap(),
+            vec![None]
+        );
+    }
 
     #[test]
     fn normalize_url_preserves_existing_schemes() {


### PR DESCRIPTION
## Description

### Problem

#2326 made the TokenSpeed servicer advertise the `dp_size` label even at width 1 ("label doubles as the capability handshake"), and made the gateway expand any advertised width into dp-annotated workers. At width 1 that chain pins `data_parallel_rank = 0` onto every request sent to an engine that isn't running attention-DP at all.

A width-1 pin selects nothing — there is only one rank — but it is not free: the engine scheduler treats an explicitly pinned request differently from a bare one, which changes batch composition (and with it floating-point reduction order) for zero routing benefit. On temperature-sampled workloads that shows up as output drift rather than any error.

Context: found while investigating the kimi-k3 accuracy drop on tokenspeed's SMG bump PR (lightseekorg/tokenspeed#1255). That regression traced to a tokenspeed engine commit (their #1254, FP8 GEMM scale handling) — not to SMG — because the affected deployment runs with `dp_aware` off, where this pin never fires. This fix is hygiene for deployments that do run `--dp-aware` against non-DP engines: they currently get pinned for no reason.

### Solution

Close both sides of the handshake:

- **Servicer**: advertise `dp_size` only when it is greater than 1. Dp-aware gateways already degrade a missing label to a plain worker (that behavior shipped in #2326), so single-rank engines simply stay label-free — the original ">= 1 keeps label semantics = capability" rationale predates that degradation path.
- **Gateway**: expand dp ranks only for widths above 1, so a width-1 label from an already-deployed 0.9.1 servicer still registers a plain, unpinned worker.

Real attention-DP deployments (`dp_size > 1`) are unchanged.

## Changes

- `grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py`: advertisement condition `>= 1` → `> 1`
- `model_gateway/src/workflow/steps/local/create_worker.rs`: dp rank expansion extracted into `dp_rank_expansion()`, gated to `dp_size > 1`; width-1 and missing labels both yield a plain worker
- `grpc_servicer/tests/test_tokenspeed_dp_rank_pin.py`: the width-1 test now asserts the label is absent (was asserting `dp_size == 1`)

## Test Plan

- New Rust unit test `dp_expansion_pins_only_multi_rank_widths`: width 3 expands to ranks 0–2, width 1 and missing both yield a single unpinned worker
- Flipped servicer test asserts width-1 engines advertise no `dp_size` label; the width-8 advertisement and no-capability tests are unchanged and still pass
- `cargo test -p smg --lib`: 1832 passed, 0 failed; `cargo clippy -p smg --lib --tests -- -D warnings` clean; `cargo +nightly fmt --all --check` clean (servicer pytest requires engine extras not installable locally — CI's servicer job covers it)
