### PR TITLE
perf(tokenizer): optimize hot dependencies for runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,11 +140,11 @@ lto = "fat"         # Full LTO for smaller binaries
 codegen-units = 1   # Better optimization, slower compile
 strip = false       # Keep symbols so production CPU profiles/flamegraphs are readable (#1575)
 
-# Optimize tokenizer hot paths for runtime performance.
+# Optimize hot dependencies in the tiktoken encode path.
 [profile.release.package.tiktoken-rs]
 opt-level = 2
 
-[profile.release.package."fancy-regex:0.17.0"]
+[profile.release.package.fancy-regex]
 opt-level = 2
 
 [profile.release.package.regex-automata]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,16 @@ lto = "fat"         # Full LTO for smaller binaries
 codegen-units = 1   # Better optimization, slower compile
 strip = false       # Keep symbols so production CPU profiles/flamegraphs are readable (#1575)
 
+# Optimize tokenizer hot paths for runtime performance.
+[profile.release.package.tiktoken-rs]
+opt-level = 2
+
+[profile.release.package."fancy-regex:0.17.0"]
+opt-level = 2
+
+[profile.release.package.regex-automata]
+opt-level = 2
+
 [profile.ci]
 inherits = "release"
 opt-level = 2       # Lighter optimization (still fast runtime, much faster compile)


### PR DESCRIPTION
## Description

### Problem

The size-optimized release profile (`opt-level = "z"`) significantly slows down tokenizer hot paths.

### Solution

Compile `tiktoken-rs`, `fancy-regex`, and `regex-automata` with `opt-level = 2`, while keeping the global release profile size-optimized.

## Changes

- Add package-specific release profile overrides for the three tokenizer hot dependencies.

## Test Plan

Benchmarked Rust tokenizer encoding on both GB300 and B300 hosts:

- GB300: NVIDIA Grace CPU
- B300: AMD EPYC 9575F
- 50 pre-rendered Kimi-K3 inputs from four multi-turn agentic conversations
- 50k–62k tokens per input
- Tokenizer caches disabled
- 10 balanced, interleaved runs per optimization level

| Opt level | GB300 Grace | B300 EPYC |
|---|---:|---:|
| `z` | 29.47 ms | 14.05 ms |
| `0` | 16.50 ms | 9.72 ms |
| `1` | 14.13 ms | 8.45 ms |
| `2` | 11.85 ms | 7.08 ms |
| `3` | 11.60 ms | 6.95 ms |

Compared with `z`, `opt-level = 2` reduces encoding latency by 59.8% on GB300 and 49.6% on B300. Moving from `2` to `3` improves latency by only another 2.1% and 1.9%, respectively.

The `O2` probe binary size increased by 0.30% on GB300 and 0.92% on B300. All measured encodes matched the expected token counts.