### PR TITLE
perf(worker): publish load state as shared immutable snapshots

### DIFF
--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -64,26 +64,23 @@ use std::{
 
 use dashmap::DashMap;
 use kv_index::{compute_request_content_hashes, PositionalIndexer, TenantId, TokenTree, Tree};
-use openai_protocol::worker::WorkerLoadResponse;
 use parking_lot::RwLock;
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
-use tokio::sync::watch;
 use tracing::{debug, warn};
 
 use super::{
     normalize_model_key, utils::PeriodicTask, CacheAwareConfig, LoadBalancingPolicy,
     SelectWorkerInfo,
 };
+/// Latest per-worker backend load snapshot stream, keyed by worker URL.
+pub(crate) use crate::worker::load_state::{LoadReceiver, LoadSnapshot};
 use crate::{
     config::CacheIndexKind,
     mesh::adapters::tree_sync::{RepairEntry, TreeDelta, TreeRepairPage, TreeSyncAdapter},
     observability::metrics::Metrics,
     worker::{KvEventMonitor, Worker},
 };
-
-/// Latest per-worker backend load snapshot stream, keyed by worker URL.
-pub(crate) type LoadReceiver = watch::Receiver<HashMap<String, WorkerLoadResponse>>;
 
 /// Cache-aware routing policy
 ///
@@ -459,7 +456,7 @@ impl CacheAwarePolicy {
     /// Set the backend load-snapshot receiver (thread-safe, after construction).
     /// Wired from the `WorkerMonitor` via the `PolicyRegistry` so the KV-usage
     /// imbalance trigger can read fresh per-worker `token_usage`.
-    pub fn set_load_receiver(&self, rx: Option<LoadReceiver>) {
+    pub(crate) fn set_load_receiver(&self, rx: Option<LoadReceiver>) {
         *self.load_rx.write() = rx;
     }
 
@@ -515,9 +512,15 @@ impl CacheAwarePolicy {
         workers: &[Arc<dyn Worker>],
         healthy_indices: &[usize],
     ) -> Option<(f64, f64)> {
-        let guard = self.load_rx.read();
-        let rx = guard.as_ref()?;
-        let loads = rx.borrow();
+        // One Arc clone of the immutable snapshot; the receiver guard and the
+        // watch borrow are both released before the scan so publishers are
+        // never blocked by it.
+        let loads = {
+            let guard = self.load_rx.read();
+            let rx = guard.as_ref()?;
+            let snapshot = rx.borrow().clone();
+            snapshot
+        };
         let mut bounds: Option<(f64, f64)> = None;
         for &idx in healthy_indices {
             if let Some(load) = loads.get(workers[idx].url()) {
@@ -1025,14 +1028,15 @@ struct OverlapCandidate {
 }
 
 /// Pressure-tuning inputs for [`CacheAwarePolicy::score_overlap`]: the two
-/// config knobs plus a waiting-prefill backlog snapshot (worker URL → queued
-/// uncached tokens, clamped non-negative) captured from the load receiver at
-/// selection time. `waiting_prefill_tokens` is `None` when decay is off or no
-/// load receiver is wired; workers absent from the map are never decayed.
+/// config knobs plus the immutable load snapshot captured from the load
+/// receiver at selection time, from which each worker's waiting-prefill
+/// backlog (queued uncached tokens, clamped non-negative) is derived at
+/// lookup. `waiting_prefill_tokens` is `None` when decay is off or no load
+/// receiver is wired; workers absent from the snapshot are never decayed.
 struct OverlapTuning<'a> {
     overlap_decay: f32,
     selection_temperature: f32,
-    waiting_prefill_tokens: Option<&'a HashMap<String, i64>>,
+    waiting_prefill_tokens: Option<&'a LoadSnapshot>,
 }
 
 impl LoadBalancingPolicy for CacheAwarePolicy {
@@ -1182,20 +1186,16 @@ impl CacheAwarePolicy {
             .is_some_and(|indexer| indexer.current_size() > 0)
     }
 
-    /// Waiting-prefill backlog snapshot (worker URL → queued uncached tokens),
-    /// or `None` when decay is off or no load receiver is wired. The clone is
-    /// per-selection; with decay off the map is never read.
-    fn waiting_prefill_snapshot(&self) -> Option<HashMap<String, i64>> {
+    /// The shared load snapshot for waiting-prefill decay, or `None` when
+    /// decay is off or no load receiver is wired. One `Arc` clone per
+    /// selection — no per-request map is built; backlog values are derived
+    /// at lookup from the same frozen snapshot.
+    fn waiting_prefill_snapshot(&self) -> Option<Arc<LoadSnapshot>> {
         if self.config.overlap_decay <= 0.0 {
             return None;
         }
         let guard = self.load_rx.read();
-        guard.as_ref().map(|rx| {
-            rx.borrow()
-                .iter()
-                .map(|(url, load)| (url.clone(), load.total_waiting_uncached_tokens().max(0)))
-                .collect::<HashMap<String, i64>>()
-        })
+        guard.as_ref().map(|rx| rx.borrow().clone())
     }
 
     /// Per-request count-pressure gate on the selected candidate: over
@@ -1258,7 +1258,7 @@ impl CacheAwarePolicy {
         let tuning = OverlapTuning {
             overlap_decay: self.config.overlap_decay,
             selection_temperature: self.config.selection_temperature,
-            waiting_prefill_tokens: waiting.as_ref(),
+            waiting_prefill_tokens: waiting.as_deref(),
         };
         let request_blocks = (request_units / self.config.block_size).max(1);
         Self::apply_overlap_decay(
@@ -1303,7 +1303,7 @@ impl CacheAwarePolicy {
         let tuning = OverlapTuning {
             overlap_decay: self.config.overlap_decay,
             selection_temperature: self.config.selection_temperature,
-            waiting_prefill_tokens: waiting_prefill_tokens.as_ref(),
+            waiting_prefill_tokens: waiting_prefill_tokens.as_deref(),
         };
 
         if let Some(idx) = Self::score_overlap(
@@ -1422,7 +1422,11 @@ impl CacheAwarePolicy {
         else {
             return;
         };
-        let backlog_of = |c: &OverlapCandidate| waiting.get(workers[c.idx].url()).copied();
+        let backlog_of = |c: &OverlapCandidate| {
+            waiting
+                .get(workers[c.idx].url())
+                .map(|load| load.total_waiting_uncached_tokens().max(0))
+        };
         let Some(min_backlog) = candidates.iter().filter_map(&backlog_of).min() else {
             return;
         };
@@ -2026,7 +2030,10 @@ impl Default for CacheAwarePolicy {
 #[cfg(test)]
 mod tests {
     use kv_index::{compute_content_hash, SequenceHash, StoredBlock, WorkerBlockMap};
-    use openai_protocol::worker::{HealthCheckConfig, SchedulerLoadSnapshot, WorkerStatus};
+    use openai_protocol::worker::{
+        HealthCheckConfig, SchedulerLoadSnapshot, WorkerLoadResponse, WorkerStatus,
+    };
+    use tokio::sync::watch;
     use tracing_test::traced_test;
 
     use super::*;
@@ -2261,6 +2268,17 @@ mod tests {
 
     // ---- is_kv_imbalanced: KV triggers (overload ∨ KV-spread) ----
 
+    /// Single-DP load snapshot with the given waiting-prefill backlog.
+    fn waiting_load(waiting_uncached: i32) -> WorkerLoadResponse {
+        WorkerLoadResponse {
+            loads: vec![SchedulerLoadSnapshot {
+                num_waiting_uncached_tokens: waiting_uncached,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
     /// Single-DP load snapshot reporting the given KV utilization (0.0–1.0).
     fn kv_load(token_usage: f64) -> WorkerLoadResponse {
         WorkerLoadResponse {
@@ -2292,13 +2310,15 @@ mod tests {
         policy: &CacheAwarePolicy,
         workers: &[Arc<dyn Worker>],
         usages: &[f64],
-    ) -> watch::Sender<HashMap<String, WorkerLoadResponse>> {
-        let map: HashMap<String, WorkerLoadResponse> = workers
-            .iter()
-            .zip(usages)
-            .map(|(w, &u)| (w.url().to_string(), kv_load(u)))
-            .collect();
-        let (tx, rx) = watch::channel(map);
+    ) -> watch::Sender<Arc<LoadSnapshot>> {
+        let snapshot = LoadSnapshot::from_loads_for_test(
+            workers
+                .iter()
+                .zip(usages)
+                .map(|(w, &u)| (w.url().to_string(), kv_load(u)))
+                .collect(),
+        );
+        let (tx, rx) = watch::channel(snapshot);
         policy.set_load_receiver(Some(rx));
         tx
     }
@@ -3206,9 +3226,9 @@ mod tests {
         // With decay on, the fleet-floor worker keeps full credit and must
         // win every draw (previously this tie was a coin flip).
         let (workers, indexer) = equal_overlap_fixture();
-        let waiting = HashMap::from([
-            ("http://w1:8000".to_string(), 0),
-            ("http://w2:8000".to_string(), 8),
+        let waiting = LoadSnapshot::from_loads_for_test(vec![
+            ("http://w1:8000".to_string(), waiting_load(0)),
+            ("http://w2:8000".to_string(), waiting_load(8)),
         ]);
         let tuning = OverlapTuning {
             overlap_decay: 4.0,
@@ -3235,7 +3255,10 @@ mod tests {
         // no entry. Neither may be decayed, so the equal-score tie — and its
         // random spreading — must survive.
         let (workers, indexer) = equal_overlap_fixture();
-        let waiting = HashMap::from([("http://w1:8000".to_string(), 0)]);
+        let waiting = LoadSnapshot::from_loads_for_test(vec![(
+            "http://w1:8000".to_string(),
+            waiting_load(0),
+        )]);
         let tuning = OverlapTuning {
             overlap_decay: 4.0,
             selection_temperature: 0.0,

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -377,7 +377,7 @@ impl PolicyRegistry {
 
     /// Set the backend load-snapshot receiver (thread-safe, can be called after
     /// initialization). Propagates to all existing cache-aware policies.
-    pub fn set_load_receiver(&self, rx: Option<LoadReceiver>) {
+    pub(crate) fn set_load_receiver(&self, rx: Option<LoadReceiver>) {
         {
             let mut guard = self.load_rx.write();
             guard.clone_from(&rx);

--- a/model_gateway/src/worker/load_state.rs
+++ b/model_gateway/src/worker/load_state.rs
@@ -1,0 +1,491 @@
+//! Shared, immutable worker-load snapshots.
+//!
+//! `WorkerMonitor`'s group loops publish per-worker load reports and routing
+//! hot paths read them. The publication contract:
+//!
+//! - **Readers** grab the current snapshot as one `Arc` clone and scan
+//!   immutable data: no channel lock is held while scanning, and no map is
+//!   copied per request.
+//! - **Publishers** rebuild by copy-on-write. The copy is shallow — `Arc`
+//!   pointer bumps for keys and values, never a deep `WorkerLoadResponse` or
+//!   `String` clone — so a full-fleet rebuild is O(fleet) pointer work at
+//!   polling cadence (seconds). That is why one global map is used instead of
+//!   per-group shards: the per-publish cost that sharding would save is
+//!   pointer-width, and a flat map keeps every reader trivial.
+//! - **Provenance fences staleness.** Every entry records the exact worker
+//!   incarnation that produced it, and a publish admits a report only while
+//!   the registry still holds that incarnation as Ready. A poll that raced a
+//!   removal, replacement, or readiness flip is dropped here instead of
+//!   resurrecting a dead worker's load; an eviction removes only its own
+//!   incarnation's entry, so a same-URL replacement never loses (or
+//!   inherits) the predecessor's state.
+//! - **Evictions batch.** They queue here and the monitor's debounced
+//!   flusher applies the whole backlog in a single rebuild, so removing N
+//!   workers costs one publish, not N.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Weak,
+    },
+};
+
+use openai_protocol::worker::{WorkerLoadResponse, WorkerStatus};
+use parking_lot::Mutex;
+use tokio::sync::{watch, Notify};
+
+use super::{registry::WorkerRegistry, Worker};
+
+/// Subscription handle to the published load snapshots. `borrow().clone()`
+/// yields an `Arc<LoadSnapshot>`; the watch guard must not be held across a
+/// scan.
+pub(crate) type LoadReceiver = watch::Receiver<Arc<LoadSnapshot>>;
+
+/// One worker's published load and the incarnation that produced it.
+#[derive(Clone)]
+struct LoadEntry {
+    load: Arc<WorkerLoadResponse>,
+    /// The exact worker the report came from, so an eviction removes only
+    /// its own incarnation's entry and never a same-URL replacement's fresh
+    /// one.
+    source: Weak<dyn Worker>,
+}
+
+/// An immutable point-in-time view of every published worker load.
+#[derive(Default)]
+pub(crate) struct LoadSnapshot {
+    entries: HashMap<Arc<str>, LoadEntry>,
+}
+
+impl std::fmt::Debug for LoadSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoadSnapshot")
+            .field("entries", &self.entries.len())
+            .finish()
+    }
+}
+
+impl LoadSnapshot {
+    pub(crate) fn get(&self, url: &str) -> Option<&WorkerLoadResponse> {
+        self.entries.get(url).map(|entry| &*entry.load)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains(&self, url: &str) -> bool {
+        self.entries.contains_key(url)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Test-only: a snapshot with the given loads and no live sources.
+    #[cfg(test)]
+    pub(crate) fn from_loads_for_test(loads: Vec<(String, WorkerLoadResponse)>) -> Arc<Self> {
+        let entries = loads
+            .into_iter()
+            .map(|(url, load)| {
+                let dangling: Weak<super::worker::BasicWorker> = Weak::new();
+                let entry = LoadEntry {
+                    load: Arc::new(load),
+                    source: dangling,
+                };
+                (Arc::<str>::from(url.as_str()), entry)
+            })
+            .collect();
+        Arc::new(Self { entries })
+    }
+}
+
+/// Publication side of the shared load view. Owned by `WorkerMonitor`.
+pub(crate) struct LoadState {
+    registry: Arc<WorkerRegistry>,
+    tx: watch::Sender<Arc<LoadSnapshot>>,
+    pending_evictions: Mutex<Vec<Arc<dyn Worker>>>,
+    /// Wakes the monitor's debounced eviction flusher.
+    eviction_notify: Notify,
+    /// Snapshot publications, so tests can assert eviction batching stays
+    /// bounded.
+    publishes: AtomicU64,
+}
+
+impl LoadState {
+    pub(crate) fn new(registry: Arc<WorkerRegistry>) -> Self {
+        let (tx, _rx) = watch::channel(Arc::new(LoadSnapshot::default()));
+        Self {
+            registry,
+            tx,
+            pending_evictions: Mutex::new(Vec::new()),
+            eviction_notify: Notify::new(),
+            publishes: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn subscribe(&self) -> LoadReceiver {
+        self.tx.subscribe()
+    }
+
+    /// The current snapshot — one `Arc` clone, no lock held afterwards.
+    #[cfg(test)]
+    pub(crate) fn snapshot(&self) -> Arc<LoadSnapshot> {
+        self.tx.borrow().clone()
+    }
+
+    /// Publish one group's polling tick: prune every entry for the group's
+    /// URLs, then insert the fresh reports that pass the incarnation fence.
+    ///
+    /// The fence admits a report only while the registry still holds the
+    /// exact worker (`Arc` identity) that produced it, and holds it Ready. A
+    /// report from a worker that was removed, replaced, or marked unready
+    /// between poll start and publish is dropped; entries that were already
+    /// published stay the eviction path's responsibility, which always runs
+    /// after the registry mutation and therefore after this fence would have
+    /// started failing.
+    pub(crate) fn publish_group(
+        &self,
+        group_urls: &[String],
+        fresh: Vec<(Arc<dyn Worker>, Arc<WorkerLoadResponse>)>,
+    ) {
+        let admitted: Vec<(Arc<str>, LoadEntry)> = fresh
+            .into_iter()
+            .filter(|(worker, _)| self.is_current_incarnation(worker))
+            .map(|(worker, load)| {
+                let entry = LoadEntry {
+                    load,
+                    source: Arc::downgrade(&worker),
+                };
+                (Arc::<str>::from(worker.url()), entry)
+            })
+            .collect();
+
+        self.rebuild(move |entries| {
+            let mut changed = false;
+            for url in group_urls {
+                changed |= entries.remove(url.as_str()).is_some();
+            }
+            for (url, entry) in admitted {
+                entries.insert(url, entry);
+                changed = true;
+            }
+            changed
+        });
+    }
+
+    fn is_current_incarnation(&self, worker: &Arc<dyn Worker>) -> bool {
+        self.registry
+            .get_by_url(worker.url())
+            .is_some_and(|current| {
+                Arc::ptr_eq(&current, worker) && current.status() == WorkerStatus::Ready
+            })
+    }
+
+    /// Queue a worker's eviction and wake the flusher. The snapshot changes
+    /// on the next [`Self::apply_pending_evictions`] batch.
+    pub(crate) fn enqueue_eviction(&self, worker: Arc<dyn Worker>) {
+        self.pending_evictions.lock().push(worker);
+        self.eviction_notify.notify_one();
+    }
+
+    /// Resolves once at least one eviction has been queued since the last
+    /// [`Self::apply_pending_evictions`].
+    pub(crate) async fn eviction_wakeup(&self) {
+        self.eviction_notify.notified().await;
+    }
+
+    /// Apply every queued eviction in one rebuild. Returns the workers whose
+    /// own entry was actually removed (the metrics sentinel set): a same-URL
+    /// replacement that already republished keeps its fresh entry, and its
+    /// series simply continues under the same URL.
+    pub(crate) fn apply_pending_evictions(&self) -> Vec<Arc<dyn Worker>> {
+        let pending: Vec<Arc<dyn Worker>> = std::mem::take(&mut *self.pending_evictions.lock());
+        if pending.is_empty() {
+            return Vec::new();
+        }
+
+        let mut removed: Vec<Arc<dyn Worker>> = Vec::new();
+        self.rebuild(|entries| {
+            let mut changed = false;
+            for worker in &pending {
+                let evict = entries.get(worker.url()).is_some_and(|entry| {
+                    match entry.source.upgrade() {
+                        // The entry belongs to the evicted incarnation.
+                        Some(source) => Arc::ptr_eq(&source, worker),
+                        // The producer is gone entirely; nothing live owns
+                        // this entry.
+                        None => true,
+                    }
+                });
+                if evict {
+                    entries.remove(worker.url());
+                    removed.push(Arc::clone(worker));
+                    changed = true;
+                }
+            }
+            changed
+        });
+        removed
+    }
+
+    /// Drop every published entry and any queued evictions (monitor
+    /// shutdown and lag-recovery rebuilds).
+    pub(crate) fn clear(&self) {
+        self.pending_evictions.lock().clear();
+        self.rebuild(|entries| {
+            let changed = !entries.is_empty();
+            entries.clear();
+            changed
+        });
+    }
+
+    /// Snapshot publications so far. Test observability for the batching
+    /// guarantees.
+    #[cfg(test)]
+    pub(crate) fn publish_count(&self) -> u64 {
+        self.publishes.load(Ordering::Relaxed)
+    }
+
+    /// Copy-on-write rebuild: clone the entry map shallowly (pointer bumps),
+    /// let `mutate` edit it, and publish a fresh `Arc` only when something
+    /// changed. Publishers serialize on the watch channel's internal lock;
+    /// readers holding older `Arc`s are unaffected.
+    fn rebuild(&self, mutate: impl FnOnce(&mut HashMap<Arc<str>, LoadEntry>) -> bool) {
+        self.tx.send_if_modified(|snapshot| {
+            let mut entries = snapshot.entries.clone();
+            let changed = mutate(&mut entries);
+            if changed {
+                *snapshot = Arc::new(LoadSnapshot { entries });
+                self.publishes.fetch_add(1, Ordering::Relaxed);
+            }
+            changed
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Barrier;
+
+    use openai_protocol::{
+        model_card::ModelCard,
+        worker::{HealthCheckConfig, SchedulerLoadSnapshot, WorkerType},
+    };
+
+    use super::*;
+    use crate::worker::{BasicWorkerBuilder, ConnectionMode};
+
+    fn ready_worker(url: &str, model: &str) -> Arc<dyn Worker> {
+        let worker = BasicWorkerBuilder::new(url)
+            .worker_type(WorkerType::Regular)
+            .connection_mode(ConnectionMode::Http)
+            .model(ModelCard::new(model))
+            .health_config(HealthCheckConfig {
+                disable_health_check: true,
+                ..Default::default()
+            })
+            .build();
+        worker.set_status(WorkerStatus::Ready);
+        Arc::new(worker)
+    }
+
+    /// A load report distinguishable by its waiting-token count.
+    fn load(waiting: i32) -> Arc<WorkerLoadResponse> {
+        Arc::new(WorkerLoadResponse {
+            loads: vec![SchedulerLoadSnapshot {
+                num_waiting_uncached_tokens: waiting,
+                ..Default::default()
+            }],
+            ..Default::default()
+        })
+    }
+
+    fn waiting_of(snapshot: &LoadSnapshot, url: &str) -> Option<i64> {
+        snapshot.get(url).map(|l| l.total_waiting_uncached_tokens())
+    }
+
+    fn setup() -> (Arc<WorkerRegistry>, LoadState) {
+        let registry = Arc::new(WorkerRegistry::new());
+        let state = LoadState::new(Arc::clone(&registry));
+        (registry, state)
+    }
+
+    #[test]
+    fn readers_scan_an_old_snapshot_while_a_new_one_publishes() {
+        let (registry, state) = setup();
+        let worker = ready_worker("http://w1:8080", "m");
+        registry.register(Arc::clone(&worker)).unwrap();
+
+        state.publish_group(&[], vec![(Arc::clone(&worker), load(1))]);
+        let held = state.snapshot();
+
+        state.publish_group(&[], vec![(Arc::clone(&worker), load(2))]);
+
+        // The held snapshot is immutable and stays scannable as-is...
+        assert_eq!(waiting_of(&held, "http://w1:8080"), Some(1));
+        // ...while a fresh grab observes the newer publication.
+        assert_eq!(waiting_of(&state.snapshot(), "http://w1:8080"), Some(2));
+    }
+
+    #[test]
+    fn concurrent_group_updates_are_both_retained() {
+        let (registry, state) = setup();
+        let w1 = ready_worker("http://w1:8080", "m1");
+        let w2 = ready_worker("http://w2:8080", "m2");
+        registry.register(Arc::clone(&w1)).unwrap();
+        registry.register(Arc::clone(&w2)).unwrap();
+
+        let state = Arc::new(state);
+        let barrier = Arc::new(Barrier::new(2));
+        let threads: Vec<_> = [w1, w2]
+            .into_iter()
+            .map(|worker| {
+                let state = Arc::clone(&state);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let group_urls = vec![worker.url().to_string()];
+                    barrier.wait();
+                    for round in 0..100 {
+                        state.publish_group(&group_urls, vec![(Arc::clone(&worker), load(round))]);
+                    }
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        // Neither group's stream of publications lost the other's entry.
+        let snapshot = state.snapshot();
+        assert_eq!(waiting_of(&snapshot, "http://w1:8080"), Some(99));
+        assert_eq!(waiting_of(&snapshot, "http://w2:8080"), Some(99));
+    }
+
+    #[test]
+    fn eviction_removes_the_workers_own_entry() {
+        let (registry, state) = setup();
+        let worker = ready_worker("http://w1:8080", "m");
+        registry.register(Arc::clone(&worker)).unwrap();
+        state.publish_group(&[], vec![(Arc::clone(&worker), load(1))]);
+
+        state.enqueue_eviction(Arc::clone(&worker));
+        let removed = state.apply_pending_evictions();
+
+        assert_eq!(removed.len(), 1);
+        assert!(Arc::ptr_eq(&removed[0], &worker));
+        assert!(state.snapshot().is_empty());
+    }
+
+    #[test]
+    fn stale_poll_cannot_resurrect_a_removed_worker() {
+        let (registry, state) = setup();
+        let worker = ready_worker("http://w1:8080", "m");
+        let id = registry.register(Arc::clone(&worker)).unwrap();
+        state.publish_group(&[], vec![(Arc::clone(&worker), load(1))]);
+
+        registry.remove(&id);
+        state.enqueue_eviction(Arc::clone(&worker));
+        state.apply_pending_evictions();
+        assert!(state.snapshot().is_empty());
+
+        // An in-flight poll that started before the removal lands late: the
+        // incarnation fence drops it instead of re-inserting the dead worker
+        // (which the pre-snapshot code did, permanently — the group's next
+        // tick no longer listed the URL to prune).
+        state.publish_group(&[], vec![(Arc::clone(&worker), load(2))]);
+        assert!(state.snapshot().is_empty());
+    }
+
+    #[test]
+    fn unready_worker_reports_are_fenced() {
+        let (registry, state) = setup();
+        let worker = ready_worker("http://w1:8080", "m");
+        registry.register(Arc::clone(&worker)).unwrap();
+
+        worker.set_status(WorkerStatus::NotReady);
+        state.publish_group(&[], vec![(Arc::clone(&worker), load(1))]);
+
+        assert!(state.snapshot().is_empty());
+    }
+
+    #[test]
+    fn same_url_replacement_does_not_inherit_the_old_incarnations_load() {
+        let (registry, state) = setup();
+        let old = ready_worker("http://w1:8080", "m");
+        let old_id = registry.register(Arc::clone(&old)).unwrap();
+        state.publish_group(&[], vec![(Arc::clone(&old), load(1))]);
+
+        // Replace: same URL, new incarnation.
+        registry.remove(&old_id);
+        let new = ready_worker("http://w1:8080", "m");
+        registry.register(Arc::clone(&new)).unwrap();
+
+        // The old incarnation's eviction flushes and its entry vanishes —
+        // the replacement starts with no inherited load...
+        state.enqueue_eviction(Arc::clone(&old));
+        state.apply_pending_evictions();
+        assert!(state.snapshot().is_empty());
+
+        // ...and once the replacement has republished, a LATE flush of the
+        // old incarnation's eviction must not tear down the fresh entry.
+        state.publish_group(&[], vec![(Arc::clone(&new), load(2))]);
+        state.enqueue_eviction(Arc::clone(&old));
+        let removed = state.apply_pending_evictions();
+        assert!(
+            removed.is_empty(),
+            "the replacement's entry is not the old worker's"
+        );
+        assert_eq!(waiting_of(&state.snapshot(), "http://w1:8080"), Some(2));
+    }
+
+    #[test]
+    fn a_large_removal_batch_causes_one_rebuild() {
+        let (registry, state) = setup();
+        let workers: Vec<Arc<dyn Worker>> = (0..50)
+            .map(|i| {
+                let worker = ready_worker(&format!("http://w{i}:8080"), "m");
+                registry.register(Arc::clone(&worker)).unwrap();
+                worker
+            })
+            .collect();
+        let fresh = workers
+            .iter()
+            .map(|w| (Arc::clone(w), load(1)))
+            .collect::<Vec<_>>();
+        state.publish_group(&[], fresh);
+        assert_eq!(state.snapshot().len(), 50);
+
+        for worker in &workers {
+            state.enqueue_eviction(Arc::clone(worker));
+        }
+        let before = state.publish_count();
+        let removed = state.apply_pending_evictions();
+
+        assert_eq!(removed.len(), 50);
+        assert!(state.snapshot().is_empty());
+        assert_eq!(
+            state.publish_count(),
+            before + 1,
+            "a 50-worker eviction batch must be one snapshot rebuild"
+        );
+    }
+
+    #[test]
+    fn clear_drops_entries_and_queued_evictions() {
+        let (registry, state) = setup();
+        let worker = ready_worker("http://w1:8080", "m");
+        registry.register(Arc::clone(&worker)).unwrap();
+        state.publish_group(&[], vec![(Arc::clone(&worker), load(1))]);
+        state.enqueue_eviction(Arc::clone(&worker));
+
+        state.clear();
+
+        assert!(state.snapshot().is_empty());
+        assert!(state.apply_pending_evictions().is_empty());
+    }
+}

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -8,6 +8,7 @@ pub mod event;
 pub mod hash_ring;
 pub mod http_client;
 pub mod kv_event_monitor;
+pub(crate) mod load_state;
 pub mod manager;
 pub mod metrics_aggregator;
 pub mod monitor;

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -61,16 +61,17 @@ use openai_protocol::worker::{
 };
 use parking_lot::{Mutex, RwLock};
 use reqwest::StatusCode;
-use tokio::{
-    sync::{broadcast, watch},
-    task::JoinHandle,
-};
+use tokio::{sync::broadcast, task::JoinHandle};
 use tracing::{debug, info, warn};
 
 use crate::{
     observability::metrics::Metrics,
     policies::PolicyRegistry,
-    worker::{event::WorkerEvent, ConnectionMode, Worker, WorkerRegistry},
+    worker::{
+        event::WorkerEvent,
+        load_state::{LoadReceiver, LoadState},
+        ConnectionMode, Worker, WorkerRegistry,
+    },
 };
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -232,8 +233,9 @@ pub struct WorkerMonitor {
     /// group member still forces the poll) instead of polling every group
     /// unconditionally from registration onward.
     conditional_polling: bool,
-    load_tx: watch::Sender<HashMap<String, WorkerLoadResponse>>,
-    load_rx: watch::Receiver<HashMap<String, WorkerLoadResponse>>,
+    /// Shared immutable load snapshots: group ticks and the eviction flusher
+    /// publish here; routing readers grab `Arc` snapshots.
+    load_state: Arc<LoadState>,
     /// Worker URLs that answered definitively that they do not serve
     /// `/v1/loads`, so the probe is not repeated every tick. Cleared by
     /// [`Self::evict_worker_loads`], which also runs on `Replaced` — an
@@ -241,7 +243,14 @@ pub struct WorkerMonitor {
     native_loads_absent: Arc<DashSet<String>>,
     group_handles: Mutex<HashMap<WorkerGroupKey, GroupState>>,
     event_task: Mutex<Option<JoinHandle<()>>>,
+    eviction_flush_task: Mutex<Option<JoinHandle<()>>>,
 }
+
+/// Debounce window for batching worker evictions into one snapshot rebuild.
+/// Registry churn (a rollout, a scale-down) emits removals as a gradual
+/// stream; waiting a beat lets the whole wave land in a single publish while
+/// staying far below the polling cadence that refreshes live entries.
+const EVICTION_DEBOUNCE: Duration = Duration::from_millis(20);
 
 impl Debug for WorkerMonitor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -265,7 +274,7 @@ impl WorkerMonitor {
         engine_metrics: bool,
         conditional_polling: bool,
     ) -> Self {
-        let (load_tx, load_rx) = watch::channel(HashMap::new());
+        let load_state = Arc::new(LoadState::new(Arc::clone(&worker_registry)));
         Self {
             worker_registry,
             policy_registry,
@@ -274,11 +283,11 @@ impl WorkerMonitor {
             default_interval: Duration::from_secs(default_interval_secs.max(1)),
             engine_metrics,
             conditional_polling,
-            load_tx,
-            load_rx,
+            load_state,
             native_loads_absent: Arc::new(DashSet::new()),
             group_handles: Mutex::new(HashMap::new()),
             event_task: Mutex::new(None),
+            eviction_flush_task: Mutex::new(None),
         }
     }
 
@@ -288,12 +297,14 @@ impl WorkerMonitor {
         &self.native_loads_absent
     }
 
-    /// Subscribe to the snapshot of per-worker loads.
+    /// Subscribe to the shared per-worker load snapshots.
     ///
-    /// The watch receiver returns the most recent fully merged map;
-    /// stale entries are pruned on each tick of the relevant group.
-    pub fn subscribe(&self) -> watch::Receiver<HashMap<String, WorkerLoadResponse>> {
-        self.load_rx.clone()
+    /// Each received value is an immutable `Arc<LoadSnapshot>`: clone the
+    /// `Arc` out of `borrow()` and scan without holding the watch guard.
+    /// Stale entries are pruned on each tick of the relevant group and by
+    /// the batched eviction flusher.
+    pub(crate) fn subscribe(&self) -> LoadReceiver {
+        self.load_state.subscribe()
     }
 
     /// Subscribe to registry events, run a synchronous bootstrap
@@ -331,6 +342,21 @@ impl WorkerMonitor {
         });
 
         *self.event_task.lock() = Some(handle);
+
+        // The debounced eviction flusher: holds the load state strongly (it
+        // is cheap and monitor-independent) and the monitor weakly, for the
+        // same cycle-breaking reason as the event loop.
+        let load_state = Arc::clone(&self.load_state);
+        let monitor = Arc::downgrade(self);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "eviction flusher runs for the monitor's lifetime; the JoinHandle is stored on the monitor and aborted in Drop"
+        )]
+        let flush_handle = tokio::spawn(async move {
+            eviction_flush_loop(load_state, monitor).await;
+        });
+
+        *self.eviction_flush_task.lock() = Some(flush_handle);
     }
 
     /// Stop every per-group polling loop and clear the shared load
@@ -364,7 +390,7 @@ impl WorkerMonitor {
         // per live URL: workers removed during the lag window would
         // otherwise leak entries, and the cost is one re-probe per
         // worker on a path that only runs on lag recovery.
-        self.load_tx.send_modify(|map| map.clear());
+        self.load_state.clear();
         self.worker_load_manager.clear();
         self.native_loads_absent.clear();
         // The feed that would clear the vetoes is being torn down: fail open,
@@ -472,29 +498,34 @@ impl WorkerMonitor {
         }
     }
 
-    /// Evict a single worker's cached loads from both the watch
-    /// channel snapshot and the DP cache. Used by the event loop on
+    /// Evict a single worker's cached loads. Used by the event loop on
     /// `Removed`, `Replaced`, and `StatusChanged` away from `Ready`.
     ///
-    /// Also sentinels the worker's `smg_engine_*` series after this monitor has
-    /// published a load for it, since metrics-rs cannot delete series.
+    /// The overload flag, DP cache, and probe memo are cleared synchronously;
+    /// the shared snapshot removal is queued so a removal wave costs one
+    /// batched rebuild instead of one per worker (see
+    /// [`Self::flush_pending_evictions`]).
     fn evict_worker_loads(&self, worker: &Arc<dyn Worker>) {
         let url = worker.url();
         // No load feed, no verdict: a flag left set would strand the worker
         // out of routing with nothing to ever clear it.
         self.worker_registry.set_worker_overloaded(worker, false);
-        let had_published_load = self.load_tx.borrow().contains_key(url);
-        self.load_tx.send_modify(|map| {
-            map.remove(url);
-        });
         self.worker_load_manager.remove_worker(url);
         self.native_loads_absent.remove(url);
-        if had_published_load {
+        self.load_state.enqueue_eviction(Arc::clone(worker));
+    }
+
+    /// Apply every queued eviction in one snapshot rebuild, and sentinel the
+    /// `smg_engine_*` series of workers whose own entry was removed —
+    /// metrics-rs cannot delete series. A same-URL replacement that already
+    /// republished keeps its entry, and its series continues uninterrupted.
+    pub(crate) fn flush_pending_evictions(&self) {
+        for worker in self.load_state.apply_pending_evictions() {
             // A worker can serve multiple models (one load group per model),
             // so sentinel every model's series — not just the primary.
             let dp_size = worker.dp_size().unwrap_or(1);
-            for model_id in WorkerRegistry::worker_model_ids(worker) {
-                Metrics::remove_engine_load_metrics(url, &model_id, dp_size);
+            for model_id in WorkerRegistry::worker_model_ids(&worker) {
+                Metrics::remove_engine_load_metrics(worker.url(), &model_id, dp_size);
             }
         }
     }
@@ -749,9 +780,32 @@ impl Drop for WorkerMonitor {
         if let Some(handle) = self.event_task.get_mut().take() {
             handle.abort();
         }
+        if let Some(handle) = self.eviction_flush_task.get_mut().take() {
+            handle.abort();
+        }
         for (_, state) in self.group_handles.get_mut().drain() {
             state.handle.abort();
         }
+    }
+}
+
+/// Debounced eviction flusher: waits for the first queued eviction, lets a
+/// gradual removal stream accumulate for [`EVICTION_DEBOUNCE`], then applies
+/// the whole backlog in one snapshot rebuild.
+///
+/// Holds the monitor weakly (same cycle-breaking rationale as the other
+/// loops); holding the `LoadState` strongly is fine — it owns no task
+/// handles back into the monitor.
+async fn eviction_flush_loop(load_state: Arc<LoadState>, monitor: Weak<WorkerMonitor>) {
+    loop {
+        load_state.eviction_wakeup().await;
+        tokio::time::sleep(EVICTION_DEBOUNCE).await;
+        let Some(monitor) = monitor.upgrade() else {
+            debug!("WorkerMonitor was dropped; exiting eviction flush loop");
+            return;
+        };
+        monitor.flush_pending_evictions();
+        drop(monitor);
     }
 }
 
@@ -1001,11 +1055,9 @@ async fn group_monitor_loop(
 
         if group_loads.is_empty() {
             debug!("No loads fetched for group {group_key}, pruning stale entries");
-            monitor.load_tx.send_modify(|map| {
-                for url in &all_group_urls {
-                    map.remove(url);
-                }
-            });
+            monitor
+                .load_state
+                .publish_group(&all_group_urls, Vec::new());
             // The DP cache deliberately keeps last-known-good entries
             // so routing decisions still have a hint to fall back to
             // when the upstream is briefly unreachable.
@@ -1036,16 +1088,24 @@ async fn group_monitor_loop(
             Metrics::record_engine_load(url, &group_key.model_id, load);
         }
 
-        // Atomically merge into the shared watch channel: clear stale
-        // entries for *this group's* URLs first, then insert the fresh
-        // loads. Workers that failed this tick get their stale entries
-        // pruned along with the rest.
-        monitor.load_tx.send_modify(|map| {
-            for url in &all_group_urls {
-                map.remove(url);
-            }
-            map.extend(group_loads);
-        });
+        // Merge into the shared snapshot in one rebuild: clear stale entries
+        // for *this group's* URLs first, then insert the fresh loads — each
+        // paired with the worker that produced it so the incarnation fence
+        // can drop reports that raced a removal or replacement. Workers that
+        // failed this tick get their stale entries pruned along with the
+        // rest. The responses move (no deep clones): the policy push and the
+        // metrics pass above already took their references.
+        let worker_by_url: HashMap<&str, &Arc<dyn Worker>> =
+            workers.iter().map(|w| (w.url(), w)).collect();
+        let fresh: Vec<(Arc<dyn Worker>, Arc<WorkerLoadResponse>)> = group_loads
+            .into_iter()
+            .filter_map(|(url, load)| {
+                worker_by_url
+                    .get(url.as_str())
+                    .map(|worker| (Arc::clone(worker), Arc::new(load)))
+            })
+            .collect();
+        monitor.load_state.publish_group(&all_group_urls, fresh);
 
         // Drop the temporary strong reference so we do not keep the
         // monitor alive across the next `interval_timer.tick().await`.
@@ -1239,12 +1299,14 @@ mod worker_monitor_tests {
         let (registry, monitor) = build_monitor();
         let worker = ready_worker("http://w:8080", "llama-3");
         let url = worker.url().to_string();
-        let id = registry.register(worker).unwrap();
+        let id = registry.register(Arc::clone(&worker)).unwrap();
         monitor.start_event_loop();
 
-        monitor.load_tx.send_modify(|map| {
-            map.insert(url.clone(), WorkerLoadResponse::default());
-        });
+        monitor.load_state.publish_group(
+            &[],
+            vec![(Arc::clone(&worker), Arc::new(WorkerLoadResponse::default()))],
+        );
+        assert!(monitor.load_state.snapshot().contains(&url));
         monitor.native_loads_absent.insert(url.clone());
         let mut dp_loads: HashMap<String, HashMap<isize, isize>> = HashMap::new();
         let mut inner = HashMap::new();
@@ -1255,11 +1317,14 @@ mod worker_monitor_tests {
         registry.remove(&id);
         tokio::task::yield_now().await;
         tokio::time::sleep(Duration::from_millis(50)).await;
+        // The event loop has queued the eviction; apply it deterministically
+        // instead of racing the debounced flusher.
+        monitor.flush_pending_evictions();
 
-        let snapshot = monitor.load_rx.borrow().clone();
+        let snapshot = monitor.load_state.snapshot();
         assert!(
-            !snapshot.contains_key(&url),
-            "load_tx must not retain entries for removed workers"
+            !snapshot.contains(&url),
+            "the load snapshot must not retain entries for removed workers"
         );
         let cached = monitor.worker_load_manager.dp_cached_loads.read();
         assert!(
@@ -1304,7 +1369,7 @@ mod worker_monitor_tests {
 
         monitor.stop_all_groups();
 
-        assert!(monitor.load_rx.borrow().is_empty());
+        assert!(monitor.load_state.snapshot().is_empty());
         assert!(monitor
             .worker_load_manager
             .dp_cached_loads
@@ -1317,13 +1382,15 @@ mod worker_monitor_tests {
         let (registry, monitor) = build_monitor();
         let worker = ready_worker("http://w:8080", "llama-3");
         let url = worker.url().to_string();
-        let id = registry.register(worker).unwrap();
+        let id = registry.register(Arc::clone(&worker)).unwrap();
         monitor.start_event_loop();
 
-        // Seed the watch channel + DP cache as if a poll had succeeded.
-        monitor.load_tx.send_modify(|map| {
-            map.insert(url.clone(), WorkerLoadResponse::default());
-        });
+        // Seed the load snapshot + DP cache as if a poll had succeeded.
+        monitor.load_state.publish_group(
+            &[],
+            vec![(Arc::clone(&worker), Arc::new(WorkerLoadResponse::default()))],
+        );
+        assert!(monitor.load_state.snapshot().contains(&url));
         let mut dp_loads: HashMap<String, HashMap<isize, isize>> = HashMap::new();
         let mut inner = HashMap::new();
         inner.insert(0, 5);
@@ -1333,10 +1400,13 @@ mod worker_monitor_tests {
         registry.transition_status(&id, WorkerStatus::NotReady);
         tokio::task::yield_now().await;
         tokio::time::sleep(Duration::from_millis(50)).await;
+        // The event loop has queued the eviction; apply it deterministically
+        // instead of racing the debounced flusher.
+        monitor.flush_pending_evictions();
 
-        // Watch channel entry pruned.
-        let snapshot = monitor.load_rx.borrow().clone();
-        assert!(!snapshot.contains_key(&url));
+        // Load snapshot entry pruned.
+        let snapshot = monitor.load_state.snapshot();
+        assert!(!snapshot.contains(&url));
 
         // DP cache entry pruned.
         let cached = monitor.worker_load_manager.dp_cached_loads.read();
@@ -1702,7 +1772,7 @@ mod native_loads_tests {
         // Wait for the feed to actually land, then assert the verdict.
         let mut rx = monitor.subscribe();
         tokio::time::timeout(Duration::from_secs(10), async {
-            while !rx.borrow().contains_key(&stub.url) {
+            while !rx.borrow().contains(&stub.url) {
                 rx.changed().await.expect("watch sender alive");
             }
         })
@@ -1758,7 +1828,7 @@ mod native_loads_tests {
 
         let mut rx = monitor.subscribe();
         tokio::time::timeout(Duration::from_secs(10), async {
-            while !rx.borrow().contains_key(&stub.url) {
+            while !rx.borrow().contains(&stub.url) {
                 rx.changed().await.expect("watch sender alive");
             }
         })
@@ -1882,7 +1952,7 @@ mod native_loads_tests {
         // Covers the immediate first tick plus one full 1s interval.
         tokio::time::sleep(Duration::from_millis(1500)).await;
         assert_eq!(stub.probes.load(Ordering::SeqCst), 0);
-        assert!(monitor.load_rx.borrow().is_empty());
+        assert!(monitor.load_state.snapshot().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

### Problem

Worker load snapshots are read on routing hot paths and written by background polling, and the current channel — `watch::Receiver<HashMap<String, WorkerLoadResponse>>` — serves both badly:

- `backend_token_usage_bounds` holds the watch borrow guard across its fleet scan, blocking every publisher's `send_modify` for the duration.
- `waiting_prefill_snapshot` builds an owned map (cloning every URL key) **per selection**.
- Eviction and group publication mutate the shared map with no notion of which worker *incarnation* a load came from, which hides a real staleness bug: a group tick captures its worker list at tick start, so an eviction that lands mid-poll gets re-inserted by that tick's merge — **and never pruned again**, because the next tick's prune set no longer contains the removed URL. Same-URL replacements can likewise briefly serve the predecessor's load.

### Solution

The channel now carries `Arc<LoadSnapshot>` — an immutable URL→load map (`model_gateway/src/worker/load_state.rs`):

- **Readers**: one `Arc` clone out of `borrow()`, guard released immediately, scan immutable data. The per-selection waiting-prefill map is gone; backlog values are derived at lookup from the same frozen snapshot, so the selection math sees identical values with zero per-request allocation.
- **Publishers**: copy-on-write rebuilds. The copy is `Arc` pointer bumps per entry — never a deep `WorkerLoadResponse` or `String` clone. That is the validation asked for on the global-map question: at polling cadence (seconds) an O(fleet) pointer-bump rebuild is noise, so one flat map beats group shards on reader simplicity with no meaningful publish cost. Publishers serialize on the watch channel's internal lock, so concurrent group updates cannot lose each other (pinned by a two-thread test).
- **Staleness fenced by provenance**: every entry records the exact worker (`Weak<dyn Worker>`) that produced it, and a publish admits a report only while the registry still holds that incarnation as Ready (`Arc::ptr_eq`). A poll racing a removal/replacement/readiness-flip is dropped at publish; an eviction removes only its own incarnation's entry, so a replacement neither inherits the predecessor's load nor loses its fresh report to the predecessor's late-flushing eviction.
- **Evictions batch**: they queue and a debounced flusher (20ms) applies the whole backlog in one rebuild — a removal wave is one publish, not one per worker, and a *gradual* stream of removals coalesces within the window (no `yield_now` tricks). The `smg_engine_*` metrics sentinel moves with it and now fires only when the dead incarnation's own entry was removed.

Unchanged by design: the `update_loads` push into load-aware policies (including its inflight-reset semantics), per-policy caches, the DP-rank cache, group polling and its conditional gates, and all selection algorithms.

One deliberate visibility note for reviewers: `WorkerMonitor::subscribe` and the two `set_load_receiver` accessors narrow `pub` → `pub(crate)`. Their payload type is now crate-internal, and rustc's `private_interfaces` lint flags the old visibility; the functions were only ever consumed in-crate.

## Changes

- `model_gateway/src/worker/load_state.rs` — new: `LoadSnapshot` (immutable view), `LoadState` (COW publication, incarnation fence, batched evictions, publish counting for tests).
- `model_gateway/src/worker/monitor.rs` — group ticks and evictions publish through `LoadState`; debounced eviction flusher task (Weak-held, aborted in Drop, same pattern as the other loops).
- `model_gateway/src/policies/cache_aware.rs` — both readers switch to O(1) snapshot grabs; `OverlapTuning` carries the snapshot instead of a derived per-request map.
- `model_gateway/src/policies/registry.rs`, `worker/mod.rs` — plumbing.

## Test Plan

New tests in `load_state.rs`, one per required guarantee:

- `readers_scan_an_old_snapshot_while_a_new_one_publishes` — held snapshots stay scannable as-is; fresh grabs see the new publication.
- `concurrent_group_updates_are_both_retained` — two threads × 100 publishes into disjoint groups; both survive.
- `eviction_removes_the_workers_own_entry` / `unready_worker_reports_are_fenced` — removed and NotReady workers vanish from the view.
- `stale_poll_cannot_resurrect_a_removed_worker` — the exact resurrection bug, now fenced.
- `same_url_replacement_does_not_inherit_the_old_incarnations_load` — both interleavings: eviction before the replacement publishes, and a late eviction flush after it has.
- `a_large_removal_batch_causes_one_rebuild` — 50 evictions, publish counter advances by exactly 1.
- `clear_drops_entries_and_queued_evictions` — the shutdown/lag-rebuild path.

Existing behavior: `cargo test -p smg --lib` — 1851 passed, 0 failed (the pre-change suite was 1843; the delta is exactly the 8 new tests). `cargo test -p smg --test routing_tests` passes. Monitor's eviction tests now flush deterministically instead of racing the debounce. `cargo clippy -p smg --all-targets -- -D warnings` and `cargo +nightly fmt --all` clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes — run as `-p smg --all-targets`; the full-workspace `--all-features` matrix needs the opencv toolchain not present locally, CI owns it
- [x] (Optional) Documentation updated — the publication contract is documented on the module
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
