### PR TITLE
chore(deps): bump TokenSpeed to 7cd7ca0b

### DIFF
--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -22,7 +22,7 @@ fi
 # engine-watch workflow files an issue when this drifts) rather than
 # floating against ``main`` — upstream has renamed APIs before and the
 # gRPC servicer broke until we caught up.
-TOKENSPEED_REF="${TOKENSPEED_REF:-eaf9e503bbfda773a4749500e973c68538247ee2}"
+TOKENSPEED_REF="${TOKENSPEED_REF:-7cd7ca0b3028dca2ce331c0599a0537379ab0e74}"
 TOKENSPEED_REPO="${TOKENSPEED_REPO:-https://github.com/lightseekorg/tokenspeed.git}"
 TOKENSPEED_DIR="${TOKENSPEED_DIR:-/tmp/tokenspeed-src}"
 


### PR DESCRIPTION
## Description

### Problem

The TokenSpeed pin is 35 commits behind (`eaf9e503b` → `7cd7ca0b3`, the target reviewed by #2309). Prior engine bumps have broken at runtime on unreviewed internal-API drift — the load-metrics path alone has broken on three releases — so this bump ships with a full compatibility review of the exact surface `smg_grpc_servicer/tokenspeed` imports and the ZMQ wire the Rust connector decodes, not just a version edit.

### Solution

Bump `TOKENSPEED_REF` to `7cd7ca0b3`. Findings from the compat review, per #2309's checklist:

**The load path (the thrice-broken one) — compatible, and it gets better.** Upstream #1210 replaces the `watch_load_thread`/`GetLoadReqInput` round-trip with a push-based `LoadSnapshotStore`. `AsyncLLM.get_load()` survives (moved to the `SchedulerControlClient` parent) with the same `list[GetLoadReqOutput]` shape the servicer's `GetLoads` consumes — now projected from pushed snapshots, so it serves fresher data without a scheduler round-trip. The deleted `GetLoadReqInput`/`WatchLoadUpdateReq` are not imported by the servicer.

**The ZMQ wire — this bump activates a waiting feature.** Upstream appends a positional load tail to `BatchTokenIDOutSlim` (`num_running`, `num_waiting`, `kv_active_pages`, `kv_total_pages`). Our Rust decoder (`crates/engine_zmq_client/src/protocol/tokenspeed/output.rs`) already models exactly that tail — zeros-as-no-snapshot for older senders, `drain_trailing` for future growth — so the previously missing in-band ZMQ load signal for TokenSpeed goes live with this bump, compatibly in both directions.

**Everything else checked:**
- `GenerateReqInput` keeps every field the servicer passes. `data_parallel_rank` exists at **neither** SHA, so the #2326 capability probe stays off and degrades as designed (it arms on a future bump; upstream's newer commits already carry the 0.4.16 proto pin).
- `_launch_subprocesses` and `ServerArgs`/`prepare_server_args`: signature-stable (the `entrypoints/engine.py` diff is comment-only; `load_watch_interval` becomes a heartbeat interval — values now publish immediately).
- Upstream #1205 ("disable smg load monitoring by default") only changes the SMG flags **their own `ts serve` launcher** passes to the SMG it embeds — no effect on this repo's launch paths.
- `multimodal/inputs.py` only gains a helper; `Modality`/`MultimodalDataItem`/`ShmTensorHandle`/`EncodeRequest`/`KVEventBatch` untouched.
- Torch: upstream pins no version and nothing torch/CUDA-related changed in range → the `torch==2.11.0+cu130` pin, the CRT header two-pass workaround, and the uv `unsafe-best-match` index strategy all remain. gRPC shadow-package removal remains (upstream #1195/#1213 confirm the bundled dists still ship).

Deliberately **not** chasing upstream head (`bec298302`, 50 further commits): those include two large scheduler/control-plane refactors (role-keyed PD, device-handle control plane) that deserve their own review — the next engine-watch issue will scope them.

## Changes

- `scripts/ci_install_tokenspeed.sh` — `TOKENSPEED_REF` bump, one line. (`check_engine_versions.sh` parses this value at runtime; no other pin locations exist.)

## Test Plan

- `bash -n` clean.
- The empirical gate: all four TokenSpeed e2e legs trigger on this file via `detect-changes` — `e2e-1gpu-chat`, `e2e-1gpu-chat-zmq`, `e2e-2gpu-chat-zmq-dp`, `e2e-4gpu-epd`. The ZMQ legs additionally exercise the newly active load tail end-to-end (decoder unit tests for both the 10-element legacy and 14-element forms already exist in `output.rs`).

Closes #2309

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes — n/a, shell pin only
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes — n/a, shell pin only
- [x] (Optional) Documentation updated — compat review recorded here and in the commit message
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
