### PR TITLE
perf: reuse worker snapshots during routing

### DIFF
--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -108,6 +108,19 @@ pub trait LoadBalancingPolicy: Send + Sync + Debug {
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
+/// Whether a built-in policy applies the complete [`Worker::is_available`]
+/// predicate before selecting. Other policies keep the caller-side filter.
+pub(crate) fn policy_filters_unavailable_workers(policy: &dyn LoadBalancingPolicy) -> bool {
+    let policy = policy.as_any();
+    policy.is::<RandomPolicy>()
+        || policy.is::<RoundRobinPolicy>()
+        || policy.is::<LeastLoadPolicy>()
+        || policy.is::<PowerOfTwoPolicy>()
+        || policy.is::<CacheAwarePolicy>()
+        || policy.is::<ManualPolicy>()
+        || policy.is::<PassthroughPolicy>()
+}
+
 pub trait DPRankLoadPolicy: Send + Sync + Debug {
     fn select_dp_rank(&self, worker: &dyn Worker, estimated_cost: isize) -> Option<isize>;
 }
@@ -419,5 +432,32 @@ mod tests {
         assert_eq!(WorkerLeg::Single.routing_id_prefix(), "");
         assert_eq!(WorkerLeg::Prefill.routing_id_prefix(), "prefill:");
         assert_eq!(WorkerLeg::Decode.routing_id_prefix(), "decode:");
+    }
+
+    #[test]
+    fn only_policies_with_complete_availability_checks_skip_prefiltering() {
+        for name in [
+            "random",
+            "round_robin",
+            "least_load",
+            "power_of_two",
+            "cache_aware",
+            "manual",
+            "passthrough",
+        ] {
+            let policy = PolicyFactory::create_by_name(name).unwrap();
+            assert!(
+                policy_filters_unavailable_workers(policy.as_ref()),
+                "{name}"
+            );
+        }
+
+        for name in ["bucket", "consistent_hashing", "prefix_hash"] {
+            let policy = PolicyFactory::create_by_name(name).unwrap();
+            assert!(
+                !policy_filters_unavailable_workers(policy.as_ref()),
+                "{name}"
+            );
+        }
     }
 }

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -462,22 +462,50 @@ mod tests {
     }
 
     /// The allowlist above is only sound if every listed policy actually
