### PR TITLE
fix(grpc_client): preserve configured HTTP/2 windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/crates/grpc_client/src/channel.rs
+++ b/crates/grpc_client/src/channel.rs
@@ -73,7 +73,7 @@ fn configured_endpoint(
         .keep_alive_while_idle(true)
         .tcp_keepalive(Some(Duration::from_secs(60)))
         .tcp_nodelay(true)
-        .http2_adaptive_window(true)
+        .http2_adaptive_window(false)
         // 16MB stream window, 32MB connection window — sized for the
         // typical inference response (multi-MB tokenized payloads +
         // streaming chunks) without head-of-line blocking.


### PR DESCRIPTION
## Description

### Problem

`h2` 0.4.16 began enforcing a connection-level safeguard against excessive small DATA frames. This is useful protection against peers that create disproportionate framing overhead, but the default used by h2 0.4.18 is too small for a highly multiplexed inference connection:

- DATA frames with payloads smaller than 256 bytes consume `256 - payload_len` units from a connection-wide budget.
- h2 0.4.18 gives every connection a fixed default budget of `256 * 100 = 25,600` units, independent of the configured receive window.
- The budget is replenished when buffered DATA is released, but under high concurrency many streaming gRPC responses can have small frames buffered at the same time on one shared HTTP/2 connection.

Consequently, high-traffic worker connections can exhaust the budget with roughly one hundred near-empty frames even though the traffic is legitimate. h2 then terminates the entire connection with:

```text
GOAWAY error code 11 (ENHANCE_YOUR_CALM): too_many_data_frames
```

This is a connection-level failure rather than a single-stream failure. Every in-flight gRPC request multiplexed over that connection is cancelled together, creating a burst of request failures before the client reconnects.

### Why this cannot be tuned through tonic

h2 0.4.18 added `data_frame_budget(...)` to its low-level client and server builders, but tonic 0.14.6 does not expose that setting through `tonic::transport::Endpoint`. Tonic's Hyper transport layer does not provide another pass-through for it, so SMG cannot raise the budget without replacing the transport connector or patching the dependency stack.

SMG already asks tonic for a 16 MiB stream window and a 32 MiB connection window. However, tonic applies the adaptive-window option after those values. Hyper's `adaptive_window(true)` resets both initial windows to the HTTP/2 default of 65,535 bytes, so the configured 16/32 MiB windows are not actually used at connection startup.

### Solution

This PR combines the upstream h2 fix with the existing SMG transport profile:

1. Update h2 from 0.4.18 to 0.4.19. Version 0.4.19 changes the automatic small-DATA-frame budget to `max(25,600, initial_connection_window / 2)`.
2. Disable adaptive receive windows so Hyper preserves SMG's existing 16 MiB stream and 32 MiB connection window settings.

With the 32 MiB fixed connection window, h2 0.4.19 derives a 16 MiB DATA-frame-overhead budget instead of the 25,600-unit fixed default. This keeps the small-frame flood protection while scaling it to the amount of legitimate multiplexed traffic the connection is configured to receive. It also avoids a private h2/Hyper/tonic patch.

### Trade-off

Disabling adaptive flow control means the receive windows no longer grow from BDP probes. SMG already specifies large fixed windows for inference traffic, so this change makes the intended 16/32 MiB profile effective rather than starting at 65,535 bytes and growing dynamically.

## Changes

- update h2 from 0.4.18 to 0.4.19
- disable adaptive HTTP/2 receive windows for worker gRPC channels
- preserve the existing 16 MiB stream and 32 MiB connection window values

## Test Plan

1. Build worker gRPC channels through the shared `smg-grpc-client` endpoint configuration.
2. Verify the fixed-window configuration compiles against tonic 0.14.6 and h2 0.4.19.
3. Run the gRPC client unit and integration suites, including connection timeout and abort-on-drop coverage.
4. Run workspace lint and tests with local proxy variables cleared so loopback h2c tests connect directly.

Results:

- `cargo +nightly fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- `cargo test -p smg-grpc-client --locked` — 77 passed
- both h2c prior-knowledge tests and all three stale-connection retry tests — passed with proxy variables cleared
- the workspace run passed all 1,882 `smg` library tests; an unrelated randomized cache-aware routing integration test remained intermittent (two of three immediate reruns passed)
- all-features clippy was not run locally because OpenCV is not installed; CI provides the required environment

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (workspace lint without `opencv-video` passed locally; full check is left to CI)
- [ ] (Optional) Documentation updated — not applicable; transport defaults only
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
