### PR TITLE
fix(protocols): keep engine-specific stream_options fields

### DIFF
--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -4,7 +4,7 @@ use serde::{
     de::{self, value::SeqAccessDeserializer, SeqAccess, Visitor},
     Deserialize, Deserializer, Serialize,
 };
-use serde_json::Value;
+use serde_json::{Map, Value};
 use validator;
 
 // ============================================================================
@@ -300,6 +300,12 @@ pub struct StreamOptions {
     /// to normalize payload sizes. Defaults to `true` upstream when absent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_obfuscation: Option<bool>,
+
+    /// Additional fields not explicitly defined above (e.g. engine-specific
+    /// streaming options). Without this, the gateway silently drops them while
+    /// re-serializing the request for the backend.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -453,7 +459,7 @@ pub struct Tool {
 /// Per the OpenAI spec, omitting `parameters` defines a function with an
 /// empty parameter list, so a missing field deserializes to an empty schema.
 fn empty_parameters_schema() -> Value {
-    Value::Object(serde_json::Map::new())
+    Value::Object(Map::new())
 }
 
 #[serde_with::skip_serializing_none]
@@ -962,6 +968,35 @@ mod tests {
     fn test_deserialize_null_as_false_rejects_non_bool() {
         let result = serde_json::from_value::<NullableBoolTest>(json!({"field": "yes"}));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn stream_options_preserve_unknown_fields() {
+        let raw = json!({
+            "include_usage": true,
+            "continuous_usage_stats": true,
+            "step_usage_chunks": "all",
+            "engine_specific": {"nested": 1},
+        });
+
+        let opts: StreamOptions = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(opts.include_usage, Some(true));
+        assert_eq!(opts.continuous_usage_stats, Some(true));
+        assert_eq!(opts.other.get("step_usage_chunks"), Some(&json!("all")));
+
+        // Re-serializing must round-trip the engine-specific keys, otherwise the
+        // gateway would strip them on the way to the backend.
+        assert_eq!(serde_json::to_value(&opts).unwrap(), raw);
+    }
+
+    #[test]
+    fn stream_options_without_unknown_fields_stay_compact() {
+        let opts: StreamOptions = serde_json::from_value(json!({"include_usage": true})).unwrap();
+        assert!(opts.other.is_empty());
+        assert_eq!(
+            serde_json::to_value(&opts).unwrap(),
+            json!({"include_usage": true})
+        );
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -666,6 +666,36 @@ mod tests {
     }
 
     #[test]
+    fn test_stream_options_unknown_fields_survive_grpc_chat_builder() {
+        // Regression: the gRPC path rebuilds a ChatCompletionRequest field by
+        // field, so engine-specific streaming options carried in the catch-all
+        // map must survive the conversion and reach the SSE assembler, which is
+        // what renders usage chunks in gRPC mode.
+        let mut extra = serde_json::Map::new();
+        extra.insert(
+            "step_usage_chunks".to_string(),
+            serde_json::Value::String("all".to_string()),
+        );
+
+        let req = ResponsesRequest {
+            input: ResponseInput::Text("hi".to_string()),
+            stream: Some(true),
+            stream_options: Some(StreamOptions {
+                include_usage: Some(true),
+                other: extra,
+                ..StreamOptions::default()
+            }),
+            ..Default::default()
+        };
+
+        let opts = responses_to_chat(&req).unwrap().stream_options.unwrap();
+        assert_eq!(
+            opts.other.get("step_usage_chunks").and_then(|v| v.as_str()),
+            Some("all")
+        );
+    }
+
+    #[test]
     fn test_stream_options_non_streaming_dropped() {
         // stream=false must produce None stream_options even if caller set it.
         let req = ResponsesRequest {

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -2216,6 +2216,56 @@ mod tests {
     }
 
     #[test]
+    fn engine_specific_stream_options_survive_bootstrap_injection() {
+        use openai_protocol::{
+            chat::{ChatCompletionRequest, ChatMessage, MessageContent},
+            common::StreamOptions,
+        };
+
+        // An engine-specific streaming option the gateway knows nothing about.
+        // It must reach the backend untouched; dropping it silently disables the
+        // feature the client asked for.
+        let mut extra = serde_json::Map::new();
+        extra.insert("step_usage_chunks".to_string(), json!("all"));
+
+        let request = ChatCompletionRequest {
+            model: "test-model".to_string(),
+            messages: vec![ChatMessage::User {
+                content: MessageContent::Text("hello".to_string()),
+                name: None,
+            }],
+            stream: true,
+            stream_options: Some(StreamOptions {
+                include_usage: Some(true),
+                continuous_usage_stats: Some(true),
+                other: extra,
+                ..StreamOptions::default()
+            }),
+            ..Default::default()
+        };
+
+        let prefill = BasicWorkerBuilder::new("http://prefill:30000".to_string())
+            .worker_type(WorkerType::Prefill)
+            .bootstrap_port(Some(8998))
+            .build();
+
+        let body = PDRouter::inject_bootstrap_into_value(
+            serde_json::to_value(&request).unwrap(),
+            &prefill,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(body["stream_options"]["step_usage_chunks"], json!("all"));
+        assert_eq!(body["stream_options"]["include_usage"], json!(true));
+        assert_eq!(
+            body["stream_options"]["continuous_usage_stats"],
+            json!(true)
+        );
+        assert_eq!(body["bootstrap_port"], json!(8998));
+    }
+
+    #[test]
     fn test_done_event_detection() {
         // Production-incident payload: a delta whose arguments contained the
         // literal sentinel text; the old substring scan treated it as


### PR DESCRIPTION
## Description

### Problem

`StreamOptions` only models `include_usage`, `continuous_usage_stats` and `include_obfuscation`. Because the gateway deserializes a request into the typed `ChatCompletionRequest` and re-serializes it before forwarding (`model_gateway/src/routers/http/pd_router.rs`, `serde_json::to_value(shared_request.as_ref())`), every other key under `stream_options` is silently dropped. The client gets a 200 and no warning — the feature it asked for is simply never enabled on the engine.

`ChatCompletionRequest` already solves this for top-level keys with a flattened catch-all (`crates/protocols/src/chat.rs`, `pub other: Map<String, Value>`), but nothing protects the nested `stream_options` object.

A concrete case: SGLang has a `stream_options.step_usage_chunks` option that makes the engine emit a usage-only chunk for decode steps whose tokens are still held inside a tool-call parser. Without those chunks a benchmark client sees no event for those steps and attributes the time to TTFT, reporting a decode latency several times lower than reality. Routed through SMG the option disappeared, so the engine-side feature looked broken.

### Solution

Give `StreamOptions` the same flattened catch-all that `ChatCompletionRequest` already has, so unmodelled keys round-trip untouched.

## Changes

- `crates/protocols/src/common.rs`: add `#[serde(flatten)] pub other: Map<String, Value>` to `StreamOptions`; two unit tests covering round-trip of unknown keys and that a request without extras still serializes compactly. (Also switched one `serde_json::Map::new()` to `Map::new()` — the new import made it trip `unused_qualifications`.)
- `model_gateway/src/routers/http/pd_router.rs`: regression test driving the real `inject_bootstrap_into_value` path and asserting an engine-specific `stream_options` key still present after bootstrap injection.
- `model_gateway/src/routers/grpc/regular/responses/conversions.rs`: regression test asserting the catch-all survives the gRPC path's field-by-field `ChatCompletionRequest` rebuild, so the SSE assembler (which renders usage chunks in gRPC mode) still sees engine-specific streaming options.

All existing `StreamOptions { .. }` literals already use `..StreamOptions::default()`, so no call sites needed touching.

## Test Plan

Unit tests:

```
$ cargo test -p openai-protocol
test common::tests::stream_options_preserve_unknown_fields ... ok
test common::tests::stream_options_without_unknown_fields_stay_compact ... ok
test result: ok. 109 passed; 0 failed
test result: ok. 128 passed; 0 failed
test result: ok. 2 passed; 0 failed
test result: ok. 1 passed; 0 failed; 4 ignored

$ cargo test -p smg --lib engine_specific_stream_options
test routers::http::pd_router::tests::engine_specific_stream_options_survive_bootstrap_injection ... ok
test result: ok. 1 passed; 0 failed
```

End-to-end against a live prefill/decode deployment (SGLang engines, DeepSeek-V4 with a tool-call parser, `--prefill-policy cache_aware --decode-policy cache_aware`). Same streaming request each time; it produces 49 completion tokens but only 5 visible deltas because the tool-call parser buffers, so the interesting number is how many usage-bearing chunks reach the client:

```
entry point                                sse_chunks  visible_deltas  usage_bearing_chunks  rid kept
smg built from this branch                        21               5                    19  yes
smg 0.3.2 as shipped in sglang-router              8               5                     1  no
python MiniLoadBalancer (--mini-lb)               21               5                    19  yes
direct to the decode engine (no gateway)          23               5                    21  yes
```

Before the change only the final usage chunk survived; after it the gateway matches what the engine emits when addressed directly, and cache-aware routing is unaffected (`Assigning policy cache_aware to new model ...` in the gateway log).

Effect on the client's measurements (32 requests, concurrency 8, SGLang's `sglang.benchmark.serving`):

```
                                     total tokens (real)   Mean TPOT   Median ITL
via smg from this branch                    825 (793)        4.71 ms      3.62 ms
via smg 0.3.2 (stream_options stripped)     819 (787)        5.03 ms      0.43 ms
```

With the option stripped, the client has to spread all buffered tokens over the single final gap, which collapses the ITL distribution (0.43 ms median against a 4.7 ms per-step latency). With the fix, ITL and TPOT agree.

<details> <summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes — ran as `cargo clippy -p openai-protocol -p smg --all-targets -- -D warnings` (clean, zero warnings). `--all-features` could not run in this environment: it pulls `llm-multimodal`, which needs the system `opencv4` package (`Package 'opencv4' ... not found`). Happy to have CI confirm.
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
