### PR TITLE
ci: publish router images to GitHub Container Registry

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -14,6 +14,11 @@ on:
         description: 'Image tag (e.g. v1.0.1). Leave empty to use version from pyproject.toml'
         required: false
         type: string
+      mirror_existing:
+        description: 'Mirror the existing Docker Hub release to GHCR without rebuilding'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -27,6 +32,9 @@ jobs:
     runs-on: ${{ vars.SMG_RUNNER_DOCKER || 'cpu-e5' }}
     permissions:
       contents: read
+      packages: write
+    env:
+      MIRROR_EXISTING: ${{ github.event_name == 'workflow_dispatch' && inputs.mirror_existing }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -73,6 +81,7 @@ jobs:
           echo "Will push: ${PUSH}"
 
       - name: Set up QEMU
+        if: env.MIRROR_EXISTING != 'true'
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
@@ -85,8 +94,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to GitHub Container Registry
+        if: steps.should-push.outputs.push == 'true'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         id: build
+        if: env.MIRROR_EXISTING != 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -95,34 +113,61 @@ jobs:
           tags: |
             lightseekorg/smg:${{ steps.version.outputs.version }}
             lightseekorg/smg:latest
+            ghcr.io/${{ github.repository_owner }}/smg:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/smg:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+
+      - name: Mirror existing release image
+        id: mirror
+        if: env.MIRROR_EXISTING == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          CURRENT_VERSION=$(grep -m1 '^version = ' bindings/python/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          if [[ "${VERSION}" != "${CURRENT_VERSION}" ]]; then
+            echo "::error::Mirror mode only supports the current release (${CURRENT_VERSION})."
+            exit 1
+          fi
+          SOURCE="lightseekorg/smg:${VERSION}"
+          GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER}/smg:${VERSION}"
+          GHCR_LATEST="ghcr.io/${GITHUB_REPOSITORY_OWNER}/smg:latest"
+          docker buildx imagetools create \
+            --tag "${GHCR_IMAGE}" \
+            --tag "${GHCR_LATEST}" \
+            "${SOURCE}"
+          DIGEST=$(docker buildx imagetools inspect "${GHCR_IMAGE}" --format '{{.Manifest.Digest}}')
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Summary
         if: always()
         env:
           PUSH: ${{ steps.should-push.outputs.push }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          PUBLISH_OUTCOME: ${{ env.MIRROR_EXISTING == 'true' && steps.mirror.outcome || steps.build.outcome }}
           VERSION: ${{ steps.version.outputs.version }}
-          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST: ${{ env.MIRROR_EXISTING == 'true' && steps.mirror.outputs.digest || steps.build.outputs.digest }}
         run: |
           IMAGE="lightseekorg/smg:${VERSION}"
           LATEST="lightseekorg/smg:latest"
-          if [[ "${BUILD_OUTCOME}" == "success" && "${PUSH}" == "true" ]]; then
+          GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER}/smg:${VERSION}"
+          GHCR_LATEST="ghcr.io/${GITHUB_REPOSITORY_OWNER}/smg:latest"
+          if [[ "${PUBLISH_OUTCOME}" == "success" && "${PUSH}" == "true" ]]; then
             {
-              echo "### ✅ Docker image pushed successfully"
+              echo "### ✅ Release images available"
               echo ""
-              echo "| Tag | Reference |"
-              echo "| --- | --- |"
-              echo "| \`${VERSION}\` | \`${IMAGE}\` |"
-              echo "| \`latest\` | \`${LATEST}\` |"
+              echo "| Registry | Tag | Reference |"
+              echo "| --- | --- | --- |"
+              echo "| Docker Hub | \`${VERSION}\` | \`${IMAGE}\` |"
+              echo "| Docker Hub | \`latest\` | \`${LATEST}\` |"
+              echo "| GHCR | \`${VERSION}\` | \`${GHCR_IMAGE}\` |"
+              echo "| GHCR | \`latest\` | \`${GHCR_LATEST}\` |"
               if [[ -n "${DIGEST}" ]]; then
                 echo ""
                 echo "Digest: \`${DIGEST}\`"
               fi
             } >> "$GITHUB_STEP_SUMMARY"
-          elif [[ "${BUILD_OUTCOME}" == "success" ]]; then
+          elif [[ "${PUBLISH_OUTCOME}" == "success" ]]; then
             {
               echo "### ⚠️ Docker image built but NOT pushed"
               echo ""
@@ -130,10 +175,19 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
             echo "::warning::Docker image ${IMAGE} was built but not pushed."
           else
-            {
-              echo "### ❌ Docker image build failed"
-              echo ""
-              echo "\`${IMAGE}\` was **not** pushed because the build did not succeed (outcome: \`${BUILD_OUTCOME}\`)."
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "::warning::Docker image ${IMAGE} was not pushed (build outcome: ${BUILD_OUTCOME})."
+            if [[ "${MIRROR_EXISTING}" == "true" ]]; then
+              {
+                echo "### ❌ GitHub Container Registry mirror failed"
+                echo ""
+                echo "\`${GHCR_IMAGE}\` was **not** published (outcome: \`${PUBLISH_OUTCOME}\`)."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::warning::GitHub Container Registry mirror failed for ${GHCR_IMAGE} (outcome: ${PUBLISH_OUTCOME})."
+            else
+              {
+                echo "### ❌ Release image publishing failed"
+                echo ""
+                echo "Release images were **not** published (outcome: \`${PUBLISH_OUTCOME}\`)."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::warning::Release images were not published (outcome: ${PUBLISH_OUTCOME})."
+            fi
           fi

--- a/scripts/release_docker_notes.sh
+++ b/scripts/release_docker_notes.sh
@@ -24,7 +24,7 @@ fi
 VERSION="${VERSION#v}"
 
 PACKAGE="smg"
-ORG="lightseekorg"
+ORG="smg-project"
 REGISTRY="ghcr.io/${ORG}/${PACKAGE}"
 
 # ---------------------------------------------------------------------------
@@ -36,15 +36,44 @@ fetch_tags_oci() {
     token=$(curl -sf "https://ghcr.io/token?scope=repository:${ORG}/${PACKAGE}:pull" \
         | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" 2>/dev/null) || return 1
 
-    # List tags from the OCI registry
-    curl -sf -H "Authorization: Bearer ${token}" \
-        "https://ghcr.io/v2/${ORG}/${PACKAGE}/tags/list" \
-        | python3 -c "
+    # List tags from the OCI registry, following rel=next pagination links.
+    local url="https://ghcr.io/v2/${ORG}/${PACKAGE}/tags/list?n=1000"
+    while [[ -n "$url" ]]; do
+        local headers body next
+        headers=$(mktemp)
+        body=$(curl -sf -D "$headers" -H "Authorization: Bearer ${token}" "$url") || {
+            rm -f "$headers"
+            return 1
+        }
+        printf '%s' "$body" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
 for tag in sorted(data.get('tags', [])):
     print(tag)
-" 2>/dev/null
+" 2>/dev/null || {
+            rm -f "$headers"
+            return 1
+        }
+        next=$(python3 - "$headers" <<'PY'
+import re
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as headers:
+    for line in headers:
+        if line.lower().startswith("link:"):
+            match = re.search(r'<([^>]+)>;\s*rel="next"', line, re.IGNORECASE)
+            if match:
+                print(match.group(1))
+                break
+PY
+)
+        rm -f "$headers"
+        if [[ -n "$next" ]]; then
+            url="https://ghcr.io${next}"
+        else
+            url=""
+        fi
+    done
 }
 
 fetch_tags_gh() {
@@ -100,7 +129,7 @@ labels = {'sglang': 'SGLang', 'vllm': 'vLLM', 'trtllm': 'TensorRT-LLM', 'other':
 
 print('### Docker Images')
 print()
-print(f'Pre-built engine images on [GitHub Container Registry](https://github.com/orgs/lightseekorg/packages/container/package/smg):')
+print(f'Pre-built engine images on [GitHub Container Registry](https://github.com/orgs/smg-project/packages/container/package/smg):')
 print()
 
 for engine in ['sglang', 'vllm', 'trtllm', 'other']:


### PR DESCRIPTION
## Description

### Problem

Router release images are published only to Docker Hub, while the GitHub Container Registry package is already used by other image workflows. The release-notes helper also points at the previous package namespace and does not request the complete tag list.

### Solution

Publish router release images to both registries from the existing multi-platform build, with a manual CI path for mirroring an existing release without rebuilding.

## Changes

- Grant package-write permission to the release job.
- Authenticate to GitHub Container Registry with the workflow token.
- Push versioned and latest tags to both registries from one build.
- Add a manual mirror mode for an already-published release image.
- Report both registries in the job summary.
- Point release-note discovery at the active package and request the complete tag list.

## Test Plan

- Run the repository formatter.
- Validate the workflow with `actionlint`.
- Validate the release-note helper shell syntax.
- Run the release-note helper against the current release and verify that it finds the published engine tags.
- Dispatch mirror mode from this branch and verify both registry tags and the final image digest.