### PR TITLE
feat(health): default worker auto-recovery to the service-discovery setting

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -454,7 +454,7 @@ struct Router {
     health_check_interval_secs: u64,
     health_check_endpoint: String,
     disable_health_check: bool,
-    remove_unhealthy_workers: bool,
+    remove_unhealthy_workers: Option<bool>,
     enable_igw: bool,
     queue_size: usize,
     queue_timeout_secs: u64,
@@ -866,7 +866,12 @@ impl Router {
                 check_interval_secs: self.health_check_interval_secs,
                 endpoint: self.health_check_endpoint.clone(),
                 disable_health_check: self.disable_health_check,
-                remove_unhealthy_workers: self.remove_unhealthy_workers,
+                // Explicit setting wins; otherwise recovery-by-removal follows
+                // service discovery, which is what re-adds a removed worker.
+                remove_unhealthy_workers: config::resolve_worker_auto_recovery(
+                    self.remove_unhealthy_workers,
+                    self.service_discovery,
+                ),
                 drain_settle_secs: self.drain_settle_secs,
             })
             .tokenizer_cache(config::TokenizerCacheConfig {
@@ -1009,7 +1014,7 @@ impl Router {
         health_check_interval_secs = 60,
         health_check_endpoint = String::from("/health"),
         disable_health_check = false,
-        remove_unhealthy_workers = false,
+        remove_unhealthy_workers = None,
         enable_igw = false,
         queue_size = 100,
         queue_timeout_secs = 60,
@@ -1160,7 +1165,7 @@ impl Router {
         health_check_interval_secs: u64,
         health_check_endpoint: String,
         disable_health_check: bool,
-        remove_unhealthy_workers: bool,
+        remove_unhealthy_workers: Option<bool>,
         enable_igw: bool,
         queue_size: usize,
         queue_timeout_secs: u64,

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -136,7 +136,10 @@ class RouterArgs:
     health_check_interval_secs: int = 60
     health_check_endpoint: str = "/health"
     disable_health_check: bool = False
-    remove_unhealthy_workers: bool = False
+    # None = follow service_discovery: recovery works by removal + discovery
+    # re-registration, so it defaults on exactly when discovery can complete
+    # the loop (resolved by the Rust core).
+    remove_unhealthy_workers: bool | None = None
     # Circuit breaker configuration
     cb_failure_threshold: int = 10
     cb_success_threshold: int = 3
@@ -1206,12 +1209,15 @@ class RouterArgs:
         health_group.add_argument(
             f"--{prefix}remove-unhealthy-workers",
             f"--{prefix}worker-auto-recovery",
-            action="store_true",
+            action=argparse.BooleanOptionalAction,
             default=RouterArgs.remove_unhealthy_workers,
             help=(
                 "Let workers recover after prolonged failure: unhealthy workers"
                 " are removed so service discovery re-registers and re-probes"
-                " them once their engine returns"
+                " them once their engine returns. Defaults to the"
+                " service-discovery setting (recovery-by-removal needs"
+                " discovery to re-add the worker); use the --no- form to keep"
+                " it off under discovery"
             ),
         )
         # Tokenizer configuration

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1237,6 +1237,18 @@ class TestFlagAliases:
         assert router_args.routing_key_override is True
         assert router_args.remove_unhealthy_workers is True
 
+    def test_worker_auto_recovery_is_tri_state(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser)
+        # Absent: undecided — the Rust core derives the default from the
+        # service-discovery setting (recovery works by removal + discovery
+        # re-registration, so it is on exactly when discovery is).
+        absent = RouterArgs.from_cli_args(parser.parse_args([]))
+        assert absent.remove_unhealthy_workers is None
+        # The --no- form pins it off even under service discovery.
+        pinned_off = RouterArgs.from_cli_args(parser.parse_args(["--no-remove-unhealthy-workers"]))
+        assert pinned_off.remove_unhealthy_workers is False
+
 
 class TestRouterArgsFieldOrder:
     """RouterArgs generates a positional __init__, so field order is a public

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -954,6 +954,19 @@ fn default_drain_settle_secs() -> u64 {
     5
 }
 
+/// Resolve `--worker-auto-recovery`'s conditional default: an explicit
+/// setting always wins; otherwise it follows service discovery.
+///
+/// The recovery mechanism is removal — a terminally failed worker is dropped
+/// from the registry so discovery re-registers and re-probes it once its
+/// engine returns. With discovery on, that loop completes and recovery is
+/// pure upside; with discovery off, nothing re-adds the worker, so removal
+/// would silently and permanently shrink a static fleet and must stay
+/// opt-in.
+pub fn resolve_worker_auto_recovery(explicit: Option<bool>, service_discovery: bool) -> bool {
+    explicit.unwrap_or(service_discovery)
+}
+
 impl Default for HealthCheckConfig {
     fn default() -> Self {
         Self {

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -12,11 +12,11 @@ use openai_protocol::worker::TransportMode;
 use rand::{distr::Alphanumeric, RngExt};
 use smg::{
     config::{
-        validate_mesh_server_name, CacheIndexKind, CircuitBreakerConfig, ConfigError, ConfigResult,
-        DiscoveryConfig, HealthCheckConfig, HistoryBackend, ManualAssignmentMode, MetricsConfig,
-        OracleConfig, PolicyConfig, PostgresConfig, RedisConfig, RetryConfig, RouterConfig,
-        RoutingKeyOverrideConfig, RoutingMode, SchemaConfig, TenantApiKeyEntry,
-        TokenizerCacheConfig, TraceConfig,
+        resolve_worker_auto_recovery, validate_mesh_server_name, CacheIndexKind,
+        CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
+        HistoryBackend, ManualAssignmentMode, MetricsConfig, OracleConfig, PolicyConfig,
+        PostgresConfig, RedisConfig, RetryConfig, RouterConfig, RoutingKeyOverrideConfig,
+        RoutingMode, SchemaConfig, TenantApiKeyEntry, TokenizerCacheConfig, TraceConfig,
     },
     observability::{
         metrics::{register_jemalloc_as_global_allocator, PrometheusConfig},
@@ -825,14 +825,20 @@ struct CliArgs {
     /// unhealthy long enough is removed from the registry so service
     /// discovery re-registers and re-probes it once its engine returns
     /// (without this, a worker unreachable for ~12 minutes reaches a
-    /// terminal Failed state and is never probed again)
+    /// terminal Failed state and is never probed again). Defaults to the
+    /// --service-discovery setting: recovery works by removal plus
+    /// discovery re-registration, so discovery-managed fleets get it for
+    /// free, while without discovery nothing would re-add the worker and
+    /// removal would permanently shrink a static fleet. Pass =false to
+    /// keep it off under discovery.
     #[arg(
         long,
         visible_alias = "worker-auto-recovery",
-        default_value_t = false,
+        num_args = 0..=1,
+        default_missing_value = "true",
         help_heading = "Health Checks"
     )]
-    remove_unhealthy_workers: bool,
+    remove_unhealthy_workers: Option<bool>,
 
     /// Seconds to keep a Ready worker in `Draining` before removing it from
     /// the registry. Applies to all RemoveWorker submissions (K8s deletion,
@@ -1821,7 +1827,10 @@ impl CliArgs {
                 check_interval_secs: self.health_check_interval_secs,
                 endpoint: self.health_check_endpoint.clone(),
                 disable_health_check: self.disable_health_check,
-                remove_unhealthy_workers: self.remove_unhealthy_workers,
+                remove_unhealthy_workers: resolve_worker_auto_recovery(
+                    self.remove_unhealthy_workers,
+                    self.service_discovery,
+                ),
                 drain_settle_secs: self.drain_settle_secs,
             })
             .tokenizer_cache(TokenizerCacheConfig {
@@ -2332,6 +2341,37 @@ mod tests {
         .to_router_config(vec![], vec![])
         .unwrap();
         assert_eq!(format!("{canonical:?}"), format!("{aliased:?}"));
+    }
+
+    /// `--worker-auto-recovery` defaults to the `--service-discovery`
+    /// setting: recovery works by removal plus discovery re-registration, so
+    /// it is on exactly when discovery can complete that loop, and off when
+    /// removal would permanently shrink a static fleet. Explicit values win
+    /// in both directions.
+    #[test]
+    fn worker_auto_recovery_follows_service_discovery_by_default() {
+        let derived_on = cli_args_from(&["--service-discovery", "--selector", "app=w"])
+            .to_router_config(vec![], vec![])
+            .unwrap();
+        assert!(derived_on.health_check.remove_unhealthy_workers);
+
+        let derived_off = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
+        assert!(!derived_off.health_check.remove_unhealthy_workers);
+
+        let forced_off = cli_args_from(&[
+            "--service-discovery",
+            "--selector",
+            "app=w",
+            "--remove-unhealthy-workers=false",
+        ])
+        .to_router_config(vec![], vec![])
+        .unwrap();
+        assert!(!forced_off.health_check.remove_unhealthy_workers);
+
+        let forced_on = cli_args_from(&["--remove-unhealthy-workers"])
+            .to_router_config(vec![], vec![])
+            .unwrap();
+        assert!(forced_on.health_check.remove_unhealthy_workers);
     }
 
     /// `--health-check-port` must flow into BOTH conversion paths


### PR DESCRIPTION
## Description

### Problem

`--worker-auto-recovery` (canonically `--remove-unhealthy-workers`) recovers a terminally failed worker by **removing** it from the registry so service discovery re-registers and re-probes it once its engine returns. Without it, a worker unreachable for ~12 minutes reaches terminal `Failed` and is never probed again.

The flag defaults to `false` unconditionally — which is backwards for the deployments the mechanism was built for. With discovery on, recovery is pure upside (discovery completes the removal→re-registration loop), yet those fleets ship with dead-forever workers unless someone knows to pass the flag. And a global `true` would be wrong too: without discovery, nothing re-adds a removed worker, so removal permanently shrinks a static fleet.

### Solution

Make the default conditional on the thing the mechanism depends on: **unset now follows `--service-discovery`.**

- One resolver, `resolve_worker_auto_recovery(explicit, service_discovery)` in `config/types.rs`, used by both construction sites — `to_router_config` and the Python bindings' `Router`, which builds `HealthCheckConfig` directly.
- The CLI flag becomes tri-state (`Option<bool>`, `num_args 0..=1`, `default_missing_value "true"`): the bare flag still forces recovery on without discovery, `--remove-unhealthy-workers=false` pins it off under discovery, absent = derived.
- The Python launcher (`RouterArgs`) mirrors it with `argparse.BooleanOptionalAction`: bare flag → on, `--no-remove-unhealthy-workers` → off, absent → `None` (derived by the Rust core). Existing bare-flag assertions in `test_arg_parser.py` hold unchanged.
- YAML configs untouched: the `HealthCheckConfig` file field stays a plain bool and an explicit value is honored exactly as before.

## Changes

- `model_gateway/src/config/types.rs` — `resolve_worker_auto_recovery` with the rationale documented.
- `model_gateway/src/main.rs` — tri-state flag + derivation at the single `HealthCheckConfig` assembly point; help text states the conditional default.
- `bindings/python/src/lib.rs` — `Option<bool>` param (default `None`), derived from the Router's own `service_discovery` at its `HealthCheckConfig` literal.
- `bindings/python/src/smg/router_args.py` — tri-state launcher flag.
- `bindings/python/tests/test_arg_parser.py` — tri-state parser test.

## Test Plan

- New `worker_auto_recovery_follows_service_discovery_by_default` (main.rs) covers the full truth table end-to-end through `to_router_config`: derived-on (discovery set), derived-off (no discovery), forced-off under discovery (`=false`), forced-on without discovery (bare flag). The existing canonical-vs-alias equivalence test still passes.
- New `test_worker_auto_recovery_is_tri_state` (Python): absent → `None`, `--no-` form → `False`; existing bare-flag → `True` tests unchanged.
- `cargo test -p smg --lib` and `--bins` pass (both binaries); `cargo clippy -p smg -p smg-python --all-targets -- -D warnings` clean; `ruff check`/`format --check` clean on the touched Python; `cargo +nightly fmt --all` applied.
- Behavior matrix for existing users: anyone passing the flag explicitly sees no change; discovery-off deployments see no change; discovery-on deployments that never set the flag now get recovery — the intended change, called out here so reviewers confirm it's wanted as a default flip.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes — run as `-p smg -p smg-python --all-targets`; the full-workspace `--all-features` matrix needs the opencv toolchain not present locally, CI owns it
- [x] (Optional) Documentation updated — CLI/launcher help text and the resolver's doc comment carry the rationale
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
