### PR TITLE
chore(release): bump versions for v1.10.1

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+SGLang |
   ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.18' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.18') }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.1' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.10.0'
+        default: 'v1.10.1'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.10.0-sglang-v0.5.18)'
+        description: 'Override image tag (e.g. v1.10.1-sglang-v0.5.18)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.sglang_repo }}
       engine_commit: ${{ inputs.sglang_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/smg-project/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.1' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+TRTLLM |
   ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc24') }} |
   engine=${{ inputs.trtllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.1' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.10.0'
+        default: 'v1.10.1'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.10.0-trtllm-1.3.0)'
+        description: 'Override image tag (e.g. v1.10.1-trtllm-1.3.0)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/smg-project/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.1' }}
       tag: ${{ inputs.tag }}
       source_build_repo: ${{ inputs.trtllm_repo }}
       source_build_ref: ${{ inputs.trtllm_commit || 'latest' }}

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+vLLM |
   ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.27.1') }} |
   engine=${{ inputs.vllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.1' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.10.0'
+        default: 'v1.10.1'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.10.0-vllm-v0.26.0)'
+        description: 'Override image tag (e.g. v1.10.1-vllm-v0.26.0)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.vllm_repo }}
       engine_commit: ${{ inputs.vllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/smg-project/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.10.1' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3868,7 +3868,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llm-multimodal"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -4876,7 +4876,7 @@ dependencies = [
 
 [[package]]
 name = "openai-protocol"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "axum",
  "bitflags 2.13.1",
@@ -7383,7 +7383,7 @@ dependencies = [
 
 [[package]]
 name = "smg"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7534,7 +7534,7 @@ dependencies = [
 
 [[package]]
 name = "smg-golang"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -7556,7 +7556,7 @@ dependencies = [
 
 [[package]]
 name = "smg-grpc-client"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "futures",
  "hyper-util",
@@ -7659,7 +7659,7 @@ dependencies = [
 
 [[package]]
 name = "smg-python"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "once_cell",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.12.0", path = "crates/protocols" }
+openai-protocol = { version = "1.13.0", path = "crates/protocols" }
 smg-mm-rdma = { version = "0.1.1", path = "crates/mm_rdma" }
 reasoning-parser = { version = "1.7.0", path = "crates/reasoning_parser" }
 tool-parser = { version = "1.7.0", path = "crates/tool_parser" }
@@ -14,10 +14,10 @@ smg-auth = { version = "1.2.3", path = "crates/auth" }
 smg-mcp = { version = "2.3.3", path = "crates/mcp" }
 kv-index = { version = "1.4.0", path = "crates/kv_index" }
 smg-data-connector = { version = "2.3.4", path = "crates/data_connector", package = "data-connector" }
-llm-multimodal = { version = "1.10.0", path = "crates/multimodal" }
+llm-multimodal = { version = "1.11.0", path = "crates/multimodal" }
 smg-wasm = { version = "1.1.4", path = "crates/wasm", package = "smg-wasm" }
 smg-mesh = { version = "1.4.3", path = "crates/mesh", package = "smg-mesh" }
-smg-grpc-client = { version = "1.11.0", path = "crates/grpc_client" }
+smg-grpc-client = { version = "1.12.0", path = "crates/grpc_client" }
 engine-zmq-client = { version = "0.1.0", path = "crates/engine_zmq_client" }
 
 # Shared dependencies

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-golang"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2021"
 
 [lib]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "1.10.0"
+version = "1.10.1"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-grpc-client"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 description = "gRPC clients for vLLM, TensorRT-LLM, MLX, TokenSpeed, and SGLang backends"
 license = "Apache-2.0"

--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-multimodal"
-version = "1.10.0"
+version = "1.11.0"
 edition = "2021"
 description = "Multimodal processing for vision and other modalities"
 license = "Apache-2.0"

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.12.0"
+version = "1.13.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/deploy/helm/smg/Chart.yaml
+++ b/deploy/helm/smg/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: smg
 description: "Shepherd Model Gateway - high-performance inference router for LLM deployments"
 type: application
-version: 1.10.0
-appVersion: "1.10.0"
+version: 1.10.1
+appVersion: "1.10.1"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/smg-project/smg
 sources:

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- bump SMG, Python and Go bindings, Helm, and engine workflow refs to v1.10.1
- bump changed independently published crates as detected by the release checker: openai-protocol 1.13.0, smg-grpc-client 1.12.0, and llm-multimodal 1.11.0
- refresh the corresponding workspace dependency pins and Cargo.lock entries

This follows the established patch-release pattern: the gateway uses VERSION_OVERRIDE=1.10.1 while changed library crates retain their independently detected semantic-version bumps.

## Verification

- `make check-versions TAG=v1.10.0 VERSION_OVERRIDE=1.10.1`
- `cargo fmt --all -- --check`

Full Rust Clippy and unit-test gates are left to CI for this version-only PR.