### PR TITLE
chore(ci): swap the nightly BFCL/tau2 Qwen leg to Qwen3.8-27B

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
     inputs:
       only:
-        description: "Run only this matrix leg (qwen3.6|gpt-oss|deepseek-v4|minimax-m2.7|kimi-k2.6|glm-5.2); empty = all"
+        description: "Run only this matrix leg (qwen3.8|gpt-oss|deepseek-v4|minimax-m2.7|kimi-k2.6|glm-5.2); empty = all"
         required: false
         default: ""
       model:
@@ -139,13 +139,14 @@ jobs:
           # half the budget: their two arms run one after the other in the same job.
           legs = [
               # H100 legs (TP=2 per arm, both arms concurrent: GPUs 0,1 + 2,3).
-              {"name": "qwen3.6", "runner": "4-gpu-h100", "tp": 2,
+              {"name": "qwen3.8", "runner": "4-gpu-h100", "tp": 2,
                "gpu_a": "0,1", "gpu_b": "2,3",
-               "model": "Qwen/Qwen3.6-27B", "bfcl_model": "Qwen/Qwen3.6-27B-FC",
+               "model": "Qwen/Qwen3.8-27B", "bfcl_model": "Qwen/Qwen3.8-27B-FC",
                "vllm_tool": "qwen3_xml", "vllm_reason": "qwen3",
                "smg_tool": "qwen_xml", "smg_reason": "qwen3",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
-               # Slowest healthy leg: 4441 cases took 4h02m per arm on 2026-08-05.
+               # Slowest healthy leg: 4441 cases took 4h02m per arm on 2026-08-05
+               # (measured on Qwen3.6-27B; cap carried over — same size/arch class).
                "run_timeout": "18000",
                "model_cache": "/models", "arm_mode": "concurrent", "max_model_len": "auto"},
               # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -8,7 +8,7 @@
 # the ONLY variable is the frontend (tokenization + tool/reasoning parsing).
 #
 # Runs nightly across retail, airline, and telecom domains over a 6-model matrix
-# (qwen3.6 + gpt-oss on H100; deepseek-v4, minimax-m2.7, kimi-k2.6, glm-5.2 on
+# (qwen3.8 + gpt-oss on H100; deepseek-v4, minimax-m2.7, kimi-k2.6, glm-5.2 on
 # Blackwell). The 4 Blackwell legs are num_tasks-capped to bound GPU time and
 # gpt-5.2 spend (tau2 is far heavier per-leg than bfcl: multi-turn + per-turn API
 # spend). On PRs that touch this pipeline ALL legs run on a tiny retail / 1-trial /
@@ -31,7 +31,7 @@ on:
   workflow_dispatch:
     inputs:
       only:
-        description: "Run only this matrix leg (qwen3.6|gpt-oss|deepseek-v4|minimax-m2.7|kimi-k2.6|glm-5.2); empty = all"
+        description: "Run only this matrix leg (qwen3.8|gpt-oss|deepseek-v4|minimax-m2.7|kimi-k2.6|glm-5.2); empty = all"
         required: false
         default: ""
       model:
@@ -145,9 +145,9 @@ jobs:
           # run_timeout x len(domains). 5400 is the default.
           legs = [
               # H100 legs (TP=2 per arm, both arms concurrent: GPUs 0,1 + 2,3).
-              {"name": "qwen3.6", "runner": "4-gpu-h100", "tp": 2,
+              {"name": "qwen3.8", "runner": "4-gpu-h100", "tp": 2,
                "gpu_a": "0,1", "gpu_b": "2,3",
-               "model": "Qwen/Qwen3.6-27B",
+               "model": "Qwen/Qwen3.8-27B",
                "vllm_tool": "qwen3_xml", "vllm_reason": "qwen3",
                "smg_tool": "qwen_xml", "smg_reason": "qwen3",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",

--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -80,10 +80,10 @@ MODEL_SPECS: dict[str, dict] = {
         "vllm_args": [] if _is_nightly else ["--enforce-eager"],
         "trtllm_extra_config": {"kv_cache_config": {"free_gpu_memory_fraction": 0.8}},
     },
-    # Qwen3.6-27B — thinking model with XML tool calls (qwen3_5 arch). Staged for
-    # the nightly BFCL A/B (scripts/bfcl); tp=2 fits the 27B on two GPUs.
-    "Qwen/Qwen3.6-27B": {
-        "model": _resolve_model_path("Qwen/Qwen3.6-27B"),
+    # Qwen3.8-27B — thinking VLM with XML tool calls (reuses the qwen3_5 arch).
+    # Staged for the nightly BFCL A/B (scripts/bfcl); tp=2 fits the 27B on two GPUs.
+    "Qwen/Qwen3.8-27B": {
+        "model": _resolve_model_path("Qwen/Qwen3.8-27B"),
         "tp": 2,
         "features": [
             "chat",

--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -32,10 +32,10 @@ python -m venv ~/bfcl-env && ~/bfcl-env/bin/pip install bfcl-eval soundfile
 ~/vllm-env/bin/pip install ninja          # then ensure ~/vllm-env/bin is on PATH
 
 # teach bfcl about a model it doesn't ship a handler for yet (new SKUs)
-~/bfcl-env/bin/python register_bfcl_model.py --model-id Qwen/Qwen3.6-27B
+~/bfcl-env/bin/python register_bfcl_model.py --model-id Qwen/Qwen3.8-27B
 
-# 1) bring up both arms (here: Qwen3.6-27B, TP=2, one arm per GPU pair)
-export BFCL_MODEL=Qwen/Qwen3.6-27B VLLM_BIN=~/vllm-env/bin/vllm \
+# 1) bring up both arms (here: Qwen3.8-27B, TP=2, one arm per GPU pair)
+export BFCL_MODEL=Qwen/Qwen3.8-27B VLLM_BIN=~/vllm-env/bin/vllm \
        VLLM_PYTHON=~/vllm-env/bin/python SMG_LAUNCH="$HOME/smg/target/ci/smg launch" \
        BFCL_TP=2 BFCL_MAX_MODEL_LEN=16384 PATH=~/vllm-env/bin:$PATH
 A_URL=$(BFCL_GPU=0,1 BFCL_VLLM_TOOL_PARSER=qwen3_xml BFCL_VLLM_REASONING_PARSER=qwen3 bash launch_arm.sh a)
@@ -45,7 +45,7 @@ B_URL=$(BFCL_GPU=2,3 BFCL_SMG_TOOL_PARSER=qwen_xml  BFCL_SMG_REASONING_PARSER=qw
 ~/bfcl-env/bin/python run_ab.py \
     --baseline  "vllm=$A_URL" \
     --candidate "smg=$B_URL" \
-    --bfcl-model Qwen/Qwen3.6-27B-FC \
+    --bfcl-model Qwen/Qwen3.8-27B-FC \
     --categories simple_python,multiple,parallel,irrelevance \
     --bfcl ~/bfcl-env/bin/bfcl --project-root ~/bfcl_ab \
     --out ~/bfcl_ab.md --json-out ~/bfcl_ab.json
@@ -62,7 +62,7 @@ Key env knobs for `launch_arm.sh`: `BFCL_GPU` (CUDA_VISIBLE_DEVICES, e.g. `0,1`)
 
 | model (matrix leg) | runner | TP/arm | pure-vLLM `--tool-call-parser` / `--reasoning-parser` | SMG `--tool-call-parser` / `--reasoning-parser` |
 |---|---|---|---|---|
-| Qwen3.6-27B (`qwen3.6`) | `4-gpu-h100` | 2 | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
+| Qwen3.8-27B (`qwen3.8`) | `4-gpu-h100` | 2 | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
 | gpt-oss-120b (`gpt-oss`) | `4-gpu-h100` | 2 | `openai` / — | _(none — SMG auto-routes harmony)_ / — |
 | DeepSeek-V4-Flash-0731 (`deepseek-v4`) | `blackwell` | 4 | `deepseek_v4` / `deepseek_v4` (+`--tokenizer-mode deepseek_v4 --trust-remote-code`) | `deepseek_v4` / `deepseek_v4` |
 | MiniMax-M2.7 (`minimax-m2.7`) | `blackwell` | 4 | `minimax_m2` / `minimax_m2` (+`--trust-remote-code`) | `minimax_m2` / `minimax` |
@@ -88,7 +88,7 @@ Key env knobs for `launch_arm.sh`: `BFCL_GPU` (CUDA_VISIBLE_DEVICES, e.g. `0,1`)
 The nightly (`.github/workflows/nightly-bfcl.yml`) runs the A/B as a GitHub Actions
 matrix — one leg per model, `fail-fast: false`, each on its own runner:
 
-- `4-gpu-h100` — Qwen3.6-27B and gpt-oss-120b, TP=2 per arm (GPUs 0,1 + 2,3).
+- `4-gpu-h100` — Qwen3.8-27B and gpt-oss-120b, TP=2 per arm (GPUs 0,1 + 2,3).
 - `blackwell` (B200) — DeepSeek-V4-Flash-0731, MiniMax-M2.7, Kimi-K2.6 int4, TP=4 per arm
   (GPUs 0-3 + 4-7).
 

--- a/scripts/tau2/README.md
+++ b/scripts/tau2/README.md
@@ -31,8 +31,8 @@ git clone https://github.com/sierra-research/tau2-bench ~/tau/tau2-bench
 cd ~/tau/tau2-bench && uv sync
 ~/vllm-env/bin/pip install ninja          # then ensure ~/vllm-env/bin is on PATH
 
-# 1) bring up both arms (here: Qwen3.6-27B, TP=2, one arm per GPU pair)
-export TAU2_MODEL=Qwen/Qwen3.6-27B VLLM_BIN=~/vllm-env/bin/vllm \
+# 1) bring up both arms (here: Qwen3.8-27B, TP=2, one arm per GPU pair)
+export TAU2_MODEL=Qwen/Qwen3.8-27B VLLM_BIN=~/vllm-env/bin/vllm \
        VLLM_PYTHON=~/vllm-env/bin/python SMG_LAUNCH="$HOME/smg/target/ci/smg launch" \
        TAU2_TP=2 TAU2_MAX_MODEL_LEN=16384 PATH=~/vllm-env/bin:$PATH
 A_URL=$(TAU2_GPU=0,1 TAU2_VLLM_TOOL_PARSER=qwen3_xml TAU2_VLLM_REASONING_PARSER=qwen3 bash launch_arms.sh a)
@@ -46,7 +46,7 @@ export OPENAI_API_KEY=sk-...
 python scripts/tau2/run_ab.py \
     --baseline  "vllm=$A_URL" \
     --candidate "smg=$B_URL" \
-    --agent-model Qwen/Qwen3.6-27B \
+    --agent-model Qwen/Qwen3.8-27B \
     --user-llm gpt-5.2 \
     --tau2 ~/tau/tau2-bench/.venv/bin/tau2 \
     --data-dir ~/tau/tau2-bench/data \
@@ -95,7 +95,7 @@ dominated by model-load time, serialized by a host lock, so a PR run is not fast
 
 | leg | model | runner (TP) | vLLM tool/reason | SMG tool/reason |
 |---|---|---|---|---|
-| qwen3.6 | Qwen/Qwen3.6-27B | 4-gpu-h100 (2) | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
+| qwen3.8 | Qwen/Qwen3.8-27B | 4-gpu-h100 (2) | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
 | gpt-oss | openai/gpt-oss-120b | 4-gpu-h100 (2) | `openai` / — | — / — (harmony auto) |
 | deepseek-v4 | deepseek-ai/DeepSeek-V4-Flash-0731 | blackwell (4) | `deepseek_v4` / `deepseek_v4` | `deepseek_v4` / `deepseek_v4` |
 | minimax-m2.7 | MiniMaxAI/MiniMax-M2.7 | blackwell (4) | `minimax_m2` / `minimax_m2` | `minimax_m2` / `minimax` |

--- a/scripts/tau2/launch_arms.sh
+++ b/scripts/tau2/launch_arms.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 ARM="${1:?usage: launch_arms.sh <a|b|stop>}"
 
-MODEL="${TAU2_MODEL:-Qwen/Qwen3.6-27B}"
+MODEL="${TAU2_MODEL:-Qwen/Qwen3.8-27B}"
 # Load source: prefer a pre-staged local copy at $ROUTER_LOCAL_MODEL_PATH/<id>
 # (e.g. NVMe /raid/models on the Blackwell node — no download); else the HF repo
 # id, which vLLM/HF downloads into HF_HOME. The canonical served name stays

--- a/scripts/tau2/run_ab.py
+++ b/scripts/tau2/run_ab.py
@@ -425,7 +425,7 @@ def main() -> int:
     )
     p.add_argument(
         "--agent-model",
-        default="Qwen/Qwen3.6-27B",
+        default="Qwen/Qwen3.8-27B",
         help="served model name on both arms (used as openai/<name>)",
     )
     p.add_argument("--user-llm", default="gpt-5.2", help="fixed user-sim model")


### PR DESCRIPTION
## Description

### Problem

The nightly BFCL and tau2 A/B matrices pin their Qwen leg to `Qwen/Qwen3.6-27B`. Qwen3.8-27B (released 2026-08-14) is the current generation of the same family; these legs exist to exercise the latest SKUs, so they should track it.

### Solution

Swap the leg in place. Qwen3.8-27B reuses the `qwen3_5` architecture (`Qwen3_5ForConditionalGeneration`) and the same `<think>` reasoning + `<tool_call><function=name><parameter=key>` XML tool-call format as Qwen3.6-27B, so everything else carries over unchanged:

- same parsers: `qwen3_xml`/`qwen3` on the vLLM arm, `qwen_xml`/`qwen3` on the SMG arm (SMG's factories already map `Qwen3.8*` → `qwen_xml` and `qwen3*` → `qwen3`)
- same `4-gpu-h100` runner at TP=2 (same 27B/BF16 footprint class)
- same timeout caps, annotated as measured on the 3.6 leg
- bfcl handler registration is covered by the existing generic `register_bfcl_model.py` step (no-op once bfcl-eval ships a native `Qwen/Qwen3.8-27B-FC` handler)

## Changes

- `.github/workflows/nightly-bfcl.yml` — leg `qwen3.6` → `qwen3.8`: model `Qwen/Qwen3.8-27B`, bfcl model `Qwen/Qwen3.8-27B-FC`; `only` input description updated
- `.github/workflows/nightly-tau2.yml` — same leg rename and model swap; header comment and `only` description updated
- `scripts/tau2/run_ab.py`, `scripts/tau2/launch_arms.sh` — local-run defaults now point at Qwen3.8-27B
- `e2e_test/infra/model_specs.py` — staged `Qwen/Qwen3.6-27B` entry replaced by `Qwen/Qwen3.8-27B` (same tp=2/features) so tier runners pre-stage the new weights
- `scripts/bfcl/README.md`, `scripts/tau2/README.md` — quickstart examples and matrix tables updated (historical timing/validation notes intentionally still name Qwen3.6)

## Test Plan

- Both workflow files parse as valid YAML; the matrix heredocs only had string literals changed
- `ruff check` clean on the touched Python files; `pre-commit` passes on all changed files
- `pytest scripts/tests` — 23 passed (tau2/bfcl script tests pass Qwen3.6 explicitly as fixtures, so they are unaffected by the default change)
- `MODEL_SPECS` imports and resolves the new entry; the old entry is fully removed
- First-run verification: dispatch `nightly-bfcl` / `nightly-tau2` with `only: qwen3.8`. One thing to watch: the vLLM recipe for Qwen3.8-27B wants `transformers >= 5.8.0` (VL processor config); if the pinned `vllm==0.27.1` resolves an older transformers, the leg will fail at engine startup and the venv needs a bump

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)