### PR TITLE
test(routing): deflake the unseen-prefix min-load assertion

### DIFF
--- a/model_gateway/tests/routing/header_routing_hints_test.rs
+++ b/model_gateway/tests/routing/header_routing_hints_test.rs
@@ -290,7 +290,13 @@ mod header_routing_hints_tests {
             );
         }
 
-        // A different hinted prefix is free to learn its own worker.
+        // A different hinted prefix is free to learn its own worker. An
+        // unseen prefix has zero overlap with every worker, and equal-score
+        // ties break RANDOMLY by design (anti-herding), so with all loads
+        // equal this pick would land back on `first` one time in three. Give
+        // the first prefix's worker real load so "goes to min-load" is a
+        // deterministic claim instead of a coin flip.
+        workers[first].increment_load();
         let other: Vec<u32> = (500u32..532).collect();
         let other_info = SelectWorkerInfo {
             tokens: Some(&other),


### PR DESCRIPTION
## Description

### Problem

`test_cache_aware_selects_same_worker_for_same_hinted_prefix` (added with the header routing hints in #2199) is flaky — it failed the `unit-tests` job on #2352's CI run, and reproduces locally at **39 failures in 100 runs**.

The failing assertion is the tail of the test: a second, *unseen* hinted prefix must route away from the first prefix's worker ("an unseen prefix goes to min-load"). But an unseen prefix has zero overlap with every worker, and with all three test workers at identical (zero) load, the selection is an equal-score tie — which `cache_aware` breaks **randomly by design** (the anti-herding tie-break that replaced deterministic ordering). One time in three, the random pick lands back on the first worker and the `assert_ne` fires. The measured 39/100 is exactly what a uniform three-way tie predicts.

### Solution

Fix the test, not the behavior — the randomized tie-break is intentional. Before the second selection, give the first prefix's worker real load (`workers[first].increment_load()`), so "goes to min-load" is the deterministic claim the assertion always intended: min-load now excludes the loaded worker, and the remaining tie between the two idle workers stays random with either outcome satisfying the assertion. The sticky-affinity assertions earlier in the test are unaffected (the load is raised after them).

## Changes

- `model_gateway/tests/routing/header_routing_hints_test.rs` — seed load on the first worker before the unseen-prefix selection; comment documents the randomized-tie rationale so the determinism assumption doesn't creep back.

## Test Plan

- Before: 61/200-scale flake (39 failures in 100 single-test runs of the compiled binary).
- After: **200/200 single-test runs pass**; full `routing_tests` target passes.
- `cargo clippy -p smg --tests -- -D warnings` and `cargo +nightly fmt --all` clean.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes — yes (test-only change)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes — run as `-p smg --tests`; full-workspace `--all-features` needs the opencv toolchain not present locally, CI owns it
- [ ] (Optional) Documentation updated — n/a
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