-    /// applies the availability predicate itself: callers skip the
-    /// `is_available()` pre-filter for them. Prove it behaviorally with the
-    /// overload veto (health stays green, so a policy that ignored
-    /// availability would happily select).
+    /// applies the complete `is_available()` predicate itself: callers skip
+    /// the pre-filter for them. Two scenarios pin the two halves:
+    /// the overload veto (shared with the weaker `is_healthy_and_eligible`
+    /// predicate) and an open circuit breaker — the one signal that
+    /// separates the full predicate from the weak one, so a policy that
+    /// regresses to the weak predicate fails here.
     #[test]
     fn allowlisted_policies_reject_unavailable_workers() {
-        use std::sync::Arc;
+        use std::{sync::Arc, time::Duration};
 
         use openai_protocol::worker::WorkerStatus;
 
-        use crate::worker::{BasicWorkerBuilder, Worker};
+        use crate::worker::{circuit_breaker::CircuitBreakerConfig, BasicWorkerBuilder, Worker};
 
-        fn worker(url: &str, overloaded: bool) -> Arc<dyn Worker> {
-            let worker: Arc<dyn Worker> = Arc::new(BasicWorkerBuilder::new(url).build());
+        fn worker(url: &str) -> Arc<dyn Worker> {
+            let worker: Arc<dyn Worker> = Arc::new(
+                BasicWorkerBuilder::new(url)
+                    .circuit_breaker_config(CircuitBreakerConfig {
+                        failure_threshold: 1,
+                        success_threshold: 1,
+                        timeout_duration: Duration::from_secs(600),
+                        window_duration: Duration::from_secs(600),
+                    })
+                    .build(),
+            );
             worker.set_status(WorkerStatus::Ready);
-            worker.set_overloaded(overloaded);
+            worker
+        }
+
+        fn overloaded(url: &str) -> Arc<dyn Worker> {
+            let worker = worker(url);
+            worker.set_overloaded(true);
+            worker
+        }
+
+        fn breaker_open(url: &str) -> Arc<dyn Worker> {
+            let worker = worker(url);
+            worker.record_outcome(500);
+            assert!(!worker.is_available(), "breaker must be open");
+            assert!(
+                worker.is_healthy_and_eligible(),
+                "the weak predicate must still accept it — that contrast is \
+                 what this scenario tests"
+            );
             worker
         }
 
@@ -492,19 +520,32 @@ mod tests {
         ] {
             let policy = PolicyFactory::create_by_name(name).unwrap();
 
-            // Every worker vetoed: the policy must come up empty on its own.
-            let vetoed = [worker("http://a:1", true), worker("http://b:1", true)];
-            assert_eq!(
-                policy.select_worker(&vetoed, &SelectWorkerInfo::default()),
-                None,
-                "{name} selected an unavailable worker"
-            );
+            // Every worker vetoed or circuit-broken: the policy must come up
+            // empty on its own.
+            for unavailable in [
+                [overloaded("http://a:1"), overloaded("http://b:1")],
+                [breaker_open("http://a:1"), breaker_open("http://b:1")],
+            ] {
+                assert_eq!(
+                    policy.select_worker(&unavailable, &SelectWorkerInfo::default()),
+                    None,
+                    "{name} selected an unavailable worker"
+                );
+            }
 
-            // Mixed pool: any selection must land on the available worker.
-            let mixed = [worker("http://a:1", false), worker("http://b:1", true)];
-            for _ in 0..16 {
-                if let Some(idx) = policy.select_worker(&mixed, &SelectWorkerInfo::default()) {
-                    assert_eq!(idx, 0, "{name} selected the vetoed worker");
+            // Mixed pools: the selection must exist and land on the
+            // available worker.
+            for mixed in [
+                [worker("http://a:1"), overloaded("http://b:1")],
+                [worker("http://a:1"), breaker_open("http://b:1")],
+            ] {
+                for _ in 0..16 {
+                    let idx = policy
+                        .select_worker(&mixed, &SelectWorkerInfo::default())
+                        .unwrap_or_else(|| {
+                            panic!("{name} found no worker despite an available one")
+                        });
+                    assert_eq!(idx, 0, "{name} selected the unavailable worker");
                 }
             }
         }

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -460,4 +460,53 @@ mod tests {
             );
         }
     }
+
+    /// The allowlist above is only sound if every listed policy actually
+    /// applies the availability predicate itself: callers skip the
+    /// `is_available()` pre-filter for them. Prove it behaviorally with the
+    /// overload veto (health stays green, so a policy that ignored
+    /// availability would happily select).
+    #[test]
+    fn allowlisted_policies_reject_unavailable_workers() {
+        use std::sync::Arc;
+
+        use openai_protocol::worker::WorkerStatus;
+
+        use crate::worker::{BasicWorkerBuilder, Worker};
+
+        fn worker(url: &str, overloaded: bool) -> Arc<dyn Worker> {
+            let worker: Arc<dyn Worker> = Arc::new(BasicWorkerBuilder::new(url).build());
+            worker.set_status(WorkerStatus::Ready);
+            worker.set_overloaded(overloaded);
+            worker
+        }
+
+        for name in [
+            "random",
+            "round_robin",
+            "least_load",
+            "power_of_two",
+            "cache_aware",
+            "manual",
+            "passthrough",
+        ] {
+            let policy = PolicyFactory::create_by_name(name).unwrap();
+
+            // Every worker vetoed: the policy must come up empty on its own.
+            let vetoed = [worker("http://a:1", true), worker("http://b:1", true)];
+            assert_eq!(
+                policy.select_worker(&vetoed, &SelectWorkerInfo::default()),
+                None,
+                "{name} selected an unavailable worker"
+            );
+
+            // Mixed pool: any selection must land on the available worker.
+            let mixed = [worker("http://a:1", false), worker("http://b:1", true)];
+            for _ in 0..16 {
+                if let Some(idx) = policy.select_worker(&mixed, &SelectWorkerInfo::default()) {
+                    assert_eq!(idx, 0, "{name} selected the vetoed worker");
+                }
+            }
+        }
+    }
 }

--- a/model_gateway/src/routers/common/worker_selection.rs
+++ b/model_gateway/src/routers/common/worker_selection.rs
@@ -70,6 +70,17 @@ impl<'a> WorkerSelector<'a> {
         Self { registry, client }
     }
 
+    fn matches_worker_filters(worker: &Arc<dyn Worker>, req: &SelectWorkerRequest<'_>) -> bool {
+        req.worker_type
+            .is_none_or(|worker_type| *worker.worker_type() == worker_type)
+            && req
+                .connection_mode
+                .is_none_or(|mode| *worker.connection_mode() == mode)
+            && req
+                .runtime_type
+                .is_none_or(|runtime| worker.metadata().spec.runtime_type == runtime)
+    }
+
     /// Select the best worker for a model with refresh-on-miss.
     ///
     /// 1. Filter available workers by the request criteria.
@@ -129,18 +140,14 @@ impl<'a> WorkerSelector<'a> {
         req: &SelectWorkerRequest<'_>,
         require_available: bool,
     ) -> Vec<Arc<dyn Worker>> {
-        let workers = self.registry.get_workers_filtered(
-            None, // model_id index lookup not used — we filter via supports_model
-            req.worker_type,
-            req.connection_mode,
-            req.runtime_type,
-            false,
-        );
-        let workers: Vec<_> = if require_available {
-            workers.into_iter().filter(|w| w.is_available()).collect()
-        } else {
-            workers
-        };
+        let workers: Vec<_> = self
+            .registry
+            .get_routing_workers()
+            .iter()
+            .filter(|worker| Self::matches_worker_filters(worker, req))
+            .filter(|worker| !require_available || worker.is_available())
+            .cloned()
+            .collect();
         let candidates = match &req.provider {
             Some(provider) => filter_by_provider(workers, provider),
             None => workers,
@@ -168,13 +175,14 @@ impl<'a> WorkerSelector<'a> {
     /// Check if any healthy worker supports the model (regardless of circuit breaker).
     /// Used to distinguish "model not found" from "all workers circuit-broken".
     fn any_worker_supports_model(&self, req: &SelectWorkerRequest<'_>) -> bool {
-        let workers = self.registry.get_workers_filtered(
-            None,
-            req.worker_type,
-            req.connection_mode,
-            req.runtime_type,
-            true, // healthy only — model exists even if circuit-broken
-        );
+        let workers: Vec<_> = self
+            .registry
+            .get_routing_workers()
+            .iter()
+            .filter(|worker| Self::matches_worker_filters(worker, req))
+            .filter(|worker| worker.is_healthy())
+            .cloned()
+            .collect();
         let candidates = match &req.provider {
             Some(p) => filter_by_provider(workers, p),
             None => workers,
@@ -195,9 +203,15 @@ impl<'a> WorkerSelector<'a> {
         auth_header: Option<&HeaderValue>,
         provider: Option<&ProviderType>,
     ) {
-        let mut external_workers =
-            self.registry
-                .get_workers_filtered(None, None, None, Some(RuntimeType::External), true);
+        let mut external_workers: Vec<_> = self
+            .registry
+            .get_routing_workers()
+            .iter()
+            .filter(|worker| {
+                worker.metadata().spec.runtime_type == RuntimeType::External && worker.is_healthy()
+            })
+            .cloned()
+            .collect();
 
         // Only refresh workers matching the request's provider to avoid sending
         // e.g. an OpenAI key to Anthropic workers during model discovery.

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -12,7 +12,10 @@ use tracing::{error, warn};
 use super::PipelineStage;
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
-    policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo, WorkerLeg},
+    policies::{
+        policy_filters_unavailable_workers, LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo,
+        WorkerLeg,
+    },
     routers::{
         common::overload,
         error,
@@ -22,8 +25,8 @@ use crate::{
         },
     },
     worker::{
-        ConnectionMode, ConnectionModeExt, HashRing, RuntimeType, Worker, WorkerRegistry,
-        WorkerType, UNKNOWN_MODEL_ID,
+        ConnectionMode, ConnectionModeExt, HashRing, RoutingPool, RuntimeType, Worker,
+        WorkerRegistry, WorkerType, UNKNOWN_MODEL_ID,
     },
 };
 
@@ -273,35 +276,29 @@ impl WorkerSelectionStage {
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
     ) -> Option<Arc<dyn Worker>> {
-        // Treat "unknown" model as wildcard (match any worker)
-        let model_filter = if model_id == UNKNOWN_MODEL_ID {
-            None
-        } else {
-            Some(model_id)
-        };
-
         // Get workers for the specified model. The gRPC router serves both gRPC
         // and direct-ZMQ workers, so accept either transport (not HTTP).
-        let workers = self.worker_registry.get_workers_filtered(
-            model_filter,
-            Some(WorkerType::Regular),
-            None,  // grpc + zmq, filtered below
-            None,  // any runtime type
-            false, // get all workers, we'll filter by is_available() next
-        );
-
-        // Use into_iter() to take ownership of Arcs without cloning (avoids atomic inc/dec)
-        let available: Vec<Arc<dyn Worker>> = workers
-            .into_iter()
-            .filter(|w| w.connection_mode().uses_grpc_pipeline() && w.is_available())
-            .collect();
-
-        if available.is_empty() {
-            return None;
-        }
+        let candidates = self
+            .worker_registry
+            .get_routing_pool(model_id, RoutingPool::GrpcPipelineRegular);
 
         // Get the appropriate policy for this model
         let policy = self.policy_registry.get_policy_or_default(model_id);
+
+        let filtered;
+        let available: &[Arc<dyn Worker>] = if policy_filters_unavailable_workers(policy.as_ref()) {
+            &candidates
+        } else {
+            filtered = candidates
+                .iter()
+                .filter(|worker| worker.is_available())
+                .cloned()
+                .collect::<Vec<_>>();
+            &filtered
+        };
+        if available.is_empty() {
+            return None;
+        }
 
         // Get cached hash ring for consistent hashing (O(log n) lookup)
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
@@ -310,7 +307,7 @@ impl WorkerSelectionStage {
         // when enabled; otherwise delegates to the configured policy).
         let idx = self.policy_registry.select_worker(
             &policy,
-            &available,
+            available,
             &SelectWorkerInfo {
                 request_text: text,
                 tokens,

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -25,7 +25,8 @@ use crate::{
         },
     },
     worker::{
-        ConnectionModeExt, HashRing, RoutingPool, RuntimeType, Worker, WorkerRegistry, WorkerType,
+        ConnectionModeExt, HashRing, ModelWorkerSnapshot, RoutingPool, RuntimeType, Worker,
+        WorkerRegistry, WorkerType,
     },
 };
 
@@ -327,11 +328,14 @@ impl WorkerSelectionStage {
         Some(selected)
     }
 
-    /// Workers from one shared routing-pool projection that also pass the
-    /// live `is_available()` check (health, circuit breaker, overload veto).
-    fn available_pool_workers(&self, model_id: &str, pool: RoutingPool) -> Vec<Arc<dyn Worker>> {
-        self.worker_registry
-            .get_routing_pool(model_id, pool)
+    /// Workers from one leg pool of `snapshot` that also pass the live
+    /// `is_available()` check (health, circuit breaker, overload veto).
+    fn available_workers(
+        snapshot: &ModelWorkerSnapshot,
+        pool: RoutingPool,
+    ) -> Vec<Arc<dyn Worker>> {
+        snapshot
+            .pool(pool)
             .iter()
             .filter(|w| w.is_available())
             .cloned()
@@ -346,12 +350,15 @@ impl WorkerSelectionStage {
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
     ) -> Option<PdWorkerPair> {
-        // Membership comes from the shared per-leg projections (strictly
-        // gRPC — a ZMQ leg would silently drop the PD bootstrap info, see
-        // `RoutingPool::GrpcPrefill`; the wildcard model maps to the global
-        // snapshot). Availability stays a live per-request check.
-        let all_prefill = self.available_pool_workers(model_id, RoutingPool::GrpcPrefill);
-        let all_decode = self.available_pool_workers(model_id, RoutingPool::GrpcDecode);
+        // Both legs derive from ONE membership snapshot: separate pool
+        // lookups could straddle a concurrent replacement and pair workers
+        // that never coexisted. The pools are strictly gRPC (a ZMQ leg would
+        // silently drop the PD bootstrap info, see `RoutingPool::GrpcPrefill`;
+        // the wildcard model maps to the global snapshot), and availability
+        // stays a live per-request check.
+        let snapshot = self.worker_registry.get_routing_snapshot(model_id);
+        let all_prefill = Self::available_workers(&snapshot, RoutingPool::GrpcPrefill);
+        let all_decode = Self::available_workers(&snapshot, RoutingPool::GrpcDecode);
 
         if all_prefill.is_empty() {
             warn!("No available prefill workers");
@@ -470,14 +477,16 @@ impl WorkerSelectionStage {
         rid_key: Option<&str>,
         encode_item_hashes: &[Vec<u8>],
     ) -> Option<EncodePrefillDecodeWorkerSelection> {
-        // Membership comes from the shared per-leg projections (strictly
-        // gRPC — encode dispatch is a gRPC encoder RPC the direct-ZMQ worker
-        // has no path for, and the ZMQ wire carries no KV-transfer
-        // rendezvous for the prefill/decode legs; the wildcard model maps to
-        // the global snapshot). Availability stays a live per-request check.
-        let all_encode = self.available_pool_workers(model_id, RoutingPool::GrpcEncode);
-        let all_prefill = self.available_pool_workers(model_id, RoutingPool::GrpcPrefill);
-        let all_decode = self.available_pool_workers(model_id, RoutingPool::GrpcDecode);
+        // All three legs derive from ONE membership snapshot (see
+        // select_pd_pair). The pools are strictly gRPC — encode dispatch is
+        // a gRPC encoder RPC the direct-ZMQ worker has no path for, and the
+        // ZMQ wire carries no KV-transfer rendezvous for the prefill/decode
+        // legs; the wildcard model maps to the global snapshot. Availability
+        // stays a live per-request check.
+        let snapshot = self.worker_registry.get_routing_snapshot(model_id);
+        let all_encode = Self::available_workers(&snapshot, RoutingPool::GrpcEncode);
+        let all_prefill = Self::available_workers(&snapshot, RoutingPool::GrpcPrefill);
+        let all_decode = Self::available_workers(&snapshot, RoutingPool::GrpcDecode);
 
         let needs_encode = !encode_item_hashes.is_empty();
         if needs_encode && all_encode.is_empty() {

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -331,6 +331,17 @@ impl WorkerSelectionStage {
         Some(selected)
     }
 
+    /// Workers from one shared routing-pool projection that also pass the
+    /// live `is_available()` check (health, circuit breaker, overload veto).
+    fn available_pool_workers(&self, model_id: &str, pool: RoutingPool) -> Vec<Arc<dyn Worker>> {
+        self.worker_registry
+            .get_routing_pool(model_id, pool)
+            .iter()
+            .filter(|w| w.is_available())
+            .cloned()
+            .collect()
+    }
+
     fn select_pd_pair(
         &self,
         model_id: &str,
@@ -339,43 +350,12 @@ impl WorkerSelectionStage {
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
     ) -> Option<PdWorkerPair> {
-        // Treat "unknown" model as wildcard (match any worker)
-        let model_filter = if model_id == UNKNOWN_MODEL_ID {
-            None
-        } else {
-            Some(model_id)
-        };
-
-        // Filtered to gRPC below: PD legs cannot ride the ZMQ transport.
-        let all_workers = self.worker_registry.get_workers_filtered(
-            model_filter,
-            None,
-            None, // filtered below
-            None, // any runtime type
-            false,
-        );
-
-        let (all_prefill, all_decode): (Vec<_>, Vec<_>) =
-            all_workers
-                .into_iter()
-                .fold((Vec::new(), Vec::new()), |mut acc, w| {
-                    // Only gRPC legs, not every grpc-pipeline mode: the ZMQ
-                    // wire carries no KV-transfer rendezvous, so a ZMQ leg
-                    // would silently drop the PD bootstrap info. Registration
-                    // rejects such workers; this keeps any that slipped in
-                    // (remote/service-discovery paths) out of PD pairs.
-                    if *w.connection_mode() == ConnectionMode::Grpc && w.is_available() {
-                        match w.metadata().spec.worker_type {
-                            WorkerType::Prefill => acc.0.push(w),
-                            WorkerType::Decode => acc.1.push(w),
-                            WorkerType::Regular => {}
-                            // Encode-prefill-decode selection is handled in select_encode_prefill_decode_workers;
-                            // the PD pair fold ignores encode workers.
-                            WorkerType::Encode => {}
-                        }
-                    }
-                    acc
-                });
+        // Membership comes from the shared per-leg projections (strictly
+        // gRPC — a ZMQ leg would silently drop the PD bootstrap info, see
+        // `RoutingPool::GrpcPrefill`; the wildcard model maps to the global
+        // snapshot). Availability stays a live per-request check.
+        let all_prefill = self.available_pool_workers(model_id, RoutingPool::GrpcPrefill);
+        let all_decode = self.available_pool_workers(model_id, RoutingPool::GrpcDecode);
 
         if all_prefill.is_empty() {
             warn!("No available prefill workers");
@@ -494,38 +474,14 @@ impl WorkerSelectionStage {
         rid_key: Option<&str>,
         encode_item_hashes: &[Vec<u8>],
     ) -> Option<EncodePrefillDecodeWorkerSelection> {
-        // Treat "unknown" model as wildcard (match any worker)
-        let model_filter = if model_id == UNKNOWN_MODEL_ID {
-            None
-        } else {
-            Some(model_id)
-        };
-
-        // Filtered to gRPC below: no EPD leg can ride the ZMQ transport.
-        let all_workers = self.worker_registry.get_workers_filtered(
-            model_filter,
-            None,
-            None, // filtered below
-            None, // any runtime type
-            false,
-        );
-
-        let (all_encode, all_prefill, all_decode): (Vec<_>, Vec<_>, Vec<_>) = all_workers
-            .into_iter()
-            .fold((Vec::new(), Vec::new(), Vec::new()), |mut acc, w| {
-                // Only gRPC legs: encode dispatch is a gRPC encoder RPC the
-                // direct-ZMQ worker has no path for, and the ZMQ wire carries
-                // no KV-transfer rendezvous for the prefill/decode legs.
-                if *w.connection_mode() == ConnectionMode::Grpc && w.is_available() {
-                    match w.metadata().spec.worker_type {
-                        WorkerType::Encode => acc.0.push(w),
-                        WorkerType::Prefill => acc.1.push(w),
-                        WorkerType::Decode => acc.2.push(w),
-                        WorkerType::Regular => {}
-                    }
-                }
-                acc
-            });
+        // Membership comes from the shared per-leg projections (strictly
+        // gRPC — encode dispatch is a gRPC encoder RPC the direct-ZMQ worker
+        // has no path for, and the ZMQ wire carries no KV-transfer
+        // rendezvous for the prefill/decode legs; the wildcard model maps to
+        // the global snapshot). Availability stays a live per-request check.
+        let all_encode = self.available_pool_workers(model_id, RoutingPool::GrpcEncode);
+        let all_prefill = self.available_pool_workers(model_id, RoutingPool::GrpcPrefill);
+        let all_decode = self.available_pool_workers(model_id, RoutingPool::GrpcDecode);
 
         let needs_encode = !encode_item_hashes.is_empty();
         if needs_encode && all_encode.is_empty() {

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -25,8 +25,7 @@ use crate::{
         },
     },
     worker::{
-        ConnectionMode, ConnectionModeExt, HashRing, RoutingPool, RuntimeType, Worker,
-        WorkerRegistry, WorkerType, UNKNOWN_MODEL_ID,
+        ConnectionModeExt, HashRing, RoutingPool, RuntimeType, Worker, WorkerRegistry, WorkerType,
     },
 };
 
@@ -249,23 +248,20 @@ impl WorkerSelectionStage {
     /// under the same worker-type and transport rules selection applied.
     /// Failure path only.
     fn leg_candidates(&self, model_id: &str, worker_type: WorkerType) -> Vec<Arc<dyn Worker>> {
-        // The wildcard model selects across every model, so its candidate pool
-        // is the unfiltered one — not the `unknown` model-index entry.
-        let model_filter = if model_id == UNKNOWN_MODEL_ID {
-            None
-        } else {
-            Some(model_id)
+        // One definition shared with selection: the same routing-pool
+        // projection, before the `is_available()` filter. Regular selection
+        // takes either gRPC-pipeline transport; the disaggregated legs are
+        // gRPC-only (no KV rendezvous on ZMQ). The wildcard model maps to
+        // the global snapshot — not the `unknown` model-index entry.
+        let pool = match worker_type {
+            WorkerType::Regular => RoutingPool::GrpcPipelineRegular,
+            WorkerType::Prefill => RoutingPool::GrpcPrefill,
+            WorkerType::Decode => RoutingPool::GrpcDecode,
+            WorkerType::Encode => RoutingPool::GrpcEncode,
         };
         self.worker_registry
-            .get_workers_filtered(model_filter, Some(worker_type), None, None, false)
-            .into_iter()
-            .filter(|w| match worker_type {
-                // Regular selection takes either gRPC-pipeline transport; the
-                // disaggregated legs are gRPC-only (no KV rendezvous on ZMQ).
-                WorkerType::Regular => w.connection_mode().uses_grpc_pipeline(),
-                _ => *w.connection_mode() == ConnectionMode::Grpc,
-            })
-            .collect()
+            .get_routing_pool(model_id, pool)
+            .to_vec()
     }
 
     fn select_single_worker(

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -55,7 +55,7 @@ use crate::{
         RouterTrait,
     },
     worker::{
-        HashRing, RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType,
+        HashRing, RoutingPool, RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry,
         UNKNOWN_MODEL_ID,
     },
 };
@@ -1317,39 +1317,16 @@ impl PDRouter {
     ) -> Result<PdPair, Box<PdSelectionFailure>> {
         debug!("Selecting PD pair: model_id={:?}", model_id);
 
-        let is_unknown_model = model_id == UNKNOWN_MODEL_ID;
-
-        let prefill_workers = {
-            let by_model: Vec<_> = self
-                .worker_registry
-                .get_by_model(model_id)
-                .iter()
-                .filter(|w| matches!(w.worker_type(), WorkerType::Prefill))
-                .cloned()
-                .collect();
-            if by_model.is_empty() && is_unknown_model {
-                // "auto" means pick any — fall back to all prefill workers
-                self.worker_registry.get_prefill_workers().to_vec()
-            } else {
-                by_model
-            }
-        };
-
-        let decode_workers = {
-            let by_model: Vec<_> = self
-                .worker_registry
-                .get_by_model(model_id)
-                .iter()
-                .filter(|w| matches!(w.worker_type(), WorkerType::Decode))
-                .cloned()
-                .collect();
-            if by_model.is_empty() && is_unknown_model {
-                // Only fall back to all workers when model is "unknown" (wildcard)
-                self.worker_registry.get_decode_workers().to_vec()
-            } else {
-                by_model
-            }
-        };
+        // Shared type-only projections (the HTTP PD legs have always been
+        // selected by worker type alone). `get_routing_pool` maps the
+        // wildcard model to the global snapshot — the "auto means pick any"
+        // fallback the explicit typed getters used to provide.
+        let prefill_workers = self
+            .worker_registry
+            .get_routing_pool(model_id, RoutingPool::AnyPrefill);
+        let decode_workers = self
+            .worker_registry
+            .get_routing_pool(model_id, RoutingPool::AnyDecode);
 
         let prefill_policy = self.policy_registry.get_prefill_policy();
         let decode_policy = self.policy_registry.get_decode_policy();

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -101,8 +101,14 @@ impl PDRouter {
         endpoint: &str,
         headers: Option<Vec<(String, String)>>,
     ) -> Response {
-        let workers = self.worker_registry.get_prefill_workers();
-        let first_worker_url = workers.first().map(|w| w.url().to_string());
+        // Plain HTTP GET to the selected URL: only healthy HTTP-transport
+        // prefill workers are eligible (same rule as the PD legs).
+        let first_worker_url = self
+            .worker_registry
+            .get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::HttpPrefill)
+            .iter()
+            .find(|w| w.is_healthy())
+            .map(|w| w.url().to_string());
 
         if let Some(worker_url) = first_worker_url {
             self.proxy_to_worker(worker_url, endpoint, headers).await
@@ -1319,33 +1325,37 @@ impl PDRouter {
 
         // Shared HTTP-transport projections: this router proxies plain HTTP
         // to the selected worker's URL, so a gRPC or ZMQ worker must never
-        // be selectable. The wildcard fallback stays conditional, matching
-        // the old code: untagged workers index under the literal "unknown"
-        // entry and win when present; only an empty entry widens to every
-        // HTTP prefill/decode worker ("auto" means pick any).
+        // be selectable. Both legs derive from ONE model snapshot (and, for
+        // the wildcard fallback, ONE global snapshot) — separate lookups
+        // could straddle a concurrent membership change and pair workers
+        // that never coexisted. The fallback stays conditional, matching the
+        // old code: untagged workers index under the literal "unknown" entry
+        // and win when present; only an empty entry widens to every HTTP
+        // prefill/decode worker ("auto" means pick any).
         let is_unknown_model = model_id == UNKNOWN_MODEL_ID;
+        let model_snapshot = self.worker_registry.model_routing_snapshot(model_id);
+        let global_snapshot =
+            is_unknown_model.then(|| self.worker_registry.get_routing_snapshot(UNKNOWN_MODEL_ID));
 
         let prefill_workers = {
-            let by_model = self
-                .worker_registry
-                .get_model_routing_pool(model_id, RoutingPool::HttpPrefill);
-            if by_model.is_empty() && is_unknown_model {
-                self.worker_registry
-                    .get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::HttpPrefill)
-            } else {
-                by_model
+            let by_model = match &model_snapshot {
+                Some(snapshot) => snapshot.pool(RoutingPool::HttpPrefill),
+                None => WorkerRegistry::empty_pool(),
+            };
+            match &global_snapshot {
+                Some(global) if by_model.is_empty() => global.pool(RoutingPool::HttpPrefill),
+                _ => by_model,
             }
         };
 
         let decode_workers = {
-            let by_model = self
-                .worker_registry
-                .get_model_routing_pool(model_id, RoutingPool::HttpDecode);
-            if by_model.is_empty() && is_unknown_model {
-                self.worker_registry
-                    .get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::HttpDecode)
-            } else {
-                by_model
+            let by_model = match &model_snapshot {
+                Some(snapshot) => snapshot.pool(RoutingPool::HttpDecode),
+                None => WorkerRegistry::empty_pool(),
+            };
+            match &global_snapshot {
+                Some(global) if by_model.is_empty() => global.pool(RoutingPool::HttpDecode),
+                _ => by_model,
             }
         };
 

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1317,16 +1317,37 @@ impl PDRouter {
     ) -> Result<PdPair, Box<PdSelectionFailure>> {
         debug!("Selecting PD pair: model_id={:?}", model_id);
 
-        // Shared type-only projections (the HTTP PD legs have always been
-        // selected by worker type alone). `get_routing_pool` maps the
-        // wildcard model to the global snapshot — the "auto means pick any"
-        // fallback the explicit typed getters used to provide.
-        let prefill_workers = self
-            .worker_registry
-            .get_routing_pool(model_id, RoutingPool::AnyPrefill);
-        let decode_workers = self
-            .worker_registry
-            .get_routing_pool(model_id, RoutingPool::AnyDecode);
+        // Shared HTTP-transport projections: this router proxies plain HTTP
+        // to the selected worker's URL, so a gRPC or ZMQ worker must never
+        // be selectable. The wildcard fallback stays conditional, matching
+        // the old code: untagged workers index under the literal "unknown"
+        // entry and win when present; only an empty entry widens to every
+        // HTTP prefill/decode worker ("auto" means pick any).
+        let is_unknown_model = model_id == UNKNOWN_MODEL_ID;
+
+        let prefill_workers = {
+            let by_model = self
+                .worker_registry
+                .get_model_routing_pool(model_id, RoutingPool::HttpPrefill);
+            if by_model.is_empty() && is_unknown_model {
+                self.worker_registry
+                    .get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::HttpPrefill)
+            } else {
+                by_model
+            }
+        };
+
+        let decode_workers = {
+            let by_model = self
+                .worker_registry
+                .get_model_routing_pool(model_id, RoutingPool::HttpDecode);
+            if by_model.is_empty() && is_unknown_model {
+                self.worker_registry
+                    .get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::HttpDecode)
+            } else {
+                by_model
+            }
+        };
 
         let prefill_policy = self.policy_registry.get_prefill_policy();
         let decode_policy = self.policy_registry.get_decode_policy();

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -47,7 +47,7 @@ use crate::{
         metrics::{bool_to_static_str, metrics_labels, Metrics},
         otel_trace::inject_trace_context_http,
     },
-    policies::{PolicyRegistry, SelectWorkerInfo},
+    policies::{policy_filters_unavailable_workers, PolicyRegistry, SelectWorkerInfo},
     routers::{
         common::{
             attach_sized_body,
@@ -76,7 +76,10 @@ use crate::{
         BodyPolicy, RouterTrait,
     },
     wasm::module::{MiddlewareAttachPoint, WasmModuleAttachPoint},
-    worker::{AttachedBody, ConnectionMode, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType},
+    worker::{
+        AttachedBody, ConnectionMode, RoutingPool, Worker, WorkerLoadGuard, WorkerRegistry,
+        WorkerType,
+    },
 };
 
 /// Max body size for a WebRTC `/v1/realtime/calls` SDP offer (10 MiB).
@@ -180,13 +183,12 @@ impl Router {
     }
 
     fn select_first_worker(&self) -> Result<String, String> {
-        let workers = self.worker_registry.get_all();
-        let healthy_workers: Vec<_> = workers.iter().filter(|w| w.is_healthy()).collect();
-        if healthy_workers.is_empty() {
-            Err("No workers are available".to_string())
-        } else {
-            Ok(healthy_workers[0].url().to_string())
-        }
+        self.worker_registry
+            .get_routing_workers()
+            .iter()
+            .find(|worker| worker.is_healthy())
+            .map(|worker| worker.url().to_string())
+            .ok_or_else(|| "No workers are available".to_string())
     }
 
     async fn proxy_get_request(&self, req: Request<Body>, endpoint: &str) -> Response {
@@ -241,38 +243,38 @@ impl Router {
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
     ) -> Option<Arc<dyn Worker>> {
-        // UNKNOWN_MODEL_ID means caller didn't specify a model — find any available worker
-        let model_filter = if model_id == crate::worker::UNKNOWN_MODEL_ID {
-            None
-        } else {
-            Some(model_id)
-        };
-        let workers = self.worker_registry.get_workers_filtered(
-            model_filter,
-            Some(WorkerType::Regular),
-            Some(ConnectionMode::Http),
-            None,  // any runtime type
-            false, // get all workers, we'll filter by is_available() next
-        );
-
-        let available: Vec<Arc<dyn Worker>> = workers
-            .iter()
-            .filter(|w| w.is_available())
-            .cloned()
-            .collect();
-        if available.is_empty() {
-            return None;
-        }
+        let candidates = self
+            .worker_registry
+            .get_routing_pool(model_id, RoutingPool::HttpRegular);
 
         // Get the appropriate policy for this model
         let policy = self.policy_registry.get_policy_or_default(model_id);
+
+        // Most policies already apply the complete availability predicate.
+        // Give them the shared registry snapshot directly instead of cloning
+        // every available worker into a second per-request Vec. Hash policies
+        // currently use a weaker health predicate and retain the pre-filter.
+        let filtered;
+        let available: &[Arc<dyn Worker>] = if policy_filters_unavailable_workers(policy.as_ref()) {
+            &candidates
+        } else {
+            filtered = candidates
+                .iter()
+                .filter(|worker| worker.is_available())
+                .cloned()
+                .collect::<Vec<_>>();
+            &filtered
+        };
+        if available.is_empty() {
+            return None;
+        }
 
         // Get cached hash ring for consistent hashing (O(log n) lookup)
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
 
         let idx = self.policy_registry.select_worker(
             &policy,
-            &available,
+            available,
             &SelectWorkerInfo {
                 request_text: text,
                 tokens,
@@ -529,18 +531,9 @@ impl Router {
             Some(w) => w,
             None => {
                 // Distinguish "no workers for this model" from "workers exist but unavailable"
-                let model_filter = if model_id == crate::worker::UNKNOWN_MODEL_ID {
-                    None
-                } else {
-                    Some(model_id)
-                };
-                let total = self.worker_registry.get_workers_filtered(
-                    model_filter,
-                    Some(WorkerType::Regular),
-                    Some(ConnectionMode::Http),
-                    None,
-                    false,
-                );
+                let total = self
+                    .worker_registry
+                    .get_routing_pool(model_id, RoutingPool::HttpRegular);
                 // `total` is exactly the pool selection drew from, wildcard
                 // model included — classifying from it rather than from the
                 // model index is what makes the shed fire for a model-less
@@ -814,18 +807,9 @@ impl Router {
         // workers. Pre-filter DP-aware workers out of the candidate pool so
         // the policy can pick a non-DP worker when one exists; only fall back
         // to model_not_found / 400 when every candidate is DP-aware.
-        let model_filter = if model_id == crate::worker::UNKNOWN_MODEL_ID {
-            None
-        } else {
-            Some(model_id)
-        };
-        let all_workers = self.worker_registry.get_workers_filtered(
-            model_filter,
-            Some(WorkerType::Regular),
-            Some(ConnectionMode::Http),
-            None,
-            false,
-        );
+        let all_workers = self
+            .worker_registry
+            .get_routing_pool(model_id, RoutingPool::HttpRegular);
         if all_workers.is_empty() {
             let resp = error::model_not_found(model_id);
             record_pre_send_error(&resp);
@@ -844,11 +828,18 @@ impl Router {
             record_pre_send_error(&resp);
             return resp;
         }
-        let available: Vec<Arc<dyn Worker>> = non_dp_workers
-            .iter()
-            .filter(|w| w.is_available())
-            .cloned()
-            .collect();
+        let policy = self.policy_registry.get_policy_or_default(model_id);
+        let filtered;
+        let available: &[Arc<dyn Worker>] = if policy_filters_unavailable_workers(policy.as_ref()) {
+            &non_dp_workers
+        } else {
+            filtered = non_dp_workers
+                .iter()
+                .filter(|worker| worker.is_available())
+                .cloned()
+                .collect::<Vec<_>>();
+            &filtered
+        };
         if available.is_empty() {
             let resp =
                 overload::shed_if_all_overloaded(&non_dp_workers, model_id).unwrap_or_else(|| {
@@ -861,11 +852,10 @@ impl Router {
             return resp;
         }
 
-        let policy = self.policy_registry.get_policy_or_default(model_id);
         let hash_ring = self.worker_registry.get_hash_ring(model_id);
         let idx = match self.policy_registry.select_worker(
             &policy,
-            &available,
+            available,
             &SelectWorkerInfo {
                 request_text: text.as_deref(),
                 tokens: hinted_tokens.as_deref(),
@@ -1645,13 +1635,9 @@ impl Router {
     /// Gather this router's per-request state for the shared decision matrix
     /// in [`crate::routers::common::body_policy`].
     fn request_body_path(&self, headers: &HeaderMap, wasm_request_hooks: bool) -> BodyPath {
-        let candidates = self.worker_registry.get_workers_filtered(
-            None,
-            Some(WorkerType::Regular),
-            Some(ConnectionMode::Http),
-            None,
-            false,
-        );
+        let candidates = self
+            .worker_registry
+            .get_routing_pool(crate::worker::UNKNOWN_MODEL_ID, RoutingPool::HttpRegular);
         decide_body_path(&BodyPathInputs {
             policy_needs_text: self
                 .policy_registry
@@ -2325,6 +2311,23 @@ mod tests {
 
         let worker = router.worker_registry.get_by_url(&url).unwrap();
         assert!(worker.is_healthy());
+    }
+
+    #[test]
+    fn model_less_selection_uses_live_availability_from_shared_pool() {
+        let router = create_test_unhealthy_router();
+
+        let selected = router
+            .select_worker_for_model(crate::worker::UNKNOWN_MODEL_ID, None, None, None, None)
+            .unwrap();
+        assert!(selected.is_available());
+
+        for worker in router.worker_registry.get_all() {
+            worker.set_status(openai_protocol::worker::WorkerStatus::NotReady);
+        }
+        assert!(router
+            .select_worker_for_model(crate::worker::UNKNOWN_MODEL_ID, None, None, None, None)
+            .is_none());
     }
 
     fn rerank_request() -> RerankRequest {

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -183,8 +183,11 @@ impl Router {
     }
 
     fn select_first_worker(&self) -> Result<String, String> {
+        // proxy_get_request sends a plain HTTP GET to the returned URL, so
+        // only HTTP-transport workers are eligible: a gRPC or ZMQ worker's
+        // URL cannot serve it.
         self.worker_registry
-            .get_routing_workers()
+            .get_routing_pool(crate::worker::UNKNOWN_MODEL_ID, RoutingPool::HttpRegular)
             .iter()
             .find(|worker| worker.is_healthy())
             .map(|worker| worker.url().to_string())
@@ -868,10 +871,18 @@ impl Router {
         ) {
             Some(i) => i,
             None => {
-                let resp = error::service_unavailable(
-                    "no_available_workers",
-                    "Policy returned no eligible worker",
-                );
+                // Self-filtering policies see the unfiltered pool, so "all
+                // workers overloaded" surfaces here as a policy miss instead
+                // of an empty pre-filter above. Classify the shed on this arm
+                // too, or the 503 loses Retry-After, retryability marking,
+                // and the overload-shed metric.
+                let resp = overload::shed_if_all_overloaded(&non_dp_workers, model_id)
+                    .unwrap_or_else(|| {
+                        error::service_unavailable(
+                            "no_available_workers",
+                            "Policy returned no eligible worker",
+                        )
+                    });
                 record_pre_send_error(&resp);
                 return resp;
             }
@@ -2299,6 +2310,34 @@ mod tests {
         let url = result.unwrap();
         // DashMap doesn't guarantee order, so just check we get one of the workers
         assert!(url == "http://worker1:8080" || url == "http://worker2:8080");
+    }
+
+    #[test]
+    fn select_first_worker_skips_non_http_transports() {
+        let router = create_test_regular_router();
+        // A healthy gRPC-pipeline worker must never receive the plain HTTP
+        // GET that proxy_get_request sends to the selected URL.
+        let grpc = BasicWorkerBuilder::new("grpc://grpc-worker:9000")
+            .worker_type(WorkerType::Regular)
+            .connection_mode(ConnectionMode::Grpc)
+            .health_config(no_health_check())
+            .build();
+        router.worker_registry.register_or_replace(Arc::new(grpc));
+
+        let url = router.select_first_worker().unwrap();
+        assert!(
+            url.starts_with("http://worker"),
+            "picked a non-HTTP transport: {url}"
+        );
+
+        // With every HTTP worker unhealthy the proxy has no eligible target,
+        // even though the gRPC worker is still healthy.
+        for worker in router.worker_registry.get_all() {
+            if *worker.connection_mode() == ConnectionMode::Http {
+                worker.set_status(openai_protocol::worker::WorkerStatus::NotReady);
+            }
+        }
+        assert!(router.select_first_worker().is_err());
     }
 
     #[test]

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -346,13 +346,17 @@ impl RouterManager {
             }
         }
 
-        let workers = if let Some(model) = model_id {
-            self.worker_registry.get_by_model(model).to_vec()
+        let by_model;
+        let all;
+        let workers: &[Arc<dyn Worker>] = if let Some(model) = model_id {
+            by_model = self.worker_registry.get_by_model(model);
+            &by_model
         } else {
-            self.worker_registry.get_all()
+            all = self.worker_registry.get_routing_workers();
+            &all
         };
 
-        self.select_router_for_workers(&workers, model_id)
+        self.select_router_for_workers(workers, model_id)
             .or_else(|| {
                 let default = self
                     .default_router

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -43,7 +43,7 @@ pub use openai_protocol::{
     worker::{ProviderType, WorkerGroupKey},
 };
 pub use overload::OverloadThresholds;
-pub(crate) use registry::RoutingPool;
+pub(crate) use registry::{ModelWorkerSnapshot, RoutingPool};
 pub use registry::{WorkerOrigin, WorkerRegistry};
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};
 pub use sampling_defaults::DEFAULT_SAMPLING_PARAMS_LABEL;

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -43,6 +43,7 @@ pub use openai_protocol::{
     worker::{ProviderType, WorkerGroupKey},
 };
 pub use overload::OverloadThresholds;
+pub(crate) use registry::RoutingPool;
 pub use registry::{WorkerOrigin, WorkerRegistry};
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};
 pub use sampling_defaults::DEFAULT_SAMPLING_PARAMS_LABEL;

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -489,11 +489,16 @@ impl WorkerRegistry {
         if model_id == UNKNOWN_MODEL_ID {
             return self.global_routing_snapshot.load_full().pool(pool);
         }
-        if let Some(snapshot) = self
+        // Bind the clone via a `let` so the shard `Ref` drops at the end of
+        // the statement (edition 2021 keeps `if let` scrutinee temporaries
+        // alive through the body): the first post-change `pool()` call does
+        // an O(workers) projection build that must not run under the shard
+        // read guard.
+        let snapshot = self
             .model_index
             .get(model_id)
-            .map(|workers| Arc::clone(workers.value()))
-        {
+            .map(|workers| Arc::clone(workers.value()));
+        if let Some(snapshot) = snapshot {
             return snapshot.pool(pool);
         }
         let canonical_id = self

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -207,6 +207,18 @@ impl Deref for ModelWorkerSnapshot {
     }
 }
 
+/// The global membership snapshot together with the epoch it was built at.
+///
+/// Carrying the epoch inside the published object makes the read fast path
+/// self-validating: load the object, compare its epoch to the live counter.
+/// A bump installs a marker with `epoch: usize::MAX`, which can never match
+/// and therefore can never be served.
+#[derive(Debug)]
+struct GlobalRoutingSnapshot {
+    epoch: usize,
+    snapshot: Arc<ModelWorkerSnapshot>,
+}
+
 /// Model index using immutable snapshots for lock-free reads.
 /// Updates create new snapshots (copy-on-write semantics); route projections
 /// are cached lazily inside each immutable snapshot.
@@ -225,27 +237,31 @@ pub struct WorkerRegistry {
     /// Uses Arc<[T]> instead of Arc<RwLock<Vec<T>>> for lock-free reads.
     model_index: ModelIndex,
 
-    /// Immutable snapshot spanning every registered worker. Model-less routes
-    /// use its lazy route projections instead of scanning the worker map and
-    /// cloning every matching `Arc` on each request.
+    /// Immutable snapshot spanning every registered worker, tagged with the
+    /// `global_epoch` it was built at. Model-less routes use its lazy route
+    /// projections instead of scanning the worker map and cloning every
+    /// matching `Arc` on each request.
     ///
-    /// Rebuilt lazily: membership mutations only bump `global_epoch` (O(1)),
-    /// and the first read after a change rebuilds once from the worker map.
-    /// A registration or removal storm therefore costs one rebuild total,
-    /// not one full-fleet copy per worker.
-    global_routing_snapshot: ArcSwap<ModelWorkerSnapshot>,
+    /// Rebuilt lazily: membership mutations only bump `global_epoch` and
+    /// install the shared empty marker (O(1) amortized), and the first read
+    /// after a change rebuilds once from the worker map. A registration or
+    /// removal storm therefore costs one rebuild total, not one full-fleet
+    /// copy per worker.
+    global_routing_snapshot: ArcSwap<GlobalRoutingSnapshot>,
 
     /// Monotonic membership generation; bumped on every register / replace /
     /// remove.
     global_epoch: AtomicUsize,
 
-    /// The `global_epoch` value `global_routing_snapshot` was built at. When
-    /// it trails `global_epoch` the snapshot is stale and the next read
-    /// rebuilds it.
-    global_published_epoch: AtomicUsize,
+    /// Orders membership writes against rebuild scans. Mutators hold the
+    /// (shared, O(1)) read side across the worker-map write and the epoch
+    /// bump; the rebuild scan holds the write side, so a published snapshot
+    /// is always a map state that truly existed — DashMap iteration alone
+    /// locks shard by shard and can capture a mixture of generations.
+    global_membership_order: parking_lot::RwLock<()>,
 
-    /// Serializes the cold rebuild path. Routing reads take it only when the
-    /// snapshot is stale; mutations never take it.
+    /// Serializes the cold rebuild path so concurrent stale readers rebuild
+    /// once. Mutations never take it.
     global_routing_update: parking_lot::Mutex<()>,
 
     /// Alias index kept separate from `model_index` so aliases do not appear as
@@ -330,11 +346,12 @@ impl WorkerRegistry {
         Self {
             workers: Arc::new(DashMap::new()),
             model_index: Arc::new(DashMap::new()),
-            global_routing_snapshot: ArcSwap::from_pointee(ModelWorkerSnapshot::new(Arc::from(
-                Vec::<Arc<dyn Worker>>::new().into_boxed_slice(),
-            ))),
+            global_routing_snapshot: ArcSwap::from_pointee(GlobalRoutingSnapshot {
+                epoch: 0,
+                snapshot: Self::empty_routing_snapshot(),
+            }),
             global_epoch: AtomicUsize::new(0),
-            global_published_epoch: AtomicUsize::new(0),
+            global_membership_order: parking_lot::RwLock::new(()),
             global_routing_update: parking_lot::Mutex::new(()),
             model_alias_index: Arc::new(DashMap::new()),
             hash_rings: Arc::new(DashMap::new()),
@@ -1311,9 +1328,13 @@ impl WorkerRegistry {
             );
         }
 
-        // Overwrite worker object atomically
-        self.workers.insert(worker_id.clone(), new_worker.clone());
-        self.bump_global_routing_epoch();
+        // Overwrite worker object atomically. The membership-order read
+        // guard keeps the rebuild scan from interleaving with this write.
+        {
+            let _order = self.global_membership_order.read();
+            self.workers.insert(worker_id.clone(), new_worker.clone());
+            self.bump_global_routing_epoch();
+        }
 
         // The replacement carries its own backend-client slot, so the old
         // instance's ZMQ handshake driver can now only hold its socket binds
@@ -1574,22 +1595,31 @@ impl WorkerRegistry {
             }
         }
 
-        // Release the overload count before the worker leaves `self.workers` —
-        // stale-handle writes are dropped, so clearing afterwards would leak it.
+        // Release the overload count and demote the worker before it leaves
+        // `self.workers` — stale-handle writes are dropped after removal, so
+        // clearing afterwards would leak the count, and routing snapshots
+        // that still hold this worker must already see it ineligible by the
+        // time the removal becomes visible.
         if let Some(entry) = self.workers.get(worker_id) {
             let worker = Arc::clone(entry.value());
             drop(entry);
             self.set_worker_overloaded(&worker, false);
-        }
-
-        if let Some((_, worker)) = self.workers.remove(worker_id) {
-            // Readers may still hold an immutable routing snapshot containing
-            // this worker. Make those stale handles ineligible before
-            // publishing snapshots without it.
             if worker.status() == WorkerStatus::Ready {
                 worker.set_status(WorkerStatus::NotReady);
             }
-            self.bump_global_routing_epoch();
+        }
+
+        // The membership-order read guard keeps the rebuild scan from
+        // interleaving with this write.
+        let removed = {
+            let _order = self.global_membership_order.read();
+            let removed = self.workers.remove(worker_id);
+            if removed.is_some() {
+                self.bump_global_routing_epoch();
+            }
+            removed
+        };
+        if let Some((_, worker)) = removed {
             self.url_to_id.remove(worker.url());
             // We hold _guard; drop the DashMap entry but the Mutex stays alive via Arc.
             self.worker_mutation_locks.remove(worker_id);
@@ -1817,8 +1847,13 @@ impl WorkerRegistry {
         // mesh-imported (peer state could mutate a local worker's status).
         self.worker_origins.insert(worker_id.clone(), origin);
 
-        self.workers.insert(worker_id.clone(), worker.clone());
-        self.bump_global_routing_epoch();
+        // The membership-order read guard keeps the rebuild scan from
+        // interleaving with this write.
+        {
+            let _order = self.global_membership_order.read();
+            self.workers.insert(worker_id.clone(), worker.clone());
+            self.bump_global_routing_epoch();
+        }
 
         // Update model index for O(1) lookups using copy-on-write.
         for model_id in Self::worker_model_ids(&worker) {
@@ -1966,56 +2001,75 @@ impl WorkerRegistry {
         drop(previous);
     }
 
-    /// Mark the global routing snapshot stale. O(1): the next routing read
-    /// rebuilds it once from the worker map, so a registration or removal
-    /// storm costs one rebuild total instead of one full-fleet copy per
-    /// worker.
+    /// Mark the global routing snapshot stale and release the superseded
+    /// generation. O(1) amortized: the first bump after a published
+    /// generation drops it (otherwise model-scoped-only traffic would retain
+    /// a full-fleet generation until a model-less read that may never come),
+    /// and every further bump in a storm drops only the shared marker. The
+    /// marker's `usize::MAX` epoch can never match the live counter, so a
+    /// racing fast-path reader can never serve it.
+    ///
+    /// Callers must hold a `global_membership_order` read guard across the
+    /// worker-map mutation and this bump, so the rebuild scan cannot observe
+    /// a half-applied write.
     fn bump_global_routing_epoch(&self) {
         self.global_epoch.fetch_add(1, Ordering::Release);
+        let previous = self
+            .global_routing_snapshot
+            .swap(Arc::new(GlobalRoutingSnapshot {
+                epoch: usize::MAX,
+                snapshot: Self::empty_routing_snapshot(),
+            }));
+        drop(previous);
     }
 
     /// The current global membership snapshot, rebuilt first when membership
     /// changed since it was last published.
     ///
-    /// A reader arriving between a membership write and its epoch bump can
-    /// still see the previous snapshot for an instant. Removal tolerates
-    /// that by demoting the worker to NotReady before bumping, so stale
-    /// handles fail the live availability check; an addition is simply not
-    /// routable for that instant.
+    /// The fast path is self-validating: the published object carries the
+    /// epoch it was built at, so a snapshot superseded between the counter
+    /// load and the pointer load fails the comparison and falls through to
+    /// the rebuild. The rebuild scans the worker map under the
+    /// `global_membership_order` write side, so every published snapshot is
+    /// a membership state that truly existed at one instant — never a
+    /// mixture of generations from interleaved shard reads.
     fn current_global_routing_snapshot(&self) -> Arc<ModelWorkerSnapshot> {
-        let epoch = self.global_epoch.load(Ordering::Acquire);
-        if self.global_published_epoch.load(Ordering::Acquire) == epoch {
-            return self.global_routing_snapshot.load_full();
+        let published = self.global_routing_snapshot.load_full();
+        if published.epoch == self.global_epoch.load(Ordering::Acquire) {
+            return Arc::clone(&published.snapshot);
         }
-        let previous = {
-            let _update = self.global_routing_update.lock();
-            // Re-read under the lock: a concurrent reader may have already
-            // rebuilt for this epoch.
+        drop(published);
+        let _update = self.global_routing_update.lock();
+        // Re-check under the rebuild lock: a concurrent reader may have
+        // already rebuilt for the current epoch.
+        let published = self.global_routing_snapshot.load_full();
+        if published.epoch == self.global_epoch.load(Ordering::Acquire) {
+            return Arc::clone(&published.snapshot);
+        }
+        drop(published);
+        let (epoch, fresh) = {
+            let _order = self.global_membership_order.write();
             let epoch = self.global_epoch.load(Ordering::Acquire);
-            if self.global_published_epoch.load(Ordering::Acquire) == epoch {
-                None
-            } else {
-                let members: Vec<Arc<dyn Worker>> = self
-                    .workers
-                    .iter()
-                    .map(|entry| Arc::clone(entry.value()))
-                    .collect();
-                let previous =
-                    self.global_routing_snapshot
-                        .swap(Arc::new(ModelWorkerSnapshot::new(Arc::from(
-                            members.into_boxed_slice(),
-                        ))));
-                // A mutation landing during the rebuild bumps `global_epoch`
-                // past the value stored here, so the next read rebuilds
-                // again — updates cannot be lost, only repeated.
-                self.global_published_epoch.store(epoch, Ordering::Release);
-                Some(previous)
-            }
+            let members: Vec<Arc<dyn Worker>> = self
+                .workers
+                .iter()
+                .map(|entry| Arc::clone(entry.value()))
+                .collect();
+            let fresh = Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                members.into_boxed_slice(),
+            )));
+            (epoch, fresh)
         };
-        // Cached projections can own large slices; drop them outside the
-        // rebuild lock.
+        let previous = self
+            .global_routing_snapshot
+            .swap(Arc::new(GlobalRoutingSnapshot {
+                epoch,
+                snapshot: Arc::clone(&fresh),
+            }));
+        // Superseded generations can own large projection slices; drop them
+        // outside the membership-order guard.
         drop(previous);
-        self.global_routing_snapshot.load_full()
+        fresh
     }
 
     /// Drop `worker_url` from the copy-on-write model index slice for `model_id`
@@ -3204,6 +3258,76 @@ mod tests {
                 .len(),
             8
         );
+    }
+
+    /// The writer replaces the prefill worker before the decode worker on
+    /// every generation, so in every membership state that ever truly
+    /// existed, generation(prefill) >= generation(decode). A rebuild scan
+    /// that interleaved with the writer could publish the reverse — an old
+    /// prefill paired with a newer decode — which is exactly the torn pair a
+    /// live PD selection must never draw from.
+    #[test]
+    fn global_snapshot_never_publishes_a_torn_generation() {
+        use std::sync::atomic::AtomicBool;
+
+        fn pd_worker(url: &str, worker_type: WorkerType, generation: usize) -> Arc<dyn Worker> {
+            Arc::new(
+                BasicWorkerBuilder::new(url)
+                    .model(ModelCard::new("model"))
+                    .worker_type(worker_type)
+                    .connection_mode(ConnectionMode::Grpc)
+                    .label("generation", generation.to_string())
+                    .health_config(no_health_check())
+                    .build(),
+            )
+        }
+
+        fn generation(pool: &[Arc<dyn Worker>]) -> usize {
+            pool[0]
+                .metadata()
+                .spec
+                .labels
+                .get("generation")
+                .and_then(|generation| generation.parse().ok())
+                .expect("every test worker carries a generation label")
+        }
+
+        let registry = WorkerRegistry::new();
+        registry.register_or_replace(pd_worker("grpc://prefill:1", WorkerType::Prefill, 0));
+        registry.register_or_replace(pd_worker("grpc://decode:1", WorkerType::Decode, 0));
+
+        let done = AtomicBool::new(false);
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                for generation in 1..=300 {
+                    registry.register_or_replace(pd_worker(
+                        "grpc://prefill:1",
+                        WorkerType::Prefill,
+                        generation,
+                    ));
+                    registry.register_or_replace(pd_worker(
+                        "grpc://decode:1",
+                        WorkerType::Decode,
+                        generation,
+                    ));
+                }
+                done.store(true, Ordering::Release);
+            });
+            scope.spawn(|| {
+                while !done.load(Ordering::Acquire) {
+                    let snapshot = registry.get_routing_snapshot(UNKNOWN_MODEL_ID);
+                    let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
+                    let decode = snapshot.pool(RoutingPool::GrpcDecode);
+                    if prefill.is_empty() || decode.is_empty() {
+                        continue;
+                    }
+                    assert!(
+                        generation(&prefill) >= generation(&decode),
+                        "torn snapshot: decode generation passed prefill"
+                    );
+                }
+            });
+        });
     }
 
     #[test]

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -93,18 +93,37 @@ pub struct WorkerDescriptor {
 pub(crate) enum RoutingPool {
     HttpRegular,
     GrpcPipelineRegular,
+    /// Strictly gRPC, unlike [`Self::GrpcPipelineRegular`]: the ZMQ wire
+    /// carries no KV-transfer rendezvous, so a ZMQ worker must never join a
+    /// PD leg even though it rides the gRPC pipeline elsewhere.
+    GrpcPrefill,
+    /// Strictly gRPC (see [`Self::GrpcPrefill`]).
+    GrpcDecode,
+    /// Strictly gRPC: encode dispatch is a gRPC encoder RPC the direct-ZMQ
+    /// worker has no path for.
+    GrpcEncode,
+    /// Transport-blind prefill pool: the HTTP PD router has always selected
+    /// PD legs by worker type alone.
+    AnyPrefill,
+    /// Transport-blind decode pool (same contract as [`Self::AnyPrefill`]).
+    AnyDecode,
 }
 
 type WorkerSnapshot = Arc<[Arc<dyn Worker>]>;
 type LazyRoutingPool = OnceLock<WorkerSnapshot>;
 
 impl RoutingPool {
-    const COUNT: usize = 2;
+    const COUNT: usize = 7;
 
     const fn index(self) -> usize {
         match self {
             Self::HttpRegular => 0,
             Self::GrpcPipelineRegular => 1,
+            Self::GrpcPrefill => 2,
+            Self::GrpcDecode => 3,
+            Self::GrpcEncode => 4,
+            Self::AnyPrefill => 5,
+            Self::AnyDecode => 6,
         }
     }
 
@@ -118,6 +137,20 @@ impl RoutingPool {
                 *worker.worker_type() == WorkerType::Regular
                     && worker.connection_mode().uses_grpc_pipeline()
             }
+            Self::GrpcPrefill => {
+                *worker.worker_type() == WorkerType::Prefill
+                    && *worker.connection_mode() == ConnectionMode::Grpc
+            }
+            Self::GrpcDecode => {
+                *worker.worker_type() == WorkerType::Decode
+                    && *worker.connection_mode() == ConnectionMode::Grpc
+            }
+            Self::GrpcEncode => {
+                *worker.worker_type() == WorkerType::Encode
+                    && *worker.connection_mode() == ConnectionMode::Grpc
+            }
+            Self::AnyPrefill => *worker.worker_type() == WorkerType::Prefill,
+            Self::AnyDecode => *worker.worker_type() == WorkerType::Decode,
         }
     }
 }
@@ -3084,6 +3117,11 @@ mod tests {
             ("zmq://regular", WorkerType::Regular, ConnectionMode::Zmq),
             ("http://prefill", WorkerType::Prefill, ConnectionMode::Http),
             ("grpc://prefill", WorkerType::Prefill, ConnectionMode::Grpc),
+            ("zmq://prefill", WorkerType::Prefill, ConnectionMode::Zmq),
+            ("http://decode", WorkerType::Decode, ConnectionMode::Http),
+            ("grpc://decode", WorkerType::Decode, ConnectionMode::Grpc),
+            ("grpc://encode", WorkerType::Encode, ConnectionMode::Grpc),
+            ("http://encode", WorkerType::Encode, ConnectionMode::Http),
         ];
         for (url, worker_type, connection_mode) in workers {
             registry
@@ -3113,6 +3151,33 @@ mod tests {
         assert_eq!(
             urls(RoutingPool::GrpcPipelineRegular),
             HashSet::from(["grpc://regular".to_string(), "zmq://regular".to_string()])
+        );
+        // PD/EPD legs are strictly gRPC: a ZMQ prefill worker that slipped
+        // past registration must not appear.
+        assert_eq!(
+            urls(RoutingPool::GrpcPrefill),
+            HashSet::from(["grpc://prefill".to_string()])
+        );
+        assert_eq!(
+            urls(RoutingPool::GrpcDecode),
+            HashSet::from(["grpc://decode".to_string()])
+        );
+        assert_eq!(
+            urls(RoutingPool::GrpcEncode),
+            HashSet::from(["grpc://encode".to_string()])
+        );
+        // The HTTP PD router selects legs by worker type alone.
+        assert_eq!(
+            urls(RoutingPool::AnyPrefill),
+            HashSet::from([
+                "http://prefill".to_string(),
+                "grpc://prefill".to_string(),
+                "zmq://prefill".to_string(),
+            ])
+        );
+        assert_eq!(
+            urls(RoutingPool::AnyDecode),
+            HashSet::from(["http://decode".to_string(), "grpc://decode".to_string()])
         );
     }
 

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -102,11 +102,12 @@ pub(crate) enum RoutingPool {
     /// Strictly gRPC: encode dispatch is a gRPC encoder RPC the direct-ZMQ
     /// worker has no path for.
     GrpcEncode,
-    /// Transport-blind prefill pool: the HTTP PD router has always selected
-    /// PD legs by worker type alone.
-    AnyPrefill,
-    /// Transport-blind decode pool (same contract as [`Self::AnyPrefill`]).
-    AnyDecode,
+    /// HTTP-transport prefill pool for the HTTP PD router: it proxies plain
+    /// HTTP to the selected worker's URL, so a gRPC or ZMQ worker must never
+    /// be selectable (the same rule `select_first_worker` follows).
+    HttpPrefill,
+    /// HTTP-transport decode pool (same contract as [`Self::HttpPrefill`]).
+    HttpDecode,
 }
 
 type WorkerSnapshot = Arc<[Arc<dyn Worker>]>;
@@ -122,8 +123,8 @@ impl RoutingPool {
             Self::GrpcPrefill => 2,
             Self::GrpcDecode => 3,
             Self::GrpcEncode => 4,
-            Self::AnyPrefill => 5,
-            Self::AnyDecode => 6,
+            Self::HttpPrefill => 5,
+            Self::HttpDecode => 6,
         }
     }
 
@@ -149,8 +150,14 @@ impl RoutingPool {
                 *worker.worker_type() == WorkerType::Encode
                     && *worker.connection_mode() == ConnectionMode::Grpc
             }
-            Self::AnyPrefill => *worker.worker_type() == WorkerType::Prefill,
-            Self::AnyDecode => *worker.worker_type() == WorkerType::Decode,
+            Self::HttpPrefill => {
+                *worker.worker_type() == WorkerType::Prefill
+                    && *worker.connection_mode() == ConnectionMode::Http
+            }
+            Self::HttpDecode => {
+                *worker.worker_type() == WorkerType::Decode
+                    && *worker.connection_mode() == ConnectionMode::Http
+            }
         }
     }
 }
@@ -522,6 +529,20 @@ impl WorkerRegistry {
         if model_id == UNKNOWN_MODEL_ID {
             return self.global_routing_snapshot.load_full().pool(pool);
         }
+        self.get_model_routing_pool(model_id, pool)
+    }
+
+    /// Like [`Self::get_routing_pool`] but never widens to the global
+    /// snapshot: the wildcard id resolves through the literal `"unknown"`
+    /// model-index entry (untagged workers index there), yielding an empty
+    /// slice when no such entry exists. The HTTP PD router uses this to keep
+    /// its conditional wildcard fallback — untagged workers win when present,
+    /// and only an empty entry widens to the global pool.
+    pub(crate) fn get_model_routing_pool(
+        &self,
+        model_id: &str,
+        pool: RoutingPool,
+    ) -> Arc<[Arc<dyn Worker>]> {
         // Bind the clone via a `let` so the shard `Ref` drops at the end of
         // the statement (edition 2021 keeps `if let` scrutinee temporaries
         // alive through the body): the first post-change `pool()` call does
@@ -3166,18 +3187,15 @@ mod tests {
             urls(RoutingPool::GrpcEncode),
             HashSet::from(["grpc://encode".to_string()])
         );
-        // The HTTP PD router selects legs by worker type alone.
+        // The HTTP PD legs are HTTP-only: the router proxies plain HTTP to
+        // the selected URL, so gRPC and ZMQ workers must never be selectable.
         assert_eq!(
-            urls(RoutingPool::AnyPrefill),
-            HashSet::from([
-                "http://prefill".to_string(),
-                "grpc://prefill".to_string(),
-                "zmq://prefill".to_string(),
-            ])
+            urls(RoutingPool::HttpPrefill),
+            HashSet::from(["http://prefill".to_string()])
         );
         assert_eq!(
-            urls(RoutingPool::AnyDecode),
-            HashSet::from(["http://decode".to_string(), "grpc://decode".to_string()])
+            urls(RoutingPool::HttpDecode),
+            HashSet::from(["http://decode".to_string()])
         );
     }
 

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -14,12 +14,14 @@
 
 use std::{
     collections::{BTreeSet, HashSet},
+    ops::Deref,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, OnceLock,
     },
 };
 
+use arc_swap::ArcSwap;
 use dashmap::{mapref::entry::Entry, DashMap};
 use openai_protocol::worker::WorkerStatus;
 use tokio::sync::{broadcast, mpsc};
@@ -82,10 +84,89 @@ pub struct WorkerDescriptor {
     pub check_interval_secs: u64,
 }
 
+/// Static routing pool inside a model snapshot.
+///
+/// Availability is deliberately not encoded here: health, circuit-breaker and
+/// overload state change independently of membership and remain lock-free on
+/// each worker. Policies validate that live state while selecting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RoutingPool {
+    HttpRegular,
+    GrpcPipelineRegular,
+}
+
+type WorkerSnapshot = Arc<[Arc<dyn Worker>]>;
+type LazyRoutingPool = OnceLock<WorkerSnapshot>;
+
+impl RoutingPool {
+    const COUNT: usize = 2;
+
+    const fn index(self) -> usize {
+        match self {
+            Self::HttpRegular => 0,
+            Self::GrpcPipelineRegular => 1,
+        }
+    }
+
+    fn matches(self, worker: &Arc<dyn Worker>) -> bool {
+        match self {
+            Self::HttpRegular => {
+                *worker.worker_type() == WorkerType::Regular
+                    && *worker.connection_mode() == ConnectionMode::Http
+            }
+            Self::GrpcPipelineRegular => {
+                *worker.worker_type() == WorkerType::Regular
+                    && worker.connection_mode().uses_grpc_pipeline()
+            }
+        }
+    }
+}
+
+/// Immutable membership snapshot. Route-specific projections are populated
+/// lazily once and then shared by every request until membership changes
+/// publish a replacement snapshot.
+#[derive(Debug)]
+struct ModelWorkerSnapshot {
+    all: WorkerSnapshot,
+    pools: [LazyRoutingPool; RoutingPool::COUNT],
+}
+
+impl ModelWorkerSnapshot {
+    fn new(all: WorkerSnapshot) -> Self {
+        Self {
+            all,
+            pools: std::array::from_fn(|_| OnceLock::new()),
+        }
+    }
+
+    fn pool(&self, pool: RoutingPool) -> WorkerSnapshot {
+        self.pools[pool.index()]
+            .get_or_init(|| {
+                if self.all.iter().all(|worker| pool.matches(worker)) {
+                    return Arc::clone(&self.all);
+                }
+                self.all
+                    .iter()
+                    .filter(|worker| pool.matches(worker))
+                    .cloned()
+                    .collect()
+            })
+            .clone()
+    }
+}
+
+impl Deref for ModelWorkerSnapshot {
+    type Target = [Arc<dyn Worker>];
+
+    fn deref(&self) -> &Self::Target {
+        &self.all
+    }
+}
+
 /// Model index using immutable snapshots for lock-free reads.
-/// Each model maps to an Arc'd slice of workers that can be read without locking.
-/// Updates create new snapshots (copy-on-write semantics).
-type ModelIndex = Arc<DashMap<String, Arc<[Arc<dyn Worker>]>>>;
+/// Updates create new snapshots (copy-on-write semantics); route projections
+/// are cached lazily inside each immutable snapshot.
+type ModelIndex = Arc<DashMap<String, Arc<ModelWorkerSnapshot>>>;
 
 /// Model alias to canonical model ID.
 type ModelAliasIndex = Arc<DashMap<String, Arc<str>>>;
@@ -99,6 +180,16 @@ pub struct WorkerRegistry {
     /// Model index for O(1) lookups using immutable snapshots.
     /// Uses Arc<[T]> instead of Arc<RwLock<Vec<T>>> for lock-free reads.
     model_index: ModelIndex,
+
+    /// Immutable snapshot spanning every registered worker. Model-less routes
+    /// use its lazy route projections instead of scanning the worker map and
+    /// cloning every matching `Arc` on each request.
+    global_routing_snapshot: ArcSwap<ModelWorkerSnapshot>,
+
+    /// Serializes the cold membership-copy path. Routing reads never take this
+    /// lock; it only avoids repeated full-snapshot CAS retries when many
+    /// workers register or leave concurrently.
+    global_routing_update: parking_lot::Mutex<()>,
 
     /// Alias index kept separate from `model_index` so aliases do not appear as
     /// models in discovery or statistics.
@@ -182,6 +273,10 @@ impl WorkerRegistry {
         Self {
             workers: Arc::new(DashMap::new()),
             model_index: Arc::new(DashMap::new()),
+            global_routing_snapshot: ArcSwap::from_pointee(ModelWorkerSnapshot::new(Arc::from(
+                Vec::<Arc<dyn Worker>>::new().into_boxed_slice(),
+            ))),
+            global_routing_update: parking_lot::Mutex::new(()),
             model_alias_index: Arc::new(DashMap::new()),
             hash_rings: Arc::new(DashMap::new()),
             type_workers: Arc::new(DashMap::new()),
@@ -367,16 +462,60 @@ impl WorkerRegistry {
     /// slice when the model is unknown.
     pub fn get_by_model(&self, model_id: &str) -> Arc<[Arc<dyn Worker>]> {
         if let Some(workers) = self.model_index.get(model_id) {
-            return Arc::clone(&workers);
+            return Arc::clone(&workers.all);
         }
         self.model_alias_index
             .get(model_id)
             .and_then(|canonical_id| {
                 self.model_index
                     .get(canonical_id.as_ref())
-                    .map(|workers| Arc::clone(&workers))
+                    .map(|workers| Arc::clone(&workers.all))
             })
             .unwrap_or_else(|| Arc::from(Self::EMPTY_WORKERS))
+    }
+
+    /// Return a shared route-specific candidate snapshot for a model.
+    ///
+    /// The first lookup after a membership change builds the projection once;
+    /// subsequent requests only clone the outer `Arc`. Dynamic availability is
+    /// intentionally checked by the policy so health, circuit-breaker and
+    /// overload changes never require rebuilding this snapshot. The wildcard
+    /// model ID uses the global registry snapshot.
+    pub(crate) fn get_routing_pool(
+        &self,
+        model_id: &str,
+        pool: RoutingPool,
+    ) -> Arc<[Arc<dyn Worker>]> {
+        if model_id == UNKNOWN_MODEL_ID {
+            return self.global_routing_snapshot.load_full().pool(pool);
+        }
+        if let Some(snapshot) = self
+            .model_index
+            .get(model_id)
+            .map(|workers| Arc::clone(workers.value()))
+        {
+            return snapshot.pool(pool);
+        }
+        let canonical_id = self
+            .model_alias_index
+            .get(model_id)
+            .map(|canonical_id| Arc::clone(canonical_id.value()));
+        canonical_id
+            .and_then(|canonical_id| {
+                self.model_index
+                    .get(canonical_id.as_ref())
+                    .map(|workers| Arc::clone(workers.value()))
+            })
+            .map_or_else(
+                || Arc::from(Self::EMPTY_WORKERS),
+                |snapshot| snapshot.pool(pool),
+            )
+    }
+
+    /// Return the immutable global membership snapshot used by routing paths
+    /// whose model/provider filters are evaluated dynamically.
+    pub(crate) fn get_routing_workers(&self) -> Arc<[Arc<dyn Worker>]> {
+        Arc::clone(&self.global_routing_snapshot.load_full().all)
     }
 
     /// Apply the absolute overload veto to `worker`, returning `true` when the
@@ -1062,6 +1201,7 @@ impl WorkerRegistry {
 
         // Overwrite worker object atomically
         self.workers.insert(worker_id.clone(), new_worker.clone());
+        self.add_worker_to_global_routing_snapshot(new_worker.clone());
 
         // The replacement carries its own backend-client slot, so the old
         // instance's ZMQ handshake driver can now only hold its socket binds
@@ -1331,6 +1471,13 @@ impl WorkerRegistry {
         }
 
         if let Some((_, worker)) = self.workers.remove(worker_id) {
+            // Readers may still hold an immutable routing snapshot containing
+            // this worker. Make those stale handles ineligible before
+            // publishing snapshots without it.
+            if worker.status() == WorkerStatus::Ready {
+                worker.set_status(WorkerStatus::NotReady);
+            }
+            self.remove_worker_from_global_routing_snapshot(worker.url());
             self.url_to_id.remove(worker.url());
             // We hold _guard; drop the DashMap entry but the Mutex stays alive via Arc.
             self.worker_mutation_locks.remove(worker_id);
@@ -1359,16 +1506,6 @@ impl WorkerRegistry {
                 conn_workers.retain(|id| id != worker_id);
             }
 
-            // Mark the worker as not-ready before tearing down its
-            // metrics so any in-flight `is_healthy()` callers that
-            // still hold an `Arc` see the correct state. Skip the
-            // transition for `Pending` (hasn't proven itself) and
-            // `Failed` (already terminal); only Ready warrants the
-            // explicit demotion. Mirrors the legacy `set_healthy(false)`
-            // semantics without going through the deprecated shim.
-            if worker.status() == WorkerStatus::Ready {
-                worker.set_status(WorkerStatus::NotReady);
-            }
             Metrics::remove_worker_metrics(worker.url());
 
             // Release background work owned by this instance — notably the ZMQ
@@ -1569,6 +1706,7 @@ impl WorkerRegistry {
         self.worker_origins.insert(worker_id.clone(), origin);
 
         self.workers.insert(worker_id.clone(), worker.clone());
+        self.add_worker_to_global_routing_snapshot(worker.clone());
 
         // Update model index for O(1) lookups using copy-on-write.
         for model_id in Self::worker_model_ids(&worker) {
@@ -1697,9 +1835,63 @@ impl WorkerRegistry {
                     .cloned()
                     .collect();
                 new_workers.push(worker.clone());
-                *existing = Arc::from(new_workers.into_boxed_slice());
+                *existing = Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                    new_workers.into_boxed_slice(),
+                )));
             })
-            .or_insert_with(|| Arc::from(vec![worker].into_boxed_slice()));
+            .or_insert_with(|| {
+                Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                    vec![worker].into_boxed_slice(),
+                )))
+            });
+    }
+
+    /// Add or replace one worker in the global copy-on-write snapshot.
+    fn add_worker_to_global_routing_snapshot(&self, worker: Arc<dyn Worker>) {
+        let previous = {
+            let _update = self.global_routing_update.lock();
+            let existing = self.global_routing_snapshot.load_full();
+            let mut new_workers = Vec::with_capacity(existing.len() + 1);
+            let mut replaced = false;
+            for current in existing.iter() {
+                if current.url() == worker.url() {
+                    new_workers.push(worker.clone());
+                    replaced = true;
+                } else {
+                    new_workers.push(current.clone());
+                }
+            }
+            if !replaced {
+                new_workers.push(worker);
+            }
+            self.global_routing_snapshot
+                .swap(Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                    new_workers.into_boxed_slice(),
+                ))))
+        };
+        // Cached projections can own large slices; release them after the
+        // writer lock so their final drop cannot delay the next mutation.
+        drop(previous);
+    }
+
+    /// Remove one worker from the global copy-on-write snapshot.
+    fn remove_worker_from_global_routing_snapshot(&self, worker_url: &str) {
+        let previous = {
+            let _update = self.global_routing_update.lock();
+            let existing = self.global_routing_snapshot.load_full();
+            let new_workers: Vec<_> = existing
+                .iter()
+                .filter(|worker| worker.url() != worker_url)
+                .cloned()
+                .collect();
+            self.global_routing_snapshot
+                .swap(Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                    new_workers.into_boxed_slice(),
+                ))))
+        };
+        // See the add path above: destruction is not part of the critical
+        // section.
+        drop(previous);
     }
 
     /// Drop `worker_url` from the copy-on-write model index slice for `model_id`
@@ -1715,10 +1907,14 @@ impl WorkerRegistry {
                 .collect();
 
             if new_workers.is_empty() {
-                *entry = Arc::from(Vec::<Arc<dyn Worker>>::new().into_boxed_slice());
+                *entry = Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                    Vec::<Arc<dyn Worker>>::new().into_boxed_slice(),
+                )));
                 should_remove_entry = true;
             } else {
-                *entry = Arc::from(new_workers.into_boxed_slice());
+                *entry = Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                    new_workers.into_boxed_slice(),
+                )));
             }
         }
 
@@ -2711,6 +2907,225 @@ mod tests {
         let llama_workers_after = registry.get_by_model("llama-3");
         assert_eq!(llama_workers_after.len(), 1);
         assert_eq!(llama_workers_after[0].url(), "http://worker2:8080");
+    }
+
+    #[test]
+    fn routing_pool_reuses_uniform_model_snapshot() {
+        let registry = WorkerRegistry::new();
+        for url in ["http://worker1:8080", "http://worker2:8080"] {
+            registry
+                .register(Arc::new(
+                    BasicWorkerBuilder::new(url)
+                        .model(ModelCard::new("llama-3"))
+                        .worker_type(WorkerType::Regular)
+                        .connection_mode(ConnectionMode::Http)
+                        .health_config(no_health_check())
+                        .build(),
+                ))
+                .unwrap();
+        }
+
+        let all = registry.get_by_model("llama-3");
+        let first = registry.get_routing_pool("llama-3", RoutingPool::HttpRegular);
+        let second = registry.get_routing_pool("llama-3", RoutingPool::HttpRegular);
+
+        assert!(Arc::ptr_eq(&all, &first));
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn routing_pool_is_cached_and_replaced_with_membership_snapshot() {
+        let registry = WorkerRegistry::new();
+        let http_id = registry
+            .register(Arc::new(
+                BasicWorkerBuilder::new("http://worker1:8080")
+                    .model(ModelCard::new("llama-3"))
+                    .worker_type(WorkerType::Regular)
+                    .connection_mode(ConnectionMode::Http)
+                    .health_config(no_health_check())
+                    .build(),
+            ))
+            .unwrap();
+        registry
+            .register(Arc::new(
+                BasicWorkerBuilder::new("grpc://worker2:8080")
+                    .model(ModelCard::new("llama-3"))
+                    .worker_type(WorkerType::Regular)
+                    .connection_mode(ConnectionMode::Grpc)
+                    .health_config(no_health_check())
+                    .build(),
+            ))
+            .unwrap();
+
+        let first = registry.get_routing_pool("llama-3", RoutingPool::HttpRegular);
+        let second = registry.get_routing_pool("llama-3", RoutingPool::HttpRegular);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].url(), "http://worker1:8080");
+        assert!(Arc::ptr_eq(&first, &second));
+
+        registry
+            .transition_status(&http_id, WorkerStatus::NotReady)
+            .unwrap();
+        let after_health_change = registry.get_routing_pool("llama-3", RoutingPool::HttpRegular);
+        assert!(Arc::ptr_eq(&first, &after_health_change));
+        assert!(!after_health_change[0].is_available());
+
+        registry.remove(&http_id).unwrap();
+        let after_remove = registry.get_routing_pool("llama-3", RoutingPool::HttpRegular);
+        assert!(after_remove.is_empty());
+        assert!(!Arc::ptr_eq(&first, &after_remove));
+        assert_eq!(first.len(), 1, "held snapshots remain immutable");
+    }
+
+    #[test]
+    fn wildcard_routing_pool_reuses_global_snapshot() {
+        let registry = WorkerRegistry::new();
+        let http_worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://worker1:8080")
+                .model(ModelCard::new("model-a"))
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Http)
+                .health_config(no_health_check())
+                .build(),
+        );
+        let http_id = registry.register(http_worker.clone()).unwrap();
+        registry
+            .register(Arc::new(
+                BasicWorkerBuilder::new("grpc://worker2:8080")
+                    .model(ModelCard::new("model-b"))
+                    .worker_type(WorkerType::Regular)
+                    .connection_mode(ConnectionMode::Grpc)
+                    .health_config(no_health_check())
+                    .build(),
+            ))
+            .unwrap();
+
+        let before = Arc::strong_count(&http_worker);
+        let first = registry.get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::HttpRegular);
+        let after_first = Arc::strong_count(&http_worker);
+        let second = registry.get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::HttpRegular);
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].url(), "http://worker1:8080");
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(after_first > before);
+        assert_eq!(Arc::strong_count(&http_worker), after_first);
+
+        registry
+            .transition_status(&http_id, WorkerStatus::NotReady)
+            .unwrap();
+        let after_health_change =
+            registry.get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::HttpRegular);
+        assert!(Arc::ptr_eq(&first, &after_health_change));
+        assert!(!after_health_change[0].is_available());
+
+        let replacement: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://worker1:8080")
+                .model(ModelCard::new("model-a"))
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Grpc)
+                .health_config(no_health_check())
+                .build(),
+        );
+        assert!(registry.replace(&http_id, replacement));
+        let after_replace = registry.get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::HttpRegular);
+        assert!(after_replace.is_empty());
+        assert!(!Arc::ptr_eq(&first, &after_replace));
+        assert_eq!(
+            registry
+                .get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::GrpcPipelineRegular)
+                .len(),
+            2
+        );
+        assert_eq!(first.len(), 1, "held snapshots remain immutable");
+    }
+
+    #[test]
+    fn concurrent_global_snapshot_updates_preserve_all_workers() {
+        let registry = Arc::new(WorkerRegistry::new());
+        std::thread::scope(|scope| {
+            for i in 0..8 {
+                let registry = Arc::clone(&registry);
+                scope.spawn(move || {
+                    registry.add_worker_to_global_routing_snapshot(Arc::new(
+                        BasicWorkerBuilder::new(format!("http://worker{i}:8080"))
+                            .worker_type(WorkerType::Regular)
+                            .connection_mode(ConnectionMode::Http)
+                            .health_config(no_health_check())
+                            .build(),
+                    ));
+                });
+            }
+        });
+
+        let workers = registry.get_routing_pool(UNKNOWN_MODEL_ID, RoutingPool::HttpRegular);
+        assert_eq!(workers.len(), 8);
+        assert_eq!(
+            workers
+                .iter()
+                .map(|worker| worker.url())
+                .collect::<HashSet<_>>()
+                .len(),
+            8
+        );
+    }
+
+    #[test]
+    fn routing_pools_filter_regular_workers_by_transport() {
+        let registry = WorkerRegistry::new();
+        let workers = [
+            ("http://regular", WorkerType::Regular, ConnectionMode::Http),
+            ("grpc://regular", WorkerType::Regular, ConnectionMode::Grpc),
+            ("zmq://regular", WorkerType::Regular, ConnectionMode::Zmq),
+            ("http://prefill", WorkerType::Prefill, ConnectionMode::Http),
+            ("grpc://prefill", WorkerType::Prefill, ConnectionMode::Grpc),
+        ];
+        for (url, worker_type, connection_mode) in workers {
+            registry
+                .register(Arc::new(
+                    BasicWorkerBuilder::new(url)
+                        .model(ModelCard::new("model"))
+                        .worker_type(worker_type)
+                        .connection_mode(connection_mode)
+                        .health_config(no_health_check())
+                        .build(),
+                ))
+                .unwrap();
+        }
+
+        let urls = |pool| {
+            registry
+                .get_routing_pool("model", pool)
+                .iter()
+                .map(|worker| worker.url().to_string())
+                .collect::<HashSet<_>>()
+        };
+
+        assert_eq!(
+            urls(RoutingPool::HttpRegular),
+            HashSet::from(["http://regular".to_string()])
+        );
+        assert_eq!(
+            urls(RoutingPool::GrpcPipelineRegular),
+            HashSet::from(["grpc://regular".to_string(), "zmq://regular".to_string()])
+        );
+    }
+
+    #[test]
+    fn routing_pool_alias_reuses_canonical_snapshot() {
+        let registry = WorkerRegistry::new();
+        registry
+            .register(worker_with_model_aliases(
+                "http://worker:8080",
+                "canonical-model",
+                &["model-alias"],
+                WorkerType::Regular,
+            ))
+            .unwrap();
+
+        let canonical = registry.get_routing_pool("canonical-model", RoutingPool::HttpRegular);
+        let alias = registry.get_routing_pool("model-alias", RoutingPool::HttpRegular);
+        assert!(Arc::ptr_eq(&canonical, &alias));
     }
 
     // Health-checker integration tests moved to worker/manager.rs along with

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -165,8 +165,12 @@ impl RoutingPool {
 /// Immutable membership snapshot. Route-specific projections are populated
 /// lazily once and then shared by every request until membership changes
 /// publish a replacement snapshot.
+///
+/// Multi-leg selection (PD/EPD) must derive every leg from ONE snapshot: two
+/// separate registry lookups can straddle a concurrent membership change and
+/// pair workers that never coexisted.
 #[derive(Debug)]
-struct ModelWorkerSnapshot {
+pub(crate) struct ModelWorkerSnapshot {
     all: WorkerSnapshot,
     pools: [LazyRoutingPool; RoutingPool::COUNT],
 }
@@ -179,7 +183,7 @@ impl ModelWorkerSnapshot {
         }
     }
 
-    fn pool(&self, pool: RoutingPool) -> WorkerSnapshot {
+    pub(crate) fn pool(&self, pool: RoutingPool) -> WorkerSnapshot {
         self.pools[pool.index()]
             .get_or_init(|| {
                 if self.all.iter().all(|worker| pool.matches(worker)) {
@@ -224,11 +228,24 @@ pub struct WorkerRegistry {
     /// Immutable snapshot spanning every registered worker. Model-less routes
     /// use its lazy route projections instead of scanning the worker map and
     /// cloning every matching `Arc` on each request.
+    ///
+    /// Rebuilt lazily: membership mutations only bump `global_epoch` (O(1)),
+    /// and the first read after a change rebuilds once from the worker map.
+    /// A registration or removal storm therefore costs one rebuild total,
+    /// not one full-fleet copy per worker.
     global_routing_snapshot: ArcSwap<ModelWorkerSnapshot>,
 
-    /// Serializes the cold membership-copy path. Routing reads never take this
-    /// lock; it only avoids repeated full-snapshot CAS retries when many
-    /// workers register or leave concurrently.
+    /// Monotonic membership generation; bumped on every register / replace /
+    /// remove.
+    global_epoch: AtomicUsize,
+
+    /// The `global_epoch` value `global_routing_snapshot` was built at. When
+    /// it trails `global_epoch` the snapshot is stale and the next read
+    /// rebuilds it.
+    global_published_epoch: AtomicUsize,
+
+    /// Serializes the cold rebuild path. Routing reads take it only when the
+    /// snapshot is stale; mutations never take it.
     global_routing_update: parking_lot::Mutex<()>,
 
     /// Alias index kept separate from `model_index` so aliases do not appear as
@@ -316,6 +333,8 @@ impl WorkerRegistry {
             global_routing_snapshot: ArcSwap::from_pointee(ModelWorkerSnapshot::new(Arc::from(
                 Vec::<Arc<dyn Worker>>::new().into_boxed_slice(),
             ))),
+            global_epoch: AtomicUsize::new(0),
+            global_published_epoch: AtomicUsize::new(0),
             global_routing_update: parking_lot::Mutex::new(()),
             model_alias_index: Arc::new(DashMap::new()),
             hash_rings: Arc::new(DashMap::new()),
@@ -527,7 +546,7 @@ impl WorkerRegistry {
         pool: RoutingPool,
     ) -> Arc<[Arc<dyn Worker>]> {
         if model_id == UNKNOWN_MODEL_ID {
-            return self.global_routing_snapshot.load_full().pool(pool);
+            return self.current_global_routing_snapshot().pool(pool);
         }
         self.get_model_routing_pool(model_id, pool)
     }
@@ -543,38 +562,72 @@ impl WorkerRegistry {
         model_id: &str,
         pool: RoutingPool,
     ) -> Arc<[Arc<dyn Worker>]> {
+        self.model_routing_snapshot(model_id).map_or_else(
+            || Arc::from(Self::EMPTY_WORKERS),
+            |snapshot| snapshot.pool(pool),
+        )
+    }
+
+    /// One membership snapshot for a model (alias-aware), from which several
+    /// leg pools can be derived atomically: a PD/EPD selection must draw all
+    /// its legs from a single generation, and two separate pool lookups could
+    /// straddle a concurrent membership change.
+    pub(crate) fn model_routing_snapshot(
+        &self,
+        model_id: &str,
+    ) -> Option<Arc<ModelWorkerSnapshot>> {
         // Bind the clone via a `let` so the shard `Ref` drops at the end of
         // the statement (edition 2021 keeps `if let` scrutinee temporaries
-        // alive through the body): the first post-change `pool()` call does
-        // an O(workers) projection build that must not run under the shard
-        // read guard.
+        // alive through the body): the caller's first post-change `pool()`
+        // call does an O(workers) projection build that must not run under
+        // the shard read guard.
         let snapshot = self
             .model_index
             .get(model_id)
             .map(|workers| Arc::clone(workers.value()));
-        if let Some(snapshot) = snapshot {
-            return snapshot.pool(pool);
+        if snapshot.is_some() {
+            return snapshot;
         }
         let canonical_id = self
             .model_alias_index
             .get(model_id)
             .map(|canonical_id| Arc::clone(canonical_id.value()));
-        canonical_id
-            .and_then(|canonical_id| {
-                self.model_index
-                    .get(canonical_id.as_ref())
-                    .map(|workers| Arc::clone(workers.value()))
-            })
-            .map_or_else(
-                || Arc::from(Self::EMPTY_WORKERS),
-                |snapshot| snapshot.pool(pool),
-            )
+        canonical_id.and_then(|canonical_id| {
+            self.model_index
+                .get(canonical_id.as_ref())
+                .map(|workers| Arc::clone(workers.value()))
+        })
+    }
+
+    /// One membership snapshot for multi-leg selection, with the wildcard
+    /// model mapping to the global snapshot and an unknown model to a shared
+    /// empty one.
+    pub(crate) fn get_routing_snapshot(&self, model_id: &str) -> Arc<ModelWorkerSnapshot> {
+        if model_id == UNKNOWN_MODEL_ID {
+            return self.current_global_routing_snapshot();
+        }
+        self.model_routing_snapshot(model_id)
+            .unwrap_or_else(Self::empty_routing_snapshot)
+    }
+
+    /// Shared empty candidate slice.
+    pub(crate) fn empty_pool() -> Arc<[Arc<dyn Worker>]> {
+        Arc::from(Self::EMPTY_WORKERS)
+    }
+
+    /// Shared empty snapshot for unknown models.
+    fn empty_routing_snapshot() -> Arc<ModelWorkerSnapshot> {
+        static EMPTY: OnceLock<Arc<ModelWorkerSnapshot>> = OnceLock::new();
+        Arc::clone(
+            EMPTY
+                .get_or_init(|| Arc::new(ModelWorkerSnapshot::new(Arc::from(Self::EMPTY_WORKERS)))),
+        )
     }
 
     /// Return the immutable global membership snapshot used by routing paths
     /// whose model/provider filters are evaluated dynamically.
     pub(crate) fn get_routing_workers(&self) -> Arc<[Arc<dyn Worker>]> {
-        Arc::clone(&self.global_routing_snapshot.load_full().all)
+        Arc::clone(&self.current_global_routing_snapshot().all)
     }
 
     /// Apply the absolute overload veto to `worker`, returning `true` when the
@@ -1260,7 +1313,7 @@ impl WorkerRegistry {
 
         // Overwrite worker object atomically
         self.workers.insert(worker_id.clone(), new_worker.clone());
-        self.add_worker_to_global_routing_snapshot(new_worker.clone());
+        self.bump_global_routing_epoch();
 
         // The replacement carries its own backend-client slot, so the old
         // instance's ZMQ handshake driver can now only hold its socket binds
@@ -1536,7 +1589,7 @@ impl WorkerRegistry {
             if worker.status() == WorkerStatus::Ready {
                 worker.set_status(WorkerStatus::NotReady);
             }
-            self.remove_worker_from_global_routing_snapshot(worker.url());
+            self.bump_global_routing_epoch();
             self.url_to_id.remove(worker.url());
             // We hold _guard; drop the DashMap entry but the Mutex stays alive via Arc.
             self.worker_mutation_locks.remove(worker_id);
@@ -1765,7 +1818,7 @@ impl WorkerRegistry {
         self.worker_origins.insert(worker_id.clone(), origin);
 
         self.workers.insert(worker_id.clone(), worker.clone());
-        self.add_worker_to_global_routing_snapshot(worker.clone());
+        self.bump_global_routing_epoch();
 
         // Update model index for O(1) lookups using copy-on-write.
         for model_id in Self::worker_model_ids(&worker) {
@@ -1885,6 +1938,10 @@ impl WorkerRegistry {
     /// Replaces any existing entry with the same URL so updates via replace()
     /// do not leave duplicate rows.
     fn add_worker_to_model_index(&self, model_id: &str, worker: Arc<dyn Worker>) {
+        // The replaced snapshot (and its cached projections) must not drop
+        // under the shard write guard: capture it and let it fall after the
+        // entry expression releases the lock.
+        let mut previous = None;
         self.model_index
             .entry(model_id.to_string())
             .and_modify(|existing| {
@@ -1894,69 +1951,80 @@ impl WorkerRegistry {
                     .cloned()
                     .collect();
                 new_workers.push(worker.clone());
-                *existing = Arc::new(ModelWorkerSnapshot::new(Arc::from(
-                    new_workers.into_boxed_slice(),
-                )));
+                previous = Some(std::mem::replace(
+                    existing,
+                    Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                        new_workers.into_boxed_slice(),
+                    ))),
+                ));
             })
             .or_insert_with(|| {
                 Arc::new(ModelWorkerSnapshot::new(Arc::from(
                     vec![worker].into_boxed_slice(),
                 )))
             });
-    }
-
-    /// Add or replace one worker in the global copy-on-write snapshot.
-    fn add_worker_to_global_routing_snapshot(&self, worker: Arc<dyn Worker>) {
-        let previous = {
-            let _update = self.global_routing_update.lock();
-            let existing = self.global_routing_snapshot.load_full();
-            let mut new_workers = Vec::with_capacity(existing.len() + 1);
-            let mut replaced = false;
-            for current in existing.iter() {
-                if current.url() == worker.url() {
-                    new_workers.push(worker.clone());
-                    replaced = true;
-                } else {
-                    new_workers.push(current.clone());
-                }
-            }
-            if !replaced {
-                new_workers.push(worker);
-            }
-            self.global_routing_snapshot
-                .swap(Arc::new(ModelWorkerSnapshot::new(Arc::from(
-                    new_workers.into_boxed_slice(),
-                ))))
-        };
-        // Cached projections can own large slices; release them after the
-        // writer lock so their final drop cannot delay the next mutation.
         drop(previous);
     }
 
-    /// Remove one worker from the global copy-on-write snapshot.
-    fn remove_worker_from_global_routing_snapshot(&self, worker_url: &str) {
+    /// Mark the global routing snapshot stale. O(1): the next routing read
+    /// rebuilds it once from the worker map, so a registration or removal
+    /// storm costs one rebuild total instead of one full-fleet copy per
+    /// worker.
+    fn bump_global_routing_epoch(&self) {
+        self.global_epoch.fetch_add(1, Ordering::Release);
+    }
+
+    /// The current global membership snapshot, rebuilt first when membership
+    /// changed since it was last published.
+    ///
+    /// A reader arriving between a membership write and its epoch bump can
+    /// still see the previous snapshot for an instant. Removal tolerates
+    /// that by demoting the worker to NotReady before bumping, so stale
+    /// handles fail the live availability check; an addition is simply not
+    /// routable for that instant.
+    fn current_global_routing_snapshot(&self) -> Arc<ModelWorkerSnapshot> {
+        let epoch = self.global_epoch.load(Ordering::Acquire);
+        if self.global_published_epoch.load(Ordering::Acquire) == epoch {
+            return self.global_routing_snapshot.load_full();
+        }
         let previous = {
             let _update = self.global_routing_update.lock();
-            let existing = self.global_routing_snapshot.load_full();
-            let new_workers: Vec<_> = existing
-                .iter()
-                .filter(|worker| worker.url() != worker_url)
-                .cloned()
-                .collect();
-            self.global_routing_snapshot
-                .swap(Arc::new(ModelWorkerSnapshot::new(Arc::from(
-                    new_workers.into_boxed_slice(),
-                ))))
+            // Re-read under the lock: a concurrent reader may have already
+            // rebuilt for this epoch.
+            let epoch = self.global_epoch.load(Ordering::Acquire);
+            if self.global_published_epoch.load(Ordering::Acquire) == epoch {
+                None
+            } else {
+                let members: Vec<Arc<dyn Worker>> = self
+                    .workers
+                    .iter()
+                    .map(|entry| Arc::clone(entry.value()))
+                    .collect();
+                let previous =
+                    self.global_routing_snapshot
+                        .swap(Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                            members.into_boxed_slice(),
+                        ))));
+                // A mutation landing during the rebuild bumps `global_epoch`
+                // past the value stored here, so the next read rebuilds
+                // again — updates cannot be lost, only repeated.
+                self.global_published_epoch.store(epoch, Ordering::Release);
+                Some(previous)
+            }
         };
-        // See the add path above: destruction is not part of the critical
-        // section.
+        // Cached projections can own large slices; drop them outside the
+        // rebuild lock.
         drop(previous);
+        self.global_routing_snapshot.load_full()
     }
 
     /// Drop `worker_url` from the copy-on-write model index slice for `model_id`
     /// and rebuild the hash ring. Evicts the whole model entry when empty.
     fn remove_worker_from_model_index(&self, model_id: &str, worker_url: &str) {
         let mut should_remove_entry = false;
+        // As in add_worker_to_model_index: the replaced snapshot drops after
+        // the shard guard, not under it.
+        let mut previous = None;
 
         if let Some(mut entry) = self.model_index.get_mut(model_id) {
             let new_workers: Vec<Arc<dyn Worker>> = entry
@@ -1966,16 +2034,23 @@ impl WorkerRegistry {
                 .collect();
 
             if new_workers.is_empty() {
-                *entry = Arc::new(ModelWorkerSnapshot::new(Arc::from(
-                    Vec::<Arc<dyn Worker>>::new().into_boxed_slice(),
-                )));
+                previous = Some(std::mem::replace(
+                    &mut *entry,
+                    Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                        Vec::<Arc<dyn Worker>>::new().into_boxed_slice(),
+                    ))),
+                ));
                 should_remove_entry = true;
             } else {
-                *entry = Arc::new(ModelWorkerSnapshot::new(Arc::from(
-                    new_workers.into_boxed_slice(),
-                )));
+                previous = Some(std::mem::replace(
+                    &mut *entry,
+                    Arc::new(ModelWorkerSnapshot::new(Arc::from(
+                        new_workers.into_boxed_slice(),
+                    ))),
+                ));
             }
         }
+        drop(previous);
 
         if should_remove_entry {
             self.model_index
@@ -3106,13 +3181,15 @@ mod tests {
             for i in 0..8 {
                 let registry = Arc::clone(&registry);
                 scope.spawn(move || {
-                    registry.add_worker_to_global_routing_snapshot(Arc::new(
-                        BasicWorkerBuilder::new(format!("http://worker{i}:8080"))
-                            .worker_type(WorkerType::Regular)
-                            .connection_mode(ConnectionMode::Http)
-                            .health_config(no_health_check())
-                            .build(),
-                    ));
+                    registry
+                        .register(Arc::new(
+                            BasicWorkerBuilder::new(format!("http://worker{i}:8080"))
+                                .worker_type(WorkerType::Regular)
+                                .connection_mode(ConnectionMode::Http)
+                                .health_config(no_health_check())
+                                .build(),
+                        ))
+                        .unwrap();
                 });
             }
         });


### PR DESCRIPTION
## Description

### Problem

Worker selection rebuilt and cloned candidate lists for each request. That made routing work grow unnecessarily with the number of registered workers.

### Solution

Reuse immutable worker snapshots across requests. Refresh snapshots when membership changes, while checking health, circuit-breaker, and overload state at selection time.

## Changes

- cache regular HTTP and gRPC/ZMQ candidate pools in the worker registry
- extend the pools to the disaggregated legs: strict-gRPC prefill/decode/encode projections for the gRPC PD and EPD paths, and HTTP-only prefill/decode pools for the HTTP PD router (an HTTP proxy must never select a gRPC/ZMQ URL); the failure-classification path shares the same pool definitions as selection
- every PD/EPD selection derives all its legs from one membership snapshot, so a concurrent replacement cannot pair workers that never coexisted; the HTTP PD wildcard fallback stays conditional (untagged workers first, global pool only when none)
- global-snapshot maintenance is epoch-based: membership changes are O(1) bumps and the first read after a change rebuilds once, so registration/removal storms cost one rebuild instead of one full-fleet copy per worker
- scope note: snapshots cache membership only — health, circuit-breaker and overload state are deliberately checked live at selection, so this PR removes registry scanning and per-request Arc-vector construction, not availability checks
- reuse a global snapshot for model-less and dynamic worker selection
- avoid duplicate availability vectors for policies that already enforce availability
- cover snapshot reuse, membership updates, wildcard routing, aliases, and concurrent updates

## Test Plan

- `cargo +nightly fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


