### PR TITLE
feat(radix-index): shared radix membership index service (WIP experiment)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6028,6 +6028,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radix-index"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "kv-index",
+ "prost",
+ "rand 0.10.2",
+ "rustc-hash 2.1.3",
+ "smg-grpc-client",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6046,6 +6046,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "tracing-subscriber",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "radix-tree"
+version = "0.1.0"
+dependencies = [
+ "kv-index",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7468,6 +7468,7 @@ dependencies = [
  "portpicker",
  "prost",
  "prost-types",
+ "radix-index",
  "rand 0.10.2",
  "rayon",
  "reasoning-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6054,6 +6054,7 @@ name = "radix-tree"
 version = "0.1.0"
 dependencies = [
  "kv-index",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6036,6 +6036,7 @@ dependencies = [
  "mock-worker",
  "portpicker",
  "prost",
+ "radix-tree",
  "rand 0.10.2",
  "rustc-hash 2.1.3",
  "smg-grpc-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6033,6 +6033,8 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "kv-index",
+ "mock-worker",
+ "portpicker",
  "prost",
  "rand 0.10.2",
  "rustc-hash 2.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/mm_rdma", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/engine_zmq_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "crates/mock_worker", "crates/sim_loadgen", "crates/radix_index"]
+members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/mm_rdma", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/engine_zmq_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "crates/mock_worker", "crates/sim_loadgen", "crates/radix_index", "crates/radix_tree"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/mm_rdma", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/engine_zmq_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "crates/mock_worker", "crates/sim_loadgen"]
+members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/mm_rdma", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/engine_zmq_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "crates/mock_worker", "crates/sim_loadgen", "crates/radix_index"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/crates/kv_index/src/event_tree.rs
+++ b/crates/kv_index/src/event_tree.rs
@@ -36,6 +36,18 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 /// Seed for XXH3 hashing.
 pub const XXH3_SEED: u64 = 1337;
 
+/// Rolling prefix hash over content hashes: `XXH3(prev || current)`, the
+/// same chaining `PositionalIndexer` computes internally. Exported so
+/// out-of-process publishers (the radix index service's placement feed)
+/// can synthesize byte-identical position chains for identical prefixes.
+#[inline]
+pub fn chain_prefix_hash(prev: SequenceHash, current: ContentHash) -> SequenceHash {
+    let mut bytes = [0u8; 16];
+    bytes[..8].copy_from_slice(&prev.0.to_le_bytes());
+    bytes[8..].copy_from_slice(&current.0.to_le_bytes());
+    SequenceHash(xxhash_rust::xxh3::xxh3_64_with_seed(&bytes, XXH3_SEED))
+}
+
 /// Shard count for the main index DashMap.
 /// Tuned iteratively — higher values reduce per-shard contention under concurrent
 /// reads+writes at the cost of more memory for shard locks.

--- a/crates/kv_index/src/lib.rs
+++ b/crates/kv_index/src/lib.rs
@@ -20,9 +20,9 @@ mod token_tree;
 
 pub use common::{MatchResult, TenantId};
 pub use event_tree::{
-    compute_content_hash, compute_request_content_hashes, ApplyError, ContentHash, OverlapScores,
-    PositionalIndexer, PruneStats, SequenceHash, StoredBlock, WorkerBlockMap, WorkerId,
-    WorkerIdExhausted,
+    chain_prefix_hash, compute_content_hash, compute_request_content_hashes, ApplyError,
+    ContentHash, OverlapScores, PositionalIndexer, PruneStats, SequenceHash, StoredBlock,
+    WorkerBlockMap, WorkerId, WorkerIdExhausted, XXH3_SEED,
 };
 pub use path_hash::{hash_node_path, hash_token_path, GLOBAL_EVICTION_HASH};
 // Re-export under names matching old tree.rs API for easier migration

--- a/crates/radix_index/Cargo.toml
+++ b/crates/radix_index/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "radix-index"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Generic radix membership index service: block-quantized prefix chains, per-holder overlap scoring, pub in / sub out"
+
+[lib]
+name = "radix_index"
+path = "src/lib.rs"
+
+[[bin]]
+name = "radix-index-service"
+path = "src/bin/service.rs"
+
+[[bin]]
+name = "radix-index-bridge"
+path = "src/bin/bridge.rs"
+
+[[bin]]
+name = "radix-index-bench"
+path = "src/bin/bench.rs"
+
+[dependencies]
+kv-index = { path = "../kv_index" }
+smg-grpc-client = { path = "../grpc_client" }
+tonic.workspace = true
+tonic-prost.workspace = true
+prost.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = "0.1"
+futures.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true }
+rustc-hash = "2"
+
+[dev-dependencies]
+rand = { workspace = true }
+
+[build-dependencies]
+tonic-prost-build = "0.14.6"

--- a/crates/radix_index/Cargo.toml
+++ b/crates/radix_index/Cargo.toml
@@ -22,7 +22,7 @@ name = "radix-index-bench"
 path = "src/bin/bench.rs"
 
 [dependencies]
-kv-index = { path = "../kv_index" }
+radix-tree = { path = "../radix_tree" }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 smg-grpc-client = { path = "../grpc_client" }
 tonic.workspace = true
@@ -36,6 +36,7 @@ tracing-subscriber = { workspace = true }
 rustc-hash = "2"
 
 [dev-dependencies]
+kv-index = { path = "../kv_index" }
 rand = { workspace = true }
 mock-worker = { path = "../mock_worker" }
 portpicker = "0.1"

--- a/crates/radix_index/Cargo.toml
+++ b/crates/radix_index/Cargo.toml
@@ -36,6 +36,8 @@ rustc-hash = "2"
 
 [dev-dependencies]
 rand = { workspace = true }
+mock-worker = { path = "../mock_worker" }
+portpicker = "0.1"
 
 [build-dependencies]
 tonic-prost-build = "0.14.6"

--- a/crates/radix_index/Cargo.toml
+++ b/crates/radix_index/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/bin/bench.rs"
 
 [dependencies]
 kv-index = { path = "../kv_index" }
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
 smg-grpc-client = { path = "../grpc_client" }
 tonic.workspace = true
 tonic-prost.workspace = true

--- a/crates/radix_index/README.md
+++ b/crates/radix_index/README.md
@@ -1,0 +1,89 @@
+# radix-index
+
+A shared radix membership index for cache-aware routing: gateways ask
+"which worker already holds the longest prefix of this request?" without
+each gateway building and syncing its own tree.
+
+The data structure is [`radix-core`](../radix_core)'s block-quantized
+positional index. This crate wraps it in a keyspace-partitioned engine,
+a gRPC surface, and the client/bridge pieces that feed and query it.
+
+## Interface: two verbs
+
+- **Publish** (client-streamed `Update`s, acked): a holder's block-hash
+  chain changed. Two feeds share the verb:
+  - **Event feed** — a bridge subscribes to engine KV events
+    (`SubscribeKvEvents`) and forwards Stored/Removed/Cleared batches,
+    sequenced per holder with epoch bumps on gap or backend loss.
+    Eviction is *observed*, so index state tracks engine truth.
+  - **Placement feed** — a gateway publishes "this request's chain now
+    (probably) resides on that worker" after each completed request
+    (`seq=0`, content-idempotent). No engine cooperation needed — this
+    is the path for engines/modes with no KV event stream. Inferred
+    state is bounded by idle TTL + per-holder capacity with tail-first
+    (prefix-closed) eviction.
+  The first sequenced or Removed-bearing update marks a holder
+  *event-fed*: placements for it are ignored from then on, so the
+  precise feed always wins.
+- **Subscribe** (bidirectional query stream): content-hash chain in,
+  per-holder matched-block counts out. The gateway enforces its own
+  deadline (2 ms in SMG) and falls back to its local policy on a miss —
+  answers are advisory, never load-bearing for correctness.
+
+`Pull` streams the whole state as synthetic `Update`s; a starting
+replica bootstraps from a sibling with it before declaring ready.
+
+## Replication: copy, don't agree
+
+No consensus. Writes are per-holder sequenced (event feed) or
+content-idempotent (placement feed), so replicas converge by applying
+the same updates in any interleaving. A replica relays each accepted
+`Publish` to its `--peers` best-effort; a wedged peer drops relayed
+updates rather than wedging ingest, and TTL plus re-placement plus
+bootstrap bound the divergence. Gateways stay stupid: one endpoint, no
+fan-out, reconnect on failure.
+
+## Keyspaces
+
+State is partitioned by `(model, symbol_kind, block_size)`. TOKENS at
+the engine page size is what SMG uses today; BYTES exists for text-mode
+(HTTP) feeds that hash normalized bytes instead of token ids.
+
+## Binaries
+
+- `radix-index-service` — the server. Flags:
+
+  | flag | default | meaning |
+  |---|---|---|
+  | `--bind` | `127.0.0.1` | listen address (set `0.0.0.0` in k8s) |
+  | `--port` | `40000` | gRPC port |
+  | `--metrics-port` | off | admin plane: `/metrics`, `/healthz`, `/readyz` |
+  | `--peers` | none | sibling replicas to relay Publishes to (comma-separated URLs) |
+  | `--bootstrap-from` | none | sibling to Pull state from before serving |
+  | `--inferred-ttl-secs` | `180` | idle TTL for placement-fed holders |
+  | `--default-capacity-blocks` | unbounded | capacity for holders that never sent `Added` |
+  | `--sweep-interval-secs` | `5` | idle-sweep cadence |
+  | `--apply-delay-stored-ms` / `--apply-delay-removed-ms` | `0` | staleness injection (experiments only) |
+
+  Stops gracefully on SIGTERM/ctrl-c. `/readyz` answers 503 until the
+  bootstrap pull completes — point the k8s readiness probe at it.
+
+- `radix-index-bridge` — per-fleet event bridge: engine KV event
+  streams in, index Updates out.
+- `radix-index-bench` — apply/query throughput and memory-per-entry
+  microbench.
+
+A reference StatefulSet lives in [`deploy/statefulset.yaml`](deploy/statefulset.yaml).
+
+## Gateway side (SMG)
+
+`--kv-indexer-url` + `--kv-indexer-block-size` on the gateway enable
+the remote path: a routing-time overlap prefetch (2 ms deadline,
+fast-fail while disconnected) feeding the cache-aware policy, and a
+placement publish of the prompt⊕output chain after each completed
+request. Flag off = every code path byte-identical to local behavior.
+
+## Metrics
+
+`/metrics` (Prometheus text): `radix_index_{keyspaces,holders,event_fed_holders,dropped_holders,blocks}`
+gauges and `radix_index_{applies,queries,relay_dropped}_total` counters.

--- a/crates/radix_index/README.md
+++ b/crates/radix_index/README.md
@@ -4,9 +4,11 @@ A shared radix membership index for cache-aware routing: gateways ask
 "which worker already holds the longest prefix of this request?" without
 each gateway building and syncing its own tree.
 
-The data structure is [`radix-core`](../radix_core)'s block-quantized
-positional index. This crate wraps it in a keyspace-partitioned engine,
-a gRPC surface, and the client/bridge pieces that feed and query it.
+The data structure is SMG `kv_index`'s block-quantized positional
+index (a direct import — whether the service should instead get a
+ground-up generic radix tree is an open evaluation). This crate wraps
+it in a keyspace-partitioned engine, a gRPC surface, and the
+client/bridge pieces that feed and query it.
 
 ## Interface: two verbs
 

--- a/crates/radix_index/README.md
+++ b/crates/radix_index/README.md
@@ -63,7 +63,7 @@ the engine page size is what SMG uses today; BYTES exists for text-mode
   | `--peers` | none | sibling replicas to relay Publishes to (comma-separated URLs) |
   | `--bootstrap-from` | none | sibling to Pull state from before serving |
   | `--inferred-ttl-secs` | `180` | idle TTL for placement-fed holders |
-  | `--default-capacity-blocks` | unbounded | capacity for holders that never sent `Added` |
+  | `--default-capacity-blocks` | unbounded | RUNAWAY PROTECTION for holders that never sent `Added` — the index truncates only past 2x this value. Leave unbounded or set well above worker KV size: the placement feed carries no removal signal, so an index that races the worker's own eviction under-matches (measured); idle TTL is the freshness bound. |
   | `--sweep-interval-secs` | `5` | idle-sweep cadence |
   | `--apply-delay-stored-ms` / `--apply-delay-removed-ms` | `0` | staleness injection (experiments only) |
 

--- a/crates/radix_index/build.rs
+++ b/crates/radix_index/build.rs
@@ -1,0 +1,9 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=proto/radix_index.proto");
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile_protos(&["proto/radix_index.proto"], &["proto"])?;
+    Ok(())
+}

--- a/crates/radix_index/deploy/statefulset.yaml
+++ b/crates/radix_index/deploy/statefulset.yaml
@@ -1,0 +1,87 @@
+# Reference deployment: 2-replica radix index behind one stable Service
+# name per replica (headless). Gateways point --kv-indexer-url at ONE
+# replica address (or a per-zone one); replicas relay to each other and
+# a restarting replica bootstraps from its sibling before going ready.
+#
+# Sizing note: state is hash-only (no tokens); production-scale fleets
+# measured ~275 B/entry in-process. Set memory limits from your fleet's
+# total block count, and default-capacity-blocks from engine KV size /
+# page size so inferred holders stay bounded.
+apiVersion: v1
+kind: Service
+metadata:
+  name: radix-index
+spec:
+  clusterIP: None
+  selector:
+    app: radix-index
+  ports:
+    - name: grpc
+      port: 40000
+    - name: metrics
+      port: 40100
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: radix-index
+spec:
+  serviceName: radix-index
+  replicas: 2
+  selector:
+    matchLabels:
+      app: radix-index
+  template:
+    metadata:
+      labels:
+        app: radix-index
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: radix-index
+          image: REGISTRY/radix-index-service:VERSION
+          args:
+            - --bind=0.0.0.0
+            - --port=40000
+            - --metrics-port=40100
+            - --inferred-ttl-secs=180
+            # Relay to every sibling; self-relay is not a peer (each pod
+            # templates its own peer list via the ordinal hostname).
+            # For replicas: 2 the two pods are radix-index-0 / radix-index-1;
+            # an init script or an env-substituting entrypoint should drop
+            # the pod's own name from PEERS.
+            - --peers=$(PEERS)
+            - --bootstrap-from=$(BOOTSTRAP_FROM)
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # Example for 2 replicas; template these per-ordinal in your
+            # deploy tooling (kustomize/helm) so each pod excludes itself.
+            - name: PEERS
+              value: "http://radix-index-0.radix-index:40000,http://radix-index-1.radix-index:40000"
+            - name: BOOTSTRAP_FROM
+              value: "http://radix-index-0.radix-index:40000"
+          ports:
+            - name: grpc
+              containerPort: 40000
+            - name: metrics
+              containerPort: 40100
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "2"
+              memory: 8Gi
+            limits:
+              memory: 64Gi

--- a/crates/radix_index/proto/radix_index.proto
+++ b/crates/radix_index/proto/radix_index.proto
@@ -37,6 +37,10 @@ message Keyspace {
   string model = 1;
   SymbolKind symbol_kind = 2;
   uint32 block_size = 3;
+  // Wire hash scheme version; 0 (unset) means scheme 1. An index
+  // rejects updates/queries whose scheme it cannot serve, so hash
+  // drift fails loudly instead of matching nothing.
+  uint32 hash_scheme = 4;
 }
 
 message Block {

--- a/crates/radix_index/proto/radix_index.proto
+++ b/crates/radix_index/proto/radix_index.proto
@@ -1,0 +1,121 @@
+// Generic radix membership index: block-quantized prefix chains with
+// per-holder overlap scoring. The service knows nothing about LLMs —
+// symbols are opaque, hashes are the currency, holders carry opaque
+// metadata. Two data verbs (Publish, Subscribe) plus Pull for replica
+// bootstrap, which speaks the same Update vocabulary.
+syntax = "proto3";
+
+package radix_index;
+
+service RadixIndex {
+  // Every mutation, from any publisher: republished holder events
+  // (worker-sequenced), inferred placements (unsequenced, idempotent by
+  // content), and membership control. Acks carry the applied watermark
+  // per holder so publishers can resume after reconnect.
+  rpc Publish(stream Update) returns (stream PublishAck);
+
+  // Routing hot path: persistent bidi stream; each Query is answered by
+  // exactly one Match echoing its query_id. Late answers are the
+  // client's to drop.
+  rpc Subscribe(stream Query) returns (stream Match);
+
+  // Replica bootstrap: current state replayed as synthetic Updates.
+  // A booting replica applies the stream fully before serving.
+  rpc Pull(PullRequest) returns (stream Update);
+}
+
+enum SymbolKind {
+  SYMBOL_KIND_UNSPECIFIED = 0;
+  TOKENS = 1;
+  BYTES = 2;
+}
+
+// Index partition. Chains from different keyspaces never match each
+// other; a holder publishing a mismatched block_size for a keyspace is
+// rejected, never merged.
+message Keyspace {
+  string model = 1;
+  SymbolKind symbol_kind = 2;
+  uint32 block_size = 3;
+}
+
+message Block {
+  // Position-chained identity: for events, the engine's block_hash; for
+  // placements, the deterministic rolling prefix hash (chain_prefix_hash
+  // over content hashes) so all publishers synthesize identical chains.
+  fixed64 seq_hash = 1;
+  // Position-independent content hash (kv_index::compute_content_hash).
+  fixed64 content_hash = 2;
+}
+
+message Stored {
+  optional fixed64 parent_seq_hash = 1; // absent = sequence start
+  repeated Block blocks = 2;            // ascending positions
+}
+
+message Removed {
+  repeated fixed64 seq_hashes = 1;
+}
+
+// Membership / capacity control. event_fed pins the holder's feed
+// authority immediately (otherwise it flips on the first Removed).
+message Added {
+  uint64 capacity_blocks = 1;
+  bool event_fed = 2;
+  bytes metadata = 3;
+}
+
+message Event {
+  oneof kind {
+    Stored stored = 1;
+    Removed removed = 2;
+    bool cleared = 3;
+  }
+}
+
+message Update {
+  Keyspace keyspace = 1;
+  string holder = 2;
+  // Holder generation (engine boot identity). A higher epoch implicitly
+  // clears all lower-epoch state for the holder; lower-epoch updates
+  // are dropped. Worker restarts and republisher cursor loss are both
+  // epoch bumps.
+  uint64 epoch = 3;
+  // Event feed: the holder's batch number; dedup + ordering key within
+  // (holder, epoch). 0 = unsequenced (placements / control), applied
+  // idempotently.
+  uint64 seq = 4;
+  // Batch-shaped: one seq may carry mixed Stored/Removed, mirroring
+  // engine event batches. Splitting one batch across seqs loses events.
+  repeated Event events = 5;
+  optional Added added = 6;
+  // Soft retire: stop scoring the holder; state expires by TTL.
+  bool dropped = 7;
+}
+
+message PublishAck {
+  string holder = 1;
+  uint64 epoch = 2;
+  uint64 applied_seq = 3;
+}
+
+message Query {
+  uint64 query_id = 1;
+  Keyspace keyspace = 2;
+  // The request prefix as content hashes, block-aligned from position 0.
+  repeated fixed64 content_hashes = 3;
+}
+
+message HolderScore {
+  string holder = 1;
+  uint32 matched_blocks = 2;
+  uint64 total_blocks = 3;
+  bool event_fed = 4;
+}
+
+message Match {
+  uint64 query_id = 1;
+  repeated HolderScore scores = 2;
+}
+
+message PullRequest {}

--- a/crates/radix_index/src/bin/bench.rs
+++ b/crates/radix_index/src/bin/bench.rs
@@ -1,0 +1,117 @@
+//! Synthetic scale bench: fill the engine to N entries, report RSS per
+//! entry, sustained apply rate, and query latency percentiles. This is
+//! the only source for production sizing claims — the sim rig's fleet is
+//! ~0.3% of production entry count.
+//!
+//! Usage:
+//!   radix-index-bench [--holders 2000] [--blocks-per-holder 9000]
+//!     [--queries 20000] [--query-depth 78]
+
+use std::time::Instant;
+
+use kv_index::compute_content_hash;
+use radix_index::{
+    placement_chain, Engine, EngineConfig, KeyspaceKey, SymbolKind, UpdateMsg, WireEvent,
+};
+
+fn parse_flag<T: std::str::FromStr>(args: &[String], flag: &str) -> Option<T> {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .and_then(|v| v.parse().ok())
+}
+
+fn rss_kib() -> u64 {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &std::process::id().to_string()])
+        .output()
+        .expect("ps");
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let holders: usize = parse_flag(&args, "--holders").unwrap_or(2000);
+    let blocks_per_holder: usize = parse_flag(&args, "--blocks-per-holder").unwrap_or(9000);
+    let queries: usize = parse_flag(&args, "--queries").unwrap_or(20_000);
+    let query_depth: usize = parse_flag(&args, "--query-depth").unwrap_or(78);
+
+    let keyspace = KeyspaceKey {
+        model: "bench".into(),
+        symbol_kind: SymbolKind::Tokens,
+        block_size: 128,
+    };
+    let engine = Engine::new(EngineConfig::default());
+    let rss_before = rss_kib();
+
+    // Fill: each holder gets a distinct chain, stored in event batches of
+    // 8 blocks (the realistic event-shape), timing the apply path.
+    let batch = 8usize;
+    let fill_start = Instant::now();
+    let mut applied_blocks = 0usize;
+    for h in 0..holders {
+        let hashes: Vec<_> = (0..blocks_per_holder as u64)
+            .map(|i| compute_content_hash(&[h as u32, (i >> 32) as u32, i as u32]))
+            .collect();
+        let chain = placement_chain(&hashes);
+        for (i, window) in chain.chunks(batch).enumerate() {
+            let parent = if i == 0 {
+                None
+            } else {
+                Some(chain[i * batch - 1].seq_hash)
+            };
+            let update = UpdateMsg {
+                keyspace: keyspace.clone(),
+                holder: format!("grpc://10.0.0.{}:{}", h % 250, 9000 + h / 250),
+                epoch: 1,
+                seq: (i + 1) as u64,
+                events: vec![WireEvent::Stored {
+                    parent,
+                    blocks: window.to_vec(),
+                }],
+                added: None,
+                dropped: false,
+            };
+            engine.apply(&update);
+            applied_blocks += window.len();
+        }
+    }
+    let fill_secs = fill_start.elapsed().as_secs_f64();
+    let rss_after = rss_kib();
+    let entries = engine.entry_count();
+
+    // Queries: warm prefixes of the filled chains at the requested depth.
+    let mut latencies = Vec::with_capacity(queries);
+    for q in 0..queries {
+        let h = q % holders;
+        let hashes: Vec<_> = (0..query_depth as u64)
+            .map(|i| compute_content_hash(&[h as u32, (i >> 32) as u32, i as u32]))
+            .collect();
+        let start = Instant::now();
+        let scores = engine.find_matches(&keyspace, &hashes);
+        latencies.push(start.elapsed().as_secs_f64() * 1e6);
+        assert!(!scores.is_empty(), "warm query must match");
+    }
+    latencies.sort_by(f64::total_cmp);
+    let pct = |p: f64| latencies[((latencies.len() as f64 * p) as usize).min(latencies.len() - 1)];
+
+    println!("entries {entries}");
+    println!(
+        "rss_total_mib {:.1}  rss_bytes_per_entry {:.1}",
+        (rss_after - rss_before) as f64 / 1024.0,
+        (rss_after - rss_before) as f64 * 1024.0 / entries.max(1) as f64
+    );
+    println!(
+        "apply_blocks_per_sec {:.0} (filled {applied_blocks} blocks in {fill_secs:.1}s)",
+        applied_blocks as f64 / fill_secs
+    );
+    println!(
+        "query_us p50 {:.1}  p99 {:.1}  max {:.1}  (depth {query_depth}, {queries} queries)",
+        pct(0.50),
+        pct(0.99),
+        pct(1.0)
+    );
+}

--- a/crates/radix_index/src/bin/bench.rs
+++ b/crates/radix_index/src/bin/bench.rs
@@ -9,9 +9,9 @@
 
 use std::time::Instant;
 
-use kv_index::compute_content_hash;
 use radix_index::{
-    placement_chain, Engine, EngineConfig, KeyspaceKey, SymbolKind, UpdateMsg, WireEvent,
+    placement_chain, wire_hash::content_hash as compute_content_hash, Engine, EngineConfig,
+    KeyspaceKey, SymbolKind, UpdateMsg, WireEvent,
 };
 
 fn parse_flag<T: std::str::FromStr>(args: &[String], flag: &str) -> Option<T> {

--- a/crates/radix_index/src/bin/bridge.rs
+++ b/crates/radix_index/src/bin/bridge.rs
@@ -1,0 +1,217 @@
+//! Event bridge: subscribes to workers' `SubscribeKvEvents` streams
+//! (TokenSpeed dialect — the sim fleet's), converts batches to index
+//! Updates with publisher-computed content hashes (hash-only wire), and
+//! publishes them to one index endpoint over a single Publish stream.
+//!
+//! Reconnect semantics mirror the gateway monitor's: resume from the
+//! last applied seq; a gap or a backend loss signal (DataLoss /
+//! OutOfRange) bumps the holder's EPOCH and restarts from zero — the
+//! epoch bump is what makes the restart safe to relay.
+//!
+//! Usage:
+//!   radix-index-bridge --workers grpc://127.0.0.1:9000,... \
+//!     --index http://127.0.0.1:40000 --model mock-model --block-size 256
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use kv_index::compute_content_hash;
+use radix_index::proto::{self, radix_index_client::RadixIndexClient};
+use smg_grpc_client::{common_proto, tokenspeed_scheduler::TokenSpeedSchedulerClient};
+use tokio::sync::mpsc;
+
+fn parse_flag<T: std::str::FromStr>(args: &[String], flag: &str) -> Option<T> {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .and_then(|v| v.parse().ok())
+}
+
+fn keyspace(model: &str, block_size: u32) -> proto::Keyspace {
+    proto::Keyspace {
+        model: model.to_string(),
+        symbol_kind: proto::SymbolKind::Tokens as i32,
+        block_size,
+    }
+}
+
+fn convert_batch(
+    batch: &common_proto::KvEventBatch,
+    model: &str,
+    block_size: u32,
+    holder: &str,
+    epoch: u64,
+) -> proto::Update {
+    let events = batch
+        .events
+        .iter()
+        .filter_map(|event| event.data.as_ref())
+        .map(|data| {
+            let kind = match data {
+                common_proto::kv_cache_event::Data::Stored(stored) => {
+                    proto::event::Kind::Stored(proto::Stored {
+                        parent_seq_hash: stored.parent_block_hash.map(|p| p as u64),
+                        blocks: stored
+                            .blocks
+                            .iter()
+                            .map(|b| proto::Block {
+                                seq_hash: b.block_hash as u64,
+                                content_hash: compute_content_hash(&b.token_ids).0,
+                            })
+                            .collect(),
+                    })
+                }
+                common_proto::kv_cache_event::Data::Removed(removed) => {
+                    proto::event::Kind::Removed(proto::Removed {
+                        seq_hashes: removed.block_hashes.iter().map(|&h| h as u64).collect(),
+                    })
+                }
+                common_proto::kv_cache_event::Data::Cleared(_) => proto::event::Kind::Cleared(true),
+            };
+            proto::Event { kind: Some(kind) }
+        })
+        .collect();
+    proto::Update {
+        keyspace: Some(keyspace(model, block_size)),
+        holder: holder.to_string(),
+        epoch,
+        seq: batch.sequence_number,
+        events,
+        added: None,
+        dropped: false,
+    }
+}
+
+/// One worker's subscription loop: resume on plain failures, epoch-bump
+/// on loss signals or sequence gaps.
+async fn worker_loop(
+    worker: String,
+    model: String,
+    block_size: u32,
+    out: mpsc::Sender<proto::Update>,
+) {
+    let mut epoch: u64 = 1;
+    let mut last_seq: u64 = 0;
+    loop {
+        let Ok(client) = TokenSpeedSchedulerClient::connect(&worker).await else {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            continue;
+        };
+        let mut stream = match client.subscribe_kv_events(last_seq).await {
+            Ok(stream) => stream,
+            Err(status) => {
+                match status.code() {
+                    // Terminal per the monitor contract.
+                    tonic::Code::Unimplemented => {
+                        tracing::warn!(%worker, "KV events unimplemented; bridge exits for this worker");
+                        return;
+                    }
+                    // Cursor lost: new generation, replay from zero.
+                    tonic::Code::OutOfRange | tonic::Code::DataLoss => {
+                        epoch += 1;
+                        last_seq = 0;
+                    }
+                    _ => {}
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                continue;
+            }
+        };
+        while let Some(batch) = stream.next().await {
+            let Ok(batch) = batch else { break };
+            if last_seq > 0 && batch.sequence_number <= last_seq {
+                continue; // duplicate replay
+            }
+            if last_seq > 0 && batch.sequence_number > last_seq + 1 {
+                // Gap: the ring may have wrapped; new generation.
+                epoch += 1;
+                last_seq = 0;
+                break;
+            }
+            last_seq = batch.sequence_number;
+            let update = convert_batch(&batch, &model, block_size, &worker, epoch);
+            if out.send(update).await.is_err() {
+                return; // publisher gone; process exiting
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "worker subscription tasks live for the process lifetime"
+)]
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    tracing_subscriber::fmt::init();
+    let args: Vec<String> = std::env::args().collect();
+    let workers: Vec<String> = parse_flag::<String>(&args, "--workers")
+        .map(|s| {
+            s.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let index: String =
+        parse_flag(&args, "--index").unwrap_or_else(|| "http://127.0.0.1:40000".to_string());
+    let model: String = parse_flag(&args, "--model").unwrap_or_else(|| "mock-model".to_string());
+    let block_size: u32 = parse_flag(&args, "--block-size").unwrap_or(256);
+    if workers.is_empty() {
+        eprintln!("--workers is required");
+        return std::process::ExitCode::from(2);
+    }
+
+    let (tx, rx) = mpsc::channel::<proto::Update>(65_536);
+    for worker in &workers {
+        tokio::spawn(worker_loop(
+            worker.clone(),
+            model.clone(),
+            block_size,
+            tx.clone(),
+        ));
+    }
+    drop(tx);
+    tracing::info!(workers = workers.len(), %index, "bridge running");
+
+    // One Publish stream to the index; reconnect forever, the receiver
+    // half persists across reconnects so no update is lost in the bridge.
+    let mut rx = rx;
+    loop {
+        let Ok(mut client) = RadixIndexClient::connect(index.clone()).await else {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            continue;
+        };
+        let (fwd_tx, fwd_rx) = mpsc::channel::<proto::Update>(1024);
+        let outbound = tokio_stream::wrappers::ReceiverStream::new(fwd_rx);
+        let mut acks = match client.publish(tonic::Request::new(outbound)).await {
+            Ok(response) => response.into_inner(),
+            Err(error) => {
+                tracing::warn!(%error, "publish stream failed; retrying");
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                continue;
+            }
+        };
+        loop {
+            tokio::select! {
+                item = rx.recv() => match item {
+                    Some(update) => {
+                        if fwd_tx.send(update).await.is_err() {
+                            break;
+                        }
+                    }
+                    // All worker loops ended (fleet torn down).
+                    None => return std::process::ExitCode::SUCCESS,
+                },
+                ack = acks.next() => {
+                    if ack.is_none() {
+                        break;
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}

--- a/crates/radix_index/src/bin/bridge.rs
+++ b/crates/radix_index/src/bin/bridge.rs
@@ -41,16 +41,18 @@ async fn main() -> std::process::ExitCode {
     }
 
     let (tx, rx) = mpsc::channel::<proto::Update>(65_536);
+    let ledger = bridge::EpochLedger::default();
     for worker in &workers {
         tokio::spawn(bridge::worker_loop(
             worker.clone(),
             model.clone(),
             block_size,
             tx.clone(),
+            ledger.clone(),
         ));
     }
     drop(tx);
     tracing::info!(workers = workers.len(), %index, "bridge running");
-    bridge::run_publisher(rx, index).await;
+    bridge::run_publisher(rx, index, ledger).await;
     std::process::ExitCode::SUCCESS
 }

--- a/crates/radix_index/src/bin/bridge.rs
+++ b/crates/radix_index/src/bin/bridge.rs
@@ -1,23 +1,10 @@
-//! Event bridge: subscribes to workers' `SubscribeKvEvents` streams
-//! (TokenSpeed dialect — the sim fleet's), converts batches to index
-//! Updates with publisher-computed content hashes (hash-only wire), and
-//! publishes them to one index endpoint over a single Publish stream.
-//!
-//! Reconnect semantics mirror the gateway monitor's: resume from the
-//! last applied seq; a gap or a backend loss signal (DataLoss /
-//! OutOfRange) bumps the holder's EPOCH and restarts from zero — the
-//! epoch bump is what makes the restart safe to relay.
+//! Event bridge binary: see `radix_index::bridge` for the semantics.
 //!
 //! Usage:
 //!   radix-index-bridge --workers grpc://127.0.0.1:9000,... \
 //!     --index http://127.0.0.1:40000 --model mock-model --block-size 256
 
-use std::time::Duration;
-
-use futures::StreamExt;
-use kv_index::compute_content_hash;
-use radix_index::proto::{self, radix_index_client::RadixIndexClient};
-use smg_grpc_client::{common_proto, tokenspeed_scheduler::TokenSpeedSchedulerClient};
+use radix_index::{bridge, proto};
 use tokio::sync::mpsc;
 
 fn parse_flag<T: std::str::FromStr>(args: &[String], flag: &str) -> Option<T> {
@@ -25,117 +12,6 @@ fn parse_flag<T: std::str::FromStr>(args: &[String], flag: &str) -> Option<T> {
         .position(|a| a == flag)
         .and_then(|i| args.get(i + 1))
         .and_then(|v| v.parse().ok())
-}
-
-fn keyspace(model: &str, block_size: u32) -> proto::Keyspace {
-    proto::Keyspace {
-        model: model.to_string(),
-        symbol_kind: proto::SymbolKind::Tokens as i32,
-        block_size,
-    }
-}
-
-fn convert_batch(
-    batch: &common_proto::KvEventBatch,
-    model: &str,
-    block_size: u32,
-    holder: &str,
-    epoch: u64,
-) -> proto::Update {
-    let events = batch
-        .events
-        .iter()
-        .filter_map(|event| event.data.as_ref())
-        .map(|data| {
-            let kind = match data {
-                common_proto::kv_cache_event::Data::Stored(stored) => {
-                    proto::event::Kind::Stored(proto::Stored {
-                        parent_seq_hash: stored.parent_block_hash.map(|p| p as u64),
-                        blocks: stored
-                            .blocks
-                            .iter()
-                            .map(|b| proto::Block {
-                                seq_hash: b.block_hash as u64,
-                                content_hash: compute_content_hash(&b.token_ids).0,
-                            })
-                            .collect(),
-                    })
-                }
-                common_proto::kv_cache_event::Data::Removed(removed) => {
-                    proto::event::Kind::Removed(proto::Removed {
-                        seq_hashes: removed.block_hashes.iter().map(|&h| h as u64).collect(),
-                    })
-                }
-                common_proto::kv_cache_event::Data::Cleared(_) => proto::event::Kind::Cleared(true),
-            };
-            proto::Event { kind: Some(kind) }
-        })
-        .collect();
-    proto::Update {
-        keyspace: Some(keyspace(model, block_size)),
-        holder: holder.to_string(),
-        epoch,
-        seq: batch.sequence_number,
-        events,
-        added: None,
-        dropped: false,
-    }
-}
-
-/// One worker's subscription loop: resume on plain failures, epoch-bump
-/// on loss signals or sequence gaps.
-async fn worker_loop(
-    worker: String,
-    model: String,
-    block_size: u32,
-    out: mpsc::Sender<proto::Update>,
-) {
-    let mut epoch: u64 = 1;
-    let mut last_seq: u64 = 0;
-    loop {
-        let Ok(client) = TokenSpeedSchedulerClient::connect(&worker).await else {
-            tokio::time::sleep(Duration::from_millis(500)).await;
-            continue;
-        };
-        let mut stream = match client.subscribe_kv_events(last_seq).await {
-            Ok(stream) => stream,
-            Err(status) => {
-                match status.code() {
-                    // Terminal per the monitor contract.
-                    tonic::Code::Unimplemented => {
-                        tracing::warn!(%worker, "KV events unimplemented; bridge exits for this worker");
-                        return;
-                    }
-                    // Cursor lost: new generation, replay from zero.
-                    tonic::Code::OutOfRange | tonic::Code::DataLoss => {
-                        epoch += 1;
-                        last_seq = 0;
-                    }
-                    _ => {}
-                }
-                tokio::time::sleep(Duration::from_millis(500)).await;
-                continue;
-            }
-        };
-        while let Some(batch) = stream.next().await {
-            let Ok(batch) = batch else { break };
-            if last_seq > 0 && batch.sequence_number <= last_seq {
-                continue; // duplicate replay
-            }
-            if last_seq > 0 && batch.sequence_number > last_seq + 1 {
-                // Gap: the ring may have wrapped; new generation.
-                epoch += 1;
-                last_seq = 0;
-                break;
-            }
-            last_seq = batch.sequence_number;
-            let update = convert_batch(&batch, &model, block_size, &worker, epoch);
-            if out.send(update).await.is_err() {
-                return; // publisher gone; process exiting
-            }
-        }
-        tokio::time::sleep(Duration::from_millis(200)).await;
-    }
 }
 
 #[expect(
@@ -166,7 +42,7 @@ async fn main() -> std::process::ExitCode {
 
     let (tx, rx) = mpsc::channel::<proto::Update>(65_536);
     for worker in &workers {
-        tokio::spawn(worker_loop(
+        tokio::spawn(bridge::worker_loop(
             worker.clone(),
             model.clone(),
             block_size,
@@ -175,43 +51,6 @@ async fn main() -> std::process::ExitCode {
     }
     drop(tx);
     tracing::info!(workers = workers.len(), %index, "bridge running");
-
-    // One Publish stream to the index; reconnect forever, the receiver
-    // half persists across reconnects so no update is lost in the bridge.
-    let mut rx = rx;
-    loop {
-        let Ok(mut client) = RadixIndexClient::connect(index.clone()).await else {
-            tokio::time::sleep(Duration::from_millis(500)).await;
-            continue;
-        };
-        let (fwd_tx, fwd_rx) = mpsc::channel::<proto::Update>(1024);
-        let outbound = tokio_stream::wrappers::ReceiverStream::new(fwd_rx);
-        let mut acks = match client.publish(tonic::Request::new(outbound)).await {
-            Ok(response) => response.into_inner(),
-            Err(error) => {
-                tracing::warn!(%error, "publish stream failed; retrying");
-                tokio::time::sleep(Duration::from_millis(500)).await;
-                continue;
-            }
-        };
-        loop {
-            tokio::select! {
-                item = rx.recv() => match item {
-                    Some(update) => {
-                        if fwd_tx.send(update).await.is_err() {
-                            break;
-                        }
-                    }
-                    // All worker loops ended (fleet torn down).
-                    None => return std::process::ExitCode::SUCCESS,
-                },
-                ack = acks.next() => {
-                    if ack.is_none() {
-                        break;
-                    }
-                }
-            }
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
+    bridge::run_publisher(rx, index).await;
+    std::process::ExitCode::SUCCESS
 }

--- a/crates/radix_index/src/bin/service.rs
+++ b/crates/radix_index/src/bin/service.rs
@@ -1,14 +1,28 @@
 //! The radix index service binary.
 //!
 //! Usage:
-//!   radix-index-service --port 40000 [--peers http://127.0.0.1:40001,..]
+//!   radix-index-service --port 40000 [--bind 0.0.0.0]
+//!     [--peers http://127.0.0.1:40001,..]
 //!     [--bootstrap-from http://127.0.0.1:40001]
-//!     [--inferred-ttl-secs 18] [--default-capacity-blocks 4688]
-//!     [--sweep-interval-secs 5] [--apply-delay-ms 0]
+//!     [--metrics-port 40100]
+//!     [--inferred-ttl-secs 180] [--default-capacity-blocks N]
+//!     [--sweep-interval-secs 5]
+//!     [--apply-delay-stored-ms 0] [--apply-delay-removed-ms 0]
+//!
+//! Stops gracefully on SIGTERM or ctrl-c: in-flight streams finish and
+//! clients reconnect to a sibling replica. The metrics port serves
+//! `/metrics`, `/healthz`, and `/readyz` (503 until the bootstrap pull
+//! completes — point the k8s readiness probe there).
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{atomic::Ordering, Arc},
+    time::Duration,
+};
 
-use radix_index::{server, Engine, EngineConfig};
+use radix_index::{
+    server::{self, ServiceStats},
+    Engine, EngineConfig,
+};
 
 fn parse_flag<T: std::str::FromStr>(args: &[String], flag: &str) -> Option<T> {
     args.iter()
@@ -17,11 +31,31 @@ fn parse_flag<T: std::str::FromStr>(args: &[String], flag: &str) -> Option<T> {
         .and_then(|v| v.parse().ok())
 }
 
+async fn shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+    #[cfg(unix)]
+    {
+        let mut term = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("SIGTERM handler");
+        tokio::select! {
+            _ = ctrl_c => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = ctrl_c.await;
+    }
+    tracing::info!("shutdown signal received; stopping gracefully");
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
     let args: Vec<String> = std::env::args().collect();
+    let bind: String = parse_flag(&args, "--bind").unwrap_or_else(|| "127.0.0.1".to_string());
     let port: u16 = parse_flag(&args, "--port").unwrap_or(40000);
+    let metrics_port: u16 = parse_flag(&args, "--metrics-port").unwrap_or(0);
     let peers: Vec<String> = parse_flag::<String>(&args, "--peers")
         .map(|s| {
             s.split(',')
@@ -44,17 +78,47 @@ async fn main() {
         Duration::from_millis(parse_flag(&args, "--apply-delay-removed-ms").unwrap_or(0));
 
     let engine = Arc::new(Engine::new(cfg));
+    let stats = Arc::new(ServiceStats::default());
+
+    // Admin plane first so /readyz answers (503) during bootstrap.
+    if metrics_port != 0 {
+        let admin_addr = format!("{bind}:{metrics_port}")
+            .parse()
+            .expect("admin addr");
+        let admin_engine = Arc::clone(&engine);
+        let admin_stats = Arc::clone(&stats);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "process-lifetime admin listener; dies with the process"
+        )]
+        tokio::spawn(async move {
+            if let Err(error) = server::serve_admin(admin_engine, admin_stats, admin_addr).await {
+                tracing::error!(%error, "admin listener exited");
+            }
+        });
+    }
+
     if let Some(peer) = bootstrap {
         match server::bootstrap_from(&engine, &peer).await {
             Ok(applied) => tracing::info!(peer, applied, "bootstrap pull complete"),
             Err(error) => tracing::warn!(peer, %error, "bootstrap pull failed; starting cold"),
         }
     }
+    stats.ready.store(true, Ordering::Relaxed);
 
-    let addr = format!("127.0.0.1:{port}").parse().expect("bind addr");
+    let addr = format!("{bind}:{port}").parse().expect("bind addr");
     tracing::info!(%addr, peers = peers.len(), "radix index serving");
-    if let Err(error) =
-        server::serve_with_delays(engine, addr, peers, sweep, delay_stored, delay_removed).await
+    if let Err(error) = server::serve_until(
+        engine,
+        addr,
+        peers,
+        sweep,
+        delay_stored,
+        delay_removed,
+        stats,
+        shutdown_signal(),
+    )
+    .await
     {
         tracing::error!(%error, "server exited");
     }

--- a/crates/radix_index/src/bin/service.rs
+++ b/crates/radix_index/src/bin/service.rs
@@ -1,0 +1,55 @@
+//! The radix index service binary.
+//!
+//! Usage:
+//!   radix-index-service --port 40000 [--peers http://127.0.0.1:40001,..]
+//!     [--bootstrap-from http://127.0.0.1:40001]
+//!     [--inferred-ttl-secs 18] [--default-capacity-blocks 4688]
+//!     [--sweep-interval-secs 5] [--apply-delay-ms 0]
+
+use std::{sync::Arc, time::Duration};
+
+use radix_index::{server, Engine, EngineConfig};
+
+fn parse_flag<T: std::str::FromStr>(args: &[String], flag: &str) -> Option<T> {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .and_then(|v| v.parse().ok())
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    let args: Vec<String> = std::env::args().collect();
+    let port: u16 = parse_flag(&args, "--port").unwrap_or(40000);
+    let peers: Vec<String> = parse_flag::<String>(&args, "--peers")
+        .map(|s| {
+            s.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let bootstrap: Option<String> = parse_flag(&args, "--bootstrap-from");
+    let cfg = EngineConfig {
+        jump_size: 64,
+        inferred_ttl: Duration::from_secs(parse_flag(&args, "--inferred-ttl-secs").unwrap_or(180)),
+        default_capacity_blocks: parse_flag(&args, "--default-capacity-blocks").unwrap_or(u64::MAX),
+    };
+    let sweep = Duration::from_secs(parse_flag(&args, "--sweep-interval-secs").unwrap_or(5));
+
+    let engine = Arc::new(Engine::new(cfg));
+    if let Some(peer) = bootstrap {
+        match server::bootstrap_from(&engine, &peer).await {
+            Ok(applied) => tracing::info!(peer, applied, "bootstrap pull complete"),
+            Err(error) => tracing::warn!(peer, %error, "bootstrap pull failed; starting cold"),
+        }
+    }
+
+    let addr = format!("127.0.0.1:{port}").parse().expect("bind addr");
+    tracing::info!(%addr, peers = peers.len(), "radix index serving");
+    if let Err(error) = server::serve(engine, addr, peers, sweep).await {
+        tracing::error!(%error, "server exited");
+    }
+}

--- a/crates/radix_index/src/bin/service.rs
+++ b/crates/radix_index/src/bin/service.rs
@@ -31,6 +31,7 @@ const KNOWN_FLAGS: &[&str] = &[
     "--peers",
     "--bootstrap-from",
     "--inferred-ttl-secs",
+    "--event-ttl-secs",
     "--default-capacity-blocks",
     "--sweep-interval-secs",
     "--apply-delay-stored-ms",
@@ -106,6 +107,10 @@ async fn main() {
     let bootstrap: Option<String> = parse_flag(&args, "--bootstrap-from");
     let cfg = EngineConfig {
         inferred_ttl: Duration::from_secs(parse_flag(&args, "--inferred-ttl-secs").unwrap_or(180)),
+        // Liveness backstop for event-fed holders whose gateway-published
+        // departure signal was lost; 0 disables. Keep well above the
+        // event feed's idle cadence.
+        event_ttl: Duration::from_secs(parse_flag(&args, "--event-ttl-secs").unwrap_or(1800)),
         default_capacity_blocks: parse_flag(&args, "--default-capacity-blocks").unwrap_or(u64::MAX),
     };
     let sweep_secs: u64 = parse_flag(&args, "--sweep-interval-secs").unwrap_or(5);
@@ -118,6 +123,7 @@ async fn main() {
 
     tracing::info!(
         inferred_ttl_secs = cfg.inferred_ttl.as_secs(),
+        event_ttl_secs = cfg.event_ttl.as_secs(),
         default_capacity_blocks = cfg.default_capacity_blocks,
         "engine config"
     );

--- a/crates/radix_index/src/bin/service.rs
+++ b/crates/radix_index/src/bin/service.rs
@@ -67,7 +67,6 @@ async fn main() {
         .unwrap_or_default();
     let bootstrap: Option<String> = parse_flag(&args, "--bootstrap-from");
     let cfg = EngineConfig {
-        jump_size: 64,
         inferred_ttl: Duration::from_secs(parse_flag(&args, "--inferred-ttl-secs").unwrap_or(180)),
         default_capacity_blocks: parse_flag(&args, "--default-capacity-blocks").unwrap_or(u64::MAX),
     };

--- a/crates/radix_index/src/bin/service.rs
+++ b/crates/radix_index/src/bin/service.rs
@@ -38,6 +38,10 @@ async fn main() {
         default_capacity_blocks: parse_flag(&args, "--default-capacity-blocks").unwrap_or(u64::MAX),
     };
     let sweep = Duration::from_secs(parse_flag(&args, "--sweep-interval-secs").unwrap_or(5));
+    let delay_stored =
+        Duration::from_millis(parse_flag(&args, "--apply-delay-stored-ms").unwrap_or(0));
+    let delay_removed =
+        Duration::from_millis(parse_flag(&args, "--apply-delay-removed-ms").unwrap_or(0));
 
     let engine = Arc::new(Engine::new(cfg));
     if let Some(peer) = bootstrap {
@@ -49,7 +53,9 @@ async fn main() {
 
     let addr = format!("127.0.0.1:{port}").parse().expect("bind addr");
     tracing::info!(%addr, peers = peers.len(), "radix index serving");
-    if let Err(error) = server::serve(engine, addr, peers, sweep).await {
+    if let Err(error) =
+        server::serve_with_delays(engine, addr, peers, sweep, delay_stored, delay_removed).await
+    {
         tracing::error!(%error, "server exited");
     }
 }

--- a/crates/radix_index/src/bin/service.rs
+++ b/crates/radix_index/src/bin/service.rs
@@ -24,11 +24,48 @@ use radix_index::{
     Engine, EngineConfig,
 };
 
+const KNOWN_FLAGS: &[&str] = &[
+    "--bind",
+    "--port",
+    "--metrics-port",
+    "--peers",
+    "--bootstrap-from",
+    "--inferred-ttl-secs",
+    "--default-capacity-blocks",
+    "--sweep-interval-secs",
+    "--apply-delay-stored-ms",
+    "--apply-delay-removed-ms",
+];
+
 fn parse_flag<T: std::str::FromStr>(args: &[String], flag: &str) -> Option<T> {
-    args.iter()
-        .position(|a| a == flag)
-        .and_then(|i| args.get(i + 1))
-        .and_then(|v| v.parse().ok())
+    let i = args.iter().position(|a| a == flag)?;
+    let value = args
+        .get(i + 1)
+        .unwrap_or_else(|| panic!("flag {flag} is missing its value"));
+    Some(
+        value
+            .parse()
+            .unwrap_or_else(|_| panic!("flag {flag} has an unparseable value: {value:?}")),
+    )
+}
+
+/// Unknown flags and unparseable values are startup errors, never
+/// silent fallbacks to defaults (audit finding: a typo'd
+/// --bootstrap-from meant silently-cold restarts forever).
+fn validate_flags(args: &[String]) {
+    let mut i = 1;
+    while i < args.len() {
+        let arg = &args[i];
+        if arg.starts_with("--") {
+            assert!(
+                KNOWN_FLAGS.contains(&arg.as_str()),
+                "unknown flag {arg}; known flags: {KNOWN_FLAGS:?}"
+            );
+            i += 2;
+        } else {
+            panic!("unexpected argument {arg}");
+        }
+    }
 }
 
 async fn shutdown_signal() {
@@ -53,6 +90,7 @@ async fn shutdown_signal() {
 async fn main() {
     tracing_subscriber::fmt::init();
     let args: Vec<String> = std::env::args().collect();
+    validate_flags(&args);
     let bind: String = parse_flag(&args, "--bind").unwrap_or_else(|| "127.0.0.1".to_string());
     let port: u16 = parse_flag(&args, "--port").unwrap_or(40000);
     let metrics_port: u16 = parse_flag(&args, "--metrics-port").unwrap_or(0);
@@ -70,12 +108,19 @@ async fn main() {
         inferred_ttl: Duration::from_secs(parse_flag(&args, "--inferred-ttl-secs").unwrap_or(180)),
         default_capacity_blocks: parse_flag(&args, "--default-capacity-blocks").unwrap_or(u64::MAX),
     };
-    let sweep = Duration::from_secs(parse_flag(&args, "--sweep-interval-secs").unwrap_or(5));
+    let sweep_secs: u64 = parse_flag(&args, "--sweep-interval-secs").unwrap_or(5);
+    assert!(sweep_secs > 0, "--sweep-interval-secs must be > 0 (a zero interval panics tokio's timer inside a detached task and silently disables TTL/retire)");
+    let sweep = Duration::from_secs(sweep_secs);
     let delay_stored =
         Duration::from_millis(parse_flag(&args, "--apply-delay-stored-ms").unwrap_or(0));
     let delay_removed =
         Duration::from_millis(parse_flag(&args, "--apply-delay-removed-ms").unwrap_or(0));
 
+    tracing::info!(
+        inferred_ttl_secs = cfg.inferred_ttl.as_secs(),
+        default_capacity_blocks = cfg.default_capacity_blocks,
+        "engine config"
+    );
     let engine = Arc::new(Engine::new(cfg));
     let stats = Arc::new(ServiceStats::default());
 
@@ -106,7 +151,13 @@ async fn main() {
     stats.ready.store(true, Ordering::Relaxed);
 
     let addr = format!("{bind}:{port}").parse().expect("bind addr");
-    tracing::info!(%addr, peers = peers.len(), "radix index serving");
+    tracing::info!(
+        %addr,
+        peers = peers.len(),
+        metrics_port,
+        sweep_secs,
+        "radix index serving (effective config logged at engine construction)"
+    );
     if let Err(error) = server::serve_until(
         engine,
         addr,

--- a/crates/radix_index/src/bridge.rs
+++ b/crates/radix_index/src/bridge.rs
@@ -1,0 +1,171 @@
+//! Event-bridge core: worker `SubscribeKvEvents` streams -> hash-only
+//! index Updates -> one Publish stream to the index. The binary in
+//! `bin/bridge.rs` is a thin flag-parsing shell over these; tests drive
+//! them in-process.
+//!
+//! Reconnect semantics mirror the gateway monitor's: resume from the
+//! last applied seq; a gap or a backend loss signal (DataLoss /
+//! OutOfRange) bumps the holder's EPOCH and restarts from zero — the
+//! epoch bump is what makes the restart safe to relay.
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use kv_index::compute_content_hash;
+use smg_grpc_client::{common_proto, tokenspeed_scheduler::TokenSpeedSchedulerClient};
+use tokio::sync::mpsc;
+
+use crate::proto::{self, radix_index_client::RadixIndexClient};
+
+pub fn keyspace(model: &str, block_size: u32) -> proto::Keyspace {
+    proto::Keyspace {
+        model: model.to_string(),
+        symbol_kind: proto::SymbolKind::Tokens as i32,
+        block_size,
+    }
+}
+
+pub fn convert_batch(
+    batch: &common_proto::KvEventBatch,
+    model: &str,
+    block_size: u32,
+    holder: &str,
+    epoch: u64,
+) -> proto::Update {
+    let events = batch
+        .events
+        .iter()
+        .filter_map(|event| event.data.as_ref())
+        .map(|data| {
+            let kind = match data {
+                common_proto::kv_cache_event::Data::Stored(stored) => {
+                    proto::event::Kind::Stored(proto::Stored {
+                        parent_seq_hash: stored.parent_block_hash.map(|p| p as u64),
+                        blocks: stored
+                            .blocks
+                            .iter()
+                            .map(|b| proto::Block {
+                                seq_hash: b.block_hash as u64,
+                                content_hash: compute_content_hash(&b.token_ids).0,
+                            })
+                            .collect(),
+                    })
+                }
+                common_proto::kv_cache_event::Data::Removed(removed) => {
+                    proto::event::Kind::Removed(proto::Removed {
+                        seq_hashes: removed.block_hashes.iter().map(|&h| h as u64).collect(),
+                    })
+                }
+                common_proto::kv_cache_event::Data::Cleared(_) => proto::event::Kind::Cleared(true),
+            };
+            proto::Event { kind: Some(kind) }
+        })
+        .collect();
+    proto::Update {
+        keyspace: Some(keyspace(model, block_size)),
+        holder: holder.to_string(),
+        epoch,
+        seq: batch.sequence_number,
+        events,
+        added: None,
+        dropped: false,
+    }
+}
+
+/// One worker's subscription loop: resume on plain failures, epoch-bump
+/// on loss signals or sequence gaps. Runs until the publish channel
+/// closes or the worker reports Unimplemented.
+pub async fn worker_loop(
+    worker: String,
+    model: String,
+    block_size: u32,
+    out: mpsc::Sender<proto::Update>,
+) {
+    let mut epoch: u64 = 1;
+    let mut last_seq: u64 = 0;
+    loop {
+        let Ok(client) = TokenSpeedSchedulerClient::connect(&worker).await else {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            continue;
+        };
+        let mut stream = match client.subscribe_kv_events(last_seq).await {
+            Ok(stream) => stream,
+            Err(status) => {
+                match status.code() {
+                    // Terminal per the monitor contract.
+                    tonic::Code::Unimplemented => {
+                        tracing::warn!(%worker, "KV events unimplemented; bridge exits for this worker");
+                        return;
+                    }
+                    // Cursor lost: new generation, replay from zero.
+                    tonic::Code::OutOfRange | tonic::Code::DataLoss => {
+                        epoch += 1;
+                        last_seq = 0;
+                    }
+                    _ => {}
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                continue;
+            }
+        };
+        while let Some(batch) = stream.next().await {
+            let Ok(batch) = batch else { break };
+            if last_seq > 0 && batch.sequence_number <= last_seq {
+                continue; // duplicate replay
+            }
+            if last_seq > 0 && batch.sequence_number > last_seq + 1 {
+                // Gap: the ring may have wrapped; new generation.
+                epoch += 1;
+                last_seq = 0;
+                break;
+            }
+            last_seq = batch.sequence_number;
+            let update = convert_batch(&batch, &model, block_size, &worker, epoch);
+            if out.send(update).await.is_err() {
+                return; // publisher gone; process exiting
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// The publish pump: drain `rx` into one (re)connected Publish stream to
+/// `index`. The receiver persists across reconnects, so no update is
+/// lost inside the bridge. Returns when all worker loops have ended.
+pub async fn run_publisher(mut rx: mpsc::Receiver<proto::Update>, index: String) {
+    loop {
+        let Ok(mut client) = RadixIndexClient::connect(index.clone()).await else {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            continue;
+        };
+        let (fwd_tx, fwd_rx) = mpsc::channel::<proto::Update>(1024);
+        let outbound = tokio_stream::wrappers::ReceiverStream::new(fwd_rx);
+        let mut acks = match client.publish(tonic::Request::new(outbound)).await {
+            Ok(response) => response.into_inner(),
+            Err(error) => {
+                tracing::warn!(%error, "publish stream failed; retrying");
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                continue;
+            }
+        };
+        loop {
+            tokio::select! {
+                item = rx.recv() => match item {
+                    Some(update) => {
+                        if fwd_tx.send(update).await.is_err() {
+                            break;
+                        }
+                    }
+                    // All worker loops ended (fleet torn down).
+                    None => return,
+                },
+                ack = acks.next() => {
+                    if ack.is_none() {
+                        break;
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}

--- a/crates/radix_index/src/bridge.rs
+++ b/crates/radix_index/src/bridge.rs
@@ -134,10 +134,13 @@ pub async fn worker_loop(
 /// lost inside the bridge. Returns when all worker loops have ended.
 pub async fn run_publisher(mut rx: mpsc::Receiver<proto::Update>, index: String) {
     loop {
-        let Ok(mut client) = RadixIndexClient::connect(index.clone()).await else {
+        let Ok(client) = RadixIndexClient::connect(index.clone()).await else {
             tokio::time::sleep(Duration::from_millis(500)).await;
             continue;
         };
+        let mut client = client
+            .max_decoding_message_size(64 * 1024 * 1024)
+            .max_encoding_message_size(64 * 1024 * 1024);
         let (fwd_tx, fwd_rx) = mpsc::channel::<proto::Update>(1024);
         let outbound = tokio_stream::wrappers::ReceiverStream::new(fwd_rx);
         let mut acks = match client.publish(tonic::Request::new(outbound)).await {

--- a/crates/radix_index/src/bridge.rs
+++ b/crates/radix_index/src/bridge.rs
@@ -8,13 +8,44 @@
 //! OutOfRange) bumps the holder's EPOCH and restarts from zero — the
 //! epoch bump is what makes the restart safe to relay.
 
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use futures::StreamExt;
 use smg_grpc_client::{common_proto, tokenspeed_scheduler::TokenSpeedSchedulerClient};
 use tokio::sync::mpsc;
 
 use crate::proto::{self, radix_index_client::RadixIndexClient};
+
+/// Cross-task view of each holder's highest epoch the INDEX has acked.
+/// `run_publisher` writes it from acks; worker loops consult it, so a
+/// restarted bridge (local epoch back at 1) adopts PAST a surviving
+/// index's higher epoch instead of having every update silently
+/// deduped until the next worker-side cursor loss happens to bump it
+/// (liveness review's latent-bug finding — `PublishAck.epoch` exists
+/// on the wire precisely for this and was ignored).
+#[derive(Clone, Default)]
+pub struct EpochLedger(Arc<Mutex<HashMap<String, u64>>>);
+
+impl EpochLedger {
+    pub fn observe(&self, holder: &str, epoch: u64) {
+        let mut map = self.0.lock().expect("epoch ledger lock");
+        let entry = map.entry(holder.to_string()).or_insert(0);
+        *entry = (*entry).max(epoch);
+    }
+
+    pub fn known(&self, holder: &str) -> u64 {
+        self.0
+            .lock()
+            .expect("epoch ledger lock")
+            .get(holder)
+            .copied()
+            .unwrap_or(0)
+    }
+}
 
 pub fn keyspace(model: &str, block_size: u32) -> proto::Keyspace {
     proto::Keyspace {
@@ -80,10 +111,20 @@ pub async fn worker_loop(
     model: String,
     block_size: u32,
     out: mpsc::Sender<proto::Update>,
+    ledger: EpochLedger,
 ) {
     let mut epoch: u64 = 1;
     let mut last_seq: u64 = 0;
     loop {
+        // Adopt past whatever epoch the index has acked for this
+        // holder: a lower local epoch means every update we send is
+        // dead on arrival. Adoption is a new generation, so replay
+        // from zero (the resubscribe below starts at `last_seq`).
+        let known = ledger.known(&worker);
+        if known >= epoch {
+            epoch = known + 1;
+            last_seq = 0;
+        }
         let Ok(client) = TokenSpeedSchedulerClient::connect(&worker).await else {
             tokio::time::sleep(Duration::from_millis(500)).await;
             continue;
@@ -124,6 +165,13 @@ pub async fn worker_loop(
             if out.send(update).await.is_err() {
                 return; // publisher gone; process exiting
             }
+            // Mid-stream adoption: acks arrive async, and a healthy
+            // stream never reconnects on its own — without this check
+            // a stale-epoch bridge would keep feeding deduped updates
+            // forever.
+            if ledger.known(&worker) >= epoch {
+                break; // outer loop adopts and resubscribes from zero
+            }
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
@@ -132,7 +180,11 @@ pub async fn worker_loop(
 /// The publish pump: drain `rx` into one (re)connected Publish stream to
 /// `index`. The receiver persists across reconnects, so no update is
 /// lost inside the bridge. Returns when all worker loops have ended.
-pub async fn run_publisher(mut rx: mpsc::Receiver<proto::Update>, index: String) {
+pub async fn run_publisher(
+    mut rx: mpsc::Receiver<proto::Update>,
+    index: String,
+    ledger: EpochLedger,
+) {
     loop {
         let Ok(client) = RadixIndexClient::connect(index.clone()).await else {
             tokio::time::sleep(Duration::from_millis(500)).await;
@@ -162,10 +214,9 @@ pub async fn run_publisher(mut rx: mpsc::Receiver<proto::Update>, index: String)
                     // All worker loops ended (fleet torn down).
                     None => return,
                 },
-                ack = acks.next() => {
-                    if ack.is_none() {
-                        break;
-                    }
+                ack = acks.next() => match ack {
+                    Some(Ok(ack)) => ledger.observe(&ack.holder, ack.epoch),
+                    Some(Err(_)) | None => break,
                 }
             }
         }

--- a/crates/radix_index/src/bridge.rs
+++ b/crates/radix_index/src/bridge.rs
@@ -11,7 +11,6 @@
 use std::time::Duration;
 
 use futures::StreamExt;
-use kv_index::compute_content_hash;
 use smg_grpc_client::{common_proto, tokenspeed_scheduler::TokenSpeedSchedulerClient};
 use tokio::sync::mpsc;
 
@@ -22,6 +21,7 @@ pub fn keyspace(model: &str, block_size: u32) -> proto::Keyspace {
         model: model.to_string(),
         symbol_kind: proto::SymbolKind::Tokens as i32,
         block_size,
+        hash_scheme: crate::wire_hash::HASH_SCHEME_V1,
     }
 }
 
@@ -46,7 +46,7 @@ pub fn convert_batch(
                             .iter()
                             .map(|b| proto::Block {
                                 seq_hash: b.block_hash as u64,
-                                content_hash: compute_content_hash(&b.token_ids).0,
+                                content_hash: crate::wire_hash::content_hash(&b.token_ids).0,
                             })
                             .collect(),
                     })

--- a/crates/radix_index/src/client.rs
+++ b/crates/radix_index/src/client.rs
@@ -173,11 +173,14 @@ async fn subscribe_driver(
     connected: Arc<AtomicBool>,
 ) {
     loop {
-        let Ok(mut client) = RadixIndexClient::connect(url.clone()).await else {
+        let Ok(client) = RadixIndexClient::connect(url.clone()).await else {
             drain_disconnected(&mut queries);
             tokio::time::sleep(Duration::from_millis(500)).await;
             continue;
         };
+        let mut client = client
+            .max_decoding_message_size(64 * 1024 * 1024)
+            .max_encoding_message_size(64 * 1024 * 1024);
         let (fwd_tx, fwd_rx) = mpsc::channel::<proto::Query>(1024);
         let outbound = tokio_stream::wrappers::ReceiverStream::new(fwd_rx);
         let mut answers = match client.subscribe(tonic::Request::new(outbound)).await {

--- a/crates/radix_index/src/client.rs
+++ b/crates/radix_index/src/client.rs
@@ -14,13 +14,13 @@ use std::{
 };
 
 use futures::StreamExt;
-use kv_index::ContentHash;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{
     bridge,
     engine::placement_chain,
     proto::{self, radix_index_client::RadixIndexClient},
+    ContentHash,
 };
 
 /// What a routing-time query resolved to; the caller maps this onto its

--- a/crates/radix_index/src/client.rs
+++ b/crates/radix_index/src/client.rs
@@ -1,0 +1,203 @@
+//! Gateway-side client: one persistent Subscribe stream for queries
+//! (query_id-correlated, caller-enforced deadline) and one Publish
+//! stream for fire-and-forget placements. Both reconnect forever in
+//! background drivers; a query during an outage resolves Disconnected
+//! and the caller falls through to its local fallback.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use futures::StreamExt;
+use kv_index::ContentHash;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::{
+    bridge,
+    engine::placement_chain,
+    proto::{self, radix_index_client::RadixIndexClient},
+};
+
+/// What a routing-time query resolved to; the caller maps this onto its
+/// fallback ladder and metrics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryOutcome {
+    /// Per-holder (url, matched_blocks), descending.
+    Scores(Vec<(String, u32)>),
+    /// The index answered with no overlap.
+    Empty,
+    /// Deadline elapsed; the late answer is dropped by id.
+    Timeout,
+    /// No live stream (index down / reconnecting).
+    Disconnected,
+}
+
+struct PendingQuery {
+    query: proto::Query,
+    reply: oneshot::Sender<proto::Match>,
+}
+
+pub struct RemoteIndex {
+    queries: mpsc::Sender<PendingQuery>,
+    placements: mpsc::Sender<proto::Update>,
+    next_id: AtomicU64,
+}
+
+impl RemoteIndex {
+    /// Lazy client: drivers connect (and reconnect) in the background.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "client-lifetime driver tasks; the owner holds the Arc for the process lifetime"
+    )]
+    pub fn connect(url: String) -> Arc<Self> {
+        let (query_tx, query_rx) = mpsc::channel::<PendingQuery>(4096);
+        let (placement_tx, placement_rx) = mpsc::channel::<proto::Update>(65_536);
+        tokio::spawn(subscribe_driver(url.clone(), query_rx));
+        tokio::spawn(bridge::run_publisher(placement_rx, url));
+        Arc::new(Self {
+            queries: query_tx,
+            placements: placement_tx,
+            next_id: AtomicU64::new(1),
+        })
+    }
+
+    /// Overlap query with a hard deadline. Never blocks longer than
+    /// `deadline`; every non-Scores outcome is a signal to fall back.
+    pub async fn query(
+        &self,
+        model: &str,
+        block_size: u32,
+        content_hashes: Vec<u64>,
+        deadline: Duration,
+    ) -> QueryOutcome {
+        let query_id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let pending = PendingQuery {
+            query: proto::Query {
+                query_id,
+                keyspace: Some(bridge::keyspace(model, block_size)),
+                content_hashes,
+            },
+            reply: reply_tx,
+        };
+        if self.queries.try_send(pending).is_err() {
+            return QueryOutcome::Disconnected;
+        }
+        match tokio::time::timeout(deadline, reply_rx).await {
+            Ok(Ok(answer)) => {
+                let scores: Vec<(String, u32)> = answer
+                    .scores
+                    .into_iter()
+                    .map(|s| (s.holder, s.matched_blocks))
+                    .collect();
+                if scores.is_empty() {
+                    QueryOutcome::Empty
+                } else {
+                    QueryOutcome::Scores(scores)
+                }
+            }
+            Ok(Err(_)) => QueryOutcome::Disconnected,
+            Err(_) => QueryOutcome::Timeout,
+        }
+    }
+
+    /// Fire-and-forget placement: the request's block-hash chain now
+    /// (probably) resides on `holder`. Never blocks; dropped on overflow
+    /// (the next turn re-places it).
+    pub fn publish_placement(
+        &self,
+        model: &str,
+        block_size: u32,
+        holder: &str,
+        content_hashes: &[u64],
+    ) {
+        let hashes: Vec<ContentHash> = content_hashes.iter().copied().map(ContentHash).collect();
+        let blocks = placement_chain(&hashes)
+            .into_iter()
+            .map(|b| proto::Block {
+                seq_hash: b.seq_hash.0,
+                content_hash: b.content_hash.0,
+            })
+            .collect();
+        let update = proto::Update {
+            keyspace: Some(bridge::keyspace(model, block_size)),
+            holder: holder.to_string(),
+            // Placements are unsequenced (seq 0) and epoch-constant: an
+            // event-fed holder rejects them regardless, and inferred-only
+            // holders never bump epochs.
+            epoch: 1,
+            seq: 0,
+            events: vec![proto::Event {
+                kind: Some(proto::event::Kind::Stored(proto::Stored {
+                    parent_seq_hash: None,
+                    blocks,
+                })),
+            }],
+            added: None,
+            dropped: false,
+        };
+        let _ = self.placements.try_send(update);
+    }
+}
+
+/// Owns the Subscribe bidi stream and the pending-answer map; reconnects
+/// forever. On disconnect all pending replies drop (callers resolve
+/// Disconnected); late answers for abandoned ids are discarded by the
+/// map lookup.
+async fn subscribe_driver(url: String, mut queries: mpsc::Receiver<PendingQuery>) {
+    loop {
+        let Ok(mut client) = RadixIndexClient::connect(url.clone()).await else {
+            drain_disconnected(&mut queries);
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            continue;
+        };
+        let (fwd_tx, fwd_rx) = mpsc::channel::<proto::Query>(1024);
+        let outbound = tokio_stream::wrappers::ReceiverStream::new(fwd_rx);
+        let mut answers = match client.subscribe(tonic::Request::new(outbound)).await {
+            Ok(response) => response.into_inner(),
+            Err(_) => {
+                drain_disconnected(&mut queries);
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                continue;
+            }
+        };
+        let mut pending: HashMap<u64, oneshot::Sender<proto::Match>> = HashMap::new();
+        loop {
+            tokio::select! {
+                item = queries.recv() => match item {
+                    Some(PendingQuery { query, reply }) => {
+                        let id = query.query_id;
+                        if fwd_tx.send(query).await.is_err() {
+                            break; // stream gone; reply drops -> Disconnected
+                        }
+                        pending.insert(id, reply);
+                    }
+                    None => return, // client dropped
+                },
+                answer = answers.next() => match answer {
+                    Some(Ok(answer)) => {
+                        if let Some(reply) = pending.remove(&answer.query_id) {
+                            let _ = reply.send(answer);
+                        }
+                    }
+                    _ => break, // stream error/closed; reconnect
+                },
+            }
+        }
+        // Pending replies drop here -> callers resolve Disconnected.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// While there is no live stream, immediately fail queued queries so
+/// callers hit their fallback instead of their deadline.
+fn drain_disconnected(queries: &mut mpsc::Receiver<PendingQuery>) {
+    while let Ok(PendingQuery { reply, .. }) = queries.try_recv() {
+        drop(reply);
+    }
+}

--- a/crates/radix_index/src/client.rs
+++ b/crates/radix_index/src/client.rs
@@ -67,7 +67,11 @@ impl RemoteIndex {
             query_rx,
             Arc::clone(&connected),
         ));
-        tokio::spawn(bridge::run_publisher(placement_rx, url));
+        tokio::spawn(bridge::run_publisher(
+            placement_rx,
+            url,
+            bridge::EpochLedger::default(),
+        ));
         Arc::new(Self {
             queries: query_tx,
             placements: placement_tx,
@@ -160,6 +164,45 @@ impl RemoteIndex {
             dropped: false,
         };
         let _ = self.placements.try_send(update);
+    }
+
+    /// Fleet-membership lifecycle: soft-retire `holder` (stop scoring
+    /// it; state expires by TTL). Published by the gateway's
+    /// worker-removal workflow — the same signal that purges the
+    /// local indexer. AWAITED (unlike placements): a lifecycle signal
+    /// must not be droppable on queue overflow.
+    pub async fn publish_dropped(&self, model: &str, block_size: u32, holder: &str) {
+        let _ = self
+            .placements
+            .send(lifecycle(model, block_size, holder, true))
+            .await;
+    }
+
+    /// Fleet-membership lifecycle: (re)announce `holder` — heals a
+    /// same-URL rejoin out of a standing soft-retire.
+    pub async fn publish_added(&self, model: &str, block_size: u32, holder: &str) {
+        let _ = self
+            .placements
+            .send(lifecycle(model, block_size, holder, false))
+            .await;
+    }
+}
+
+fn lifecycle(model: &str, block_size: u32, holder: &str, dropped: bool) -> proto::Update {
+    proto::Update {
+        keyspace: Some(bridge::keyspace(model, block_size)),
+        holder: holder.to_string(),
+        // Control payloads apply independent of the epoch gate, so the
+        // constant epoch is safe even against a bridge-advanced holder.
+        epoch: 1,
+        seq: 0,
+        events: Vec::new(),
+        added: (!dropped).then_some(proto::Added {
+            capacity_blocks: 0,
+            event_fed: false,
+            metadata: Vec::new(),
+        }),
+        dropped,
     }
 }
 

--- a/crates/radix_index/src/client.rs
+++ b/crates/radix_index/src/client.rs
@@ -7,7 +7,7 @@
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
     },
     time::Duration,
@@ -46,6 +46,10 @@ pub struct RemoteIndex {
     queries: mpsc::Sender<PendingQuery>,
     placements: mpsc::Sender<proto::Update>,
     next_id: AtomicU64,
+    /// Flipped by the subscribe driver on stream up/down. While false, a
+    /// query resolves Disconnected immediately instead of burning its
+    /// deadline on a stream that cannot answer.
+    connected: Arc<AtomicBool>,
 }
 
 impl RemoteIndex {
@@ -57,13 +61,24 @@ impl RemoteIndex {
     pub fn connect(url: String) -> Arc<Self> {
         let (query_tx, query_rx) = mpsc::channel::<PendingQuery>(4096);
         let (placement_tx, placement_rx) = mpsc::channel::<proto::Update>(65_536);
-        tokio::spawn(subscribe_driver(url.clone(), query_rx));
+        let connected = Arc::new(AtomicBool::new(false));
+        tokio::spawn(subscribe_driver(
+            url.clone(),
+            query_rx,
+            Arc::clone(&connected),
+        ));
         tokio::spawn(bridge::run_publisher(placement_rx, url));
         Arc::new(Self {
             queries: query_tx,
             placements: placement_tx,
             next_id: AtomicU64::new(1),
+            connected,
         })
+    }
+
+    /// Whether the subscribe stream is currently established.
+    pub fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::Relaxed)
     }
 
     /// Overlap query with a hard deadline. Never blocks longer than
@@ -75,6 +90,9 @@ impl RemoteIndex {
         content_hashes: Vec<u64>,
         deadline: Duration,
     ) -> QueryOutcome {
+        if !self.is_connected() {
+            return QueryOutcome::Disconnected;
+        }
         let query_id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (reply_tx, reply_rx) = oneshot::channel();
         let pending = PendingQuery {
@@ -149,7 +167,11 @@ impl RemoteIndex {
 /// forever. On disconnect all pending replies drop (callers resolve
 /// Disconnected); late answers for abandoned ids are discarded by the
 /// map lookup.
-async fn subscribe_driver(url: String, mut queries: mpsc::Receiver<PendingQuery>) {
+async fn subscribe_driver(
+    url: String,
+    mut queries: mpsc::Receiver<PendingQuery>,
+    connected: Arc<AtomicBool>,
+) {
     loop {
         let Ok(mut client) = RadixIndexClient::connect(url.clone()).await else {
             drain_disconnected(&mut queries);
@@ -166,6 +188,7 @@ async fn subscribe_driver(url: String, mut queries: mpsc::Receiver<PendingQuery>
                 continue;
             }
         };
+        connected.store(true, Ordering::Relaxed);
         let mut pending: HashMap<u64, oneshot::Sender<proto::Match>> = HashMap::new();
         loop {
             tokio::select! {
@@ -189,7 +212,9 @@ async fn subscribe_driver(url: String, mut queries: mpsc::Receiver<PendingQuery>
                 },
             }
         }
-        // Pending replies drop here -> callers resolve Disconnected.
+        // Pending replies drop here -> callers resolve Disconnected;
+        // new queries fast-fail on the flag until the stream is back.
+        connected.store(false, Ordering::Relaxed);
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 }

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -474,21 +474,13 @@ pub struct EngineStats {
 /// wire blocks, using the indexer's own rolling prefix hash so every
 /// publisher synthesizes byte-identical chains for identical prefixes.
 pub fn placement_chain(content_hashes: &[ContentHash]) -> Vec<WireBlock> {
-    let mut out = Vec::with_capacity(content_hashes.len());
-    let mut prev = SequenceHash(0);
-    for (i, &content_hash) in content_hashes.iter().enumerate() {
-        let seq_hash = if i == 0 {
-            SequenceHash(content_hash.0)
-        } else {
-            kv_index::chain_prefix_hash(prev, content_hash)
-        };
-        out.push(WireBlock {
+    crate::wire_hash::placement_chain(content_hashes)
+        .into_iter()
+        .map(|(seq_hash, content_hash)| WireBlock {
             seq_hash,
             content_hash,
-        });
-        prev = seq_hash;
-    }
-    out
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -24,6 +24,7 @@
 
 use std::{
     collections::HashMap,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -141,21 +142,64 @@ struct KeyspaceState {
     holders: HashMap<String, HolderState>,
 }
 
-/// The engine: all keyspaces. One lock over everything — apply and query
-/// rates in scope (hundreds of k ops/s) are far below contention range
-/// for the critical sections involved, and single-lock semantics make
-/// the convergence argument checkable.
+/// Poisoned-lock policy: a panic mid-mutation leaves state that must
+/// never be served; crash so the replica re-bootstraps clean from a
+/// sibling.
+const LOCK_MSG: &str = "engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling";
+
+/// The engine: all keyspaces, locked at TWO levels. The outer RwLock
+/// guards only the keyspace map (creation/removal — rare); every
+/// keyspace mutates under its own mutex. Snapshot, sweep, and stats
+/// therefore stall at most ONE keyspace at a time instead of the whole
+/// engine (a full-fleet Pull used to block every apply and query for
+/// its entire serialization). Convergence arguments are unaffected:
+/// all wire-visible ordering (epoch, seq, feed authority) is per
+/// HOLDER, and a holder lives in exactly one keyspace.
 pub struct Engine {
     cfg: EngineConfig,
-    keyspaces: std::sync::Mutex<HashMap<KeyspaceKey, KeyspaceState>>,
+    keyspaces: std::sync::RwLock<HashMap<KeyspaceKey, Arc<std::sync::Mutex<KeyspaceState>>>>,
 }
 
 impl Engine {
     pub fn new(cfg: EngineConfig) -> Self {
         Self {
             cfg,
-            keyspaces: std::sync::Mutex::new(HashMap::new()),
+            keyspaces: std::sync::RwLock::new(HashMap::new()),
         }
+    }
+
+    fn space(&self, key: &KeyspaceKey) -> Option<Arc<std::sync::Mutex<KeyspaceState>>> {
+        self.keyspaces.read().expect(LOCK_MSG).get(key).cloned()
+    }
+
+    fn space_or_create(&self, key: &KeyspaceKey) -> Arc<std::sync::Mutex<KeyspaceState>> {
+        if let Some(space) = self.space(key) {
+            return space;
+        }
+        self.keyspaces
+            .write()
+            .expect(LOCK_MSG)
+            .entry(key.clone())
+            .or_insert_with(|| {
+                Arc::new(std::sync::Mutex::new(KeyspaceState {
+                    tree: RadixTree::new(TreeConfig::default()),
+                    scratch: OverlapScratch::default(),
+                    answers: Vec::new(),
+                    holders: HashMap::new(),
+                }))
+            })
+            .clone()
+    }
+
+    /// Stable iteration set for the cross-keyspace paths: each entry is
+    /// then locked INDIVIDUALLY, so the walk never freezes the engine.
+    fn all_spaces(&self) -> Vec<(KeyspaceKey, Arc<std::sync::Mutex<KeyspaceState>>)> {
+        self.keyspaces
+            .read()
+            .expect(LOCK_MSG)
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
     }
 
     /// Apply one update. Returns what happened, the holder's applied
@@ -165,8 +209,6 @@ impl Engine {
     /// forever (the metrics timeline caught ~190x apply amplification
     /// from exactly that loop).
     pub fn apply(&self, update: &UpdateMsg) -> (ApplyOutcome, u64, bool) {
-        let mut spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
-
         // A keyspace is created on first contact; a later publisher whose
         // key differs only in block_size is a DIFFERENT keyspace by key
         // construction, so mismatch cannot silently merge. Reject only
@@ -174,14 +216,9 @@ impl Engine {
         if update.keyspace.block_size == 0 {
             return (ApplyOutcome::KeyspaceMismatch, 0, false);
         }
-        let space = spaces
-            .entry(update.keyspace.clone())
-            .or_insert_with(|| KeyspaceState {
-                tree: RadixTree::new(TreeConfig::default()),
-                scratch: OverlapScratch::default(),
-                answers: Vec::new(),
-                holders: HashMap::new(),
-            });
+        let space = self.space_or_create(&update.keyspace);
+        let mut space = space.lock().expect(LOCK_MSG);
+        let space = &mut *space;
 
         if !space.holders.contains_key(&update.holder) {
             let id = space.tree.create_holder(&update.holder);
@@ -321,20 +358,41 @@ impl Engine {
     /// timestamps; run from a timer.
     pub fn sweep_idle(&self) {
         let ttl = self.cfg.inferred_ttl;
-        let mut spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
-        for space in spaces.values_mut() {
-            let mut retire: Vec<String> = Vec::new();
-            for (name, holder) in space.holders.iter_mut() {
-                let idle = holder.last_publish.elapsed() > ttl;
-                if holder.dropped && idle {
-                    retire.push(name.clone());
-                } else if !holder.event_fed && idle {
-                    space.tree.clear(holder.id);
+        for (key, space_arc) in self.all_spaces() {
+            let now_empty = {
+                let mut space = space_arc.lock().expect(LOCK_MSG);
+                let space = &mut *space;
+                let mut retire: Vec<String> = Vec::new();
+                for (name, holder) in space.holders.iter_mut() {
+                    let idle = holder.last_publish.elapsed() > ttl;
+                    if holder.dropped && idle {
+                        retire.push(name.clone());
+                    } else if !holder.event_fed && idle {
+                        space.tree.clear(holder.id);
+                    }
                 }
-            }
-            for name in retire {
-                if let Some(holder) = space.holders.remove(&name) {
-                    space.tree.retire_holder(holder.id);
+                for name in retire {
+                    if let Some(holder) = space.holders.remove(&name) {
+                        space.tree.retire_holder(holder.id);
+                    }
+                }
+                space.holders.is_empty()
+            };
+            // Keyspace GC (audit finding: any publisher can mint
+            // keyspaces and they were never removed). A keyspace whose
+            // last holder retired is unlinked — but only when nothing
+            // else holds its Arc: a concurrent apply that already
+            // cloned it would otherwise mutate an orphan and lose the
+            // update. New clones need the map lock we hold, so the
+            // count check cannot race; a skipped removal is retried
+            // next sweep.
+            if now_empty {
+                let mut map = self.keyspaces.write().expect(LOCK_MSG);
+                if let Some(arc) = map.get(&key) {
+                    let unshared = Arc::strong_count(arc) == 2; // map + our iteration clone
+                    if unshared && arc.lock().expect(LOCK_MSG).holders.is_empty() {
+                        map.remove(&key);
+                    }
                 }
             }
         }
@@ -343,17 +401,17 @@ impl Engine {
     /// Overlap query: per-holder matched prefix depth, dropped holders
     /// excluded. Missing keyspace = empty answer (advisory semantics).
     pub fn find_matches(&self, keyspace: &KeyspaceKey, hashes: &[ContentHash]) -> Vec<HolderScore> {
-        let mut spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
-        let Some(space) = spaces.get_mut(keyspace) else {
+        let Some(space) = self.space(keyspace) else {
             return Vec::new();
         };
+        let mut space = space.lock().expect(LOCK_MSG);
         let chain: Vec<u64> = hashes.iter().map(|h| h.0).collect();
         let KeyspaceState {
             tree,
             scratch,
             answers,
             holders,
-        } = space;
+        } = &mut *space;
         tree.overlap(&chain, scratch, answers);
         let mut scores = Vec::with_capacity(answers.len());
         for o in answers.iter() {
@@ -384,10 +442,14 @@ impl Engine {
     /// dedup posture. (Gap positions collapse to a contiguous chain,
     /// as before: bootstrap equivalence is scoped to gap-free
     /// holders; gapped ones converge through the feeds.)
+    /// Consistency: the cut is per KEYSPACE, not global — sufficient
+    /// because every UpdateMsg (and all dedup posture: epoch, seq,
+    /// feed authority) is scoped to one holder in one keyspace, so a
+    /// puller lands each holder exactly as some real moment saw it.
     pub fn snapshot(&self) -> Vec<UpdateMsg> {
-        let spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
         let mut out = Vec::new();
-        for (key, space) in spaces.iter() {
+        for (key, space_arc) in self.all_spaces() {
+            let space = space_arc.lock().expect(LOCK_MSG);
             for (holder_key, holder) in &space.holders {
                 let blocks: Vec<WireBlock> = space
                     .tree
@@ -447,22 +509,22 @@ impl Engine {
 
     /// Total indexed blocks across keyspaces (stats/tests).
     pub fn entry_count(&self) -> usize {
-        let spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
-        spaces
-            .values()
-            .map(|s| s.tree.stats().distinct_entries as usize)
+        self.all_spaces()
+            .iter()
+            .map(|(_, s)| s.lock().expect(LOCK_MSG).tree.stats().distinct_entries as usize)
             .sum()
     }
 
-    /// Point-in-time gauges for the metrics endpoint. One pass under the
-    /// engine lock; cheap relative to apply/query traffic.
+    /// Point-in-time gauges for the metrics endpoint. One keyspace
+    /// locked at a time; cheap relative to apply/query traffic.
     pub fn stats(&self) -> EngineStats {
-        let spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
+        let spaces = self.all_spaces();
         let mut stats = EngineStats {
             keyspaces: spaces.len(),
             ..EngineStats::default()
         };
-        for space in spaces.values() {
+        for (_, space_arc) in &spaces {
+            let space = space_arc.lock().expect(LOCK_MSG);
             stats.blocks += space.tree.stats().distinct_entries as usize;
             for holder in space.holders.values() {
                 stats.holders += 1;
@@ -831,5 +893,75 @@ mod tests {
         // the watermark seq travels, so a replayed old batch is dropped.
         let (outcome, _, _) = b.apply(&event_batch("w2", 2, vec![WireEvent::Cleared]));
         assert_eq!(outcome, ApplyOutcome::Deduped);
+    }
+
+    #[test]
+    fn keyspace_gc_removes_emptied_keyspaces_only() {
+        let engine = Engine::new(EngineConfig {
+            inferred_ttl: Duration::ZERO,
+            ..EngineConfig::default()
+        });
+        engine.apply(&placement("w1", 31, 4));
+        let mut other = placement("w2", 32, 4);
+        other.keyspace.model = "other-model".into();
+        engine.apply(&other);
+        assert_eq!(engine.stats().keyspaces, 2);
+
+        // Dropping w1 and sweeping (TTL zero: instantly idle) retires
+        // the holder AND unlinks its now-empty keyspace; the live
+        // keyspace stays.
+        let mut drop_w1 = placement("w1", 31, 0);
+        drop_w1.events.clear();
+        drop_w1.dropped = true;
+        engine.apply(&drop_w1);
+        engine.sweep_idle();
+        let stats = engine.stats();
+        assert_eq!(stats.keyspaces, 1);
+        assert_eq!(stats.holders, 1);
+        // Recreation after GC is a fresh first contact, not a resurrection.
+        engine.apply(&placement("w1", 31, 4));
+        assert_eq!(engine.stats().keyspaces, 2);
+        assert!(!scores(&engine, 31, 4).is_empty());
+    }
+
+    #[test]
+    fn per_keyspace_locking_survives_concurrent_mixed_traffic() {
+        // Not a performance proof — a race smoke: applies to two
+        // keyspaces race snapshot/stats/sweep from other threads, and
+        // the end state must equal the sequential expectation.
+        let engine = std::sync::Arc::new(Engine::new(EngineConfig::default()));
+        let mut handles = Vec::new();
+        for space_no in 0..2u32 {
+            let engine = engine.clone();
+            handles.push(std::thread::spawn(move || {
+                for round in 0..200u32 {
+                    let mut update = placement(&format!("w{space_no}"), 40 + space_no, 6);
+                    if space_no == 1 {
+                        update.keyspace.model = "other-model".into();
+                    }
+                    engine.apply(&update);
+                    if round % 16 == 0 {
+                        engine.sweep_idle();
+                    }
+                }
+            }));
+        }
+        for _ in 0..2 {
+            let engine = engine.clone();
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..200 {
+                    let _ = engine.snapshot();
+                    let _ = engine.stats();
+                    let _ = engine.entry_count();
+                }
+            }));
+        }
+        for handle in handles {
+            handle.join().expect("no thread may panic");
+        }
+        let stats = engine.stats();
+        assert_eq!(stats.keyspaces, 2);
+        assert_eq!(stats.holders, 2);
+        assert_eq!(scores(&engine, 40, 6).len(), 1);
     }
 }

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -431,7 +431,7 @@ impl Engine {
                             parent,
                             blocks: chunk.to_vec(),
                         }],
-                        added: first.then(|| AddedControl {
+                        added: first.then_some(AddedControl {
                             capacity_blocks: holder.capacity_blocks,
                             event_fed: holder.event_fed,
                         }),

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -25,9 +25,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use kv_index::{
-    ContentHash, PositionalIndexer, SequenceHash, StoredBlock, WorkerBlockMap, WorkerId,
-};
+use radix_tree::{Config as TreeConfig, HolderId, Overlap, OverlapScratch, RadixTree, StoreError};
+
+use crate::{ContentHash, SequenceHash};
 
 /// One block on the wire: position-chained identity + content identity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -103,8 +103,6 @@ pub struct HolderScore {
 }
 
 pub struct EngineConfig {
-    /// Jump stride for the positional index query search.
-    pub jump_size: usize,
     /// Idle TTL for INFERRED holder state; an inferred holder with no
     /// publish inside the window is cleared entirely (coarse but
     /// prefix-closed). Event-fed holders are never TTL'd — their
@@ -118,7 +116,6 @@ pub struct EngineConfig {
 impl Default for EngineConfig {
     fn default() -> Self {
         Self {
-            jump_size: 64,
             inferred_ttl: Duration::from_secs(180),
             default_capacity_blocks: u64::MAX,
         }
@@ -126,25 +123,20 @@ impl Default for EngineConfig {
 }
 
 struct HolderState {
-    worker_id: WorkerId,
+    id: HolderId,
     epoch: u64,
     last_seq: u64,
     event_fed: bool,
     capacity_blocks: u64,
     dropped: bool,
-    /// Reverse map the indexer's write path requires (caller-owned).
-    blocks: WorkerBlockMap,
-    /// Position-ordered chain, maintained for INFERRED holders only, so
-    /// capacity eviction can pop the tail and keep the prefix closed.
-    /// Event-fed holders evict wherever their engine says.
-    chain: Vec<SequenceHash>,
     last_publish: Instant,
 }
 
 struct KeyspaceState {
-    indexer: PositionalIndexer,
+    tree: RadixTree,
+    scratch: OverlapScratch,
+    answers: Vec<Overlap>,
     holders: HashMap<String, HolderState>,
-    by_worker_id: HashMap<WorkerId, String>,
 }
 
 /// The engine: all keyspaces. One lock over everything — apply and query
@@ -180,49 +172,43 @@ impl Engine {
         if update.keyspace.block_size == 0 {
             return (ApplyOutcome::KeyspaceMismatch, 0, false);
         }
-        let KeyspaceState {
-            indexer,
-            holders,
-            by_worker_id,
-        } = spaces
+        let space = spaces
             .entry(update.keyspace.clone())
             .or_insert_with(|| KeyspaceState {
-                indexer: PositionalIndexer::new(self.cfg.jump_size),
+                tree: RadixTree::new(TreeConfig::default()),
+                scratch: OverlapScratch::default(),
+                answers: Vec::new(),
                 holders: HashMap::new(),
-                by_worker_id: HashMap::new(),
             });
 
-        if !holders.contains_key(&update.holder) {
-            let Ok(worker_id) = indexer.intern_worker(&update.holder) else {
-                return (ApplyOutcome::KeyspaceMismatch, 0, false);
-            };
-            by_worker_id.insert(worker_id, update.holder.clone());
-            holders.insert(
+        if !space.holders.contains_key(&update.holder) {
+            let id = space.tree.create_holder(&update.holder);
+            space.holders.insert(
                 update.holder.clone(),
                 HolderState {
-                    worker_id,
+                    id,
                     epoch: update.epoch,
                     last_seq: 0,
                     event_fed: false,
                     capacity_blocks: self.cfg.default_capacity_blocks,
                     dropped: false,
-                    blocks: WorkerBlockMap::default(),
-                    chain: Vec::new(),
                     last_publish: Instant::now(),
                 },
             );
         }
-        let holder = holders
+        let tree = &mut space.tree;
+        let holder = space
+            .holders
             .get_mut(&update.holder)
             .expect("holder inserted above");
 
+        let mut changed = false;
+        let len_before = tree.holder_blocks(holder.id);
+
         // Epoch gate: higher epoch supersedes (implicit clear), lower is
         // dropped, equal proceeds.
-        let mut changed = false;
-        let len_before = holder.blocks.len();
         if update.epoch > holder.epoch {
-            indexer.apply_cleared(holder.worker_id, &mut holder.blocks);
-            holder.chain.clear();
+            tree.clear(holder.id);
             holder.epoch = update.epoch;
             holder.last_seq = 0;
             changed = true;
@@ -272,42 +258,39 @@ impl Engine {
                         // First sequenced traffic pins feed authority too:
                         // a holder with a real event stream is observed.
                         holder.event_fed = true;
-                        holder.chain.clear();
                     }
-                    let stored: Vec<StoredBlock> = blocks
+                    let pairs: Vec<(u64, u64)> = blocks
                         .iter()
-                        .map(|b| StoredBlock {
-                            seq_hash: b.seq_hash,
-                            content_hash: b.content_hash,
-                        })
+                        .map(|b| (b.seq_hash.0, b.content_hash.0))
                         .collect();
-                    let applied = indexer
-                        .apply_stored(holder.worker_id, &stored, *parent, &mut holder.blocks)
-                        .or_else(|_| {
+                    let stored = tree
+                        .store(holder.id, parent.map(|p| p.0), &pairs)
+                        .or_else(|e| match e {
                             // Unresolvable parent re-anchors at position 0,
                             // mirroring the gateway monitor's recovery.
-                            indexer.apply_stored(
-                                holder.worker_id,
-                                &stored,
-                                None,
-                                &mut holder.blocks,
-                            )
+                            StoreError::ParentNotFound => tree.store(holder.id, None, &pairs),
+                            other => Err(other),
                         });
-                    if applied.is_ok() && !holder.event_fed {
-                        Self::extend_chain(holder, blocks);
-                        Self::evict_tail(indexer, holder);
+                    if stored.is_ok() && !holder.event_fed {
+                        // Capacity eviction, forest-wide and prefix-
+                        // closed (the tree owns the order; this
+                        // deliberately fixes the old last-chain-only
+                        // accounting).
+                        let held = tree.holder_blocks(holder.id);
+                        if held > holder.capacity_blocks {
+                            tree.truncate_tail(holder.id, holder.capacity_blocks);
+                        }
                     }
                 }
                 WireEvent::Removed { seq_hashes } => {
                     if !holder.event_fed {
                         holder.event_fed = true;
-                        holder.chain.clear();
                     }
-                    indexer.apply_removed(holder.worker_id, seq_hashes, &mut holder.blocks);
+                    let keys: Vec<u64> = seq_hashes.iter().map(|h| h.0).collect();
+                    tree.remove(holder.id, &keys);
                 }
                 WireEvent::Cleared => {
-                    indexer.apply_cleared(holder.worker_id, &mut holder.blocks);
-                    holder.chain.clear();
+                    tree.clear(holder.id);
                     changed = true;
                 }
             }
@@ -315,50 +298,30 @@ impl Engine {
         // Registry-length delta covers stores and removes; mixed
         // batches that net to zero blocks still flip `changed` via
         // the Cleared/control arms above or are true no-ops.
-        changed |= holder.blocks.len() != len_before;
+        changed |= tree.holder_blocks(holder.id) != len_before;
         (outcome, holder.last_seq, changed)
     }
 
-    /// Position-ordered chain bookkeeping for inferred holders. The
-    /// stored blocks landed at parent_pos+1.. (or 0): reflect that in the
-    /// tail vector so capacity eviction stays prefix-closed.
-    fn extend_chain(holder: &mut HolderState, blocks: &[WireBlock]) {
-        let Some(first) = blocks.first() else { return };
-        let Some(&(start_pos, _, _)) = holder.blocks.get(&first.seq_hash) else {
-            return;
-        };
-        if holder.chain.len() < start_pos {
-            // A gap should be impossible for deterministic placement
-            // chains; anchor defensively at the current tail.
-            return;
-        }
-        holder.chain.truncate(start_pos);
-        holder.chain.extend(blocks.iter().map(|b| b.seq_hash));
-    }
-
-    fn evict_tail(indexer: &PositionalIndexer, holder: &mut HolderState) {
-        let capacity = usize::try_from(holder.capacity_blocks).unwrap_or(usize::MAX);
-        while holder.chain.len() > capacity {
-            let Some(tail) = holder.chain.pop() else {
-                break;
-            };
-            indexer.apply_removed(holder.worker_id, &[tail], &mut holder.blocks);
-        }
-    }
-
-    /// TTL sweep: clear inferred holders idle beyond the window. Cheap
-    /// (per-holder timestamps only); run from a timer.
+    /// TTL sweep: clear inferred holders idle beyond the window, and
+    /// RETIRE dropped holders entirely (including event-fed ones —
+    /// the lifecycle leak the old engine carried). Cheap per-holder
+    /// timestamps; run from a timer.
     pub fn sweep_idle(&self) {
         let ttl = self.cfg.inferred_ttl;
         let mut spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
         for space in spaces.values_mut() {
-            let KeyspaceState {
-                indexer, holders, ..
-            } = space;
-            for holder in holders.values_mut() {
-                if !holder.event_fed && holder.last_publish.elapsed() > ttl {
-                    indexer.apply_cleared(holder.worker_id, &mut holder.blocks);
-                    holder.chain.clear();
+            let mut retire: Vec<String> = Vec::new();
+            for (name, holder) in space.holders.iter_mut() {
+                let idle = holder.last_publish.elapsed() > ttl;
+                if holder.dropped && idle {
+                    retire.push(name.clone());
+                } else if !holder.event_fed && idle {
+                    space.tree.clear(holder.id);
+                }
+            }
+            for name in retire {
+                if let Some(holder) = space.holders.remove(&name) {
+                    space.tree.retire_holder(holder.id);
                 }
             }
         }
@@ -367,30 +330,33 @@ impl Engine {
     /// Overlap query: per-holder matched prefix depth, dropped holders
     /// excluded. Missing keyspace = empty answer (advisory semantics).
     pub fn find_matches(&self, keyspace: &KeyspaceKey, hashes: &[ContentHash]) -> Vec<HolderScore> {
-        let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
-        let Some(space) = spaces.get(keyspace) else {
+        let mut spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(space) = spaces.get_mut(keyspace) else {
             return Vec::new();
         };
-        let overlap = space.indexer.find_matches(hashes, false);
-        let mut scores = Vec::with_capacity(overlap.scores.len());
-        for (worker_id, matched) in overlap.scores {
-            let Some(holder_key) = space.by_worker_id.get(&worker_id) else {
+        let chain: Vec<u64> = hashes.iter().map(|h| h.0).collect();
+        let KeyspaceState {
+            tree,
+            scratch,
+            answers,
+            holders,
+        } = space;
+        tree.overlap(&chain, scratch, answers);
+        let mut scores = Vec::with_capacity(answers.len());
+        for o in answers.iter() {
+            let Some(name) = tree.holder_name(o.holder) else {
                 continue;
             };
-            let Some(holder) = space.holders.get(holder_key) else {
+            let Some(holder) = holders.get(name) else {
                 continue;
             };
-            if holder.dropped || matched == 0 {
+            if holder.dropped || o.depth == 0 {
                 continue;
             }
             scores.push(HolderScore {
-                holder: holder_key.clone(),
-                matched_blocks: matched,
-                total_blocks: overlap
-                    .tree_sizes
-                    .get(&worker_id)
-                    .copied()
-                    .unwrap_or_default() as u64,
+                holder: name.to_string(),
+                matched_blocks: o.depth,
+                total_blocks: o.total_blocks,
                 event_fed: holder.event_fed,
             });
         }
@@ -399,27 +365,23 @@ impl Engine {
     }
 
     /// Serialize current state as synthetic Updates (for `Pull`): one
-    /// Stored per holder carrying its full chain in position order, under
+    /// Stored per holder carrying its blocks in position order, under
     /// the holder's current epoch, unsequenced-for-inferred /
     /// watermark-seq-for-observed so the puller lands with the same
-    /// dedup posture.
+    /// dedup posture. (Gap positions collapse to a contiguous chain,
+    /// as before: bootstrap equivalence is scoped to gap-free
+    /// holders; gapped ones converge through the feeds.)
     pub fn snapshot(&self) -> Vec<UpdateMsg> {
         let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
         let mut out = Vec::new();
         for (key, space) in spaces.iter() {
             for (holder_key, holder) in &space.holders {
-                // Reconstruct position order from the reverse map.
-                let mut ordered: Vec<(usize, SequenceHash, ContentHash)> = holder
-                    .blocks
-                    .iter()
-                    .map(|(&seq, &(pos, content, _))| (pos, seq, content))
-                    .collect();
-                ordered.sort_by_key(|&(pos, _, _)| pos);
-                let blocks: Vec<WireBlock> = ordered
-                    .iter()
-                    .map(|&(_, seq_hash, content_hash)| WireBlock {
-                        seq_hash,
-                        content_hash,
+                let blocks: Vec<WireBlock> = space
+                    .tree
+                    .enumerate(holder.id)
+                    .map(|(_pos, k, content)| WireBlock {
+                        seq_hash: SequenceHash(k),
+                        content_hash: ContentHash(content),
                     })
                     .collect();
                 out.push(UpdateMsg {
@@ -449,7 +411,10 @@ impl Engine {
     /// Total indexed blocks across keyspaces (stats/tests).
     pub fn entry_count(&self) -> usize {
         let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
-        spaces.values().map(|s| s.indexer.entry_count()).sum()
+        spaces
+            .values()
+            .map(|s| s.tree.stats().distinct_entries as usize)
+            .sum()
     }
 
     /// Point-in-time gauges for the metrics endpoint. One pass under the
@@ -461,7 +426,7 @@ impl Engine {
             ..EngineStats::default()
         };
         for space in spaces.values() {
-            stats.blocks += space.indexer.entry_count();
+            stats.blocks += space.tree.stats().distinct_entries as usize;
             for holder in space.holders.values() {
                 stats.holders += 1;
                 if holder.event_fed {
@@ -501,10 +466,10 @@ pub fn placement_chain(content_hashes: &[ContentHash]) -> Vec<WireBlock> {
 
 #[cfg(test)]
 mod tests {
-    use kv_index::compute_content_hash;
     use rand::{rngs::StdRng, seq::SliceRandom, RngExt, SeedableRng};
 
     use super::*;
+    use crate::wire_hash::content_hash as compute_content_hash;
 
     fn keyspace() -> KeyspaceKey {
         KeyspaceKey {
@@ -739,7 +704,7 @@ mod tests {
         assert_eq!(scores(&engine, 11, 6), vec![("w1".into(), 5)]);
 
         // A placement for the now event-fed holder is rejected.
-        let (outcome, _) = engine.apply(&placement("w1", 12, 3));
+        let (outcome, _, _) = engine.apply(&placement("w1", 12, 3));
         assert_eq!(outcome, ApplyOutcome::FeedRejected);
         assert!(scores(&engine, 12, 3).is_empty());
 
@@ -778,7 +743,7 @@ mod tests {
 
         // The bootstrapped replica keeps the event holder's dedup posture:
         // the watermark seq travels, so a replayed old batch is dropped.
-        let (outcome, _) = b.apply(&event_batch("w2", 2, vec![WireEvent::Cleared]));
+        let (outcome, _, _) = b.apply(&event_batch("w2", 2, vec![WireEvent::Cleared]));
         assert_eq!(outcome, ApplyOutcome::Deduped);
     }
 }

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -165,7 +165,7 @@ impl Engine {
     /// forever (the metrics timeline caught ~190x apply amplification
     /// from exactly that loop).
     pub fn apply(&self, update: &UpdateMsg) -> (ApplyOutcome, u64, bool) {
-        let mut spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        let mut spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
 
         // A keyspace is created on first contact; a later publisher whose
         // key differs only in block_size is a DIFFERENT keyspace by key
@@ -205,7 +205,6 @@ impl Engine {
             .expect("holder inserted above");
 
         let mut changed = false;
-        let len_before = tree.holder_blocks(holder.id);
 
         // Epoch gate: higher epoch supersedes (implicit clear), lower is
         // dropped, equal proceeds.
@@ -273,6 +272,15 @@ impl Engine {
                             StoreError::ParentNotFound => tree.store(holder.id, None, &pairs),
                             other => Err(other),
                         });
+                    // `changed` comes from the OUTCOME, never a
+                    // length delta: a MOVE (the re-anchor path above
+                    // produces them) changes query answers while
+                    // netting zero blocks, and a length-delta
+                    // heuristic would suppress its relay — replica
+                    // divergence (audit finding).
+                    if let Ok(outcome) = &stored {
+                        changed |= outcome.applied > 0;
+                    }
                     if stored.is_ok() && !holder.event_fed {
                         // Capacity is RUNAWAY PROTECTION, not an
                         // eviction mirror: the placement feed carries
@@ -296,7 +304,7 @@ impl Engine {
                         holder.event_fed = true;
                     }
                     let keys: Vec<u64> = seq_hashes.iter().map(|h| h.0).collect();
-                    tree.remove(holder.id, &keys);
+                    changed |= tree.remove(holder.id, &keys) > 0;
                 }
                 WireEvent::Cleared => {
                     tree.clear(holder.id);
@@ -304,10 +312,6 @@ impl Engine {
                 }
             }
         }
-        // Registry-length delta covers stores and removes; mixed
-        // batches that net to zero blocks still flip `changed` via
-        // the Cleared/control arms above or are true no-ops.
-        changed |= tree.holder_blocks(holder.id) != len_before;
         (outcome, holder.last_seq, changed)
     }
 
@@ -317,7 +321,7 @@ impl Engine {
     /// timestamps; run from a timer.
     pub fn sweep_idle(&self) {
         let ttl = self.cfg.inferred_ttl;
-        let mut spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        let mut spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
         for space in spaces.values_mut() {
             let mut retire: Vec<String> = Vec::new();
             for (name, holder) in space.holders.iter_mut() {
@@ -339,7 +343,7 @@ impl Engine {
     /// Overlap query: per-holder matched prefix depth, dropped holders
     /// excluded. Missing keyspace = empty answer (advisory semantics).
     pub fn find_matches(&self, keyspace: &KeyspaceKey, hashes: &[ContentHash]) -> Vec<HolderScore> {
-        let mut spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        let mut spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
         let Some(space) = spaces.get_mut(keyspace) else {
             return Vec::new();
         };
@@ -381,7 +385,7 @@ impl Engine {
     /// as before: bootstrap equivalence is scoped to gap-free
     /// holders; gapped ones converge through the feeds.)
     pub fn snapshot(&self) -> Vec<UpdateMsg> {
-        let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        let spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
         let mut out = Vec::new();
         for (key, space) in spaces.iter() {
             for (holder_key, holder) in &space.holders {
@@ -393,25 +397,49 @@ impl Engine {
                         content_hash: ContentHash(content),
                     })
                     .collect();
-                out.push(UpdateMsg {
-                    keyspace: key.clone(),
-                    holder: holder_key.clone(),
-                    epoch: holder.epoch,
-                    seq: if holder.event_fed { holder.last_seq } else { 0 },
-                    events: if blocks.is_empty() {
-                        Vec::new()
-                    } else {
-                        vec![WireEvent::Stored {
-                            parent: None,
-                            blocks,
-                        }]
-                    },
-                    added: Some(AddedControl {
-                        capacity_blocks: holder.capacity_blocks,
-                        event_fed: holder.event_fed,
-                    }),
-                    dropped: holder.dropped,
-                });
+                // CHUNKED: one giant Stored per holder blows through
+                // gRPC message limits at production block counts
+                // (audit finding: >4MiB past ~210k blocks). Chunks
+                // are parent-linked so the puller reassembles the
+                // exact chain; the control payload rides only the
+                // first chunk.
+                const SNAPSHOT_CHUNK: usize = 16_384;
+                let mut first = true;
+                let mut parent: Option<SequenceHash> = None;
+                let mut chunks = blocks.chunks(SNAPSHOT_CHUNK).peekable();
+                if chunks.peek().is_none() {
+                    out.push(UpdateMsg {
+                        keyspace: key.clone(),
+                        holder: holder_key.clone(),
+                        epoch: holder.epoch,
+                        seq: if holder.event_fed { holder.last_seq } else { 0 },
+                        events: Vec::new(),
+                        added: Some(AddedControl {
+                            capacity_blocks: holder.capacity_blocks,
+                            event_fed: holder.event_fed,
+                        }),
+                        dropped: holder.dropped,
+                    });
+                }
+                for chunk in chunks {
+                    out.push(UpdateMsg {
+                        keyspace: key.clone(),
+                        holder: holder_key.clone(),
+                        epoch: holder.epoch,
+                        seq: if holder.event_fed { holder.last_seq } else { 0 },
+                        events: vec![WireEvent::Stored {
+                            parent,
+                            blocks: chunk.to_vec(),
+                        }],
+                        added: first.then(|| AddedControl {
+                            capacity_blocks: holder.capacity_blocks,
+                            event_fed: holder.event_fed,
+                        }),
+                        dropped: holder.dropped,
+                    });
+                    parent = chunk.last().map(|b| b.seq_hash);
+                    first = false;
+                }
             }
         }
         out
@@ -419,7 +447,7 @@ impl Engine {
 
     /// Total indexed blocks across keyspaces (stats/tests).
     pub fn entry_count(&self) -> usize {
-        let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        let spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
         spaces
             .values()
             .map(|s| s.tree.stats().distinct_entries as usize)
@@ -429,7 +457,7 @@ impl Engine {
     /// Point-in-time gauges for the metrics endpoint. One pass under the
     /// engine lock; cheap relative to apply/query traffic.
     pub fn stats(&self) -> EngineStats {
-        let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        let spaces = self.keyspaces.lock().expect("engine lock poisoned by a panic mid-mutation: aborting so the replica re-bootstraps clean state from a sibling");
         let mut stats = EngineStats {
             keyspaces: spaces.len(),
             ..EngineStats::default()
@@ -475,6 +503,46 @@ pub fn placement_chain(content_hashes: &[ContentHash]) -> Vec<WireBlock> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn move_only_apply_reports_changed_for_relay() {
+        // A re-anchor MOVE changes query answers while netting zero
+        // blocks; the relay gate must still forward it (audit
+        // finding: a length-delta heuristic suppressed it and let
+        // replicas diverge).
+        let engine = Engine::new(EngineConfig::default());
+        let (_, _, changed) = engine.apply(&placement("w1", 21, 4));
+        assert!(changed);
+        // Same blocks re-anchored under a DIFFERENT prefix: every
+        // key moves, block count unchanged.
+        let chain = placement_chain(&prefix_hashes(21, 4));
+        let other_parent = placement_chain(&prefix_hashes(22, 2));
+        let mut setup = UpdateMsg {
+            keyspace: keyspace(),
+            holder: "w1".into(),
+            epoch: 1,
+            seq: 0,
+            events: vec![WireEvent::Stored {
+                parent: None,
+                blocks: other_parent.clone(),
+            }],
+            added: None,
+            dropped: false,
+        };
+        engine.apply(&setup);
+        setup.events = vec![WireEvent::Stored {
+            parent: Some(other_parent[1].seq_hash),
+            blocks: chain.clone(),
+        }];
+        let before = engine.entry_count();
+        let (_, _, changed) = engine.apply(&setup);
+        assert!(changed, "move-only apply must relay");
+        // Re-applying the identical update is a true no-op and must
+        // NOT relay (echo suppression).
+        let (_, _, changed) = engine.apply(&setup);
+        assert!(!changed, "idempotent echo must not relay");
+        let _ = before;
+    }
+
     use rand::{rngs::StdRng, seq::SliceRandom, RngExt, SeedableRng};
 
     use super::*;

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -435,6 +435,39 @@ impl Engine {
         let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
         spaces.values().map(|s| s.indexer.entry_count()).sum()
     }
+
+    /// Point-in-time gauges for the metrics endpoint. One pass under the
+    /// engine lock; cheap relative to apply/query traffic.
+    pub fn stats(&self) -> EngineStats {
+        let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        let mut stats = EngineStats {
+            keyspaces: spaces.len(),
+            ..EngineStats::default()
+        };
+        for space in spaces.values() {
+            stats.blocks += space.indexer.entry_count();
+            for holder in space.holders.values() {
+                stats.holders += 1;
+                if holder.event_fed {
+                    stats.event_fed_holders += 1;
+                }
+                if holder.dropped {
+                    stats.dropped_holders += 1;
+                }
+            }
+        }
+        stats
+    }
+}
+
+/// Point-in-time engine gauges (see [`Engine::stats`]).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EngineStats {
+    pub keyspaces: usize,
+    pub holders: usize,
+    pub event_fed_holders: usize,
+    pub dropped_holders: usize,
+    pub blocks: usize,
 }
 
 /// Deterministic placement chain: content hashes -> position-chained

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -1,0 +1,743 @@
+//! The index engine: keyspaces of holders over a shared
+//! [`PositionalIndexer`], with epoch-scoped holder state, per-feed
+//! eviction semantics, and overlap queries. Pure and synchronous — the
+//! gRPC surface, relay, and bootstrap live in `server.rs`.
+//!
+//! Correctness model (see `.claude/kv-index-service/01-design.md`):
+//! - Event feed: one worker-sequenced stream per (holder, epoch); apply
+//!   in order, dedup on `seq <= last_seq`, batch-shaped (one seq may mix
+//!   Stored and Removed).
+//! - Placement feed: unsequenced (`seq == 0`), idempotent by content —
+//!   publishers synthesize identical chains for identical prefixes, so
+//!   cross-publisher ordering never matters.
+//! - Epochs: a higher epoch clears all lower-epoch state for the holder;
+//!   lower-epoch updates are dropped. Restarts and cursor loss are both
+//!   epoch bumps, which is what makes relaying `Cleared` safe.
+//! - Feed authority: a holder becomes event-fed on its first observed
+//!   removal (or an explicit `Added { event_fed: true }`); inferred
+//!   Stored updates for an event-fed holder are dropped.
+//! - Inferred eviction is tail-first per holder (prefix-closed, which
+//!   the jump search assumes), by capacity in blocks with a TTL floor
+//!   that retires whole idle holders.
+
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use kv_index::{
+    ContentHash, PositionalIndexer, SequenceHash, StoredBlock, WorkerBlockMap, WorkerId,
+};
+
+/// One block on the wire: position-chained identity + content identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WireBlock {
+    pub seq_hash: SequenceHash,
+    pub content_hash: ContentHash,
+}
+
+/// A cache transition within one update.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WireEvent {
+    Stored {
+        parent: Option<SequenceHash>,
+        blocks: Vec<WireBlock>,
+    },
+    Removed {
+        seq_hashes: Vec<SequenceHash>,
+    },
+    Cleared,
+}
+
+/// Membership / capacity control payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddedControl {
+    pub capacity_blocks: u64,
+    pub event_fed: bool,
+}
+
+/// One `Publish` message, decoded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateMsg {
+    pub keyspace: KeyspaceKey,
+    pub holder: String,
+    pub epoch: u64,
+    /// 0 = unsequenced (placement / control), else the holder's batch seq.
+    pub seq: u64,
+    pub events: Vec<WireEvent>,
+    pub added: Option<AddedControl>,
+    pub dropped: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyOutcome {
+    Applied,
+    /// Dropped as a duplicate / stale seq or stale epoch.
+    Deduped,
+    /// Inferred Stored dropped because the holder is event-fed.
+    FeedRejected,
+    /// Keyspace block_size conflict — publisher misconfigured.
+    KeyspaceMismatch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SymbolKind {
+    Tokens,
+    Bytes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KeyspaceKey {
+    pub model: String,
+    pub symbol_kind: SymbolKind,
+    pub block_size: u32,
+}
+
+/// Per-holder score in a query answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HolderScore {
+    pub holder: String,
+    pub matched_blocks: u32,
+    pub total_blocks: u64,
+    pub event_fed: bool,
+}
+
+pub struct EngineConfig {
+    /// Jump stride for the positional index query search.
+    pub jump_size: usize,
+    /// Idle TTL for INFERRED holder state; an inferred holder with no
+    /// publish inside the window is cleared entirely (coarse but
+    /// prefix-closed). Event-fed holders are never TTL'd — their
+    /// eviction is observed.
+    pub inferred_ttl: Duration,
+    /// Default capacity (blocks) for inferred holders that never sent
+    /// `Added`.
+    pub default_capacity_blocks: u64,
+}
+
+impl Default for EngineConfig {
+    fn default() -> Self {
+        Self {
+            jump_size: 64,
+            inferred_ttl: Duration::from_secs(180),
+            default_capacity_blocks: u64::MAX,
+        }
+    }
+}
+
+struct HolderState {
+    worker_id: WorkerId,
+    epoch: u64,
+    last_seq: u64,
+    event_fed: bool,
+    capacity_blocks: u64,
+    dropped: bool,
+    /// Reverse map the indexer's write path requires (caller-owned).
+    blocks: WorkerBlockMap,
+    /// Position-ordered chain, maintained for INFERRED holders only, so
+    /// capacity eviction can pop the tail and keep the prefix closed.
+    /// Event-fed holders evict wherever their engine says.
+    chain: Vec<SequenceHash>,
+    last_publish: Instant,
+}
+
+struct KeyspaceState {
+    indexer: PositionalIndexer,
+    holders: HashMap<String, HolderState>,
+    by_worker_id: HashMap<WorkerId, String>,
+}
+
+/// The engine: all keyspaces. One lock over everything — apply and query
+/// rates in scope (hundreds of k ops/s) are far below contention range
+/// for the critical sections involved, and single-lock semantics make
+/// the convergence argument checkable.
+pub struct Engine {
+    cfg: EngineConfig,
+    keyspaces: std::sync::Mutex<HashMap<KeyspaceKey, KeyspaceState>>,
+}
+
+impl Engine {
+    pub fn new(cfg: EngineConfig) -> Self {
+        Self {
+            cfg,
+            keyspaces: std::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Apply one update. Returns what happened, plus the holder's applied
+    /// watermark for the publisher's ack.
+    pub fn apply(&self, update: &UpdateMsg) -> (ApplyOutcome, u64) {
+        let mut spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+
+        // A keyspace is created on first contact; a later publisher whose
+        // key differs only in block_size is a DIFFERENT keyspace by key
+        // construction, so mismatch cannot silently merge. Reject only
+        // the degenerate block size.
+        if update.keyspace.block_size == 0 {
+            return (ApplyOutcome::KeyspaceMismatch, 0);
+        }
+        let KeyspaceState {
+            indexer,
+            holders,
+            by_worker_id,
+        } = spaces
+            .entry(update.keyspace.clone())
+            .or_insert_with(|| KeyspaceState {
+                indexer: PositionalIndexer::new(self.cfg.jump_size),
+                holders: HashMap::new(),
+                by_worker_id: HashMap::new(),
+            });
+
+        if !holders.contains_key(&update.holder) {
+            let Ok(worker_id) = indexer.intern_worker(&update.holder) else {
+                return (ApplyOutcome::KeyspaceMismatch, 0);
+            };
+            by_worker_id.insert(worker_id, update.holder.clone());
+            holders.insert(
+                update.holder.clone(),
+                HolderState {
+                    worker_id,
+                    epoch: update.epoch,
+                    last_seq: 0,
+                    event_fed: false,
+                    capacity_blocks: self.cfg.default_capacity_blocks,
+                    dropped: false,
+                    blocks: WorkerBlockMap::default(),
+                    chain: Vec::new(),
+                    last_publish: Instant::now(),
+                },
+            );
+        }
+        let holder = holders
+            .get_mut(&update.holder)
+            .expect("holder inserted above");
+
+        // Epoch gate: higher epoch supersedes (implicit clear), lower is
+        // dropped, equal proceeds.
+        if update.epoch > holder.epoch {
+            indexer.apply_cleared(holder.worker_id, &mut holder.blocks);
+            holder.chain.clear();
+            holder.epoch = update.epoch;
+            holder.last_seq = 0;
+        } else if update.epoch < holder.epoch {
+            return (ApplyOutcome::Deduped, holder.last_seq);
+        }
+        holder.last_publish = Instant::now();
+
+        if let Some(added) = &update.added {
+            holder.capacity_blocks = if added.capacity_blocks == 0 {
+                self.cfg.default_capacity_blocks
+            } else {
+                added.capacity_blocks
+            };
+            if added.event_fed {
+                holder.event_fed = true;
+            }
+            holder.dropped = false;
+        }
+        if update.dropped {
+            holder.dropped = true;
+        }
+
+        // Sequenced = event feed; unsequenced = placement/control.
+        let sequenced = update.seq != 0;
+        if sequenced {
+            if update.seq <= holder.last_seq {
+                return (ApplyOutcome::Deduped, holder.last_seq);
+            }
+            holder.last_seq = update.seq;
+        }
+
+        let mut outcome = ApplyOutcome::Applied;
+        for event in &update.events {
+            match event {
+                WireEvent::Stored { parent, blocks } => {
+                    if !sequenced && holder.event_fed {
+                        // D4: placements never pollute observed holders.
+                        outcome = ApplyOutcome::FeedRejected;
+                        continue;
+                    }
+                    if sequenced && !holder.event_fed {
+                        // First sequenced traffic pins feed authority too:
+                        // a holder with a real event stream is observed.
+                        holder.event_fed = true;
+                        holder.chain.clear();
+                    }
+                    let stored: Vec<StoredBlock> = blocks
+                        .iter()
+                        .map(|b| StoredBlock {
+                            seq_hash: b.seq_hash,
+                            content_hash: b.content_hash,
+                        })
+                        .collect();
+                    let applied = indexer
+                        .apply_stored(holder.worker_id, &stored, *parent, &mut holder.blocks)
+                        .or_else(|_| {
+                            // Unresolvable parent re-anchors at position 0,
+                            // mirroring the gateway monitor's recovery.
+                            indexer.apply_stored(
+                                holder.worker_id,
+                                &stored,
+                                None,
+                                &mut holder.blocks,
+                            )
+                        });
+                    if applied.is_ok() && !holder.event_fed {
+                        Self::extend_chain(holder, blocks);
+                        Self::evict_tail(indexer, holder);
+                    }
+                }
+                WireEvent::Removed { seq_hashes } => {
+                    if !holder.event_fed {
+                        holder.event_fed = true;
+                        holder.chain.clear();
+                    }
+                    indexer.apply_removed(holder.worker_id, seq_hashes, &mut holder.blocks);
+                }
+                WireEvent::Cleared => {
+                    indexer.apply_cleared(holder.worker_id, &mut holder.blocks);
+                    holder.chain.clear();
+                }
+            }
+        }
+        (outcome, holder.last_seq)
+    }
+
+    /// Position-ordered chain bookkeeping for inferred holders. The
+    /// stored blocks landed at parent_pos+1.. (or 0): reflect that in the
+    /// tail vector so capacity eviction stays prefix-closed.
+    fn extend_chain(holder: &mut HolderState, blocks: &[WireBlock]) {
+        let Some(first) = blocks.first() else { return };
+        let Some(&(start_pos, _, _)) = holder.blocks.get(&first.seq_hash) else {
+            return;
+        };
+        if holder.chain.len() < start_pos {
+            // A gap should be impossible for deterministic placement
+            // chains; anchor defensively at the current tail.
+            return;
+        }
+        holder.chain.truncate(start_pos);
+        holder.chain.extend(blocks.iter().map(|b| b.seq_hash));
+    }
+
+    fn evict_tail(indexer: &PositionalIndexer, holder: &mut HolderState) {
+        let capacity = usize::try_from(holder.capacity_blocks).unwrap_or(usize::MAX);
+        while holder.chain.len() > capacity {
+            let Some(tail) = holder.chain.pop() else {
+                break;
+            };
+            indexer.apply_removed(holder.worker_id, &[tail], &mut holder.blocks);
+        }
+    }
+
+    /// TTL sweep: clear inferred holders idle beyond the window. Cheap
+    /// (per-holder timestamps only); run from a timer.
+    pub fn sweep_idle(&self) {
+        let ttl = self.cfg.inferred_ttl;
+        let mut spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        for space in spaces.values_mut() {
+            let KeyspaceState {
+                indexer, holders, ..
+            } = space;
+            for holder in holders.values_mut() {
+                if !holder.event_fed && holder.last_publish.elapsed() > ttl {
+                    indexer.apply_cleared(holder.worker_id, &mut holder.blocks);
+                    holder.chain.clear();
+                }
+            }
+        }
+    }
+
+    /// Overlap query: per-holder matched prefix depth, dropped holders
+    /// excluded. Missing keyspace = empty answer (advisory semantics).
+    pub fn find_matches(&self, keyspace: &KeyspaceKey, hashes: &[ContentHash]) -> Vec<HolderScore> {
+        let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(space) = spaces.get(keyspace) else {
+            return Vec::new();
+        };
+        let overlap = space.indexer.find_matches(hashes, false);
+        let mut scores = Vec::with_capacity(overlap.scores.len());
+        for (worker_id, matched) in overlap.scores {
+            let Some(holder_key) = space.by_worker_id.get(&worker_id) else {
+                continue;
+            };
+            let Some(holder) = space.holders.get(holder_key) else {
+                continue;
+            };
+            if holder.dropped || matched == 0 {
+                continue;
+            }
+            scores.push(HolderScore {
+                holder: holder_key.clone(),
+                matched_blocks: matched,
+                total_blocks: overlap
+                    .tree_sizes
+                    .get(&worker_id)
+                    .copied()
+                    .unwrap_or_default() as u64,
+                event_fed: holder.event_fed,
+            });
+        }
+        scores.sort_by_key(|s| std::cmp::Reverse(s.matched_blocks));
+        scores
+    }
+
+    /// Serialize current state as synthetic Updates (for `Pull`): one
+    /// Stored per holder carrying its full chain in position order, under
+    /// the holder's current epoch, unsequenced-for-inferred /
+    /// watermark-seq-for-observed so the puller lands with the same
+    /// dedup posture.
+    pub fn snapshot(&self) -> Vec<UpdateMsg> {
+        let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        let mut out = Vec::new();
+        for (key, space) in spaces.iter() {
+            for (holder_key, holder) in &space.holders {
+                // Reconstruct position order from the reverse map.
+                let mut ordered: Vec<(usize, SequenceHash, ContentHash)> = holder
+                    .blocks
+                    .iter()
+                    .map(|(&seq, &(pos, content, _))| (pos, seq, content))
+                    .collect();
+                ordered.sort_by_key(|&(pos, _, _)| pos);
+                let blocks: Vec<WireBlock> = ordered
+                    .iter()
+                    .map(|&(_, seq_hash, content_hash)| WireBlock {
+                        seq_hash,
+                        content_hash,
+                    })
+                    .collect();
+                out.push(UpdateMsg {
+                    keyspace: key.clone(),
+                    holder: holder_key.clone(),
+                    epoch: holder.epoch,
+                    seq: if holder.event_fed { holder.last_seq } else { 0 },
+                    events: if blocks.is_empty() {
+                        Vec::new()
+                    } else {
+                        vec![WireEvent::Stored {
+                            parent: None,
+                            blocks,
+                        }]
+                    },
+                    added: Some(AddedControl {
+                        capacity_blocks: holder.capacity_blocks,
+                        event_fed: holder.event_fed,
+                    }),
+                    dropped: holder.dropped,
+                });
+            }
+        }
+        out
+    }
+
+    /// Total indexed blocks across keyspaces (stats/tests).
+    pub fn entry_count(&self) -> usize {
+        let spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
+        spaces.values().map(|s| s.indexer.entry_count()).sum()
+    }
+}
+
+/// Deterministic placement chain: content hashes -> position-chained
+/// wire blocks, using the indexer's own rolling prefix hash so every
+/// publisher synthesizes byte-identical chains for identical prefixes.
+pub fn placement_chain(content_hashes: &[ContentHash]) -> Vec<WireBlock> {
+    let mut out = Vec::with_capacity(content_hashes.len());
+    let mut prev = SequenceHash(0);
+    for (i, &content_hash) in content_hashes.iter().enumerate() {
+        let seq_hash = if i == 0 {
+            SequenceHash(content_hash.0)
+        } else {
+            kv_index::chain_prefix_hash(prev, content_hash)
+        };
+        out.push(WireBlock {
+            seq_hash,
+            content_hash,
+        });
+        prev = seq_hash;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use kv_index::compute_content_hash;
+    use rand::{rngs::StdRng, seq::SliceRandom, RngExt, SeedableRng};
+
+    use super::*;
+
+    fn keyspace() -> KeyspaceKey {
+        KeyspaceKey {
+            model: "m".into(),
+            symbol_kind: SymbolKind::Tokens,
+            block_size: 4,
+        }
+    }
+
+    /// Content hashes for a synthetic prefix: block i hashes tokens
+    /// [seed, i] so shared prefixes share leading hashes.
+    fn prefix_hashes(seed: u32, blocks: usize) -> Vec<ContentHash> {
+        (0..blocks as u32)
+            .map(|i| compute_content_hash(&[seed, i]))
+            .collect()
+    }
+
+    fn placement(holder: &str, seed: u32, blocks: usize) -> UpdateMsg {
+        UpdateMsg {
+            keyspace: keyspace(),
+            holder: holder.into(),
+            epoch: 1,
+            seq: 0,
+            events: vec![WireEvent::Stored {
+                parent: None,
+                blocks: placement_chain(&prefix_hashes(seed, blocks)),
+            }],
+            added: None,
+            dropped: false,
+        }
+    }
+
+    fn event_batch(holder: &str, seq: u64, events: Vec<WireEvent>) -> UpdateMsg {
+        UpdateMsg {
+            keyspace: keyspace(),
+            holder: holder.into(),
+            epoch: 1,
+            seq,
+            events,
+            added: None,
+            dropped: false,
+        }
+    }
+
+    fn scores(engine: &Engine, seed: u32, blocks: usize) -> Vec<(String, u32)> {
+        engine
+            .find_matches(&keyspace(), &prefix_hashes(seed, blocks))
+            .into_iter()
+            .map(|s| (s.holder, s.matched_blocks))
+            .collect()
+    }
+
+    #[test]
+    fn placement_chain_is_deterministic_and_positions_match() {
+        let hashes = prefix_hashes(7, 6);
+        assert_eq!(placement_chain(&hashes), placement_chain(&hashes));
+        let engine = Engine::new(EngineConfig::default());
+        engine.apply(&placement("w1", 7, 6));
+        assert_eq!(scores(&engine, 7, 6), vec![("w1".into(), 6)]);
+        // A shorter shared prefix matches its depth only.
+        assert_eq!(scores(&engine, 7, 3), vec![("w1".into(), 3)]);
+    }
+
+    #[test]
+    fn placements_are_idempotent_across_publishers() {
+        let a = Engine::new(EngineConfig::default());
+        let b = Engine::new(EngineConfig::default());
+        // "Gateways" 1..4 place the same prefix repeatedly and extensions
+        // of it, in different orders per replica.
+        let mut updates = Vec::new();
+        for _publisher in 0..4 {
+            updates.push(placement("w1", 9, 4));
+            updates.push(placement("w1", 9, 8)); // extension
+            updates.push(placement("w2", 9, 2)); // shorter copy elsewhere
+        }
+        let mut rng = StdRng::seed_from_u64(1);
+        let mut for_a = updates.clone();
+        let mut for_b = updates.clone();
+        for_a.shuffle(&mut rng);
+        for_b.shuffle(&mut rng);
+        for u in &for_a {
+            a.apply(u);
+        }
+        for u in &for_b {
+            b.apply(u);
+        }
+        assert_eq!(scores(&a, 9, 8), scores(&b, 9, 8));
+        assert_eq!(a.entry_count(), b.entry_count());
+        // And identical to the once-only application.
+        let once = Engine::new(EngineConfig::default());
+        once.apply(&placement("w1", 9, 8));
+        once.apply(&placement("w2", 9, 2));
+        assert_eq!(scores(&once, 9, 8), scores(&a, 9, 8));
+    }
+
+    #[test]
+    fn replicas_converge_under_interleaving_and_duplication() {
+        // Event holders: per-holder order preserved (the stream contract);
+        // cross-holder interleaving and duplicates are free game.
+        // Placement holders: any order, any duplication.
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut per_holder: Vec<Vec<UpdateMsg>> = Vec::new();
+        for h in 0..4u32 {
+            let holder = format!("ev{h}");
+            let mut seqs = Vec::new();
+            let mut chain = placement_chain(&prefix_hashes(100 + h, 12));
+            for (i, window) in chain.chunks(3).enumerate() {
+                let parent = if i == 0 {
+                    None
+                } else {
+                    Some(chain[i * 3 - 1].seq_hash)
+                };
+                let mut events = vec![WireEvent::Stored {
+                    parent,
+                    blocks: window.to_vec(),
+                }];
+                // Mixed batch: occasionally remove an old tail block in the
+                // same seq as a store.
+                if i == 3 {
+                    events.push(WireEvent::Removed {
+                        seq_hashes: vec![chain[11].seq_hash],
+                    });
+                }
+                seqs.push(event_batch(&holder, (i + 1) as u64, events));
+            }
+            chain.clear();
+            per_holder.push(seqs);
+        }
+        let placements: Vec<UpdateMsg> = (0..6u32)
+            .map(|p| placement(&format!("pl{}", p % 2), 200 + (p % 3), 4 + (p % 5) as usize))
+            .collect();
+
+        let deliver = |engine: &Engine, rng: &mut StdRng| {
+            // Merge per-holder event queues preserving each holder's order.
+            let mut cursors = vec![0usize; per_holder.len()];
+            let mut pending_placements = placements.clone();
+            loop {
+                let live: Vec<usize> = cursors
+                    .iter()
+                    .enumerate()
+                    .filter(|(h, &c)| c < per_holder[*h].len())
+                    .map(|(h, _)| h)
+                    .collect();
+                if live.is_empty() && pending_placements.is_empty() {
+                    break;
+                }
+                if !pending_placements.is_empty() && (live.is_empty() || rng.random_bool(0.4)) {
+                    let i = rng.random_range(0..pending_placements.len());
+                    let u = pending_placements.swap_remove(i);
+                    engine.apply(&u);
+                    if rng.random_bool(0.3) {
+                        engine.apply(&u); // duplicate
+                    }
+                } else {
+                    let h = live[rng.random_range(0..live.len())];
+                    let u = &per_holder[h][cursors[h]];
+                    engine.apply(u);
+                    if rng.random_bool(0.3) {
+                        engine.apply(u); // duplicate (deduped by seq)
+                    }
+                    cursors[h] += 1;
+                }
+            }
+        };
+
+        let a = Engine::new(EngineConfig::default());
+        let b = Engine::new(EngineConfig::default());
+        deliver(&a, &mut rng);
+        deliver(&b, &mut rng);
+        for h in 0..4u32 {
+            assert_eq!(
+                scores(&a, 100 + h, 12),
+                scores(&b, 100 + h, 12),
+                "event holder {h} diverged"
+            );
+        }
+        for p in 0..3u32 {
+            assert_eq!(scores(&a, 200 + p, 8), scores(&b, 200 + p, 8));
+        }
+        assert_eq!(a.entry_count(), b.entry_count());
+    }
+
+    #[test]
+    fn higher_epoch_clears_lower_and_stale_epochs_drop() {
+        let engine = Engine::new(EngineConfig::default());
+        engine.apply(&placement("w1", 5, 6));
+        assert_eq!(scores(&engine, 5, 6), vec![("w1".into(), 6)]);
+
+        // Restarted holder announces epoch 2 with a fresh (shorter) cache.
+        let mut restarted = placement("w1", 5, 2);
+        restarted.epoch = 2;
+        let (outcome, _) = engine.apply(&restarted);
+        assert_eq!(outcome, ApplyOutcome::Applied);
+        assert_eq!(scores(&engine, 5, 6), vec![("w1".into(), 2)]);
+
+        // A late epoch-1 update (relay stragglers) is dropped.
+        let (outcome, _) = engine.apply(&placement("w1", 5, 6));
+        assert_eq!(outcome, ApplyOutcome::Deduped);
+        assert_eq!(scores(&engine, 5, 6), vec![("w1".into(), 2)]);
+    }
+
+    #[test]
+    fn tail_eviction_keeps_prefixes_closed() {
+        let engine = Engine::new(EngineConfig {
+            default_capacity_blocks: 4,
+            ..EngineConfig::default()
+        });
+        engine.apply(&placement("w1", 3, 8));
+        // Head survives, tail evicted: prefix-closed at depth 4.
+        assert_eq!(scores(&engine, 3, 8), vec![("w1".into(), 4)]);
+        assert_eq!(engine.entry_count(), 4);
+    }
+
+    #[test]
+    fn event_fed_holders_reject_placements_and_split_batches_do_not_lose_events() {
+        let engine = Engine::new(EngineConfig::default());
+        let chain = placement_chain(&prefix_hashes(11, 6));
+        // One seq carrying Stored + Removed together (engine batch shape).
+        engine.apply(&event_batch(
+            "w1",
+            1,
+            vec![
+                WireEvent::Stored {
+                    parent: None,
+                    blocks: chain.clone(),
+                },
+                WireEvent::Removed {
+                    seq_hashes: vec![chain[5].seq_hash],
+                },
+            ],
+        ));
+        assert_eq!(scores(&engine, 11, 6), vec![("w1".into(), 5)]);
+
+        // A placement for the now event-fed holder is rejected.
+        let (outcome, _) = engine.apply(&placement("w1", 12, 3));
+        assert_eq!(outcome, ApplyOutcome::FeedRejected);
+        assert!(scores(&engine, 12, 3).is_empty());
+
+        // Duplicate seq is deduped even with different content.
+        engine.apply(&event_batch(
+            "w1",
+            1,
+            vec![WireEvent::Removed {
+                seq_hashes: vec![chain[4].seq_hash],
+            }],
+        ));
+        assert_eq!(scores(&engine, 11, 6), vec![("w1".into(), 5)]);
+    }
+
+    #[test]
+    fn snapshot_bootstrap_reproduces_answers() {
+        let a = Engine::new(EngineConfig::default());
+        a.apply(&placement("w1", 21, 5));
+        let chain = placement_chain(&prefix_hashes(22, 4));
+        a.apply(&event_batch(
+            "w2",
+            3,
+            vec![WireEvent::Stored {
+                parent: None,
+                blocks: chain,
+            }],
+        ));
+
+        let b = Engine::new(EngineConfig::default());
+        for update in a.snapshot() {
+            b.apply(&update);
+        }
+        assert_eq!(scores(&a, 21, 5), scores(&b, 21, 5));
+        assert_eq!(scores(&a, 22, 4), scores(&b, 22, 4));
+        assert_eq!(a.entry_count(), b.entry_count());
+
+        // The bootstrapped replica keeps the event holder's dedup posture:
+        // the watermark seq travels, so a replayed old batch is dropped.
+        let (outcome, _) = b.apply(&event_batch("w2", 2, vec![WireEvent::Cleared]));
+        assert_eq!(outcome, ApplyOutcome::Deduped);
+    }
+}

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -108,9 +108,19 @@ pub struct HolderScore {
 pub struct EngineConfig {
     /// Idle TTL for INFERRED holder state; an inferred holder with no
     /// publish inside the window is cleared entirely (coarse but
-    /// prefix-closed). Event-fed holders are never TTL'd — their
-    /// eviction is observed.
+    /// prefix-closed). Event-fed holders' BLOCK eviction is observed,
+    /// never TTL'd; their liveness backstop is `event_ttl`.
     pub inferred_ttl: Duration,
+    /// Liveness BACKSTOP for event-fed holders whose fleet-departure
+    /// signal was lost (the primary signal is the gateway's removal
+    /// workflow publishing `dropped`; a gateway crash mid-workflow
+    /// loses it, and before this backstop such a holder persisted
+    /// FOREVER — liveness review finding). An event-fed holder silent
+    /// for this window is soft-retired (`dropped`), which stops its
+    /// scoring and starts the retire clock; a next observed event
+    /// batch self-heals it. Keep an order of magnitude above
+    /// `inferred_ttl`; zero disables the backstop.
+    pub event_ttl: Duration,
     /// Default capacity (blocks) for inferred holders that never sent
     /// `Added`.
     pub default_capacity_blocks: u64,
@@ -120,6 +130,7 @@ impl Default for EngineConfig {
     fn default() -> Self {
         Self {
             inferred_ttl: Duration::from_secs(180),
+            event_ttl: Duration::from_secs(1800),
             default_capacity_blocks: u64::MAX,
         }
     }
@@ -243,28 +254,23 @@ impl Engine {
 
         let mut changed = false;
 
-        // Epoch gate: higher epoch supersedes (implicit clear), lower is
-        // dropped, equal proceeds.
-        if update.epoch > holder.epoch {
-            tree.clear(holder.id);
-            holder.epoch = update.epoch;
-            holder.last_seq = 0;
-            changed = true;
-        } else if update.epoch < holder.epoch {
-            return (ApplyOutcome::Deduped, holder.last_seq, false);
-        }
-        holder.last_publish = Instant::now();
-
+        // Control payloads (membership lifecycle) apply BEFORE the
+        // epoch gate: the gateway's removal workflow publishes
+        // `dropped` at whatever epoch it last saw, while the bridge
+        // may have bumped the holder past it — a lifecycle signal
+        // silently discarded on epoch mismatch is a holder leak (the
+        // liveness review caught exactly this: `dropped` at epoch 1
+        // vs a bridge on epoch 2 was Deduped).
         if update.added.is_some() || update.dropped {
-            // Control payloads always change holder posture.
             changed = true;
         }
         if let Some(added) = &update.added {
-            holder.capacity_blocks = if added.capacity_blocks == 0 {
-                self.cfg.default_capacity_blocks
-            } else {
-                added.capacity_blocks
-            };
+            // Zero means "no capacity claim" — leave the standing
+            // value: a bare lifecycle re-announce must not clobber a
+            // worker-declared capacity back to the default.
+            if added.capacity_blocks != 0 {
+                holder.capacity_blocks = added.capacity_blocks;
+            }
             if added.event_fed {
                 holder.event_fed = true;
             }
@@ -274,6 +280,22 @@ impl Engine {
             holder.dropped = true;
         }
 
+        // Epoch gate: higher epoch supersedes (implicit clear), lower is
+        // dropped, equal proceeds. A bump is proof of life — a new feed
+        // generation exists, so a standing soft-retire is healed.
+        if update.epoch > holder.epoch {
+            tree.clear(holder.id);
+            holder.epoch = update.epoch;
+            holder.last_seq = 0;
+            if !update.dropped {
+                holder.dropped = false;
+            }
+            changed = true;
+        } else if update.epoch < holder.epoch {
+            return (ApplyOutcome::Deduped, holder.last_seq, changed);
+        }
+        holder.last_publish = Instant::now();
+
         // Sequenced = event feed; unsequenced = placement/control.
         let sequenced = update.seq != 0;
         if sequenced {
@@ -281,6 +303,12 @@ impl Engine {
                 return (ApplyOutcome::Deduped, holder.last_seq, changed);
             }
             holder.last_seq = update.seq;
+            if holder.dropped && !update.dropped {
+                // Observed engine events are proof of life: heal a
+                // stale (or wrongly relayed) soft-retire.
+                holder.dropped = false;
+                changed = true;
+            }
         }
 
         let mut outcome = ApplyOutcome::Applied;
@@ -358,6 +386,7 @@ impl Engine {
     /// timestamps; run from a timer.
     pub fn sweep_idle(&self) {
         let ttl = self.cfg.inferred_ttl;
+        let event_ttl = self.cfg.event_ttl;
         for (key, space_arc) in self.all_spaces() {
             let now_empty = {
                 let mut space = space_arc.lock().expect(LOCK_MSG);
@@ -369,6 +398,18 @@ impl Engine {
                         retire.push(name.clone());
                     } else if !holder.event_fed && idle {
                         space.tree.clear(holder.id);
+                    } else if holder.event_fed
+                        && !holder.dropped
+                        && !event_ttl.is_zero()
+                        && holder.last_publish.elapsed() > event_ttl
+                    {
+                        // Liveness backstop: silence far beyond the
+                        // event feed's cadence means the departure
+                        // signal was lost. Soft-retire; a next event
+                        // batch self-heals. Replicas converge on this
+                        // independently — each observes the same
+                        // silence on its own clock.
+                        holder.dropped = true;
                     }
                 }
                 for name in retire {
@@ -893,6 +934,88 @@ mod tests {
         // the watermark seq travels, so a replayed old batch is dropped.
         let (outcome, _, _) = b.apply(&event_batch("w2", 2, vec![WireEvent::Cleared]));
         assert_eq!(outcome, ApplyOutcome::Deduped);
+    }
+
+    #[test]
+    fn lifecycle_controls_apply_across_the_epoch_gate() {
+        let engine = Engine::new(EngineConfig::default());
+        // Bridge feeds the holder at epoch 3.
+        let mut feed = event_batch(
+            "w1",
+            1,
+            vec![WireEvent::Stored {
+                parent: None,
+                blocks: placement_chain(&prefix_hashes(51, 4)),
+            }],
+        );
+        feed.epoch = 3;
+        engine.apply(&feed);
+        assert_eq!(scores(&engine, 51, 4).len(), 1);
+
+        // The gateway's removal workflow publishes `dropped` at the
+        // stale epoch it last saw. It must apply anyway (a lifecycle
+        // signal silently discarded on epoch mismatch is a holder
+        // leak) — and it must RELAY (changed=true) so replicas learn.
+        let drop_msg = UpdateMsg {
+            keyspace: keyspace(),
+            holder: "w1".into(),
+            epoch: 1,
+            seq: 0,
+            events: Vec::new(),
+            added: None,
+            dropped: true,
+        };
+        let (_, _, changed) = engine.apply(&drop_msg);
+        assert!(changed, "stale-epoch drop must still relay");
+        assert!(scores(&engine, 51, 4).is_empty(), "dropped holder scored");
+
+        // Observed event traffic is proof of life: the next sequenced
+        // batch heals the soft-retire.
+        let mut alive = event_batch(
+            "w1",
+            2,
+            vec![WireEvent::Stored {
+                parent: None,
+                blocks: placement_chain(&prefix_hashes(52, 2)),
+            }],
+        );
+        alive.epoch = 3;
+        engine.apply(&alive);
+        assert_eq!(
+            scores(&engine, 52, 2).len(),
+            1,
+            "event batch must heal drop"
+        );
+    }
+
+    #[test]
+    fn silent_event_holders_are_soft_retired_by_the_backstop() {
+        let engine = Engine::new(EngineConfig {
+            inferred_ttl: Duration::ZERO,
+            event_ttl: Duration::from_nanos(1),
+            ..EngineConfig::default()
+        });
+        engine.apply(&event_batch(
+            "w1",
+            1,
+            vec![WireEvent::Stored {
+                parent: None,
+                blocks: placement_chain(&prefix_hashes(53, 4)),
+            }],
+        ));
+        assert_eq!(scores(&engine, 53, 4).len(), 1);
+        std::thread::sleep(Duration::from_millis(2));
+        // First sweep: silence past event_ttl soft-retires (stops
+        // scoring); second sweep: dropped + idle retires entirely and
+        // the emptied keyspace unlinks.
+        engine.sweep_idle();
+        assert!(
+            scores(&engine, 53, 4).is_empty(),
+            "backstop must stop scoring"
+        );
+        engine.sweep_idle();
+        assert_eq!(engine.stats().holders, 0, "dropped idle holder must retire");
+        assert_eq!(engine.stats().keyspaces, 0);
     }
 
     #[test]

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -272,13 +272,20 @@ impl Engine {
                             other => Err(other),
                         });
                     if stored.is_ok() && !holder.event_fed {
-                        // Capacity eviction, forest-wide and prefix-
-                        // closed (the tree owns the order; this
-                        // deliberately fixes the old last-chain-only
-                        // accounting).
-                        let held = tree.holder_blocks(holder.id);
-                        if held > holder.capacity_blocks {
-                            tree.truncate_tail(holder.id, holder.capacity_blocks);
+                        // Capacity is RUNAWAY PROTECTION, not an
+                        // eviction mirror: the placement feed carries
+                        // no removal signal, so index-side eviction
+                        // order can never match the worker's real
+                        // order — truncating AT the worker's size
+                        // races it and under-matches (measured: p95
+                        // prediction error 0 -> 9216 tokens when the
+                        // forest-correct accounting made the old
+                        // at-capacity bound actually bind). Truncate
+                        // only past 2x declared capacity; TTL remains
+                        // the freshness bound.
+                        let bound = holder.capacity_blocks.saturating_mul(2);
+                        if tree.holder_blocks(holder.id) > bound {
+                            tree.truncate_tail(holder.id, bound);
                         }
                     }
                 }

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -164,9 +164,13 @@ impl Engine {
         }
     }
 
-    /// Apply one update. Returns what happened, plus the holder's applied
-    /// watermark for the publisher's ack.
-    pub fn apply(&self, update: &UpdateMsg) -> (ApplyOutcome, u64) {
+    /// Apply one update. Returns what happened, the holder's applied
+    /// watermark for the publisher's ack, and whether OBSERVABLE STATE
+    /// CHANGED — the relay forwards only changing applies, so a
+    /// symmetric-peer echo dies in one hop instead of ping-ponging
+    /// forever (the metrics timeline caught ~190x apply amplification
+    /// from exactly that loop).
+    pub fn apply(&self, update: &UpdateMsg) -> (ApplyOutcome, u64, bool) {
         let mut spaces = self.keyspaces.lock().unwrap_or_else(|p| p.into_inner());
 
         // A keyspace is created on first contact; a later publisher whose
@@ -174,7 +178,7 @@ impl Engine {
         // construction, so mismatch cannot silently merge. Reject only
         // the degenerate block size.
         if update.keyspace.block_size == 0 {
-            return (ApplyOutcome::KeyspaceMismatch, 0);
+            return (ApplyOutcome::KeyspaceMismatch, 0, false);
         }
         let KeyspaceState {
             indexer,
@@ -190,7 +194,7 @@ impl Engine {
 
         if !holders.contains_key(&update.holder) {
             let Ok(worker_id) = indexer.intern_worker(&update.holder) else {
-                return (ApplyOutcome::KeyspaceMismatch, 0);
+                return (ApplyOutcome::KeyspaceMismatch, 0, false);
             };
             by_worker_id.insert(worker_id, update.holder.clone());
             holders.insert(
@@ -214,16 +218,23 @@ impl Engine {
 
         // Epoch gate: higher epoch supersedes (implicit clear), lower is
         // dropped, equal proceeds.
+        let mut changed = false;
+        let len_before = holder.blocks.len();
         if update.epoch > holder.epoch {
             indexer.apply_cleared(holder.worker_id, &mut holder.blocks);
             holder.chain.clear();
             holder.epoch = update.epoch;
             holder.last_seq = 0;
+            changed = true;
         } else if update.epoch < holder.epoch {
-            return (ApplyOutcome::Deduped, holder.last_seq);
+            return (ApplyOutcome::Deduped, holder.last_seq, false);
         }
         holder.last_publish = Instant::now();
 
+        if update.added.is_some() || update.dropped {
+            // Control payloads always change holder posture.
+            changed = true;
+        }
         if let Some(added) = &update.added {
             holder.capacity_blocks = if added.capacity_blocks == 0 {
                 self.cfg.default_capacity_blocks
@@ -243,7 +254,7 @@ impl Engine {
         let sequenced = update.seq != 0;
         if sequenced {
             if update.seq <= holder.last_seq {
-                return (ApplyOutcome::Deduped, holder.last_seq);
+                return (ApplyOutcome::Deduped, holder.last_seq, changed);
             }
             holder.last_seq = update.seq;
         }
@@ -297,10 +308,15 @@ impl Engine {
                 WireEvent::Cleared => {
                     indexer.apply_cleared(holder.worker_id, &mut holder.blocks);
                     holder.chain.clear();
+                    changed = true;
                 }
             }
         }
-        (outcome, holder.last_seq)
+        // Registry-length delta covers stores and removes; mixed
+        // batches that net to zero blocks still flip `changed` via
+        // the Cleared/control arms above or are true no-ops.
+        changed |= holder.blocks.len() != len_before;
+        (outcome, holder.last_seq, changed)
     }
 
     /// Position-ordered chain bookkeeping for inferred holders. The
@@ -680,12 +696,12 @@ mod tests {
         // Restarted holder announces epoch 2 with a fresh (shorter) cache.
         let mut restarted = placement("w1", 5, 2);
         restarted.epoch = 2;
-        let (outcome, _) = engine.apply(&restarted);
+        let (outcome, _, _) = engine.apply(&restarted);
         assert_eq!(outcome, ApplyOutcome::Applied);
         assert_eq!(scores(&engine, 5, 6), vec![("w1".into(), 2)]);
 
         // A late epoch-1 update (relay stragglers) is dropped.
-        let (outcome, _) = engine.apply(&placement("w1", 5, 6));
+        let (outcome, _, _) = engine.apply(&placement("w1", 5, 6));
         assert_eq!(outcome, ApplyOutcome::Deduped);
         assert_eq!(scores(&engine, 5, 6), vec![("w1".into(), 2)]);
     }

--- a/crates/radix_index/src/engine.rs
+++ b/crates/radix_index/src/engine.rs
@@ -1,7 +1,7 @@
-//! The index engine: keyspaces of holders over a shared
-//! [`PositionalIndexer`], with epoch-scoped holder state, per-feed
-//! eviction semantics, and overlap queries. Pure and synchronous — the
-//! gRPC surface, relay, and bootstrap live in `server.rs`.
+//! The index engine: one `radix_tree::RadixTree` per keyspace, with
+//! epoch-scoped holder state, per-feed eviction semantics, and
+//! overlap queries. Pure and synchronous — the gRPC surface, relay,
+//! and bootstrap live in `server.rs`.
 //!
 //! Correctness model (see `.claude/kv-index-service/01-design.md`):
 //! - Event feed: one worker-sequenced stream per (holder, epoch); apply
@@ -16,9 +16,11 @@
 //! - Feed authority: a holder becomes event-fed on its first observed
 //!   removal (or an explicit `Added { event_fed: true }`); inferred
 //!   Stored updates for an event-fed holder are dropped.
-//! - Inferred eviction is tail-first per holder (prefix-closed, which
-//!   the jump search assumes), by capacity in blocks with a TTL floor
-//!   that retires whole idle holders.
+//! - Freshness is holder-granular: idle inferred holders are cleared
+//!   by TTL, idle dropped holders are RETIRED entirely. Capacity is
+//!   runaway protection only (truncate past 2x declared, tail-first
+//!   and prefix-closed) — the placement feed has no removal signal,
+//!   so index-side eviction must never race the worker's own.
 
 use std::{
     collections::HashMap,
@@ -684,10 +686,19 @@ mod tests {
             default_capacity_blocks: 4,
             ..EngineConfig::default()
         });
+        // Capacity is runaway protection: truncation fires only past
+        // 2x the declared value (racing the worker's own unobservable
+        // eviction was measured to under-match), so 8 blocks at
+        // capacity 4 stay put...
         engine.apply(&placement("w1", 3, 8));
-        // Head survives, tail evicted: prefix-closed at depth 4.
-        assert_eq!(scores(&engine, 3, 8), vec![("w1".into(), 4)]);
-        assert_eq!(engine.entry_count(), 4);
+        assert_eq!(scores(&engine, 3, 8), vec![("w1".into(), 8)]);
+        // ...and 12 blocks truncate to the 2x bound, prefix-closed:
+        // the HEAD survives (depth 8 from position 0), never a
+        // mid-chain hole.
+        engine.apply(&placement("w1", 3, 12));
+        assert_eq!(scores(&engine, 3, 12), vec![("w1".into(), 8)]);
+        assert_eq!(scores(&engine, 3, 4), vec![("w1".into(), 4)]);
+        assert_eq!(engine.entry_count(), 8);
     }
 
     #[test]

--- a/crates/radix_index/src/lib.rs
+++ b/crates/radix_index/src/lib.rs
@@ -1,0 +1,115 @@
+//! Generic radix membership index: block-quantized prefix chains with
+//! per-holder overlap scoring. Pub in, sub out; state is a materialized
+//! view of publisher streams (no consensus — see the design doc's
+//! epoch/commutativity argument).
+
+pub mod engine;
+pub mod server;
+
+pub use engine::{
+    placement_chain, AddedControl, ApplyOutcome, Engine, EngineConfig, HolderScore, KeyspaceKey,
+    SymbolKind, UpdateMsg, WireBlock, WireEvent,
+};
+
+/// Generated protobuf/tonic types.
+pub mod proto {
+    tonic::include_proto!("radix_index");
+}
+
+use kv_index::{ContentHash, SequenceHash};
+
+impl From<&proto::Update> for UpdateMsg {
+    fn from(u: &proto::Update) -> Self {
+        let keyspace = u.keyspace.as_ref();
+        UpdateMsg {
+            keyspace: KeyspaceKey {
+                model: keyspace.map(|k| k.model.clone()).unwrap_or_default(),
+                symbol_kind: match keyspace.map(|k| k.symbol_kind) {
+                    Some(k) if k == proto::SymbolKind::Bytes as i32 => SymbolKind::Bytes,
+                    _ => SymbolKind::Tokens,
+                },
+                block_size: keyspace.map(|k| k.block_size).unwrap_or_default(),
+            },
+            holder: u.holder.clone(),
+            epoch: u.epoch,
+            seq: u.seq,
+            events: u
+                .events
+                .iter()
+                .filter_map(|e| e.kind.as_ref())
+                .map(|kind| match kind {
+                    proto::event::Kind::Stored(s) => WireEvent::Stored {
+                        parent: s.parent_seq_hash.map(SequenceHash),
+                        blocks: s
+                            .blocks
+                            .iter()
+                            .map(|b| WireBlock {
+                                seq_hash: SequenceHash(b.seq_hash),
+                                content_hash: ContentHash(b.content_hash),
+                            })
+                            .collect(),
+                    },
+                    proto::event::Kind::Removed(r) => WireEvent::Removed {
+                        seq_hashes: r.seq_hashes.iter().copied().map(SequenceHash).collect(),
+                    },
+                    proto::event::Kind::Cleared(_) => WireEvent::Cleared,
+                })
+                .collect(),
+            added: u.added.as_ref().map(|a| AddedControl {
+                capacity_blocks: a.capacity_blocks,
+                event_fed: a.event_fed,
+            }),
+            dropped: u.dropped,
+        }
+    }
+}
+
+impl From<&UpdateMsg> for proto::Update {
+    fn from(u: &UpdateMsg) -> Self {
+        proto::Update {
+            keyspace: Some(proto::Keyspace {
+                model: u.keyspace.model.clone(),
+                symbol_kind: match u.keyspace.symbol_kind {
+                    SymbolKind::Tokens => proto::SymbolKind::Tokens as i32,
+                    SymbolKind::Bytes => proto::SymbolKind::Bytes as i32,
+                },
+                block_size: u.keyspace.block_size,
+            }),
+            holder: u.holder.clone(),
+            epoch: u.epoch,
+            seq: u.seq,
+            events: u
+                .events
+                .iter()
+                .map(|e| proto::Event {
+                    kind: Some(match e {
+                        WireEvent::Stored { parent, blocks } => {
+                            proto::event::Kind::Stored(proto::Stored {
+                                parent_seq_hash: parent.map(|p| p.0),
+                                blocks: blocks
+                                    .iter()
+                                    .map(|b| proto::Block {
+                                        seq_hash: b.seq_hash.0,
+                                        content_hash: b.content_hash.0,
+                                    })
+                                    .collect(),
+                            })
+                        }
+                        WireEvent::Removed { seq_hashes } => {
+                            proto::event::Kind::Removed(proto::Removed {
+                                seq_hashes: seq_hashes.iter().map(|h| h.0).collect(),
+                            })
+                        }
+                        WireEvent::Cleared => proto::event::Kind::Cleared(true),
+                    }),
+                })
+                .collect(),
+            added: u.added.as_ref().map(|a| proto::Added {
+                capacity_blocks: a.capacity_blocks,
+                event_fed: a.event_fed,
+                metadata: Vec::new(),
+            }),
+            dropped: u.dropped,
+        }
+    }
+}

--- a/crates/radix_index/src/lib.rs
+++ b/crates/radix_index/src/lib.rs
@@ -3,6 +3,7 @@
 //! view of publisher streams (no consensus — see the design doc's
 //! epoch/commutativity argument).
 
+pub mod bridge;
 pub mod engine;
 pub mod server;
 

--- a/crates/radix_index/src/lib.rs
+++ b/crates/radix_index/src/lib.rs
@@ -4,6 +4,7 @@
 //! epoch/commutativity argument).
 
 pub mod bridge;
+pub mod client;
 pub mod engine;
 pub mod server;
 

--- a/crates/radix_index/src/lib.rs
+++ b/crates/radix_index/src/lib.rs
@@ -7,6 +7,7 @@ pub mod bridge;
 pub mod client;
 pub mod engine;
 pub mod server;
+pub mod wire_hash;
 
 pub use engine::{
     placement_chain, AddedControl, ApplyOutcome, Engine, EngineConfig, HolderScore, KeyspaceKey,
@@ -76,6 +77,7 @@ impl From<&UpdateMsg> for proto::Update {
                     SymbolKind::Bytes => proto::SymbolKind::Bytes as i32,
                 },
                 block_size: u.keyspace.block_size,
+                hash_scheme: wire_hash::HASH_SCHEME_V1,
             }),
             holder: u.holder.clone(),
             epoch: u.epoch,

--- a/crates/radix_index/src/lib.rs
+++ b/crates/radix_index/src/lib.rs
@@ -19,7 +19,17 @@ pub mod proto {
     tonic::include_proto!("radix_index");
 }
 
-use kv_index::{ContentHash, SequenceHash};
+/// Position-independent content identity — the wire's matching
+/// currency. Owned by the service (R2 dropped the kv_index import;
+/// the numeric scheme lives in [`wire_hash`], pinned by golden
+/// vectors).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ContentHash(pub u64);
+
+/// Position-aware block identity (backend block hash on the event
+/// feed; deterministic chain hash on the placement feed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SequenceHash(pub u64);
 
 impl From<&proto::Update> for UpdateMsg {
     fn from(u: &proto::Update) -> Self {

--- a/crates/radix_index/src/server.rs
+++ b/crates/radix_index/src/server.rs
@@ -203,6 +203,14 @@ impl RadixIndex for IndexService {
         tokio::spawn(async move {
             while let Some(update) = inbound.next().await {
                 let Ok(update) = update else { break };
+                // Hash-scheme gate: a publisher on a scheme this build
+                // cannot serve would poison the keyspace with hashes
+                // that match nothing — reject loudly instead.
+                let scheme = update.keyspace.as_ref().map_or(0, |k| k.hash_scheme);
+                if !crate::wire_hash::scheme_supported(scheme) {
+                    tracing::warn!(scheme, holder = %update.holder, "unsupported hash scheme; update dropped");
+                    continue;
+                }
                 let mut delay = Duration::ZERO;
                 for event in &update.events {
                     match event.kind.as_ref() {
@@ -239,6 +247,18 @@ impl RadixIndex for IndexService {
             while let Some(query) = inbound.next().await {
                 let Ok(query) = query else { break };
                 stats.queries.fetch_add(1, Ordering::Relaxed);
+                let scheme = query.keyspace.as_ref().map_or(0, |k| k.hash_scheme);
+                if !crate::wire_hash::scheme_supported(scheme) {
+                    tracing::warn!(scheme, "unsupported hash scheme; empty answer");
+                    let answer = proto::Match {
+                        query_id: query.query_id,
+                        scores: Vec::new(),
+                    };
+                    if tx.send(Ok(answer)).await.is_err() {
+                        break;
+                    }
+                    continue;
+                }
                 let keyspace = query.keyspace.as_ref();
                 let key = KeyspaceKey {
                     model: keyspace.map(|k| k.model.clone()).unwrap_or_default(),

--- a/crates/radix_index/src/server.rs
+++ b/crates/radix_index/src/server.rs
@@ -98,21 +98,6 @@ impl IndexService {
             delay_removed,
         }
     }
-
-    /// Injected apply delay for one update: the max over its event kinds
-    /// (Stored covers placements too; a mixed batch takes the larger
-    /// delay so its internal order is preserved).
-    fn apply_delay(&self, update: &proto::Update) -> Duration {
-        let mut delay = Duration::ZERO;
-        for event in &update.events {
-            match event.kind.as_ref() {
-                Some(proto::event::Kind::Stored(_)) => delay = delay.max(self.delay_stored),
-                Some(proto::event::Kind::Removed(_)) => delay = delay.max(self.delay_removed),
-                _ => {}
-            }
-        }
-        delay
-    }
 }
 
 /// One background relay: queue -> (re)connected Publish stream to `peer`.
@@ -326,10 +311,6 @@ pub async fn bootstrap_from(engine: &Engine, peer: &str) -> Result<usize, tonic:
 }
 
 /// Serve the index on `addr` until the process exits.
-#[expect(
-    clippy::disallowed_methods,
-    reason = "service-lifetime sweeper; the index process is its own supervisor"
-)]
 pub async fn serve(
     engine: Arc<Engine>,
     addr: std::net::SocketAddr,

--- a/crates/radix_index/src/server.rs
+++ b/crates/radix_index/src/server.rs
@@ -1,0 +1,246 @@
+//! The gRPC surface: Publish (apply + best-effort peer relay),
+//! Subscribe (query stream), Pull (state as synthetic Updates for
+//! replica bootstrap). Relay and bootstrap speak the same Update
+//! vocabulary as publishers, so replicas copy — they never agree.
+
+use std::{pin::Pin, sync::Arc, time::Duration};
+
+use futures::{Stream, StreamExt};
+use kv_index::ContentHash;
+use tokio::sync::mpsc;
+use tonic::{transport::Server, Request, Response, Status, Streaming};
+
+use crate::{
+    engine::{Engine, KeyspaceKey, SymbolKind},
+    proto::{
+        self,
+        radix_index_client::RadixIndexClient,
+        radix_index_server::{RadixIndex, RadixIndexServer},
+    },
+    UpdateMsg,
+};
+
+type AckStream = Pin<Box<dyn Stream<Item = Result<proto::PublishAck, Status>> + Send>>;
+type MatchStream = Pin<Box<dyn Stream<Item = Result<proto::Match, Status>> + Send>>;
+type PullStream = Pin<Box<dyn Stream<Item = Result<proto::Update, Status>> + Send>>;
+
+/// Bound on the per-peer relay queue; overflowing drops the oldest
+/// (divergence is bounded by TTL + re-placement + digest heal, and a
+/// wedged peer must not wedge ingest).
+const RELAY_QUEUE: usize = 65_536;
+
+pub struct IndexService {
+    engine: Arc<Engine>,
+    relay: Vec<mpsc::Sender<proto::Update>>,
+}
+
+impl IndexService {
+    /// `peers`: sibling replica endpoints to relay Publishes to (empty
+    /// for single-replica runs or when publishers fan out themselves).
+    /// Relay is async and best-effort: a wedged peer drops updates, and
+    /// epoch/seq dedup plus TTL/re-placement bound the divergence.
+    pub fn new(engine: Arc<Engine>, peers: Vec<String>) -> Self {
+        let relay = peers.into_iter().map(spawn_relay).collect();
+        Self { engine, relay }
+    }
+}
+
+/// One background relay: queue -> (re)connected Publish stream to `peer`.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "service-lifetime task; the index process is its own supervisor"
+)]
+fn spawn_relay(peer: String) -> mpsc::Sender<proto::Update> {
+    let (tx, mut rx) = mpsc::channel::<proto::Update>(RELAY_QUEUE);
+    tokio::spawn(async move {
+        loop {
+            match RadixIndexClient::connect(peer.clone()).await {
+                Ok(mut client) => {
+                    let (fwd_tx, fwd_rx) = mpsc::channel::<proto::Update>(1024);
+                    let outbound = tokio_stream::wrappers::ReceiverStream::new(fwd_rx);
+                    let mut acks = match client.publish(Request::new(outbound)).await {
+                        Ok(response) => response.into_inner(),
+                        Err(error) => {
+                            tracing::warn!(%peer, %error, "relay publish failed; retrying");
+                            tokio::time::sleep(Duration::from_millis(500)).await;
+                            continue;
+                        }
+                    };
+                    loop {
+                        tokio::select! {
+                            item = rx.recv() => match item {
+                                Some(update) => {
+                                    if fwd_tx.send(update).await.is_err() {
+                                        break; // stream torn down; reconnect
+                                    }
+                                }
+                                None => return, // service dropped
+                            },
+                            ack = acks.next() => {
+                                if ack.is_none() {
+                                    break; // peer closed; reconnect
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(%peer, %error, "relay connect failed; retrying");
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    });
+    tx
+}
+
+#[tonic::async_trait]
+impl RadixIndex for IndexService {
+    type PublishStream = AckStream;
+    type SubscribeStream = MatchStream;
+    type PullStream = PullStream;
+
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "per-stream task, bounded by the stream's lifetime"
+    )]
+    async fn publish(
+        &self,
+        request: Request<Streaming<proto::Update>>,
+    ) -> Result<Response<Self::PublishStream>, Status> {
+        let mut inbound = request.into_inner();
+        let engine = Arc::clone(&self.engine);
+        let relay = self.relay.clone();
+        let (tx, rx) = mpsc::channel::<Result<proto::PublishAck, Status>>(1024);
+        tokio::spawn(async move {
+            while let Some(update) = inbound.next().await {
+                let Ok(update) = update else { break };
+                let msg = UpdateMsg::from(&update);
+                let (_outcome, applied_seq) = engine.apply(&msg);
+                for peer in &relay {
+                    let _ = peer.try_send(update.clone());
+                }
+                let ack = proto::PublishAck {
+                    holder: msg.holder,
+                    epoch: msg.epoch,
+                    applied_seq,
+                };
+                if tx.send(Ok(ack)).await.is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(Response::new(Box::pin(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        )))
+    }
+
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "per-stream task, bounded by the stream's lifetime"
+    )]
+    async fn subscribe(
+        &self,
+        request: Request<Streaming<proto::Query>>,
+    ) -> Result<Response<Self::SubscribeStream>, Status> {
+        let mut inbound = request.into_inner();
+        let engine = Arc::clone(&self.engine);
+        let (tx, rx) = mpsc::channel::<Result<proto::Match, Status>>(1024);
+        tokio::spawn(async move {
+            while let Some(query) = inbound.next().await {
+                let Ok(query) = query else { break };
+                let keyspace = query.keyspace.as_ref();
+                let key = KeyspaceKey {
+                    model: keyspace.map(|k| k.model.clone()).unwrap_or_default(),
+                    symbol_kind: match keyspace.map(|k| k.symbol_kind) {
+                        Some(k) if k == proto::SymbolKind::Bytes as i32 => SymbolKind::Bytes,
+                        _ => SymbolKind::Tokens,
+                    },
+                    block_size: keyspace.map(|k| k.block_size).unwrap_or_default(),
+                };
+                let hashes: Vec<ContentHash> = query
+                    .content_hashes
+                    .iter()
+                    .copied()
+                    .map(ContentHash)
+                    .collect();
+                let scores = engine.find_matches(&key, &hashes);
+                let answer = proto::Match {
+                    query_id: query.query_id,
+                    scores: scores
+                        .into_iter()
+                        .map(|s| proto::HolderScore {
+                            holder: s.holder,
+                            matched_blocks: s.matched_blocks,
+                            total_blocks: s.total_blocks,
+                            event_fed: s.event_fed,
+                        })
+                        .collect(),
+                };
+                if tx.send(Ok(answer)).await.is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(Response::new(Box::pin(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        )))
+    }
+
+    async fn pull(
+        &self,
+        _request: Request<proto::PullRequest>,
+    ) -> Result<Response<Self::PullStream>, Status> {
+        let snapshot = self.engine.snapshot();
+        let updates = snapshot
+            .iter()
+            .map(|u| Ok(proto::Update::from(u)))
+            .collect::<Vec<_>>();
+        Ok(Response::new(Box::pin(futures::stream::iter(updates))))
+    }
+}
+
+/// Bootstrap: pull the full state from `peer` and apply it before
+/// serving. Returns Ok(applied_count); a connect failure is Ok(0) so a
+/// lone first replica can boot cold.
+pub async fn bootstrap_from(engine: &Engine, peer: &str) -> Result<usize, tonic::Status> {
+    let Ok(mut client) = RadixIndexClient::connect(peer.to_string()).await else {
+        return Ok(0);
+    };
+    let mut stream = client
+        .pull(Request::new(proto::PullRequest {}))
+        .await?
+        .into_inner();
+    let mut applied = 0usize;
+    while let Some(update) = stream.next().await {
+        let update = update?;
+        engine.apply(&UpdateMsg::from(&update));
+        applied += 1;
+    }
+    Ok(applied)
+}
+
+/// Serve the index on `addr` until the process exits.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "service-lifetime sweeper; the index process is its own supervisor"
+)]
+pub async fn serve(
+    engine: Arc<Engine>,
+    addr: std::net::SocketAddr,
+    peers: Vec<String>,
+    sweep_interval: Duration,
+) -> Result<(), tonic::transport::Error> {
+    let sweeper = Arc::clone(&engine);
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(sweep_interval);
+        loop {
+            tick.tick().await;
+            sweeper.sweep_idle();
+        }
+    });
+    Server::builder()
+        .add_service(RadixIndexServer::new(IndexService::new(engine, peers)))
+        .serve(addr)
+        .await
+}

--- a/crates/radix_index/src/server.rs
+++ b/crates/radix_index/src/server.rs
@@ -117,7 +117,10 @@ fn spawn_relay(peer: String) -> mpsc::Sender<proto::Update> {
     tokio::spawn(async move {
         loop {
             match RadixIndexClient::connect(peer.clone()).await {
-                Ok(mut client) => {
+                Ok(client) => {
+                    let mut client = client
+                        .max_decoding_message_size(64 * 1024 * 1024)
+                        .max_encoding_message_size(64 * 1024 * 1024);
                     let (fwd_tx, fwd_rx) = mpsc::channel::<proto::Update>(1024);
                     let outbound = tokio_stream::wrappers::ReceiverStream::new(fwd_rx);
                     let mut acks = match client.publish(Request::new(outbound)).await {
@@ -180,8 +183,12 @@ impl RadixIndex for IndexService {
         // apply deadline, and a drainer applies each at its deadline —
         // per-stream order (and so per-holder seq order) is preserved,
         // and throughput is unaffected. Zero-delay legs skip the queue.
+        // BOUNDED: when the applier lags, this fills, the inbound
+        // task blocks on send, tonic stops reading, and HTTP/2 flow
+        // control pushes back on the publisher — instead of an
+        // unbounded queue quietly absorbing an OOM (audit finding).
         let (delayed_tx, mut delayed_rx) =
-            mpsc::unbounded_channel::<(tokio::time::Instant, proto::Update)>();
+            mpsc::channel::<(tokio::time::Instant, proto::Update)>(65_536);
         let apply_engine = Arc::clone(&engine);
         let apply_relay = relay.clone();
         let apply_stats = Arc::clone(&self.stats);
@@ -208,8 +215,13 @@ impl RadixIndex for IndexService {
                     epoch: msg.epoch,
                     applied_seq,
                 };
-                if ack_tx.send(Ok(ack)).await.is_err() {
-                    break;
+                // Acks are advisory (clients watch for stream death,
+                // not individual acks): drop when the publisher is
+                // not reading rather than wedging the applier behind
+                // its ack window.
+                match ack_tx.try_send(Ok(ack)) {
+                    Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
+                    Err(mpsc::error::TrySendError::Closed(_)) => break,
                 }
             }
         });
@@ -233,7 +245,7 @@ impl RadixIndex for IndexService {
                     }
                 }
                 let deadline = tokio::time::Instant::now() + delay;
-                if delayed_tx.send((deadline, update)).is_err() {
+                if delayed_tx.send((deadline, update)).await.is_err() {
                     break;
                 }
             }
@@ -281,6 +293,17 @@ impl RadixIndex for IndexService {
                     },
                     block_size: keyspace.map(|k| k.block_size).unwrap_or_default(),
                 };
+                // Cap query length: callers send request-sized
+                // chains; anything longer is an abuse/DoS shape that
+                // would run under the engine lock (audit finding).
+                const MAX_QUERY_BLOCKS: usize = 16_384;
+                if query.content_hashes.len() > MAX_QUERY_BLOCKS {
+                    let _ = tx.try_send(Ok(proto::Match {
+                        query_id: query.query_id,
+                        scores: Vec::new(),
+                    }));
+                    continue;
+                }
                 let hashes: Vec<ContentHash> = query
                     .content_hashes
                     .iter()
@@ -300,8 +323,13 @@ impl RadixIndex for IndexService {
                         })
                         .collect(),
                 };
-                if tx.send(Ok(answer)).await.is_err() {
-                    break;
+                // Answers are deadline-bound on the caller: when the
+                // gateway stops reading, drop answers rather than
+                // blocking this task off the inbound stream
+                // (head-of-line deadlock shape, audit finding).
+                match tx.try_send(Ok(answer)) {
+                    Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
+                    Err(mpsc::error::TrySendError::Closed(_)) => break,
                 }
             }
         });
@@ -327,9 +355,12 @@ impl RadixIndex for IndexService {
 /// serving. Returns Ok(applied_count); a connect failure is Ok(0) so a
 /// lone first replica can boot cold.
 pub async fn bootstrap_from(engine: &Engine, peer: &str) -> Result<usize, tonic::Status> {
-    let Ok(mut client) = RadixIndexClient::connect(peer.to_string()).await else {
+    let Ok(client) = RadixIndexClient::connect(peer.to_string()).await else {
         return Ok(0);
     };
+    let mut client = client
+        .max_decoding_message_size(64 * 1024 * 1024)
+        .max_encoding_message_size(64 * 1024 * 1024);
     let mut stream = client
         .pull(Request::new(proto::PullRequest {}))
         .await?
@@ -413,13 +444,20 @@ pub async fn serve_until(
         }
     });
     Server::builder()
-        .add_service(RadixIndexServer::new(IndexService::with_stats(
-            engine,
-            stats,
-            peers,
-            delay_stored,
-            delay_removed,
-        )))
+        // Explicit, generous decode cap (chunked snapshots keep real
+        // messages far below it; the default 4MiB was a silent
+        // bootstrap killer at scale — audit finding).
+        .add_service(
+            RadixIndexServer::new(IndexService::with_stats(
+                engine,
+                stats,
+                peers,
+                delay_stored,
+                delay_removed,
+            ))
+            .max_decoding_message_size(64 * 1024 * 1024)
+            .max_encoding_message_size(64 * 1024 * 1024),
+        )
         .serve_with_shutdown(addr, shutdown)
         .await
 }
@@ -441,8 +479,14 @@ pub async fn serve_admin(
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     let listener = tokio::net::TcpListener::bind(addr).await?;
     loop {
-        let Ok((mut socket, _)) = listener.accept().await else {
-            continue;
+        let (mut socket, _) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(_) => {
+                // Back off instead of busy-spinning on accept errors
+                // (fd exhaustion would otherwise pin a core).
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                continue;
+            }
         };
         let engine = Arc::clone(&engine);
         let stats = Arc::clone(&stats);

--- a/crates/radix_index/src/server.rs
+++ b/crates/radix_index/src/server.rs
@@ -3,7 +3,14 @@
 //! replica bootstrap). Relay and bootstrap speak the same Update
 //! vocabulary as publishers, so replicas copy — they never agree.
 
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::{
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use futures::{Stream, StreamExt};
 use kv_index::ContentHash;
@@ -29,8 +36,21 @@ type PullStream = Pin<Box<dyn Stream<Item = Result<proto::Update, Status>> + Sen
 /// wedged peer must not wedge ingest).
 const RELAY_QUEUE: usize = 65_536;
 
+/// Process counters for the metrics endpoint. Shared between the gRPC
+/// service and the admin listener.
+#[derive(Debug, Default)]
+pub struct ServiceStats {
+    pub applies: AtomicU64,
+    pub queries: AtomicU64,
+    pub relay_dropped: AtomicU64,
+    /// Flipped true once the bootstrap pull (if any) has completed; the
+    /// admin listener's /readyz reports it.
+    pub ready: AtomicBool,
+}
+
 pub struct IndexService {
     engine: Arc<Engine>,
+    stats: Arc<ServiceStats>,
     relay: Vec<mpsc::Sender<proto::Update>>,
     /// Staleness injection for the experiment's sweep: delay applied
     /// before Stored / Removed events land in the engine. Zero = off.
@@ -53,9 +73,26 @@ impl IndexService {
         delay_stored: Duration,
         delay_removed: Duration,
     ) -> Self {
+        Self::with_stats(
+            engine,
+            Arc::new(ServiceStats::default()),
+            peers,
+            delay_stored,
+            delay_removed,
+        )
+    }
+
+    pub fn with_stats(
+        engine: Arc<Engine>,
+        stats: Arc<ServiceStats>,
+        peers: Vec<String>,
+        delay_stored: Duration,
+        delay_removed: Duration,
+    ) -> Self {
         let relay = peers.into_iter().map(spawn_relay).collect();
         Self {
             engine,
+            stats,
             relay,
             delay_stored,
             delay_removed,
@@ -155,14 +192,18 @@ impl RadixIndex for IndexService {
             mpsc::unbounded_channel::<(tokio::time::Instant, proto::Update)>();
         let apply_engine = Arc::clone(&engine);
         let apply_relay = relay.clone();
+        let apply_stats = Arc::clone(&self.stats);
         let ack_tx = tx.clone();
         tokio::spawn(async move {
             while let Some((deadline, update)) = delayed_rx.recv().await {
                 tokio::time::sleep_until(deadline).await;
                 let msg = UpdateMsg::from(&update);
                 let (_outcome, applied_seq) = apply_engine.apply(&msg);
+                apply_stats.applies.fetch_add(1, Ordering::Relaxed);
                 for peer in &apply_relay {
-                    let _ = peer.try_send(update.clone());
+                    if peer.try_send(update.clone()).is_err() {
+                        apply_stats.relay_dropped.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
                 let ack = proto::PublishAck {
                     holder: msg.holder,
@@ -207,10 +248,12 @@ impl RadixIndex for IndexService {
     ) -> Result<Response<Self::SubscribeStream>, Status> {
         let mut inbound = request.into_inner();
         let engine = Arc::clone(&self.engine);
+        let stats = Arc::clone(&self.stats);
         let (tx, rx) = mpsc::channel::<Result<proto::Match, Status>>(1024);
         tokio::spawn(async move {
             while let Some(query) = inbound.next().await {
                 let Ok(query) = query else { break };
+                stats.queries.fetch_add(1, Ordering::Relaxed);
                 let keyspace = query.keyspace.as_ref();
                 let key = KeyspaceKey {
                     model: keyspace.map(|k| k.model.clone()).unwrap_or_default(),
@@ -313,6 +356,40 @@ pub async fn serve_with_delays(
     delay_stored: Duration,
     delay_removed: Duration,
 ) -> Result<(), tonic::transport::Error> {
+    serve_until(
+        engine,
+        addr,
+        peers,
+        sweep_interval,
+        delay_stored,
+        delay_removed,
+        Arc::new(ServiceStats::default()),
+        std::future::pending::<()>(),
+    )
+    .await
+}
+
+/// The full server: gRPC on `addr`, idle sweeper on `sweep_interval`,
+/// graceful stop when `shutdown` resolves (in-flight streams get to
+/// finish; publishers and gateways reconnect to a sibling replica).
+#[expect(
+    clippy::disallowed_methods,
+    reason = "service-lifetime sweeper; the index process is its own supervisor"
+)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "top-level composition point mirroring the binary's flags"
+)]
+pub async fn serve_until(
+    engine: Arc<Engine>,
+    addr: std::net::SocketAddr,
+    peers: Vec<String>,
+    sweep_interval: Duration,
+    delay_stored: Duration,
+    delay_removed: Duration,
+    stats: Arc<ServiceStats>,
+    shutdown: impl std::future::Future<Output = ()> + Send,
+) -> Result<(), tonic::transport::Error> {
     let sweeper = Arc::clone(&engine);
     tokio::spawn(async move {
         let mut tick = tokio::time::interval(sweep_interval);
@@ -322,12 +399,100 @@ pub async fn serve_with_delays(
         }
     });
     Server::builder()
-        .add_service(RadixIndexServer::new(IndexService::with_delays(
+        .add_service(RadixIndexServer::new(IndexService::with_stats(
             engine,
+            stats,
             peers,
             delay_stored,
             delay_removed,
         )))
-        .serve(addr)
+        .serve_with_shutdown(addr, shutdown)
         .await
+}
+
+/// Admin plane on its own port: `/metrics` (Prometheus text),
+/// `/healthz` (liveness: the process answers), `/readyz` (readiness:
+/// bootstrap finished — 503 until then). Deliberately handwritten over
+/// a plain TCP listener: three fixed GET routes don't justify an HTTP
+/// framework dependency in this crate.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "service-lifetime admin listener; the index process is its own supervisor"
+)]
+pub async fn serve_admin(
+    engine: Arc<Engine>,
+    stats: Arc<ServiceStats>,
+    addr: std::net::SocketAddr,
+) -> std::io::Result<()> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    loop {
+        let Ok((mut socket, _)) = listener.accept().await else {
+            continue;
+        };
+        let engine = Arc::clone(&engine);
+        let stats = Arc::clone(&stats);
+        tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            let Ok(n) = socket.read(&mut buf).await else {
+                return;
+            };
+            let request = String::from_utf8_lossy(&buf[..n]);
+            let path = request.split_whitespace().nth(1).unwrap_or("/");
+            let (status, body) = match path {
+                "/metrics" => (200, render_metrics(&engine, &stats)),
+                "/healthz" => (200, "ok\n".to_string()),
+                "/readyz" => {
+                    if stats.ready.load(Ordering::Relaxed) {
+                        (200, "ready\n".to_string())
+                    } else {
+                        (503, "bootstrapping\n".to_string())
+                    }
+                }
+                _ => (404, "not found\n".to_string()),
+            };
+            let reason = match status {
+                200 => "OK",
+                503 => "Service Unavailable",
+                _ => "Not Found",
+            };
+            let response = format!(
+                "HTTP/1.1 {status} {reason}\r\ncontent-type: text/plain; version=0.0.4\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+        });
+    }
+}
+
+fn render_metrics(engine: &Engine, stats: &ServiceStats) -> String {
+    let gauges = engine.stats();
+    format!(
+        concat!(
+            "# TYPE radix_index_keyspaces gauge\n",
+            "radix_index_keyspaces {}\n",
+            "# TYPE radix_index_holders gauge\n",
+            "radix_index_holders {}\n",
+            "# TYPE radix_index_event_fed_holders gauge\n",
+            "radix_index_event_fed_holders {}\n",
+            "# TYPE radix_index_dropped_holders gauge\n",
+            "radix_index_dropped_holders {}\n",
+            "# TYPE radix_index_blocks gauge\n",
+            "radix_index_blocks {}\n",
+            "# TYPE radix_index_applies_total counter\n",
+            "radix_index_applies_total {}\n",
+            "# TYPE radix_index_queries_total counter\n",
+            "radix_index_queries_total {}\n",
+            "# TYPE radix_index_relay_dropped_total counter\n",
+            "radix_index_relay_dropped_total {}\n",
+        ),
+        gauges.keyspaces,
+        gauges.holders,
+        gauges.event_fed_holders,
+        gauges.dropped_holders,
+        gauges.blocks,
+        stats.applies.load(Ordering::Relaxed),
+        stats.queries.load(Ordering::Relaxed),
+        stats.relay_dropped.load(Ordering::Relaxed),
+    )
 }

--- a/crates/radix_index/src/server.rs
+++ b/crates/radix_index/src/server.rs
@@ -32,6 +32,10 @@ const RELAY_QUEUE: usize = 65_536;
 pub struct IndexService {
     engine: Arc<Engine>,
     relay: Vec<mpsc::Sender<proto::Update>>,
+    /// Staleness injection for the experiment's sweep: delay applied
+    /// before Stored / Removed events land in the engine. Zero = off.
+    delay_stored: Duration,
+    delay_removed: Duration,
 }
 
 impl IndexService {
@@ -40,8 +44,37 @@ impl IndexService {
     /// Relay is async and best-effort: a wedged peer drops updates, and
     /// epoch/seq dedup plus TTL/re-placement bound the divergence.
     pub fn new(engine: Arc<Engine>, peers: Vec<String>) -> Self {
+        Self::with_delays(engine, peers, Duration::ZERO, Duration::ZERO)
+    }
+
+    pub fn with_delays(
+        engine: Arc<Engine>,
+        peers: Vec<String>,
+        delay_stored: Duration,
+        delay_removed: Duration,
+    ) -> Self {
         let relay = peers.into_iter().map(spawn_relay).collect();
-        Self { engine, relay }
+        Self {
+            engine,
+            relay,
+            delay_stored,
+            delay_removed,
+        }
+    }
+
+    /// Injected apply delay for one update: the max over its event kinds
+    /// (Stored covers placements too; a mixed batch takes the larger
+    /// delay so its internal order is preserved).
+    fn apply_delay(&self, update: &proto::Update) -> Duration {
+        let mut delay = Duration::ZERO;
+        for event in &update.events {
+            match event.kind.as_ref() {
+                Some(proto::event::Kind::Stored(_)) => delay = delay.max(self.delay_stored),
+                Some(proto::event::Kind::Removed(_)) => delay = delay.max(self.delay_removed),
+                _ => {}
+            }
+        }
+        delay
     }
 }
 
@@ -111,13 +144,24 @@ impl RadixIndex for IndexService {
         let mut inbound = request.into_inner();
         let engine = Arc::clone(&self.engine);
         let relay = self.relay.clone();
+        let delays = (self.delay_stored, self.delay_removed);
         let (tx, rx) = mpsc::channel::<Result<proto::PublishAck, Status>>(1024);
+        // Staleness injection is a constant LAG, not per-update service
+        // time: updates flow through an unbounded FIFO stamped with an
+        // apply deadline, and a drainer applies each at its deadline —
+        // per-stream order (and so per-holder seq order) is preserved,
+        // and throughput is unaffected. Zero-delay legs skip the queue.
+        let (delayed_tx, mut delayed_rx) =
+            mpsc::unbounded_channel::<(tokio::time::Instant, proto::Update)>();
+        let apply_engine = Arc::clone(&engine);
+        let apply_relay = relay.clone();
+        let ack_tx = tx.clone();
         tokio::spawn(async move {
-            while let Some(update) = inbound.next().await {
-                let Ok(update) = update else { break };
+            while let Some((deadline, update)) = delayed_rx.recv().await {
+                tokio::time::sleep_until(deadline).await;
                 let msg = UpdateMsg::from(&update);
-                let (_outcome, applied_seq) = engine.apply(&msg);
-                for peer in &relay {
+                let (_outcome, applied_seq) = apply_engine.apply(&msg);
+                for peer in &apply_relay {
                     let _ = peer.try_send(update.clone());
                 }
                 let ack = proto::PublishAck {
@@ -125,11 +169,29 @@ impl RadixIndex for IndexService {
                     epoch: msg.epoch,
                     applied_seq,
                 };
-                if tx.send(Ok(ack)).await.is_err() {
+                if ack_tx.send(Ok(ack)).await.is_err() {
                     break;
                 }
             }
         });
+        tokio::spawn(async move {
+            while let Some(update) = inbound.next().await {
+                let Ok(update) = update else { break };
+                let mut delay = Duration::ZERO;
+                for event in &update.events {
+                    match event.kind.as_ref() {
+                        Some(proto::event::Kind::Stored(_)) => delay = delay.max(delays.0),
+                        Some(proto::event::Kind::Removed(_)) => delay = delay.max(delays.1),
+                        _ => {}
+                    }
+                }
+                let deadline = tokio::time::Instant::now() + delay;
+                if delayed_tx.send((deadline, update)).is_err() {
+                    break;
+                }
+            }
+        });
+        drop(tx);
         Ok(Response::new(Box::pin(
             tokio_stream::wrappers::ReceiverStream::new(rx),
         )))
@@ -231,6 +293,26 @@ pub async fn serve(
     peers: Vec<String>,
     sweep_interval: Duration,
 ) -> Result<(), tonic::transport::Error> {
+    serve_with_delays(
+        engine,
+        addr,
+        peers,
+        sweep_interval,
+        Duration::ZERO,
+        Duration::ZERO,
+    )
+    .await
+}
+
+/// [`serve`] with staleness injection (the experiment's sweep knob).
+pub async fn serve_with_delays(
+    engine: Arc<Engine>,
+    addr: std::net::SocketAddr,
+    peers: Vec<String>,
+    sweep_interval: Duration,
+    delay_stored: Duration,
+    delay_removed: Duration,
+) -> Result<(), tonic::transport::Error> {
     let sweeper = Arc::clone(&engine);
     tokio::spawn(async move {
         let mut tick = tokio::time::interval(sweep_interval);
@@ -240,7 +322,12 @@ pub async fn serve(
         }
     });
     Server::builder()
-        .add_service(RadixIndexServer::new(IndexService::new(engine, peers)))
+        .add_service(RadixIndexServer::new(IndexService::with_delays(
+            engine,
+            peers,
+            delay_stored,
+            delay_removed,
+        )))
         .serve(addr)
         .await
 }

--- a/crates/radix_index/src/server.rs
+++ b/crates/radix_index/src/server.rs
@@ -13,7 +13,6 @@ use std::{
 };
 
 use futures::{Stream, StreamExt};
-use kv_index::ContentHash;
 use tokio::sync::mpsc;
 use tonic::{transport::Server, Request, Response, Status, Streaming};
 
@@ -24,7 +23,7 @@ use crate::{
         radix_index_client::RadixIndexClient,
         radix_index_server::{RadixIndex, RadixIndexServer},
     },
-    UpdateMsg,
+    ContentHash, UpdateMsg,
 };
 
 type AckStream = Pin<Box<dyn Stream<Item = Result<proto::PublishAck, Status>> + Send>>;

--- a/crates/radix_index/src/server.rs
+++ b/crates/radix_index/src/server.rs
@@ -31,10 +31,18 @@ type AckStream = Pin<Box<dyn Stream<Item = Result<proto::PublishAck, Status>> + 
 type MatchStream = Pin<Box<dyn Stream<Item = Result<proto::Match, Status>> + Send>>;
 type PullStream = Pin<Box<dyn Stream<Item = Result<proto::Update, Status>> + Send>>;
 
-/// Bound on the per-peer relay queue; overflowing drops the oldest
-/// (divergence is bounded by TTL + re-placement + digest heal, and a
-/// wedged peer must not wedge ingest).
+/// Bound on the per-peer relay queue; overflowing drops updates
+/// (divergence is bounded by TTL + re-placement, and a wedged peer
+/// must not wedge ingest). Overridable via RADIX_RELAY_QUEUE for
+/// overflow drills.
 const RELAY_QUEUE: usize = 65_536;
+
+fn relay_queue_len() -> usize {
+    std::env::var("RADIX_RELAY_QUEUE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(RELAY_QUEUE)
+}
 
 /// Process counters for the metrics endpoint. Shared between the gRPC
 /// service and the admin listener.
@@ -106,7 +114,7 @@ impl IndexService {
     reason = "service-lifetime task; the index process is its own supervisor"
 )]
 fn spawn_relay(peer: String) -> mpsc::Sender<proto::Update> {
-    let (tx, mut rx) = mpsc::channel::<proto::Update>(RELAY_QUEUE);
+    let (tx, mut rx) = mpsc::channel::<proto::Update>(relay_queue_len());
     tokio::spawn(async move {
         loop {
             match RadixIndexClient::connect(peer.clone()).await {
@@ -183,11 +191,17 @@ impl RadixIndex for IndexService {
             while let Some((deadline, update)) = delayed_rx.recv().await {
                 tokio::time::sleep_until(deadline).await;
                 let msg = UpdateMsg::from(&update);
-                let (_outcome, applied_seq) = apply_engine.apply(&msg);
+                let (_outcome, applied_seq, state_changed) = apply_engine.apply(&msg);
                 apply_stats.applies.fetch_add(1, Ordering::Relaxed);
-                for peer in &apply_relay {
-                    if peer.try_send(update.clone()).is_err() {
-                        apply_stats.relay_dropped.fetch_add(1, Ordering::Relaxed);
+                // Relay ONLY state-changing applies: a relayed update
+                // echoed back by a symmetric peer is a no-op here and
+                // stops, instead of ping-ponging forever (bounded
+                // O(K^2) fan-out instead of unbounded amplification).
+                if state_changed {
+                    for peer in &apply_relay {
+                        if peer.try_send(update.clone()).is_err() {
+                            apply_stats.relay_dropped.fetch_add(1, Ordering::Relaxed);
+                        }
                     }
                 }
                 let ack = proto::PublishAck {

--- a/crates/radix_index/src/wire_hash.rs
+++ b/crates/radix_index/src/wire_hash.rs
@@ -20,7 +20,7 @@
 //! Keyspace messages carry `hash_scheme`; 0 (unset) means v1 for
 //! backward compatibility with in-flight publishers.
 
-use kv_index::{ContentHash, SequenceHash};
+use crate::{ContentHash, SequenceHash};
 
 /// The only scheme in existence. Proto `hash_scheme = 0` means this.
 pub const HASH_SCHEME_V1: u32 = 1;
@@ -98,18 +98,31 @@ mod tests {
         };
         for _ in 0..64 {
             let block: Vec<u32> = (0..256).map(|_| (next() & 0x3FFFF) as u32).collect();
-            assert_eq!(content_hash(&block), kv_index::compute_content_hash(&block));
-            let prev = SequenceHash(next());
-            let cur = ContentHash(next());
             assert_eq!(
-                chain_prefix_hash(prev, cur),
-                kv_index::chain_prefix_hash(prev, cur)
+                content_hash(&block).0,
+                kv_index::compute_content_hash(&block).0
+            );
+            let prev = next();
+            let cur = next();
+            assert_eq!(
+                chain_prefix_hash(SequenceHash(prev), ContentHash(cur)).0,
+                kv_index::chain_prefix_hash(
+                    kv_index::SequenceHash(prev),
+                    kv_index::ContentHash(cur)
+                )
+                .0
             );
         }
         let tokens: Vec<u32> = (0..1000).collect();
         assert_eq!(
-            request_content_hashes(&tokens, 256),
+            request_content_hashes(&tokens, 256)
+                .iter()
+                .map(|h| h.0)
+                .collect::<Vec<_>>(),
             kv_index::compute_request_content_hashes(&tokens, 256)
+                .iter()
+                .map(|h| h.0)
+                .collect::<Vec<_>>()
         );
     }
 
@@ -169,17 +182,17 @@ mod tests {
         println!(
             "GOLDEN_CHAIN_FROM_ZERO: {:#x}",
             kv_index::chain_prefix_hash(
-                SequenceHash(0),
-                ContentHash(kv_index::compute_content_hash(&ascending).0)
+                kv_index::SequenceHash(0),
+                kv_index::ContentHash(kv_index::compute_content_hash(&ascending).0)
             )
             .0
         );
         let tokens: Vec<u32> = (0..768).collect();
         let hashes = kv_index::compute_request_content_hashes(&tokens, 256);
-        let mut prev = SequenceHash(0);
+        let mut prev = kv_index::SequenceHash(0);
         for (i, &h) in hashes.iter().enumerate() {
             let seq = if i == 0 {
-                SequenceHash(h.0)
+                kv_index::SequenceHash(h.0)
             } else {
                 kv_index::chain_prefix_hash(prev, h)
             };

--- a/crates/radix_index/src/wire_hash.rs
+++ b/crates/radix_index/src/wire_hash.rs
@@ -1,0 +1,190 @@
+//! The wire hash scheme, owned by the service.
+//!
+//! Every hash that crosses a process boundary is defined HERE: the
+//! content hash the gateway queries with and the bridge converts
+//! events with, and the placement chain every publisher synthesizes.
+//! The implementation is deliberately independent of `kv_index` — the
+//! golden-vector tests pin it against values captured from the
+//! production gateway crate, so agreement is proven, not inherited.
+//! (`SPEC.md` §10.2 in `crates/radix_tree` — after R2 this module is
+//! the service's only source of the scheme.)
+//!
+//! Scheme v1 (`HASH_SCHEME_V1`):
+//! - content hash: XXH3-64, seed 1337, over the block's token ids as
+//!   little-endian u32 bytes; only FULL blocks are hashed.
+//! - chain hash: `XXH3-64(prev_le_bytes || current_le_bytes)`, seed
+//!   1337, over 16 bytes.
+//! - position 0 rule: a chain's first seq hash IS its content hash
+//!   (no parent to chain from).
+//!
+//! Keyspace messages carry `hash_scheme`; 0 (unset) means v1 for
+//! backward compatibility with in-flight publishers.
+
+use kv_index::{ContentHash, SequenceHash};
+
+/// The only scheme in existence. Proto `hash_scheme = 0` means this.
+pub const HASH_SCHEME_V1: u32 = 1;
+
+const SEED: u64 = 1337;
+
+/// Is `scheme` one this build can serve? (0 = unset = v1.)
+pub fn scheme_supported(scheme: u32) -> bool {
+    scheme == 0 || scheme == HASH_SCHEME_V1
+}
+
+/// Content hash of one full block of token ids.
+pub fn content_hash(token_ids: &[u32]) -> ContentHash {
+    use std::hash::Hasher;
+    let mut hasher = xxhash_rust::xxh3::Xxh3::with_seed(SEED);
+    for &t in token_ids {
+        hasher.write(&t.to_le_bytes());
+    }
+    ContentHash(hasher.finish())
+}
+
+/// Rolling chain hash: `XXH3(prev || current)` over LE bytes.
+pub fn chain_prefix_hash(prev: SequenceHash, current: ContentHash) -> SequenceHash {
+    let mut bytes = [0u8; 16];
+    bytes[..8].copy_from_slice(&prev.0.to_le_bytes());
+    bytes[8..].copy_from_slice(&current.0.to_le_bytes());
+    SequenceHash(xxhash_rust::xxh3::xxh3_64_with_seed(&bytes, SEED))
+}
+
+/// Query-path chunking: one content hash per FULL block; the partial
+/// trailing chunk is discarded (backends only cache full blocks).
+pub fn request_content_hashes(tokens: &[u32], block_size: usize) -> Vec<ContentHash> {
+    if block_size == 0 {
+        return Vec::new();
+    }
+    tokens
+        .chunks(block_size)
+        .filter(|chunk| chunk.len() == block_size)
+        .map(content_hash)
+        .collect()
+}
+
+/// Deterministic placement chain: content hashes -> position-chained
+/// (seq, content) pairs, identical across every publisher for
+/// identical prefixes (the placement feed's idempotence contract).
+pub fn placement_chain(content_hashes: &[ContentHash]) -> Vec<(SequenceHash, ContentHash)> {
+    let mut out = Vec::with_capacity(content_hashes.len());
+    let mut prev = SequenceHash(0);
+    for (i, &content_hash) in content_hashes.iter().enumerate() {
+        let seq_hash = if i == 0 {
+            SequenceHash(content_hash.0)
+        } else {
+            chain_prefix_hash(prev, content_hash)
+        };
+        out.push((seq_hash, content_hash));
+        prev = seq_hash;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The scheme must agree with the production gateway crate on
+    /// every path — proven directly, not assumed.
+    #[test]
+    fn agrees_with_kv_index_on_random_inputs() {
+        let mut state = 0x9E3779B97F4A7C15u64;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        for _ in 0..64 {
+            let block: Vec<u32> = (0..256).map(|_| (next() & 0x3FFFF) as u32).collect();
+            assert_eq!(content_hash(&block), kv_index::compute_content_hash(&block));
+            let prev = SequenceHash(next());
+            let cur = ContentHash(next());
+            assert_eq!(
+                chain_prefix_hash(prev, cur),
+                kv_index::chain_prefix_hash(prev, cur)
+            );
+        }
+        let tokens: Vec<u32> = (0..1000).collect();
+        assert_eq!(
+            request_content_hashes(&tokens, 256),
+            kv_index::compute_request_content_hashes(&tokens, 256)
+        );
+    }
+
+    /// Golden vectors: captured from `kv_index` output and PINNED as
+    /// constants. If these ever fail, the wire scheme changed and
+    /// every deployed publisher/index disagrees — that is a
+    /// wire-compatibility break, not a refactor.
+    #[test]
+    fn golden_vectors() {
+        // content_hash over [0, 1, ..., 255]
+        let ascending: Vec<u32> = (0..256).collect();
+        assert_eq!(content_hash(&ascending).0, GOLDEN_CONTENT_ASCENDING);
+        // content_hash over 256 zeros
+        assert_eq!(content_hash(&[0u32; 256]).0, GOLDEN_CONTENT_ZEROS);
+        // content_hash of the empty slice (never on the wire, pinned anyway)
+        assert_eq!(content_hash(&[]).0, GOLDEN_CONTENT_EMPTY);
+        // chain step from prev=0
+        assert_eq!(
+            chain_prefix_hash(SequenceHash(0), ContentHash(GOLDEN_CONTENT_ASCENDING)).0,
+            GOLDEN_CHAIN_FROM_ZERO
+        );
+        // three-block placement chain over blocks [0..256), [256..512), [512..768)
+        let tokens: Vec<u32> = (0..768).collect();
+        let chain = placement_chain(&request_content_hashes(&tokens, 256));
+        assert_eq!(chain.len(), 3);
+        // position-0 rule
+        assert_eq!(chain[0].0 .0, chain[0].1 .0);
+        let seqs: Vec<u64> = chain.iter().map(|b| b.0 .0).collect();
+        assert_eq!(seqs, GOLDEN_PLACEMENT_SEQS);
+    }
+
+    const GOLDEN_CONTENT_ASCENDING: u64 = 0xbb79c83a0cdfbb76;
+    const GOLDEN_CONTENT_ZEROS: u64 = 0x5672308b9a027dcd;
+    const GOLDEN_CONTENT_EMPTY: u64 = 0xd1f3e77444430ab9;
+    const GOLDEN_CHAIN_FROM_ZERO: u64 = 0x02639359a1a2c74b;
+    const GOLDEN_PLACEMENT_SEQS: [u64; 3] =
+        [0xbb79c83a0cdfbb76, 0xa85c3e553a06b20d, 0x086e95e44d3314d7];
+
+    /// Capture helper the constants above came from (kept for
+    /// provenance; run with --ignored --nocapture to re-derive).
+    #[test]
+    #[ignore = "provenance tool, not a test"]
+    fn print_golden_capture() {
+        let ascending: Vec<u32> = (0..256).collect();
+        println!(
+            "GOLDEN_CONTENT_ASCENDING: {:#x}",
+            kv_index::compute_content_hash(&ascending).0
+        );
+        println!(
+            "GOLDEN_CONTENT_ZEROS: {:#x}",
+            kv_index::compute_content_hash(&[0u32; 256]).0
+        );
+        println!(
+            "GOLDEN_CONTENT_EMPTY: {:#x}",
+            kv_index::compute_content_hash(&[]).0
+        );
+        println!(
+            "GOLDEN_CHAIN_FROM_ZERO: {:#x}",
+            kv_index::chain_prefix_hash(
+                SequenceHash(0),
+                ContentHash(kv_index::compute_content_hash(&ascending).0)
+            )
+            .0
+        );
+        let tokens: Vec<u32> = (0..768).collect();
+        let hashes = kv_index::compute_request_content_hashes(&tokens, 256);
+        let mut prev = SequenceHash(0);
+        for (i, &h) in hashes.iter().enumerate() {
+            let seq = if i == 0 {
+                SequenceHash(h.0)
+            } else {
+                kv_index::chain_prefix_hash(prev, h)
+            };
+            println!("GOLDEN_PLACEMENT_SEQS[{i}]: {:#x}", seq.0);
+            prev = seq;
+        }
+    }
+}

--- a/crates/radix_index/tests/live_smoke.rs
+++ b/crates/radix_index/tests/live_smoke.rs
@@ -1,0 +1,162 @@
+//! Live end-to-end smoke: a real mock gRPC sim worker -> bridge ->
+//! index service (over the wire) -> Subscribe query. Verifies the whole
+//! event path: worker KV events, hash-only conversion, publish, apply,
+//! and overlap scoring, with the query hashed exactly the way a gateway
+//! would hash a request.
+
+use std::{sync::Arc, time::Duration};
+
+use futures::StreamExt;
+use kv_index::compute_request_content_hashes;
+use radix_index::{
+    bridge, proto, proto::radix_index_client::RadixIndexClient, server, Engine, EngineConfig,
+};
+use smg_grpc_client::tokenspeed_scheduler::{tokenspeed_proto as ts, TokenSpeedSchedulerClient};
+use tokio::sync::mpsc;
+
+const MODEL: &str = "smoke-model";
+const BLOCK: u32 = 4;
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test fixture: fire-and-forget servers for the test's lifetime"
+)]
+#[tokio::test]
+async fn worker_events_reach_the_index_over_the_wire() {
+    // 1. Mock gRPC sim worker with KV events (block size 4).
+    let worker_port = portpicker::pick_unused_port().expect("port for worker");
+    let cfg = Arc::new(mock_worker::config::Config {
+        host: "127.0.0.1".to_string(),
+        http_base_port: 0,
+        http_count: 0,
+        grpc_base_port: worker_port,
+        grpc_count: 1,
+        zmq_handshake: None,
+        zmq_count: 0,
+        zmq_start_index: 0,
+        model_id: MODEL.to_string(),
+        tokenizer_path: MODEL.to_string(),
+        gen_delay: Duration::ZERO,
+        output_tokens: 4,
+        realistic: false,
+        engine: mock_worker::engine::EngineParams::default(),
+        sim: true,
+        sim_params: mock_worker::sim::SimParams {
+            block_size: BLOCK as usize,
+            itl_ms: 1.0,
+            ttft_base_ms: 1.0,
+            prefill_tps: 1_000_000.0,
+            ..mock_worker::sim::SimParams::default()
+        },
+    });
+    tokio::spawn(mock_worker::grpc::serve(
+        cfg,
+        "127.0.0.1".to_string(),
+        worker_port,
+    ));
+
+    // 2. Index service over the wire.
+    let index_port = portpicker::pick_unused_port().expect("port for index");
+    let engine = Arc::new(Engine::new(EngineConfig::default()));
+    let addr = format!("127.0.0.1:{index_port}").parse().unwrap();
+    tokio::spawn(server::serve(
+        Arc::clone(&engine),
+        addr,
+        Vec::new(),
+        Duration::from_secs(60),
+    ));
+
+    // 3. Bridge: worker events -> index.
+    let worker_url = format!("grpc://127.0.0.1:{worker_port}");
+    let index_url = format!("http://127.0.0.1:{index_port}");
+    let (tx, rx) = mpsc::channel::<proto::Update>(1024);
+    tokio::spawn(bridge::worker_loop(
+        worker_url.clone(),
+        MODEL.to_string(),
+        BLOCK,
+        tx,
+    ));
+    tokio::spawn(bridge::run_publisher(rx, index_url.clone()));
+
+    // 4. Drive one generate on the worker (8 tokens = 2 blocks) and wait
+    //    for its stream to finish (prefill published at first chunk).
+    let input_ids: Vec<u32> = vec![10, 20, 30, 40, 50, 60, 70, 80];
+    let client = {
+        let mut attempt = 0;
+        loop {
+            match TokenSpeedSchedulerClient::connect(&worker_url).await {
+                Ok(client) => break client,
+                Err(_) if attempt < 50 => {
+                    attempt += 1;
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                Err(error) => panic!("worker never came up: {error}"),
+            }
+        }
+    };
+    let mut stream = client
+        .generate(ts::GenerateRequest {
+            request_id: "smoke-1".into(),
+            tokenized: Some(ts::TokenizedInput {
+                input_ids: input_ids.clone(),
+                original_text: String::new(),
+            }),
+            sampling_params: Some(ts::SamplingParams {
+                max_new_tokens: Some(4),
+                ..Default::default()
+            }),
+            stream: true,
+            ..Default::default()
+        })
+        .await
+        .expect("generate");
+    while let Some(item) = stream.next().await {
+        item.expect("generate stream item");
+    }
+
+    // 5. Query over the wire until the holder shows up (event propagation
+    //    is async end to end).
+    let mut index = RadixIndexClient::connect(index_url).await.expect("index");
+    let hashes: Vec<u64> = compute_request_content_hashes(&input_ids, BLOCK as usize)
+        .into_iter()
+        .map(|h| h.0)
+        .collect();
+    let (query_tx, query_rx) = mpsc::channel::<proto::Query>(8);
+    let outbound = tokio_stream::wrappers::ReceiverStream::new(query_rx);
+    let mut answers = index
+        .subscribe(tonic::Request::new(outbound))
+        .await
+        .expect("subscribe")
+        .into_inner();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut best: Option<proto::HolderScore> = None;
+    let mut query_id = 0u64;
+    while tokio::time::Instant::now() < deadline {
+        query_id += 1;
+        query_tx
+            .send(proto::Query {
+                query_id,
+                keyspace: Some(bridge::keyspace(MODEL, BLOCK)),
+                content_hashes: hashes.clone(),
+            })
+            .await
+            .expect("send query");
+        let answer = answers
+            .next()
+            .await
+            .expect("answer stream open")
+            .expect("answer ok");
+        assert_eq!(answer.query_id, query_id, "answers correlate by id");
+        if let Some(top) = answer.scores.first() {
+            best = Some(top.clone());
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let best = best.expect("the worker's blocks never reached the index");
+    assert_eq!(best.holder, worker_url);
+    assert_eq!(best.matched_blocks, 2, "both prompt blocks must match");
+    assert!(best.event_fed, "bridge traffic is the event feed");
+}

--- a/crates/radix_index/tests/live_smoke.rs
+++ b/crates/radix_index/tests/live_smoke.rs
@@ -160,3 +160,64 @@ async fn worker_events_reach_the_index_over_the_wire() {
     assert_eq!(best.matched_blocks, 2, "both prompt blocks must match");
     assert!(best.event_fed, "bridge traffic is the event feed");
 }
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test fixture: fire-and-forget servers for the test's lifetime"
+)]
+#[tokio::test]
+async fn client_placements_and_queries_roundtrip() {
+    use radix_index::client::{QueryOutcome, RemoteIndex};
+
+    let port = portpicker::pick_unused_port().expect("port");
+    let engine = Arc::new(Engine::new(EngineConfig::default()));
+    let addr = format!("127.0.0.1:{port}").parse().unwrap();
+    tokio::spawn(server::serve(
+        engine,
+        addr,
+        Vec::new(),
+        Duration::from_secs(60),
+    ));
+
+    let client = RemoteIndex::connect(format!("http://127.0.0.1:{port}"));
+    let tokens: Vec<u32> = (0..16).collect();
+    let hashes: Vec<u64> = compute_request_content_hashes(&tokens, BLOCK as usize)
+        .into_iter()
+        .map(|h| h.0)
+        .collect();
+
+    // Before any placement: Empty (or Disconnected while dialing).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        match client
+            .query(MODEL, BLOCK, hashes.clone(), Duration::from_millis(50))
+            .await
+        {
+            QueryOutcome::Empty => break,
+            QueryOutcome::Scores(scores) => panic!("unexpected scores {scores:?}"),
+            _ if tokio::time::Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            outcome => panic!("index never became reachable: {outcome:?}"),
+        }
+    }
+
+    client.publish_placement(MODEL, BLOCK, "grpc://10.0.0.1:9000", &hashes);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        match client
+            .query(MODEL, BLOCK, hashes.clone(), Duration::from_millis(50))
+            .await
+        {
+            QueryOutcome::Scores(scores) => {
+                assert_eq!(scores[0].0, "grpc://10.0.0.1:9000");
+                assert_eq!(scores[0].1, 4, "16 tokens at block 4 = 4 blocks");
+                break;
+            }
+            _ if tokio::time::Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            outcome => panic!("placement never became queryable: {outcome:?}"),
+        }
+    }
+}

--- a/crates/radix_index/tests/live_smoke.rs
+++ b/crates/radix_index/tests/live_smoke.rs
@@ -70,13 +70,15 @@ async fn worker_events_reach_the_index_over_the_wire() {
     let worker_url = format!("grpc://127.0.0.1:{worker_port}");
     let index_url = format!("http://127.0.0.1:{index_port}");
     let (tx, rx) = mpsc::channel::<proto::Update>(1024);
+    let ledger = bridge::EpochLedger::default();
     tokio::spawn(bridge::worker_loop(
         worker_url.clone(),
         MODEL.to_string(),
         BLOCK,
         tx,
+        ledger.clone(),
     ));
-    tokio::spawn(bridge::run_publisher(rx, index_url.clone()));
+    tokio::spawn(bridge::run_publisher(rx, index_url.clone(), ledger.clone()));
 
     // 4. Drive one generate on the worker (8 tokens = 2 blocks) and wait
     //    for its stream to finish (prefill published at first chunk).

--- a/crates/radix_index/tests/replica_convergence.rs
+++ b/crates/radix_index/tests/replica_convergence.rs
@@ -1,0 +1,218 @@
+//! Two LIVE replicas peered with each other over real gRPC, driven
+//! through the real Publish surface. This is the drill that would have
+//! caught the audit's move-only relay suppression: a dangling-parent
+//! re-anchor MOVES blocks (net length delta zero — query answers
+//! change, block count does not), and the peer must still converge.
+//! The symmetric peering also exercises echo suppression: every relay
+//! the peer applies is offered back, and must die as a no-op instead
+//! of amplifying.
+
+use std::{sync::Arc, time::Duration};
+
+use radix_index::{
+    bridge, engine::placement_chain, proto, proto::radix_index_client::RadixIndexClient, server,
+    ContentHash, Engine, EngineConfig,
+};
+use tokio::sync::mpsc;
+
+const MODEL: &str = "conv-model";
+const BLOCK: u32 = 4;
+
+fn keyspace_key() -> radix_index::engine::KeyspaceKey {
+    radix_index::engine::KeyspaceKey {
+        model: MODEL.into(),
+        symbol_kind: radix_index::engine::SymbolKind::Tokens,
+        block_size: BLOCK,
+    }
+}
+
+fn stored(seq: u64, parent: Option<u64>, blocks: &[(u64, u64)]) -> proto::Update {
+    proto::Update {
+        keyspace: Some(bridge::keyspace(MODEL, BLOCK)),
+        holder: "worker-a".into(),
+        epoch: 1,
+        seq,
+        events: vec![proto::Event {
+            kind: Some(proto::event::Kind::Stored(proto::Stored {
+                parent_seq_hash: parent,
+                blocks: blocks
+                    .iter()
+                    .map(|&(seq_hash, content_hash)| proto::Block {
+                        seq_hash,
+                        content_hash,
+                    })
+                    .collect(),
+            })),
+        }],
+        added: None,
+        dropped: false,
+    }
+}
+
+/// Both engines' full answer for `chain`, as comparable rows.
+fn answers(engine: &Engine, chain: &[u64]) -> Vec<(String, u32, u64)> {
+    let hashes: Vec<ContentHash> = chain.iter().map(|&h| ContentHash(h)).collect();
+    engine
+        .find_matches(&keyspace_key(), &hashes)
+        .into_iter()
+        .map(|s| (s.holder, s.matched_blocks, s.total_blocks))
+        .collect()
+}
+
+async fn converged(a: &Engine, b: &Engine, chains: &[Vec<u64>]) -> bool {
+    for _ in 0..200 {
+        let mut all_equal = true;
+        for chain in chains {
+            let left = answers(a, chain);
+            if left.is_empty() || left != answers(b, chain) {
+                all_equal = false;
+                break;
+            }
+        }
+        if all_equal {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    false
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test fixture: fire-and-forget servers for the test's lifetime"
+)]
+#[tokio::test]
+async fn peered_replicas_converge_through_moves_and_echoes() {
+    let port_a = portpicker::pick_unused_port().expect("port a");
+    let port_b = portpicker::pick_unused_port().expect("port b");
+    let url_a = format!("http://127.0.0.1:{port_a}");
+    let url_b = format!("http://127.0.0.1:{port_b}");
+
+    let engine_a = Arc::new(Engine::new(EngineConfig::default()));
+    let engine_b = Arc::new(Engine::new(EngineConfig::default()));
+    tokio::spawn(server::serve(
+        Arc::clone(&engine_a),
+        format!("127.0.0.1:{port_a}").parse().unwrap(),
+        vec![url_b.clone()],
+        Duration::from_secs(60),
+    ));
+    tokio::spawn(server::serve(
+        Arc::clone(&engine_b),
+        format!("127.0.0.1:{port_b}").parse().unwrap(),
+        vec![url_a.clone()],
+        Duration::from_secs(60),
+    ));
+
+    let mut client_a = {
+        let mut attempt = 0;
+        loop {
+            match RadixIndexClient::connect(url_a.clone()).await {
+                Ok(client) => break client,
+                Err(_) if attempt < 50 => {
+                    attempt += 1;
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                Err(error) => panic!("replica A never came up: {error}"),
+            }
+        }
+    };
+
+    // Event-fed chain on A only; relay must carry everything to B.
+    // Keys 1..=6 with contents 101..=106; k5/k6 first extend the chain
+    // at positions 4..5...
+    let (tx, rx) = mpsc::channel::<proto::Update>(64);
+    tx.send(stored(1, None, &[(1, 101), (2, 102), (3, 103), (4, 104)]))
+        .await
+        .unwrap();
+    tx.send(stored(2, Some(4), &[(5, 105), (6, 106)]))
+        .await
+        .unwrap();
+    // ...then re-arrive under a DANGLING parent: the engine re-anchors
+    // at position 0, which is a same-key MOVE — zero net blocks, so a
+    // length-delta relay heuristic would suppress it and B would keep
+    // answering with the pre-move placement forever.
+    tx.send(stored(3, Some(0xDEAD_BEEF), &[(5, 105), (6, 106)]))
+        .await
+        .unwrap();
+    let outbound = tokio_stream::wrappers::ReceiverStream::new(rx);
+    let mut acks = client_a
+        .publish(tonic::Request::new(outbound))
+        .await
+        .expect("publish stream")
+        .into_inner();
+    for _ in 0..3 {
+        tonic::codegen::tokio_stream::StreamExt::next(&mut acks)
+            .await
+            .expect("ack")
+            .expect("ack ok");
+    }
+
+    // After the move, [105, 106] matches from position 0 and the old
+    // six-deep prefix no longer fully matches; whatever A answers, B
+    // must answer identically.
+    let moved_chain = vec![105, 106];
+    let original_chain = vec![101, 102, 103, 104];
+    assert!(
+        converged(
+            &engine_a,
+            &engine_b,
+            &[moved_chain.clone(), original_chain.clone()]
+        )
+        .await,
+        "replica B never converged with A: A={:?}/{:?} B={:?}/{:?}",
+        answers(&engine_a, &moved_chain),
+        answers(&engine_a, &original_chain),
+        answers(&engine_b, &moved_chain),
+        answers(&engine_b, &original_chain),
+    );
+    // The move really moved: depth-2 match at the NEW anchor.
+    assert_eq!(answers(&engine_a, &moved_chain)[0].1, 2);
+
+    // Placement idempotence + echo death: publish the SAME placement
+    // to BOTH replicas (as fan-out publishers do). Each relays to the
+    // other; the echo must apply as a no-op and stop.
+    let contents: Vec<ContentHash> = (201..=204).map(ContentHash).collect();
+    let chain: Vec<(u64, u64)> = placement_chain(&contents)
+        .iter()
+        .map(|b| (b.seq_hash.0, b.content_hash.0))
+        .collect();
+    let mut placement = stored(0, None, &chain);
+    placement.holder = "worker-p".into();
+    for url in [&url_a, &url_b] {
+        let mut client = RadixIndexClient::connect(url.clone())
+            .await
+            .expect("client");
+        let (tx, rx) = mpsc::channel::<proto::Update>(4);
+        tx.send(placement.clone()).await.unwrap();
+        drop(tx);
+        let _ = client
+            .publish(tonic::Request::new(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            ))
+            .await
+            .expect("publish placement")
+            .into_inner();
+    }
+    let placement_chain_query = vec![201, 202, 203, 204];
+    assert!(
+        converged(
+            &engine_a,
+            &engine_b,
+            std::slice::from_ref(&placement_chain_query)
+        )
+        .await,
+        "placement never converged"
+    );
+
+    // Quiet-period stability: with no new publishes, block counts must
+    // hold still — an echo loop would keep mutating (the fault drill
+    // measured ~190x apply amplification from exactly that bug).
+    let before = (engine_a.entry_count(), engine_b.entry_count());
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let after = (engine_a.entry_count(), engine_b.entry_count());
+    assert_eq!(before, after, "state kept changing with no publisher");
+    assert_eq!(
+        answers(&engine_a, &placement_chain_query),
+        answers(&engine_b, &placement_chain_query)
+    );
+}

--- a/crates/radix_tree/Cargo.toml
+++ b/crates/radix_tree/Cargo.toml
@@ -6,8 +6,9 @@ description = "Generic prefix-membership index (spec stage; see SPEC.md)"
 license = "Apache-2.0"
 
 [dependencies]
-# Deliberately empty: zero SMG dependencies (SPEC.md §1), and no core
-# code lands before the verification harness exists (§12 R0).
+# Zero SMG dependencies (SPEC.md §1). External utility crates only.
+rustc-hash = "2"
+
 
 [dev-dependencies]
 # The differential oracle. Dev-only: the published crate never

--- a/crates/radix_tree/Cargo.toml
+++ b/crates/radix_tree/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "radix-tree"
+version = "0.1.0"
+edition = "2021"
+description = "Generic prefix-membership index (spec stage; see SPEC.md)"
+license = "Apache-2.0"
+
+[dependencies]
+# Deliberately empty: zero SMG dependencies (SPEC.md §1), and no core
+# code lands before the verification harness exists (§12 R0).
+
+[dev-dependencies]
+# The differential oracle. Dev-only: the published crate never
+# depends on SMG code.
+kv-index = { path = "../kv_index" }

--- a/crates/radix_tree/R3-DESIGN.md
+++ b/crates/radix_tree/R3-DESIGN.md
@@ -1,0 +1,100 @@
+# R3 core — chain-native layout (design note)
+
+Status: design for the second-generation storage layout behind the
+UNCHANGED §4 API and §6/§7 contract. The R1 flat core stays in-tree
+until R3 passes the identical referee (model equality on in-contract
+AND chaos inputs, audit, determinism) and the ORIGINAL §11 gates.
+
+## Why the flat layout cannot meet the last two gates (measured)
+
+- Cold query: one hash probe per position. Depth-78 answers cost 78
+  independent DRAM/TLB misses into a multi-GB table (~16 µs measured;
+  the walk itself is 542 ns warm — memory is the whole cost).
+- Memory: every block owns a hash-map slot (~40–56 B) plus a
+  per-holder registry entry (~42 B), so ~170 B/holder-block against
+  the 100 B gate, regardless of how boring the block's neighborhood
+  is.
+
+## The R3 shape: store chains, not positions
+
+The lineage value at position p identifies the entire prefix 0..=p
+(injective modulo 64-bit fingerprint collisions — same assumption R1
+already rests on, quantified under C5). Therefore prefixes form a
+TREE, and consecutive positions of one chain are CONTIGUOUS DATA, not
+independent map entries.
+
+Structures (one instance per keyspace, single-writer as today):
+
+1. **ChainData** (one per distinct chain path): `parent:
+   Option<(chain, pos)>` (trie edge for divergent tails), `base_pos`,
+   `contents: Vec<u64>`, `keys: Vec<u64>` — 16 B per position ONCE
+   per chain, shared by every holder of that chain.
+2. **node_by_lineage**: `FxHashMap<lineage → (chain, offset)>` for
+   chain STARTS and BRANCH POINTS only — not per position. This is
+   the query's single entry probe.
+3. **Membership spans** per chain: `Vec<(start, len, SetRef)>` — the
+   canonical MAXIMAL-RUN partition of position→holder-set, reusing
+   the R1 interner for the sets. Canonicality is free: the maximal-run
+   partition is the unique normal form of the underlying per-position
+   mapping, so §7 convergence holds whenever the underlying mapping
+   converges — split/merge operations must simply renormalize
+   neighbors, and the fuzz+audit prove they do.
+4. **Per-holder key map**: `FxHashMap<key → (chain, pos)>` (8 B
+   value; per-holder because out-of-contract inputs can register one
+   key differently across holders — chaos covers this). Parent
+   resolution and removal route through it.
+5. Per-holder coverage list (chain → intervals) for truncate_tail /
+   enumerate / holder_blocks — cold paths derive order on demand as
+   in R1.
+
+## The query walk
+
+Probe `node_by_lineage[l_0]` once → (chain, offset). Then:
+- **Divergence localization is a linear scan of `contents`**: compare
+  query contents against the chain's contiguous array — ~8 B per
+  position, prefetcher-friendly, ~10 cache lines for depth 78 versus
+  78 random lines today.
+- At chain end, follow the child edge by next content (in-node map or
+  a `node_by_lineage` probe) — hash probes total ≈ 1 + branch hops.
+- Holder answers come from the span list overlapping [0, depth):
+  typically 1–3 spans; per-holder depth = extent of coverage from 0
+  intersected with the walk, sets compared by interned pointer as in
+  R1.
+
+Cold estimate: entry probe (~100 ns) + contiguous content stream
+(~100 ns) + span reads (~100 ns) ≈ well under 1 µs at the gate shape —
+versus the 10 µs gate. Memory estimate per holder-block: chain data
+16/H + key map ~30 + span amortization ≈ ~45 B at H=1, ~1–5 B at
+H≥8; blended ~30–50 B against the 100 B gate. Both leave real margin
+for implementation slack — and both get MEASURED, not asserted.
+
+## Semantics carried over exactly (the referee enforces them)
+
+- §4 alias rules: same-triple twin keys are duplicates (never
+  registered); refused moves are non-destructive; same-key
+  re-placement is a move. "Same triple" = (position, content,
+  lineage), all of which R3 derives identically.
+- Removal punches holes: spans stop covering a position; chain data
+  is freed when no spans and no children reference it (refcount GC —
+  audited).
+- Duplicate re-publish lands on the SAME chain object via
+  node_by_lineage (canonical chain identity), which is what makes
+  cross-publisher placement idempotence structural.
+- Epoch clear / retire: drop the holder from every span it covers
+  (via the coverage list), renormalizing runs; audit proves no
+  orphaned chain data.
+
+## Risks and their instruments
+
+1. Span split/merge renormalization bugs → the total-model referee +
+   audit-after-every-op chaos fuzz (already proven to catch exactly
+   this class).
+2. Chain GC leaks/dangles → audit extends: every chain reachable from
+   spans/children/key-maps and vice versa; bytes bounded under churn
+   (existing churn property).
+3. Fingerprint collisions now also select chain identity → C5
+   quantifies; the bound is unchanged from R1 (collisions already
+   decided membership identity there).
+4. Perf regressions on writes (span surgery per store) → the pinned
+   bench write gate (≥ 1M blocks/s) stands; batch appends amortize to
+   O(1) span updates in-contract.

--- a/crates/radix_tree/README.md
+++ b/crates/radix_tree/README.md
@@ -1,0 +1,84 @@
+# radix-tree
+
+A generic prefix-membership index: given per-holder chains of
+content-addressed blocks, answer *"which holders already hold the
+longest prefix of this chain, and how deep?"* — plus the write and
+lifecycle operations a long-lived, multi-tenant index service needs
+as first-class API. Zero SMG dependencies; everything it sees is a
+hash.
+
+Built as the ground-up replacement for the radix-index service's
+import of the gateway's `kv_index::PositionalIndexer`; the service
+(`crates/radix_index`) runs on it.
+
+## API in one glance
+
+```rust
+let mut tree = RadixTree::new(Config::default());
+let w = tree.create_holder("worker-7");            // generational id
+tree.store(w, None, &[(key, content), ...])?;      // anchor a chain
+tree.store(w, Some(parent_key), &more)?;           // extend it
+tree.remove(w, &[key]);                            // event-feed eviction
+tree.truncate_tail(w, keep);                       // prefix-closed capacity cut
+tree.clear(w);                                     // epoch bump
+tree.retire_holder(w);                             // frees everything, id recycled
+
+let mut scratch = OverlapScratch::default();
+let mut out = Vec::new();
+tree.overlap(&chain_hashes, &mut scratch, &mut out);
+// out: [{ holder, depth, total_blocks }]
+tree.enumerate(w);                                 // (pos, key, content) for snapshots
+```
+
+Contract details (matching semantics, convergence scope, alias
+rules): [`SPEC.md`](SPEC.md). Layout rationale:
+[`R3-DESIGN.md`](R3-DESIGN.md).
+
+## Structure
+
+Prefixes form a trie of **chains**. A chain's contents are one
+contiguous array, stored once no matter how many holders cover it;
+membership is a short list of maximal runs pointing at interned
+(hash-consed) holder sets; a query is one hash probe to the root
+chain, a linear scan of contiguous contents to the divergence point,
+a child-fork hop if needed, and a handful of span reads. Matching is
+exact and content-verified — fingerprint collisions cannot
+cross-credit.
+
+`FlatTree` is the first-generation flat layout, kept as a second,
+independently verified implementation: the test harness asserts BOTH
+cores equal the reference model on every run.
+
+## Verification
+
+The crate was built harness-first (see
+[`VERIFICATION.md`](VERIFICATION.md) for the campaign record):
+
+- `tests/differential.rs` — both cores vs a representationally
+  complete reference model AND the production `kv_index` oracle
+  (dev-dependency), with full-state `audit()` at every checkpoint.
+- `tests/fuzz_differential.rs` — wide-config fuzz plus a CHAOS mode
+  that violates every contract precondition under a no-panic,
+  audit-green, model-equal, deterministic-replay contract.
+  `RADIX_FUZZ_SEEDS=10000` ran green.
+- `tests/api.rs` — lifecycle, boundary, and exactness cases the model
+  deliberately doesn't express.
+- `tests/alloc_gate.rs` — counting-allocator gate: single-holder
+  stores amortize to zero allocations.
+- `tests/pinned_bench.rs` — the normative performance workload
+  (`RADIX_BENCH_SIDE=oracle|r1|r3`, `RADIX_BENCH_SCALE=large`,
+  `RADIX_BENCH_SOAK_SECS=n`).
+
+## Measured (pinned workload: 12.8M holder-blocks, 256 holders)
+
+| | old `PositionalIndexer` + glue | `RadixTree` |
+|---|---|---|
+| bytes / holder-block | 166.7 | **26.9** |
+| worst cell (d78, 64 holders) cold p99 | 6.0 µs (unsound skip) | **7.6 µs exact** |
+| single-holder query p50 | 917 ns | **292 ns** |
+| writes, mixed stream | 5.5M blocks/s | 4.6M blocks/s |
+| at 128M blocks: worst-cell p99 | 29 µs | **8.0 µs** |
+
+No timestamps live in the tree: freshness policy (idle TTL per
+holder) belongs to the consumer; chain data is freed by reference
+counting.

--- a/crates/radix_tree/SPEC.md
+++ b/crates/radix_tree/SPEC.md
@@ -132,11 +132,26 @@ Write semantics (revised, all normative):
   deterministic resolution the engine's re-anchor recovery needs.
   Chain-consistent workloads (§7) never do this.
 - A SECOND key stored by the same holder at an identical (position,
-  content, lineage) is counted a duplicate and NOT registered (and a
-  move landing on such a triple removes the moved key). Added after
-  the chaos fuzz caught the alternative corrupting shared membership
-  state: two keys, one membership pair, first removal orphaning the
-  second (campaign C1, chaos seed 7).
+  content, lineage) is counted a duplicate and NOT registered; a
+  move landing on such a triple is REFUSED NON-DESTRUCTIVELY — the
+  moved key keeps its old placement. (An independent contract review
+  caught this sentence still describing the destructive alternative
+  after the code was fixed; the destructive order corrupts shared
+  membership state — two keys, one membership pair, first removal
+  orphaning the second — campaign C1, chaos seed 7.)
+- Pinned mechanical readings (all three implementations agree; an
+  independent review flagged each as underdetermined by the clauses
+  above, so they are now normative):
+  - An EMPTY batch is a no-op that succeeds without resolving
+    `parent` — `store(h, Some(dangling), &[])` is `Applied {0, 0}`,
+    not `ParentNotFound`.
+  - A chain of exactly `max_chain_len` blocks is legal (last position
+    `max_chain_len - 1`); the batch that would make it longer errs.
+  - A key appearing twice in ONE batch composes the per-block rules
+    in order: the later occurrence is a move, the earlier position
+    becomes a hole.
+  - `truncate_tail`'s equal-position tie evicts the LARGEST
+    `BlockKey` first.
 - `remove` of an unknown key is a no-op (counts only actual removals).
 - **`truncate_tail` on the forest**: remove blocks in strictly
   decreasing position order across ALL chains, ties at a position

--- a/crates/radix_tree/SPEC.md
+++ b/crates/radix_tree/SPEC.md
@@ -131,6 +131,12 @@ Write semantics (revised, all normative):
   **moves** the block (the prior placement is removed first) — the
   deterministic resolution the engine's re-anchor recovery needs.
   Chain-consistent workloads (§7) never do this.
+- A SECOND key stored by the same holder at an identical (position,
+  content, lineage) is counted a duplicate and NOT registered (and a
+  move landing on such a triple removes the moved key). Added after
+  the chaos fuzz caught the alternative corrupting shared membership
+  state: two keys, one membership pair, first removal orphaning the
+  second (campaign C1, chaos seed 7).
 - `remove` of an unknown key is a no-op (counts only actual removals).
 - **`truncate_tail` on the forest**: remove blocks in strictly
   decreasing position order across ALL chains, ties at a position

--- a/crates/radix_tree/SPEC.md
+++ b/crates/radix_tree/SPEC.md
@@ -1,0 +1,454 @@
+# radix-tree — specification (pre-implementation)
+
+Status: SPEC ONLY. No code yet. This crate is the planned ground-up
+replacement for the radix-index service's current direct import of
+`kv_index::PositionalIndexer`. The import stays in place as the
+stopgap; `kv_index` remains untouched in the production gateway and
+serves as the differential-testing reference and the measured
+performance baseline throughout.
+
+Derived from the adversarial design review of 2026-08-29 (five
+code-reading lenses + two advocates over `kv_index/src/event_tree.rs`
+and `radix_index/src/engine.rs`), then revised against a second
+adversarial pass on this spec itself (engine-fit, semantics, and
+performance reviewers; 8 blocking findings incorporated — the notable
+ones are flagged inline as "revised:").
+
+## 1. Purpose
+
+A generic, standalone prefix-membership index: given per-holder chains
+of content-addressed blocks, answer "which holders hold the longest
+prefix of this chain, and how deep?" — the routing question — plus the
+write and lifecycle operations a long-lived, multi-tenant index
+service needs as first-class API rather than caller-side bookkeeping.
+
+Zero dependencies on SMG crates. One instance indexes one keyspace;
+the service maps keyspaces to instances (as it does today).
+
+## 2. Non-goals
+
+- Distribution protocol: epochs, per-holder sequence dedup, feed
+  authority (event vs placement), and capacity/TTL *policy* stay in
+  the service engine. Revised: an epoch bump maps onto `clear()` —
+  same holder, same id, engine-side posture retained — exactly what
+  the engine does today with `apply_cleared`. `retire_holder` is
+  reserved for holder *disappearance* (TTL sweep, permanent drop),
+  never for restarts.
+- Networking, serialization, keyspace routing.
+- The wire hash scheme. This crate is hash-agnostic; the service owns
+  the wire vocabulary (§10.2).
+- Replacing `kv_index`'s StringTree/TokenTree in the gateway. Out of
+  scope; the only concession to that future is that this crate only
+  ever sees hashes.
+- Internal concurrency. Single-writer per instance (§8).
+
+## 3. Vocabulary
+
+- **Block**: one quantum of cache (a token page / byte page),
+  identified two ways:
+  - `ContentHash(u64)` — position-independent content identity; the
+    matching currency on the query path and the wire.
+  - `BlockKey(u64)` — the publisher's removal key (the backend's block
+    hash on the event feed; a synthesized chain hash on the placement
+    feed). Opaque to matching; needed because event-feed removals
+    arrive as backend keys and are not derivable from content.
+- **Chain**: blocks at consecutive positions `0..n`, each linked to
+  the prefix that produced it. A chain is what a *query* presents.
+- **Holder state is a forest** (revised): a holder holds MANY chains —
+  one per cached prompt prefix on the placement feed (the engine's own
+  convergence tests feed one holder several disjoint parent-None
+  chains). Every per-holder operation below is defined on the forest.
+- **Lineage**: a stored block's identity includes the specific chain
+  prefix it was stored under, not just (position, content). Two chains
+  that coincide in content at position p are still different blocks —
+  a block's KV values depend on its whole prefix. Internally this is a
+  rolling lineage fingerprint (an implementation detail, NOT the wire
+  hash scheme).
+- **Holder**: the entity that holds blocks (a worker). Identified by a
+  generational `HolderId` (§5).
+- **Position**: `u32` depth in a chain, starting at 0.
+
+## 4. Public API (normative sketch)
+
+```rust
+pub struct RadixTree { /* one keyspace's index */ }
+
+pub struct Config {
+    pub max_chain_len: u32,        // hard bound; default 65_536
+}
+
+// --- holder lifecycle ---
+pub fn create_holder(&mut self, name: &str) -> HolderId;
+pub fn holder_name(&self, id: HolderId) -> Option<&str>;
+pub fn retire_holder(&mut self, id: HolderId);
+pub fn holder_blocks(&self, id: HolderId) -> u64;   // O(1)
+
+// --- writes ---
+pub struct StoreOutcome {
+    pub applied: u32,              // blocks newly inserted
+    pub duplicates: u32,           // already present (idempotent hits)
+}
+pub enum StoreError {
+    UnknownHolder,                 // includes stale generation (§5)
+    ParentNotFound,
+    ChainTooLong,
+}
+pub fn store(
+    &mut self,
+    holder: HolderId,
+    parent: Option<BlockKey>,      // None = anchor a new chain at 0
+    blocks: &[(BlockKey, ContentHash)],
+) -> Result<StoreOutcome, StoreError>;
+
+pub fn remove(&mut self, holder: HolderId, keys: &[BlockKey]) -> u32;
+pub fn truncate_tail(&mut self, holder: HolderId, keep: u64) -> u64;
+pub fn clear(&mut self, holder: HolderId);
+
+// --- reads ---
+pub struct Overlap {
+    pub holder: HolderId,
+    pub depth: u32,
+    pub total_blocks: u64,         // revised: the wire answer carries
+                                   // it per hit; O(1) at query time
+}
+pub fn overlap(&self, chain: &[ContentHash], out: &mut Vec<Overlap>);
+pub fn enumerate(&self, holder: HolderId)
+    -> impl Iterator<Item = (u32, BlockKey, ContentHash)> + '_;
+pub fn stats(&self) -> Stats;
+```
+
+Write semantics (revised, all normative):
+
+- **`store` is all-or-nothing**: on any `Err`, no effect was applied.
+  `ParentNotFound` is the ONLY error for which re-anchoring at
+  position 0 is the sanctioned caller recovery; `ChainTooLong` is
+  terminal for the batch (the caller drops it — re-anchoring a
+  too-long batch cannot succeed and must not be attempted).
+- `store` with `parent: Some(k)` anchors at (position of k) + 1 *on
+  the chain k belongs to*; the batch extends that chain's lineage.
+  `parent: None` starts a new chain in the forest at position 0.
+- Re-registering an existing `BlockKey` at a different placement
+  **moves** the block (the prior placement is removed first) — the
+  deterministic resolution the engine's re-anchor recovery needs.
+  Chain-consistent workloads (§7) never do this.
+- `remove` of an unknown key is a no-op (counts only actual removals).
+- **`truncate_tail` on the forest**: remove blocks in strictly
+  decreasing position order across ALL chains, ties at a position
+  broken deterministically by `BlockKey`, until `keep` remain. A pure
+  function of (state, keep). This is prefix-closed for every chain
+  simultaneously. Note: this deliberately *fixes* today's engine,
+  whose parallel chain Vec tracks only the most recent chain and lets
+  earlier chains escape capacity accounting until TTL.
+- **Return values are advisory** (`StoreOutcome`, `remove`'s count):
+  they are order-dependent under duplication and are explicitly
+  outside the convergence contract (§7).
+
+`Stats` (revised — two block quantities, both defined):
+
+```rust
+pub struct Stats {
+    pub holders: u64,
+    pub holder_blocks: u64,    // sum of holder_blocks(h) — capacity math
+    pub distinct_entries: u64, // unique (position, content, lineage)
+                               // — the oracle-parity metric the
+                               // engine's entry_count() tests assert
+    pub bytes_estimate: u64,
+}
+```
+
+Deliberate differences from the oracle's API, each traced to a review
+finding:
+
+| finding (oracle) | this API |
+|---|---|
+| caller-owned `WorkerBlockMap` threaded into every write | registry is internal |
+| engine keeps a parallel position-ordered chain Vec for eviction | `truncate_tail` is native, and forest-correct |
+| `OverlapScores` keyed by `u32` with no reverse lookup | `holder_name` on the query path |
+| `WorkerIdExhausted` surfaced as a false `KeyspaceMismatch` | generational ids; truthful errors |
+| no enumeration API; snapshot sorts an inverted caller map | `enumerate` in position order |
+| parent-not-found handled by copied gateway heuristics | `ParentNotFound` is an explicit, recoverable error |
+| global `prune` breaking prefix-closure; per-entry touch atomics | no TTL machinery at all; policy is the engine's |
+| `total_blocks` from a side structure per answer | carried on `Overlap`, O(1) |
+
+## 5. Holder lifecycle (the service-class fix)
+
+The oracle interns worker ids monotonically and never frees them —
+invisible in a gateway restarted every deploy, unbounded in a
+long-lived service under pod churn.
+
+- **`HolderId` is generational** (revised): index + generation.
+  `retire_holder` bumps the generation; every operation through a
+  stale id fails loudly (`UnknownHolder` / `None`), never silently
+  addressing a recycled slot. This is what makes recycling safe for a
+  caller that caches ids (the engine does, in `HolderState`).
+- `retire_holder` releases every byte attributable to the holder and
+  returns the slot to a free list; name maps shrink.
+- Property tests: (a) create/store/retire cycled N times leaves
+  `stats().bytes_estimate` bounded by a constant independent of N;
+  (b) operations through a retired id fail loudly, never alias.
+
+## 6. Matching semantics (the contract)
+
+Revised — depth is defined over *lineage*, not bare positional
+content:
+
+> depth(h) = the largest `d` such that holder `h` holds the chain
+> `chain[0..d]` — i.e., for every position `p < d`, `h` holds a block
+> with content `chain[p]` at position `p` whose lineage is exactly
+> `chain[0..p]`.
+
+Exact — no probabilistic skip acceptance, no lineage shortcuts. A
+holder holding two content-coincident chains never over-matches on
+the strength of the wrong chain's block.
+
+The oracle deviates from this contract in three known ways (the
+adjudication classes for §10):
+
+1. **Jump-landing acceptance on holder-count equality** without
+   membership verification — can credit a holder across a mid-chain
+   gap or past its true depth.
+2. **The linear-scan retain guard**, which skips verification whenever
+   a position's matching set is at least as large as the active set —
+   same over-count direction, and it operates even on gap-free states
+   (count parity is not set equality).
+3. **The Single-entry lineage skip**: the oracle checks lineage only
+   for Multi entries; a Single-represented block matches on
+   (position, content) alone, so the oracle may over-match where this
+   crate is exact — representation-dependent semantics this contract
+   deliberately does not reproduce.
+
+All three deviate in the same direction: oracle ≥ truth ≥ this crate
+is NOT the invariant — the invariant is that *this crate equals the
+model* (§10.1); the oracle may exceed the model through exactly these
+three mechanisms and no others.
+
+## 7. Convergence requirement (the load-bearing property)
+
+Revised — the earlier "any arrival order" claim was false (store and
+remove do not commute: `{store k, remove k}` ends present or absent by
+order, in the oracle and in any sane implementation).
+
+**Chain-consistent** (definition): a per-holder store multiset is
+chain-consistent iff there exists a single mapping
+`BlockKey → (position, content, lineage)` such that every batch places
+every key at that mapping's placement, every `parent` resolves under
+the mapping to the batch anchor's position − 1 on the same chain, and
+no two distinct keys map to the same (chain, position) for the holder.
+
+**The guarantee**: for any workload where
+
+- each holder's own operation order is preserved whenever that
+  holder's sequence contains `remove` or `clear`,
+- remove-free, clear-free per-holder store multisets may additionally
+  be reordered arbitrarily,
+- cross-holder interleaving is arbitrary, and individual operations
+  may be duplicated (re-applied) arbitrarily,
+- all stores are chain-consistent,
+
+the resulting `overlap` answers (as a full holder→depth map),
+`enumerate` output, and `stats()` block quantities are identical.
+
+Excluded from the guarantee: return values (§4, advisory);
+`truncate_tail` and `retire_holder` (engine-sequenced local decisions,
+not replicated effects); `ParentNotFound` caller compensation — a
+re-anchor is a NEW operation whose convergence is the caller's
+obligation, and the engine must derive it deterministically from
+update content, never from local arrival history.
+
+The oracle satisfies this scoped property because its index inserts
+are set-idempotent — but its caller-side reverse map is
+last-writer-wins and needs the same restrictions; "trivially
+convergent" overstates it. Every candidate layout here re-earns the
+same scoped property, and it is the R1-vs-R3 fork's dividing question
+(§9).
+
+Snapshot note (revised): replaying `enumerate` output through
+`store()` collapses mid-chain gaps into contiguous chains — exactly
+what the engine's Pull/bootstrap does today. Bootstrap-equivalence
+assertions are therefore scoped to gap-free states; gapped holders
+converge through the feeds, not through snapshot transfer.
+
+## 8. Concurrency model
+
+Single writer, `&mut self` writes, `&self` reads. No internal locks,
+no atomics, no shards. The consumer already serializes per keyspace;
+the review measured the imported structure's concurrency machinery as
+unexercised there, and its per-entry atomics as pure overhead on every
+store *and every query probe*. Concurrent-read designs, if ever
+needed, are an engine-layer snapshot-publication concern.
+
+## 9. Storage layouts: R1 flat core, R3 linked tree
+
+The public API and every contract above are layout-independent.
+
+**R1 — flat positional core (ships first).**
+
+- Entry side: `FxHashMap<(u32, ContentHash), Membership>` where
+  `Membership` disambiguates by lineage fingerprint and holds the
+  common case inline: one `(lineage, holder)` with **zero heap
+  allocation** — one step past the oracle's Single-entry
+  representation, which still heap-allocates a one-element worker set
+  per entry — spilling to a small lineage→holders map only when
+  shared.
+- Registry side (per holder): `BlockKey → (position, content)` map
+  plus a position-ordered `(BlockKey, ContentHash)` index — ≈36–40
+  B/holder-block with hashmap overhead, within ~10% of the oracle's
+  externalized `WorkerBlockMap`. **The R1 memory saving comes from the
+  entry side** (no per-entry heap set, no atomics, no shard tables),
+  not from the registry.
+- Convergence (§7) holds by construction (set-idempotent inserts under
+  the chain-consistency scope).
+- Historical reference: the oracle measured 274.7 B/entry on the old
+  unique-chain bench — superseded as a target by the §11 gates, which
+  are defined on the pinned shared-prefix workload.
+
+**R3 — path-compressed linked tree (gated).**
+
+Arena-allocated trie over positions branching on lineage, with
+membership stored per *run* (maximal span of positions with identical
+holder set). Structural prefix-closure (leaf-pop eviction, O(subtree)
+holder retirement). Canonicality: a path-compressed trie's shape is a
+pure function of its key set; the genuinely hard, novel work is
+keeping run boundaries and membership canonical under interleaved
+store/remove with duplication — splits and merges must depend only on
+the resulting key/membership set, never on arrival order. This is the
+part expected to be much harder than R1; it gets its own design note
+before any code.
+
+Honest arithmetic (revised): run compression only collapses the entry
+side; the per-holder registry (~36–40 B/holder-block) is a floor it
+cannot touch. At sharing factor H=1 the projected total win over R1 is
+≈2×; at H=32 it decays toward ≈1.2×. **A ≥2× total win therefore also
+requires a registry redesign** — e.g. replacing the per-holder hashmap
+with a dense position-indexed `Vec<(BlockKey, ContentHash)>` per chain
+(≈16 B/holder-block, gap-tolerant via run splits) — and the R3 design
+note must carry both. Go/no-go is computed from run statistics
+*measured on R1* under a written per-run byte model (§11), not from
+this projection.
+
+## 10. Verification (written BEFORE the core — the R0 deliverable)
+
+1. **Model-referee differential harness** (revised) in
+   `tests/differential.rs`, `kv-index` as a dev-dependency only. The
+   harness maintains a trivially-correct model (per-holder
+   chain-forest map; depth computed literally per §6). Assertions:
+   - `RadixTree == model`, on every state, always — this is the hard
+     gate;
+   - full holder→depth *map* equality (holders at depth 0 absent from
+     both) — never a bare multiset of depths;
+   - oracle-vs-model divergences are recorded and each must classify
+     into one of §6's three oracle-quirk classes; an unclassifiable
+     divergence fails the run (it means the model, the spec, or our
+     understanding of the oracle is wrong) — but oracle divergence
+     never fails `RadixTree` while it equals the model.
+   Workloads: many holders sharing deep prefixes, divergent tails,
+   duplicate/reordered batches within §7's scope, event-feed gap
+   patterns, placement re-publishes, forest-shaped placement holders.
+2. **Golden hash vectors**: the wire hash scheme (XXH3-64 seed 1337,
+   LE u32 full-block chunking, chain rule, position-0
+   prefix==content convention) pinned as hard-coded u64 constants
+   captured from production `kv_index` output. Revised: after R2
+   drops the service's `kv_index` import, the wire scheme's
+   implementation lives in a small service-side `wire_hash` module in
+   `radix_index` — NOT in this crate, which stays hash-agnostic — and
+   the golden vectors test that module. The service's proto grows a
+   `hash_scheme` version field so drift fails loudly instead of as
+   silent empty matches.
+3. **Property tests**: §5 lifecycle boundedness and stale-id
+   loudness, §6 exactness on constructed gap and content-coincidence
+   cases, §7 convergence interleavings within scope, forest
+   `truncate_tail` prefix-closure and determinism (tie-break
+   included).
+4. **Ported engine acceptance tests**: the service's existing
+   structure-independent tests must pass after the R2 switch, with
+   two documented behavior changes: capacity eviction becomes
+   forest-correct (§4), and dropped holders release memory (§12).
+
+## 11. Performance gates (measured, not argued)
+
+**The pinned workload** (revised — normative constants, so gates are
+not gameable after the fact): ≥1e7 holder-blocks total; 256 holders;
+sharing mixture H ∈ {1, 8, 64} at 50%/35%/15% of blocks; shared-depth
+distribution log-uniform over [8, 512] blocks; divergent tails
+uniform over [4, 64] blocks; query mix replaying stored prefixes plus
+20% misses, depth distribution matching stores; 5% duplicate
+re-stores; 2% gap injection via removes. Numbers quoted as the median
+of ≥3 runs; same global allocator both sides; RSS sampled after fill
+and before query-phase allocations; no asserts or allocation inside
+timed regions; latency reported per (depth, active-set-size) cell.
+
+**R1 adoption gates:**
+
+- *Memory*: RSS-delta / holder-blocks ≤ the oracle measured on the
+  SAME workload with its production glue replicated (indexer +
+  per-holder `WorkerBlockMap` + chain Vec + `by_worker_id`, exactly
+  as `engine.rs` holds them) — and, independently, **≤ 100
+  B/holder-block absolute**, so beating the glue-laden oracle cannot
+  hide a bloated layout.
+- *Allocation*: storing a fresh single-holder block performs zero
+  heap allocations amortized beyond map growth (counting-allocator
+  property test) — the §13.4 risk gated directly, since the RSS gate
+  alone cannot catch it.
+- *Latency* (revised): exactness forbids the oracle's count-equality
+  jump skip, so ≤-oracle is not the bar. Gate: **overlap p99 ≤ 10 µs
+  at depth 78 with 64 candidate holders** on the pinned workload
+  (~200× headroom under the service's 2 ms routing deadline); the
+  oracle's number on the same bench is recorded as reference, not as
+  a gate.
+- *Writes*: **≥ 1M blocks/s sustained single-thread on the mixed
+  write stream** (batch 8, duplicates and removes included as part of
+  the gated stream). Absolute, not vs the oracle: write load has ≥10×
+  headroom at 1M, while reads and memory are the scaling constraints
+  — R1 is permitted to be slower than the oracle's 4.6M pure-fill
+  blocks/s.
+
+**R3 gates** (revised — go/no-go and acceptance are different
+measurements):
+
+- *Go/no-go* (before building): projected total win ≥ 2×, computed
+  from run statistics measured on R1 under the pinned workload (count
+  and length of maximal identical-membership runs, membership sizes,
+  registry byte share) under the written per-run byte model of §9.
+- *Acceptance* (after building): measured RSS/holder-block ≤ 0.5× R1
+  on the pinned workload, and overlap p99 ≤ R1's on the same query
+  mix.
+
+## 12. Milestones
+
+- **R0** — this spec reviewed; model-referee rig, golden vectors,
+  `wire_hash` module carve-out, and the pinned bench built and run
+  against the *oracle alone* (baseline numbers recorded). No core
+  code before the harness exists.
+- **R1** — flat core passes differential + property + perf gates.
+- **R2** — service engine rewires to the new API: deletes the chain
+  Vec, `by_worker_id`, and caller-owned maps; epoch bump calls
+  `clear()`; `sweep_idle` retires idle inferred holders via
+  `retire_holder` **and drops the engine's own `HolderState` in
+  lockstep** (stale-id hygiene, §5); revised: holders marked
+  `dropped` are retired immediately — including event-fed ones, which
+  today leak forever — with an engine-side tombstone carrying the
+  last-seen epoch for a grace window so a late lower-epoch relay
+  straggler cannot resurrect pre-restart state. The service's
+  `kv_index` import is dropped (`wire_hash` takes over, §10.2). Live
+  smoke + one sim leg rerun for sanity. Gateway untouched.
+- **R3** — linked-tree core behind the same API, gated per §11, with
+  its canonical-maintenance design note written and reviewed first.
+
+## 13. Risks, ranked
+
+1. **R3 canonical incremental maintenance** (§9) — the one genuinely
+   hard algorithmic problem; contained by being last, optional, and
+   gated on measured run statistics rather than projections.
+2. **Oracle-quirk adjudication** — the model-referee design (§10.1)
+   bounds it: divergences classify against three enumerated
+   mechanisms or the run fails loudly; no case-by-case judgment calls
+   inside the harness.
+3. **Silent hash drift** — the failure mode is empty matches, not
+   errors; mitigated by golden vectors + the proto version field +
+   one owning module.
+4. **Perf regression subtlety** — gated directly by the
+   counting-allocator test and the absolute byte budget, not just the
+   relative RSS comparison.
+5. **Two implementations in-tree during the window** — bounded by R2
+   removing the service's import; the gateway's `kv_index` and this
+   crate never share a caller afterward.

--- a/crates/radix_tree/SPEC.md
+++ b/crates/radix_tree/SPEC.md
@@ -452,3 +452,43 @@ measurements):
 5. **Two implementations in-tree during the window** — bounded by R2
    removing the service's import; the gateway's `kv_index` and this
    crate never share a caller afterward.
+
+## Measurement log (append-only; gates unchanged above)
+
+R0 oracle baseline and R1 results on the §11 pinned workload
+(12.84M resident holder-blocks; medians of 3 runs, Apple Silicon,
+system allocator):
+
+| metric | oracle + engine glue | R1 flat core | §11 gate | verdict |
+|---|---|---|---|---|
+| fill (mixed stream) | 5.47M blocks/s | **10.58M blocks/s** | ≥ 1M | PASS (10.6×) |
+| allocations / fresh single-holder block | n/a | **0.0002** | amortized zero | PASS |
+| memory (B/holder-block) | 166.7 | 170.9 | ≤ oracle AND ≤ 100 | FAIL by +2.5% / FAIL |
+| overlap p50, miss | 250 ns | **208 ns** | — | — |
+| overlap p50, H=8 | 1.5 µs | 1.9 µs | — | — |
+| overlap p50, H=64 (log-uniform depths) | 4.9 µs | **4.4 µs** | — | — |
+| gate cell (d=78, W=64) p99 | 6.0 µs (unsound skip) | 18.0 µs (exact) | ≤ 10 µs | FAIL |
+
+Open decisions the failed gates raise (maintainer's call, not
+quietly amended):
+
+1. The absolute 100 B/holder-block came from §9's idealized
+   arithmetic; measurement says BOTH designs pay ~165–170 B on this
+   allocator (hash-table load factors and headers the estimate
+   ignored). R1 is a memory TIE with the incumbent (+2.5%), reached
+   while deleting the standing order structure (position order now
+   derived on demand in the cold truncate/enumerate paths).
+2. The 10 µs gate-cell budget bought exactness headroom against the
+   oracle's 6 µs — but the oracle's number is produced by the
+   count-equality skip this contract rejects as unsound. Exact
+   verification of 64 candidates × 78 positions measures ~13–18 µs
+   (two-phase walk: independent probes overlap their cache misses;
+   dense per-lineage holder runs; memcmp fast path on unchanged
+   membership). Still ~110× under the 2 ms routing deadline.
+
+Both misses are precisely what R3's run compression targets
+(structural runs make shared spans O(1) to verify and collapse the
+entry side): the options are to amend the R1 gates to the measured
+basis (≤ oracle + 5% memory; ≤ 20 µs gate-cell p99) and keep the
+original numbers as R3's bar, or to hold R2 until R3-grade run
+metadata lands. R2 does NOT proceed until this is decided.

--- a/crates/radix_tree/SPEC.md
+++ b/crates/radix_tree/SPEC.md
@@ -246,7 +246,10 @@ no two distinct keys map to the same (chain, position) for the holder.
 - each holder's own operation order is preserved whenever that
   holder's sequence contains `remove` or `clear`,
 - remove-free, clear-free per-holder store multisets may additionally
-  be reordered arbitrarily,
+  be reordered in any DEPENDENCY-RESPECTING order (a parent-anchored
+  batch after the batch that registers its parent — a reorder that
+  changes which stores get ACCEPTED changes the applied multiset
+  itself and is outside this clause),
 - cross-holder interleaving is arbitrary, and individual operations
   may be duplicated (re-applied) arbitrarily,
 - all stores are chain-consistent,

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -257,6 +257,27 @@ merged with the author's own pre-registered list. Dispositions:
 - Fault-drill evidence lives on the local simrig branch; the drills'
   harness is committed on the sim PR, results summarized here.
 
+## Workload-profile matrix (2026-09-01, release, this Mac, single run each)
+
+Four stream shapes x both sides; RADIX_BENCH_PROFILE selects. All
+percentiles ns; fill in M stream-blocks/s; memory in B/holder-block.
+`pinned` is the normative §11 gate config; the others answer "does
+the win hold off the pinned distribution?" — it does, on every axis,
+except write throughput on deep chains (agentic), which stays >2x
+above the 1M/s gate but is the clear next optimization target.
+
+| profile | fill old/new | B/blk old/new | H=1 p50 old/new | gate-cell p99 old/new |
+|---|---|---|---|---|
+| pinned  | 5.44 / 4.38 | 167.5 / 26.7 | 1000 / 292 | 9.7µs / 7.9µs |
+| agentic (deep chains, heavy sharing) | 5.77 / 2.16 | 143.2 / 26.5 | 1041 / 750 | 7.8µs / 6.5µs |
+| churn (short chains, 20% dups, 10% gaps) | 5.99 / 7.12 | 146.9 / 29.4 | 917 / 292 | n=1 cell |
+| fleet (1024 holders) | 5.39 / 3.48 | 144.4 / 33.6 | 2041 / 375 | 11.2µs / 7.5µs |
+
+(The churn profile's first run tripped the resident cross-check —
+the check was calibrated for pinned's 2% gaps and refused to report
+memory over a wrong denominator, exactly its job; the bench now
+subtracts workload-removed blocks exactly.)
+
 ## What a single machine cannot prove (standing honesty)
 
 Connection fan-in from hundreds of real gateways; real network

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -239,10 +239,21 @@ merged with the author's own pre-registered list. Dispositions:
   them): bound the accepted keyspace set at the auth layer.
 
 **Accepted with eyes open:**
-- The reference model shares an author with both cores (mitigated by
-  the kv_index oracle, the API suite, and now-stronger observables;
-  an independent reader of SPEC.md reviewing model.rs is the
-  remaining step).
+- The reference model shares an author with both cores. The planned
+  mitigation RAN: an independent adversarial reader reviewed model.rs
+  clause-by-clause against SPEC.md (16 findings; 12 CLEAN). It caught
+  the feared failure mode live — SPEC §4's refused-move parenthetical
+  still described the DESTRUCTIVE behavior the code had been fixed
+  away from, so model+cores agreed with each other while all three
+  contradicted the spec text (spec corrected; the non-destructive
+  refusal was always the intent — the destructive order is the C1
+  corruption). Four underdetermined mechanical readings (empty batch,
+  exact chain-length inequality, in-batch duplicate key, truncation
+  tie direction) are now pinned as normative in §4.
+- §5 stale-id/UnknownHolder semantics sit OUTSIDE the model gate (the
+  model is not total over retire): they are enforced by direct chaos
+  assertions instead — narrower than model equality, kept explicit
+  here.
 - Fault-drill evidence lives on the local simrig branch; the drills'
   harness is committed on the sim PR, results summarized here.
 

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -13,13 +13,14 @@ evidence linked/recorded next to it. Status legend: [ ] open,
 
 ## Pillar 1 — Correctness
 
-- C1 [~] **Continuous differential fuzz**: the model-referee harness
-  scaled from 16 seeds to a sustained campaign — hours of randomized
-  workloads over a WIDE config space (holders 2..512, chains to
-  max_chain_len edges, gap/dup/clear rates to extremes, content
-  coincidence, forest fan-out), RadixTree == model on every
-  checkpoint of every seed. Target: >= 10,000 seeds, zero
-  divergences, plus a standing soak entry point.
+- C1 [x] **Continuous differential fuzz** — 10,000 seeds green in
+  one 3.4-hour run (12,382s): randomized configs (holders 2..256,
+  chains to 512, extreme dup/gap/clear/coincidence rates), ~3,300
+  chaos runs interleaved, model equality at every checkpoint, audit
+  at every op, deterministic replay. Zero divergences. The standing
+  entry point (RADIX_FUZZ_SEEDS/RADIX_FUZZ_START) remains for
+  continuous use; the dual-core harness now covers R3 in the same
+  runs going forward.
 - C2 [x] **Internal invariant checker** — audit() recomputes every
   counter, forward+reverse containment, bucket order, name/free-list
   coherence, interner coherence; green after EVERY op across the

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -171,8 +171,17 @@ refused-move, u32 generation wrap, per-holder alias divergence,
 chain double-free, clear-order GC leak, move-order GC leak, cursor
 write-into-freed-slot, and the relay echo amplification — the last
 one a production-service protocol bug no unit test would have seen).
-What remains is the section below, and the R2 service switch onto
-the verified core.
+R2 IS DONE: the service engine runs on the verified core (kv_index
+dropped to a dev-dependency oracle), every service test green
+first-shot, and the end-to-end placement leg on the full sim rig
+matches or beats every reference — cached 0.9433 (old stack 0.9398;
+event-fed ground truth 0.9423), prediction error mean -5.4 / p95 0,
+zero request errors. One more real bug was caught on the way (#10):
+the forest-correct capacity accounting made the old calibrated
+at-capacity bound BIND, racing worker-side eviction the index cannot
+observe (p95 error 0 -> 9216 tokens); capacity is now runaway
+protection at 2x declared, documented, and the attribution leg
+proves the fix exact. What remains is the section below.
 
 ## What a single machine cannot prove (standing honesty)
 

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -84,14 +84,19 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   retrying its address), converged to sibling state by end. 0
   errors. Dynamic membership beyond pre-configured peers remains a
   documented design backlog item.
-- F6 [~] **Relay overflow** — the first 90s run instead EXPOSED A
+- F6 [x] **Relay overflow** — the first 90s run instead EXPOSED A
   REAL PROTOCOL BUG: ~190x apply amplification from symmetric peers
   echoing relayed placements forever (idempotent, so correctness
   held — invisible before the per-replica timeline existed). FIXED:
   the engine reports whether an apply changed state and the relay
   forwards only changing applies, so echoes die in one hop (bounded
-  O(K^2)). True overflow drill (small queue via RADIX_RELAY_QUEUE +
-  90s partition) running on the fixed relay.
+  O(K^2)). Verified on the fixed relay: apply counts dropped ~100x
+  to placement-rate levels, replicas in exact lockstep pre-fault.
+  TRUE OVERFLOW then measured (queue=2000, 90s partition): 39,167
+  relay drops at the ingest replica, ingest never blocked, ZERO
+  request errors, routing held (0.9424 cached), and the partitioned
+  replica's divergence stayed bounded per the TTL+re-placement
+  design. MET.
 - F7 [x] **Flap** — 3 kill/relaunch-with-bootstrap cycles on a live
   replica: 0 errors, routing held (0.939 cached), all flaps recorded
   with recovery.
@@ -117,13 +122,16 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   166.7; flat core 169-171): 6.2x smaller than the incumbent. At
   128M blocks: 53.2 B/block (macOS-compression caveat noted, and
   still under the gate even pessimistically).
-- P4 [~] **Mixed-phase latency + soak** — mixed-phase MET: p50
+- P4 [x] **Mixed-phase latency + soak** — mixed-phase MET: p50
   ~400 ns / p99 ~5 us during live writes (8 us p99 at 128M blocks).
   Soak: the first 30-min run measured +27MB linear drift — which
   reproduced the retire-GC leak fixed an hour earlier (that soak had
   compiled a mid-edit tree); the fixed core's diagnostic soak is
   RSS-flat with every internal structure constant (debug_footprint)
-  across 28M ops. 15-min certifying soak on the pushed code running.
+  across 28M ops. CERTIFIED: 15-minute soak on the pushed code —
+  108M ops + 3.46M queries, RSS drift +2.7MB warm-up then +16KB over
+  the final 14 minutes, every internal structure constant to the
+  unit. MET.
 - P5 [x] **Writes >= 1M blocks/s mixed stream**: flat core 10.58M;
   R3 4.6M (trie-walk + span surgery cost; 4.6x over the gate, ~par
   with the oracle's 5.5M). Evidence: SPEC log + campaign3.
@@ -152,6 +160,19 @@ match latency. Block size is configurable end to end
 (`--kv-indexer-block-size` on the gateway, `--block-size` on the
 bridge, keyspace-keyed on the service) and MUST equal the engine page
 size — this table is why.
+
+## Campaign result
+
+Every locally-provable criterion is MET: 7/7 correctness, 7/7 fault
+tolerance, 6/6 performance — with the ORIGINAL gates, no amendments.
+Nine real bugs were found by the instruments and fixed with
+regression locks along the way (twin-key corruption, destructive
+refused-move, u32 generation wrap, per-holder alias divergence,
+chain double-free, clear-order GC leak, move-order GC leak, cursor
+write-into-freed-slot, and the relay echo amplification — the last
+one a production-service protocol bug no unit test would have seen).
+What remains is the section below, and the R2 service switch onto
+the verified core.
 
 ## What a single machine cannot prove (standing honesty)
 

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -183,6 +183,69 @@ observe (p95 error 0 -> 9216 tokens); capacity is now runaway
 protection at 2x declared, documented, and the attribution leg
 proves the fix exact. What remains is the section below.
 
+## Audit triage (the "too good to be true" pass)
+
+Four skeptical reviewers attacked the harness's validity, production
+scale, operations/trust, and service-layer coverage; their findings
+merged with the author's own pre-registered list. Dispositions:
+
+**Fixed immediately (each with a regression lock):**
+- Move-only relay suppression (replica divergence via the length-
+  delta `changed` heuristic; outcome-based now).
+- Pull bootstrap message sizes (chunked parent-linked snapshots;
+  explicit 64MiB limits everywhere).
+- Unbounded publish ingest (bounded channel restoring HTTP/2
+  backpressure; acks advisory).
+- Subscribe head-of-line deadlock shapes (try_send both sides;
+  query length cap).
+- Poisoned-lock behavior (abort into clean sibling bootstrap instead
+  of serving corrupt state).
+- Admin plane slowloris/accept-spin; silent flag fallbacks; zero
+  sweep interval.
+- HARNESS GAPS the campaign's own claims rested on: queries now
+  enter divergent tails and diverge mid-match; membership decays
+  with depth (prefix-only members, mid-chain forks); within-holder
+  dependency-respecting reordering exercises §7's stronger clause
+  (and sharpened §7's wording — literal arbitrary order changes the
+  accepted multiset and was never the contract); StoreOutcome parity
+  and terminal enumerate/distinct parity in every fuzz seed; the
+  bench no longer swallows store errors and cross-checks its memory
+  denominator against the structure; model-gated sharing widened to
+  the bench's H=64.
+
+**Scheduled (real work, tracked):**
+- Per-keyspace locking (snapshot/sweep currently hold the one engine
+  lock O(everything) — the audit's strongest scale finding).
+- Holder liveness: nothing produces dropped/Added on the wire, so
+  event-fed holders of decommissioned workers persist; plan is
+  bridge heartbeats + an event-holder TTL + fleet integration.
+- Streaming/chat placement publishing (today only non-streaming
+  generate feeds the index; streaming traffic queries but never
+  publishes — the sim's non-streaming legs masked this).
+- Relay/bridge in-flight loss on reconnect (ack-tracked resend;
+  today bounded by placement idempotence and epoch bumps, unbounded
+  for a lost event-feed Removed).
+- Per-outcome/per-keyspace observability; snapshot double-
+  materialization in Pull.
+
+**Deployment requirements, documented not code:**
+- NO AUTH/TLS: all three RPCs are open — a spoofed epoch=MAX Cleared
+  poisons routing fleet-wide and Pull leaks fleet topology. mTLS or
+  a token interceptor plus NetworkPolicy is REQUIRED before any
+  non-lab deployment.
+- Reference manifest needs anti-affinity/PDB and per-ordinal
+  bootstrap sources.
+- Keyspaces are never garbage-collected (any publisher can mint
+  them): bound the accepted keyspace set at the auth layer.
+
+**Accepted with eyes open:**
+- The reference model shares an author with both cores (mitigated by
+  the kv_index oracle, the API suite, and now-stronger observables;
+  an independent reader of SPEC.md reviewing model.rs is the
+  remaining step).
+- Fault-drill evidence lives on the local simrig branch; the drills'
+  harness is committed on the sim PR, results summarized here.
+
 ## What a single machine cannot prove (standing honesty)
 
 Connection fan-in from hundreds of real gateways; real network

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -78,16 +78,23 @@ evidence linked/recorded next to it. Status legend: [ ] open,
 - F4 [x] **Kill + relaunch under load** (rerun) — 0 errors; degraded
   window = the outage (gateways fast-fail to local fallback), then
   recovery via peer bootstrap, matching M2's shape.
-- F5 [~] **Add replica under live load** — deferred-replica drill
-  built (peers pre-configured, replica starts mid-run and bootstraps
-  under load, the k8s StatefulSet shape); run queued (campaign4).
-  Dynamic membership beyond pre-configured peers remains a design
-  backlog item, documented.
-- F6 [~] **Relay overflow** — 90s partition (vs the 45s the queue
-  absorbed) queued (campaign4); expecting relay_dropped > 0 and
-  post-heal divergence bounded by TTL + re-placement.
-- F7 [~] **Flap** — kill/relaunch-with-bootstrap x3 drill built;
-  run queued (campaign4).
+- F5 [x] **Add replica under live load** — deferred replica started
+  mid-run: bootstrapped 1.26M blocks from a sibling under live
+  writes, picked up the live relay immediately (peers had been
+  retrying its address), converged to sibling state by end. 0
+  errors. Dynamic membership beyond pre-configured peers remains a
+  documented design backlog item.
+- F6 [~] **Relay overflow** — the first 90s run instead EXPOSED A
+  REAL PROTOCOL BUG: ~190x apply amplification from symmetric peers
+  echoing relayed placements forever (idempotent, so correctness
+  held — invisible before the per-replica timeline existed). FIXED:
+  the engine reports whether an apply changed state and the relay
+  forwards only changing applies, so echoes die in one hop (bounded
+  O(K^2)). True overflow drill (small queue via RADIX_RELAY_QUEUE +
+  90s partition) running on the fixed relay.
+- F7 [x] **Flap** — 3 kill/relaunch-with-bootstrap cycles on a live
+  replica: 0 errors, routing held (0.939 cached), all flaps recorded
+  with recovery.
 
 ## Pillar 3 — Extreme performance (original gates, no amendment)
 
@@ -110,9 +117,13 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   166.7; flat core 169-171): 6.2x smaller than the incumbent. At
   128M blocks: 53.2 B/block (macOS-compression caveat noted, and
   still under the gate even pessimistically).
-- P4 [~] **Mixed-phase latency + soak** — bench instrumented (probe
-  queries inside the live write phase; RADIX_BENCH_SOAK_SECS churn
-  with RSS-drift-is-a-leak semantics); runs queued (campaign3/4).
+- P4 [~] **Mixed-phase latency + soak** — mixed-phase MET: p50
+  ~400 ns / p99 ~5 us during live writes (8 us p99 at 128M blocks).
+  Soak: the first 30-min run measured +27MB linear drift — which
+  reproduced the retire-GC leak fixed an hour earlier (that soak had
+  compiled a mid-edit tree); the fixed core's diagnostic soak is
+  RSS-flat with every internal structure constant (debug_footprint)
+  across 28M ops. 15-min certifying soak on the pushed code running.
 - P5 [x] **Writes >= 1M blocks/s mixed stream**: flat core 10.58M;
   R3 4.6M (trie-walk + span surgery cost; 4.6x over the gate, ~par
   with the oracle's 5.5M). Evidence: SPEC log + campaign3.

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -20,15 +20,29 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   coincidence, forest fan-out), RadixTree == model on every
   checkpoint of every seed. Target: >= 10,000 seeds, zero
   divergences, plus a standing soak entry point.
-- C2 [ ] **Internal invariant checker**: a debug-audit method proving
+- C2 [x] **Internal invariant checker** — audit() recomputes every
+  counter, forward+reverse containment, bucket order, name/free-list
+  coherence, interner coherence; green after EVERY op across the
+  fuzz. First extended run caught real state corruption (twin-key
+  membership sharing) within minutes.: a debug-audit method proving
   cross-structure consistency (registry <-> entries <-> counters <->
   name maps <-> free list) after every operation in fuzz mode — this
   catches state corruption that answer-comparison alone cannot.
-- C3 [ ] **Out-of-contract determinism**: deliberately violate
+- C3 [x] **Out-of-contract determinism** — the referee model is now
+  TOTAL (per-block literal lineages; every §4 alias rule mirrored,
+  chain bound mirrored), so chaos runs under the same hard gate:
+  subject == model on arbitrary inputs, deterministic replay, no
+  panics, audit green. Two more real bugs fixed on the way: the
+  destructive refused-move, and the twin-key drop semantics now
+  normative in SPEC §4.: deliberately violate
   chain-consistency (duplicate keys across positions, moves, parent
   inversions, post-clear orphans): no panics, invariants hold,
   behavior deterministic under per-holder order.
-- C4 [ ] **Boundary audit**: max_chain_len edges, position u32
+- C4 [x] **Boundary audit** — ChainTooLong atomicity tested;
+  positions capped to the u32 wire range in the walk; generation
+  wrap: u64 now (reviewers wrapped u32 empirically in ~3 min of
+  tight churn; u64 is ~10^19 retires of one slot); slot-space
+  exhaustion guarded loudly.: max_chain_len edges, position u32
   bounds, empty batches, holder-slot reuse at scale, generation
   wraparound analysis (u32 wrap = 4e9 retires of ONE slot —
   quantified, documented).
@@ -36,7 +50,12 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   probability at 1.7e8-block production scale, quantified; upgrade
   path (128-bit) evaluated with measured memory cost if the bound is
   not comfortably negligible.
-- C6 [ ] **Adversarial code review**: independent reviewers attack
+- C6 [x] **Adversarial code review** — four reviewers (accounting /
+  lifecycle / query walk / panics+OOB), 138 tool calls of attack.
+  Verdicts: accounting exact, lifecycle sound, walk sound. Every
+  confirmed finding fixed (destructive refused-move, u32 generation,
+  &mut-self read path, Miss-probe waste, model/spec/subject alias
+  alignment) with regression coverage via the total-model chaos gate.: independent reviewers attack
   lib.rs (counter maintenance, generation logic, merge walk, move
   semantics, panic surfaces); every finding fixed or refuted with a
   test.
@@ -46,16 +65,26 @@ evidence linked/recorded next to it. Status legend: [ ] open,
 
 ## Pillar 2 — Fault tolerance
 
-- F1 [~] **Network partition**: full inter-replica partition
+- F1 [x] **Network partition** — 45s full inter-replica partition
+  under load: 0 errors, routing held (0.9414 follow-up cached),
+  partitioned replica TTL-drained to zero, relay queue absorbed the
+  window (0 drops), heal replayed ~1M blocks in 20s; residual gap ==
+  pre-partition state exactly (the designed TTL+re-placement bound,
+  measured).: full inter-replica partition
   (severable TCP proxies) injected mid-load and healed; per-replica
   metrics timeline shows bounded divergence during and reconvergence
   after; zero request errors.
-- F2 [~] **Wedged replica** (SIGSTOP): TCP up, nothing drains —
+- F2 [x] **Wedged replica** (SIGSTOP 45s) — ingest never blocked,
+  0 errors, and after SIGCONT the replica converged EXACTLY (applies
+  equal to within in-flight).: TCP up, nothing drains —
   relay-drop counters climb, ingest never blocks, resume converges.
-- F3 [~] **Replica count**: 1 / 2 / 4 replicas, routing parity and
+- F3 [x] **Replica count** (smoke) — 1/2/4 replicas: 0 errors at
+  every K; mild accuracy dip at K=4 consistent with shared-box relay
+  CPU, no protocol failure.: 1 / 2 / 4 replicas, routing parity and
   relay cost measured.
-- F4 [ ] **Kill + relaunch under load** (M2 drill rerun on current
-  binaries): zero errors, one-bin recovery via peer bootstrap.
+- F4 [x] **Kill + relaunch under load** (rerun) — 0 errors; degraded
+  window = the outage (gateways fast-fail to local fallback), then
+  recovery via peer bootstrap, matching M2's shape.
 - F5 [ ] **Add replica under live load**: bootstrap-while-writing
   converges to sibling answers.
 - F6 [ ] **Relay overflow**: partition long enough to overflow the
@@ -66,7 +95,13 @@ evidence linked/recorded next to it. Status legend: [ ] open,
 
 ## Pillar 3 — Extreme performance (original gates, no amendment)
 
-- P1 [~] **Solo large-scale**: 128M holder-blocks (~75% of production
+- P1 [x] **Solo large-scale** — 128M holder-blocks (cap chosen for
+  the 48GB box), both sides, solo protocol: R1 degrades ~2x gentler
+  than the oracle (fill 5.63M vs 2.28M bl/s; H=1 p50 1.5 vs 3.9us;
+  miss 250 vs 750ns); oracle keeps only the skip-powered gate cell.
+  CAVEAT: RSS-based memory is INVALID at this footprint on macOS
+  (compressed memory) — bytes/block evidence stays at the 12.8M
+  scale; large-scale memory needs a Linux/staging box.: 128M holder-blocks (~75% of production
   target), both implementations, box otherwise idle — growth
   nonlinearities quantified. (First attempt invalidated: concurrent
   benches contaminated RSS/fill; protocol now enforced.)

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -98,18 +98,24 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   CAVEAT: RSS-based memory is INVALID at this footprint on macOS
   (compressed memory) — bytes/block evidence stays at the 12.8M
   scale; large-scale memory needs a Linux/staging box.
-- P2 [~] **Gate cell p99 <= 10 us EXACT** at the normative scale —
-  the R3 chain-native core is BUILT and referee-equal (contents
-  stored contiguously; one entry probe + linear scan + span reads);
-  gate measurement queued (campaign3).
-- P3 [~] **Memory <= 100 B/holder-block absolute** (and <= oracle on
-  the same bench) — R3 stores chain data once per chain and dropped
-  chain-side keys entirely; gate measurement queued (campaign3).
+- P2 [x] **Gate cell p99 <= 10 us EXACT** — R3 measures p50 2.3 us /
+  p99 7.6 us at the normative scale (medians of 3, solo box) and p99
+  8.0 us at 128M blocks — scale-stable, EXACT matching, nearly tying
+  the oracle's unsound-skip 6.0 us. Every other cell beats the
+  oracle outright (H=1 292 ns vs 917; H=8 500 ns vs 1.5 us; miss
+  under timer resolution). Mixed-phase (queries during live writes):
+  p50 ~400 ns, p99 ~5 us.
+- P3 [x] **Memory <= 100 B/holder-block absolute** — R3 measures
+  26.9 B/holder-block at the normative scale (gate 100; oracle+glue
+  166.7; flat core 169-171): 6.2x smaller than the incumbent. At
+  128M blocks: 53.2 B/block (macOS-compression caveat noted, and
+  still under the gate even pessimistically).
 - P4 [~] **Mixed-phase latency + soak** — bench instrumented (probe
   queries inside the live write phase; RADIX_BENCH_SOAK_SECS churn
   with RSS-drift-is-a-leak semantics); runs queued (campaign3/4).
-- P5 [x] **Writes >= 1M blocks/s mixed stream**: 10.58M measured
-  (1.9x oracle). Evidence: SPEC measurement log.
+- P5 [x] **Writes >= 1M blocks/s mixed stream**: flat core 10.58M;
+  R3 4.6M (trie-walk + span surgery cost; 4.6x over the gate, ~par
+  with the oracle's 5.5M). Evidence: SPEC log + campaign3.
 - P6 [x] **Allocation: amortized zero per single-holder block**:
   0.0002 allocs/block via counting allocator. Evidence: alloc_gate.
 

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -24,28 +24,19 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   counter, forward+reverse containment, bucket order, name/free-list
   coherence, interner coherence; green after EVERY op across the
   fuzz. First extended run caught real state corruption (twin-key
-  membership sharing) within minutes.: a debug-audit method proving
-  cross-structure consistency (registry <-> entries <-> counters <->
-  name maps <-> free list) after every operation in fuzz mode — this
-  catches state corruption that answer-comparison alone cannot.
+  membership sharing) within minutes.
 - C3 [x] **Out-of-contract determinism** — the referee model is now
   TOTAL (per-block literal lineages; every §4 alias rule mirrored,
   chain bound mirrored), so chaos runs under the same hard gate:
   subject == model on arbitrary inputs, deterministic replay, no
   panics, audit green. Two more real bugs fixed on the way: the
   destructive refused-move, and the twin-key drop semantics now
-  normative in SPEC §4.: deliberately violate
-  chain-consistency (duplicate keys across positions, moves, parent
-  inversions, post-clear orphans): no panics, invariants hold,
-  behavior deterministic under per-holder order.
+  normative in SPEC §4.
 - C4 [x] **Boundary audit** — ChainTooLong atomicity tested;
   positions capped to the u32 wire range in the walk; generation
   wrap: u64 now (reviewers wrapped u32 empirically in ~3 min of
   tight churn; u64 is ~10^19 retires of one slot); slot-space
-  exhaustion guarded loudly.: max_chain_len edges, position u32
-  bounds, empty batches, holder-slot reuse at scale, generation
-  wraparound analysis (u32 wrap = 4e9 retires of ONE slot —
-  quantified, documented).
+  exhaustion guarded loudly.
 - C5 [x] **Lineage collision analysis** — quantified, and R3 made
   structurally immune. Flat core: a collision matters only between
   two lineages coexisting in ONE (position, content) bucket;
@@ -64,10 +55,7 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   Verdicts: accounting exact, lifecycle sound, walk sound. Every
   confirmed finding fixed (destructive refused-move, u32 generation,
   &mut-self read path, Miss-probe waste, model/spec/subject alias
-  alignment) with regression coverage via the total-model chaos gate.: independent reviewers attack
-  lib.rs (counter maintenance, generation logic, merge walk, move
-  semantics, panic surfaces); every finding fixed or refuted with a
-  test.
+  alignment) with regression coverage via the total-model chaos gate.
 - C7 [x] **Oracle parity, in-contract**: oracle never under-matches
   the model; every over-match classifies into the three documented
   quirk classes. Evidence: differential runs, census in test output.
@@ -79,28 +67,26 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   partitioned replica TTL-drained to zero, relay queue absorbed the
   window (0 drops), heal replayed ~1M blocks in 20s; residual gap ==
   pre-partition state exactly (the designed TTL+re-placement bound,
-  measured).: full inter-replica partition
-  (severable TCP proxies) injected mid-load and healed; per-replica
-  metrics timeline shows bounded divergence during and reconvergence
-  after; zero request errors.
+  measured).
 - F2 [x] **Wedged replica** (SIGSTOP 45s) — ingest never blocked,
   0 errors, and after SIGCONT the replica converged EXACTLY (applies
-  equal to within in-flight).: TCP up, nothing drains —
-  relay-drop counters climb, ingest never blocks, resume converges.
+  equal to within in-flight).
 - F3 [x] **Replica count** (smoke) — 1/2/4 replicas: 0 errors at
   every K; mild accuracy dip at K=4 consistent with shared-box relay
-  CPU, no protocol failure.: 1 / 2 / 4 replicas, routing parity and
-  relay cost measured.
+  CPU, no protocol failure.
 - F4 [x] **Kill + relaunch under load** (rerun) — 0 errors; degraded
   window = the outage (gateways fast-fail to local fallback), then
   recovery via peer bootstrap, matching M2's shape.
-- F5 [ ] **Add replica under live load**: bootstrap-while-writing
-  converges to sibling answers.
-- F6 [ ] **Relay overflow**: partition long enough to overflow the
-  bounded relay queue; divergence bounded by TTL + re-placement as
-  designed, measured.
-- F7 [ ] **Client under flap**: gateway fast-fail/fallback correct
-  across repeated index restarts (extends M2's single-kill evidence).
+- F5 [~] **Add replica under live load** — deferred-replica drill
+  built (peers pre-configured, replica starts mid-run and bootstraps
+  under load, the k8s StatefulSet shape); run queued (campaign4).
+  Dynamic membership beyond pre-configured peers remains a design
+  backlog item, documented.
+- F6 [~] **Relay overflow** — 90s partition (vs the 45s the queue
+  absorbed) queued (campaign4); expecting relay_dropped > 0 and
+  post-heal divergence bounded by TTL + re-placement.
+- F7 [~] **Flap** — kill/relaunch-with-bootstrap x3 drill built;
+  run queued (campaign4).
 
 ## Pillar 3 — Extreme performance (original gates, no amendment)
 
@@ -110,20 +96,17 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   miss 250 vs 750ns); oracle keeps only the skip-powered gate cell.
   CAVEAT: RSS-based memory is INVALID at this footprint on macOS
   (compressed memory) — bytes/block evidence stays at the 12.8M
-  scale; large-scale memory needs a Linux/staging box.: 128M holder-blocks (~75% of production
-  target), both implementations, box otherwise idle — growth
-  nonlinearities quantified. (First attempt invalidated: concurrent
-  benches contaminated RSS/fill; protocol now enforced.)
-- P2 [ ] **Gate cell p99 <= 10 us EXACT** at the normative scale:
-  requires sound write-time run metadata (the R3 skip mechanism,
-  pulled forward — verification of a shared span in O(1) per run
-  WITHOUT the oracle's unsound count-equality acceptance).
-- P3 [ ] **Memory <= 100 B/holder-block absolute** (and <= oracle on
-  the same bench): requires the registry redesign (dense per-chain
-  storage) — pulled forward from R3.
-- P4 [ ] **Mixed-phase latency**: query percentiles measured WHILE
-  the write stream runs (today's cells are quiesced), plus soak-hours
-  throughput stability and RSS flatness (leak detection).
+  scale; large-scale memory needs a Linux/staging box.
+- P2 [~] **Gate cell p99 <= 10 us EXACT** at the normative scale —
+  the R3 chain-native core is BUILT and referee-equal (contents
+  stored contiguously; one entry probe + linear scan + span reads);
+  gate measurement queued (campaign3).
+- P3 [~] **Memory <= 100 B/holder-block absolute** (and <= oracle on
+  the same bench) — R3 stores chain data once per chain and dropped
+  chain-side keys entirely; gate measurement queued (campaign3).
+- P4 [~] **Mixed-phase latency + soak** — bench instrumented (probe
+  queries inside the live write phase; RADIX_BENCH_SOAK_SECS churn
+  with RSS-drift-is-a-leak semantics); runs queued (campaign3/4).
 - P5 [x] **Writes >= 1M blocks/s mixed stream**: 10.58M measured
   (1.9x oracle). Evidence: SPEC measurement log.
 - P6 [x] **Allocation: amortized zero per single-holder block**:

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -46,10 +46,19 @@ evidence linked/recorded next to it. Status legend: [ ] open,
   bounds, empty batches, holder-slot reuse at scale, generation
   wraparound analysis (u32 wrap = 4e9 retires of ONE slot —
   quantified, documented).
-- C5 [ ] **Lineage collision analysis**: 64-bit fingerprint collision
-  probability at 1.7e8-block production scale, quantified; upgrade
-  path (128-bit) evaluated with measured memory cost if the bound is
-  not comfortably negligible.
+- C5 [x] **Lineage collision analysis** — quantified, and R3 made
+  structurally immune. Flat core: a collision matters only between
+  two lineages coexisting in ONE (position, content) bucket;
+  multi-lineage buckets require content coincidence (rare) and the
+  joint probability is bounded by sum(n_bucket^2)/2^65 — < 1e-12 at
+  the 1.7e8-block production scale. Documented residual for R1 only.
+  R3: every lineage-keyed resolution is CONTENT-VERIFIED (roots carry
+  collision lists checked against literal first contents; forks are
+  content-keyed; walks compare stored contents directly), so a
+  collision can never cross-credit or merge chains — the analysis
+  turned up a latent unverified root resolution in the initial R3
+  and it is fixed with an audit rule. This immunity is an R3-only
+  property: the flat core stores no contents to verify against.
 - C6 [x] **Adversarial code review** — four reviewers (accounting /
   lifecycle / query walk / panics+OOB), 138 tool calls of attack.
   Verdicts: accounting exact, lifecycle sound, walk sound. Every

--- a/crates/radix_tree/VERIFICATION.md
+++ b/crates/radix_tree/VERIFICATION.md
@@ -1,0 +1,117 @@
+# Verification campaign — the home run
+
+Mandate (2026-09-01, maintainer): 100% correctness against the old
+implementation, fault tolerance under every injectable failure,
+extreme performance — no shortcuts, no compromises, nothing deferred.
+The ORIGINAL §11 gates stand (no measured-basis amendment): that
+means the run-skip acceleration and the memory reduction get built,
+not argued around.
+
+Every criterion below is falsifiable and CHECKED-OFF only with the
+evidence linked/recorded next to it. Status legend: [ ] open,
+[~] running, [x] met with evidence.
+
+## Pillar 1 — Correctness
+
+- C1 [~] **Continuous differential fuzz**: the model-referee harness
+  scaled from 16 seeds to a sustained campaign — hours of randomized
+  workloads over a WIDE config space (holders 2..512, chains to
+  max_chain_len edges, gap/dup/clear rates to extremes, content
+  coincidence, forest fan-out), RadixTree == model on every
+  checkpoint of every seed. Target: >= 10,000 seeds, zero
+  divergences, plus a standing soak entry point.
+- C2 [ ] **Internal invariant checker**: a debug-audit method proving
+  cross-structure consistency (registry <-> entries <-> counters <->
+  name maps <-> free list) after every operation in fuzz mode — this
+  catches state corruption that answer-comparison alone cannot.
+- C3 [ ] **Out-of-contract determinism**: deliberately violate
+  chain-consistency (duplicate keys across positions, moves, parent
+  inversions, post-clear orphans): no panics, invariants hold,
+  behavior deterministic under per-holder order.
+- C4 [ ] **Boundary audit**: max_chain_len edges, position u32
+  bounds, empty batches, holder-slot reuse at scale, generation
+  wraparound analysis (u32 wrap = 4e9 retires of ONE slot —
+  quantified, documented).
+- C5 [ ] **Lineage collision analysis**: 64-bit fingerprint collision
+  probability at 1.7e8-block production scale, quantified; upgrade
+  path (128-bit) evaluated with measured memory cost if the bound is
+  not comfortably negligible.
+- C6 [ ] **Adversarial code review**: independent reviewers attack
+  lib.rs (counter maintenance, generation logic, merge walk, move
+  semantics, panic surfaces); every finding fixed or refuted with a
+  test.
+- C7 [x] **Oracle parity, in-contract**: oracle never under-matches
+  the model; every over-match classifies into the three documented
+  quirk classes. Evidence: differential runs, census in test output.
+
+## Pillar 2 — Fault tolerance
+
+- F1 [~] **Network partition**: full inter-replica partition
+  (severable TCP proxies) injected mid-load and healed; per-replica
+  metrics timeline shows bounded divergence during and reconvergence
+  after; zero request errors.
+- F2 [~] **Wedged replica** (SIGSTOP): TCP up, nothing drains —
+  relay-drop counters climb, ingest never blocks, resume converges.
+- F3 [~] **Replica count**: 1 / 2 / 4 replicas, routing parity and
+  relay cost measured.
+- F4 [ ] **Kill + relaunch under load** (M2 drill rerun on current
+  binaries): zero errors, one-bin recovery via peer bootstrap.
+- F5 [ ] **Add replica under live load**: bootstrap-while-writing
+  converges to sibling answers.
+- F6 [ ] **Relay overflow**: partition long enough to overflow the
+  bounded relay queue; divergence bounded by TTL + re-placement as
+  designed, measured.
+- F7 [ ] **Client under flap**: gateway fast-fail/fallback correct
+  across repeated index restarts (extends M2's single-kill evidence).
+
+## Pillar 3 — Extreme performance (original gates, no amendment)
+
+- P1 [~] **Solo large-scale**: 128M holder-blocks (~75% of production
+  target), both implementations, box otherwise idle — growth
+  nonlinearities quantified. (First attempt invalidated: concurrent
+  benches contaminated RSS/fill; protocol now enforced.)
+- P2 [ ] **Gate cell p99 <= 10 us EXACT** at the normative scale:
+  requires sound write-time run metadata (the R3 skip mechanism,
+  pulled forward — verification of a shared span in O(1) per run
+  WITHOUT the oracle's unsound count-equality acceptance).
+- P3 [ ] **Memory <= 100 B/holder-block absolute** (and <= oracle on
+  the same bench): requires the registry redesign (dense per-chain
+  storage) — pulled forward from R3.
+- P4 [ ] **Mixed-phase latency**: query percentiles measured WHILE
+  the write stream runs (today's cells are quiesced), plus soak-hours
+  throughput stability and RSS flatness (leak detection).
+- P5 [x] **Writes >= 1M blocks/s mixed stream**: 10.58M measured
+  (1.9x oracle). Evidence: SPEC measurement log.
+- P6 [x] **Allocation: amortized zero per single-holder block**:
+  0.0002 allocs/block via counting allocator. Evidence: alloc_gate.
+
+## Cross-structure evidence (recorded)
+
+TokenTree / StringTree / RadixTree on one 5M-token corpus (64
+tenants, 400 shared-prefix families), one process per structure:
+
+| structure | B/token | match p50/p99 | promised-vs-physical (page 256) |
+|---|---|---|---|
+| TokenTree (per-token) | 6.92 | 666 ns / 5.4 µs | +116 tokens over-promise |
+| StringTree (per-char) | 7.47 | 1.8 µs / 10.9 µs | +124 tokens over-promise |
+| RadixTree block 64 | 2.71 | 250 ns | +93 |
+| RadixTree block 128 | 1.61 | 166 ns | +61 |
+| RadixTree block 256 (= engine page) | **0.87** | **84 ns** | **exactly 0** |
+| RadixTree block 512 | 0.43 | 83 ns | −117 under-promise |
+
+Reading: at block == engine page, the index promises exactly what the
+engine can physically reuse; the per-token/char trees promise ~120
+tokens MORE than a page-granular engine can honor (accuracy that
+looks better and routes no better), at ~8x the memory and ~8-20x the
+match latency. Block size is configurable end to end
+(`--kv-indexer-block-size` on the gateway, `--block-size` on the
+bridge, keyspace-keyed on the service) and MUST equal the engine page
+size — this table is why.
+
+## What a single machine cannot prove (standing honesty)
+
+Connection fan-in from hundreds of real gateways; real network
+fabrics (loss, reordering, asymmetric partitions between DCs); days-
+scale memory fragmentation and holder churn; kernel/socket limits
+under production concurrency. These need a staging soak — tracked as
+the campaign's exit criterion into real-cluster validation.

--- a/crates/radix_tree/src/chain.rs
+++ b/crates/radix_tree/src/chain.rs
@@ -1,4 +1,4 @@
-//! The R3 chain-native core (R3-DESIGN.md): chains as contiguous
+//! The chain-native core (R3-DESIGN.md): chains as contiguous
 //! data, canonical maximal-run membership spans, one entry probe per
 //! query. Same §4 API and §6/§7 contract as the flat core; the
 //! differential referee proves equality.
@@ -80,7 +80,7 @@ struct Slot3 {
     state: Option<HolderState3>,
 }
 
-pub struct RadixTree3 {
+pub struct RadixTree {
     cfg: Config,
     chains: Vec<ChainData>,
     free_chains: Vec<u32>,
@@ -100,7 +100,7 @@ pub struct RadixTree3 {
     distinct_entries: u64,
 }
 
-impl RadixTree3 {
+impl RadixTree {
     pub fn new(cfg: Config) -> Self {
         Self {
             cfg,
@@ -342,7 +342,8 @@ impl RadixTree3 {
         // The CURSOR chain is pinned against GC for the gap between
         // this removal and the add just below: an in-batch move can
         // otherwise free the chain the batch is standing on, and the
-        // next block would write into a freed slot (chaos seed 2).
+        // next block would write into a freed slot (found by the
+        // chaos fuzz).
         if let Some(old) = self.state_of(holder).keys.get(&key).copied() {
             self.state_of_mut(holder).keys.remove(&key);
             self.remove_membership_pinned(holder, old, Some(chain));

--- a/crates/radix_tree/src/core3.rs
+++ b/crates/radix_tree/src/core3.rs
@@ -1,0 +1,1035 @@
+//! The R3 chain-native core (R3-DESIGN.md): chains as contiguous
+//! data, canonical maximal-run membership spans, one entry probe per
+//! query. Same §4 API and §6/§7 contract as the flat core; the
+//! differential referee proves equality.
+
+use rustc_hash::FxHashMap;
+
+use crate::{
+    lineage_root, lineage_step, BlockKey, Config, ContentHash, HolderId, Overlap, OverlapScratch,
+    SetInterner, SetRef, Stats, StoreError, StoreOutcome,
+};
+
+/// One trie chain: contiguous contents/keys stored ONCE, shared by
+/// every holder covering any span of it.
+#[derive(Debug, Default)]
+struct ChainData {
+    /// Trie edge: (parent chain, absolute position of the parent
+    /// block). `None` = a root chain (base_pos == 0).
+    parent: Option<(u32, u32)>,
+    /// Absolute position of contents[0].
+    base_pos: u32,
+    contents: Vec<ContentHash>,
+    /// Lineage fingerprint at contents[0] (audit + canonical iden).
+    start_lineage: u64,
+    /// Lineage at the last position (extension cache).
+    end_lineage: u64,
+    /// Canonical maximal-run membership: sorted, non-overlapping,
+    /// non-adjacent-equal, non-empty sets, within [base_pos,
+    /// base_pos + len).
+    spans: Vec<Span>,
+    /// Child forks: (fork position ON THIS CHAIN, first child
+    /// content, child chain), sorted.
+    children: Vec<(u32, ContentHash, u32)>,
+}
+
+#[derive(Debug, Clone)]
+struct Span {
+    start: u32,
+    len: u32,
+    holders: SetRef,
+}
+
+impl ChainData {
+    fn end_pos(&self) -> u32 {
+        self.base_pos + self.contents.len() as u32
+    }
+    fn content_at(&self, pos: u32) -> ContentHash {
+        self.contents[(pos - self.base_pos) as usize]
+    }
+    fn child_at(&self, fork_pos: u32, content: ContentHash) -> Option<u32> {
+        self.children
+            .binary_search_by_key(&(fork_pos, content), |&(p, c, _)| (p, c))
+            .ok()
+            .map(|i| self.children[i].2)
+    }
+    /// Is `holder` in the span covering `pos` (if any)?
+    fn covered(&self, pos: u32, holder: u32) -> bool {
+        self.span_index(pos)
+            .is_some_and(|i| self.spans[i].holders.binary_search(&holder).is_ok())
+    }
+    fn span_index(&self, pos: u32) -> Option<usize> {
+        let i = self.spans.partition_point(|s| s.start + s.len <= pos);
+        (i < self.spans.len() && self.spans[i].start <= pos).then_some(i)
+    }
+}
+
+#[derive(Debug, Default)]
+struct HolderState3 {
+    name: String,
+    /// key -> (chain, absolute pos). Per-holder (out-of-contract
+    /// inputs can register one key differently across holders).
+    keys: FxHashMap<BlockKey, (u32, u32)>,
+    /// Chains this holder covers (maintenance index).
+    chains: rustc_hash::FxHashSet<u32>,
+}
+
+#[derive(Debug)]
+struct Slot3 {
+    generation: u64,
+    state: Option<HolderState3>,
+}
+
+pub struct RadixTree3 {
+    cfg: Config,
+    chains: Vec<ChainData>,
+    free_chains: Vec<u32>,
+    /// Root chains by their start lineage (single query entry probe).
+    roots: FxHashMap<u64, u32>,
+    slots: Vec<Slot3>,
+    by_name: FxHashMap<String, u32>,
+    free: Vec<u32>,
+    interner: SetInterner,
+    holder_blocks_total: u64,
+    /// Distinct covered (position, content, lineage) = chain
+    /// positions with a non-empty holder set.
+    distinct_entries: u64,
+}
+
+impl RadixTree3 {
+    pub fn new(cfg: Config) -> Self {
+        Self {
+            cfg,
+            chains: Vec::new(),
+            free_chains: Vec::new(),
+            roots: FxHashMap::default(),
+            slots: Vec::new(),
+            by_name: FxHashMap::default(),
+            free: Vec::new(),
+            interner: SetInterner::default(),
+            holder_blocks_total: 0,
+            distinct_entries: 0,
+        }
+    }
+
+    // ---- holder lifecycle (mirrors the flat core exactly) ----
+
+    pub fn create_holder(&mut self, name: &str) -> HolderId {
+        if let Some(&index) = self.by_name.get(name) {
+            return HolderId::assemble(index, self.slots[index as usize].generation);
+        }
+        let state = HolderState3 {
+            name: name.to_string(),
+            ..HolderState3::default()
+        };
+        let index = if let Some(index) = self.free.pop() {
+            self.slots[index as usize].state = Some(state);
+            index
+        } else {
+            assert!(
+                self.slots.len() < u32::MAX as usize,
+                "holder slot space exhausted (u32 indices)"
+            );
+            self.slots.push(Slot3 {
+                generation: 0,
+                state: Some(state),
+            });
+            (self.slots.len() - 1) as u32
+        };
+        self.by_name.insert(name.to_string(), index);
+        HolderId::assemble(index, self.slots[index as usize].generation)
+    }
+
+    pub fn holder_name(&self, id: HolderId) -> Option<&str> {
+        self.live(id).map(|s| s.name.as_str())
+    }
+
+    pub fn retire_holder(&mut self, id: HolderId) {
+        if self.live(id).is_none() {
+            return;
+        }
+        self.clear(id);
+        let slot = &mut self.slots[id.parts().0 as usize];
+        let state = slot.state.take().expect("checked live");
+        self.by_name.remove(&state.name);
+        slot.generation = slot.generation.wrapping_add(1);
+        self.free.push(id.parts().0);
+    }
+
+    pub fn holder_blocks(&self, id: HolderId) -> u64 {
+        self.live(id).map_or(0, |s| s.keys.len() as u64)
+    }
+
+    fn live(&self, id: HolderId) -> Option<&HolderState3> {
+        let (index, generation) = id.parts();
+        let slot = self.slots.get(index as usize)?;
+        if slot.generation != generation {
+            return None;
+        }
+        slot.state.as_ref()
+    }
+
+    // ---- writes ----
+
+    pub fn store(
+        &mut self,
+        id: HolderId,
+        parent: Option<BlockKey>,
+        blocks: &[(BlockKey, ContentHash)],
+    ) -> Result<StoreOutcome, StoreError> {
+        if self.live(id).is_none() {
+            return Err(StoreError::UnknownHolder);
+        }
+        let holder = id.parts().0;
+        if blocks.is_empty() {
+            return Ok(StoreOutcome {
+                applied: 0,
+                duplicates: 0,
+            });
+        }
+        // Resolve the anchor BEFORE any mutation.
+        let anchor: Option<(u32, u32)> = match parent {
+            Some(parent_key) => {
+                let state = self.state_of(holder);
+                match state.keys.get(&parent_key) {
+                    None => return Err(StoreError::ParentNotFound),
+                    Some(&at) => Some(at),
+                }
+            }
+            None => None,
+        };
+        let start_pos = anchor.map_or(0, |(_, p)| p + 1);
+        if start_pos as u64 + blocks.len() as u64 > self.cfg.max_chain_len as u64 {
+            return Err(StoreError::ChainTooLong);
+        }
+
+        // Walk-insert: follow the trie from the anchor, consuming
+        // blocks; matching content = membership add (or §4 alias
+        // duplicate), mismatch or chain end = fork/extend.
+        let mut applied = 0u32;
+        let mut duplicates = 0u32;
+        // Current walk point: chain + next absolute position to fill,
+        // or None before the first block when anchoring a root.
+        let mut cursor: Option<(u32, u32)> = anchor.map(|(c, p)| (c, p + 1));
+        let mut lineage = anchor.map(|(c, p)| self.lineage_at(c, p));
+        for &(key, content) in blocks {
+            let next_lineage = match lineage {
+                None => lineage_root(content),
+                Some(prev) => lineage_step(prev, content),
+            };
+            let landed = self.place_block(holder, id, key, content, next_lineage, &mut cursor)?;
+            match landed {
+                Placed::Applied => applied += 1,
+                Placed::Duplicate => duplicates += 1,
+            }
+            lineage = Some(next_lineage);
+        }
+        Ok(StoreOutcome {
+            applied,
+            duplicates,
+        })
+    }
+
+    /// Place one block at the cursor. Advances the cursor to the
+    /// placed position.
+    fn place_block(
+        &mut self,
+        holder: u32,
+        id: HolderId,
+        key: BlockKey,
+        content: ContentHash,
+        lineage: u64,
+        cursor: &mut Option<(u32, u32)>,
+    ) -> Result<Placed, StoreError> {
+        // Resolve the target (chain, pos) for this block canonically.
+        let target: (u32, u32) = match *cursor {
+            None => {
+                // Root anchor: canonical root chain by root lineage.
+                match self.roots.get(&lineage) {
+                    Some(&c) => (c, 0),
+                    None => {
+                        let c = self.alloc_chain(ChainData {
+                            parent: None,
+                            base_pos: 0,
+                            contents: vec![content],
+                            start_lineage: lineage,
+                            end_lineage: lineage,
+                            spans: Vec::new(),
+                            children: Vec::new(),
+                        });
+                        self.roots.insert(lineage, c);
+                        (c, 0)
+                    }
+                }
+            }
+            Some((chain, pos)) => {
+                let cd = &self.chains[chain as usize];
+                if pos < cd.end_pos() {
+                    if cd.content_at(pos) == content {
+                        (chain, pos)
+                    } else {
+                        // Fork at pos-1 (or a new root when pos==0 is
+                        // impossible here: cursor mid-chain implies
+                        // pos > base 0 path came through parent).
+                        match cd.child_at(pos - 1, content) {
+                            Some(child) => {
+                                let base = self.chains[child as usize].base_pos;
+                                (child, base)
+                            }
+                            None => {
+                                let c = self.new_child(chain, pos - 1, content, lineage);
+                                (c, pos)
+                            }
+                        }
+                    }
+                } else {
+                    // Past the tip: extend in place, or descend into
+                    // an existing child continuation.
+                    match cd.child_at(pos - 1, content) {
+                        Some(child) => {
+                            let base = self.chains[child as usize].base_pos;
+                            (child, base)
+                        }
+                        None => {
+                            let has_children_at_tip =
+                                cd.children.iter().any(|&(p, _, _)| p + 1 == pos);
+                            if has_children_at_tip {
+                                // The tip already forks; a new
+                                // continuation is another child (in-
+                                // place extension would change the
+                                // fork point's shape non-canonically).
+                                let c = self.new_child(chain, pos - 1, content, lineage);
+                                (c, pos)
+                            } else {
+                                let cd = &mut self.chains[chain as usize];
+                                cd.contents.push(content);
+                                cd.end_lineage = lineage;
+                                (chain, pos)
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        let (chain, pos) = target;
+        *cursor = Some((chain, pos + 1));
+
+        // §4 semantics at the resolved position, PER HOLDER (chaos
+        // finding: chain-global key canonicity diverged from the
+        // model — aliasing is a per-holder concept, so the chain
+        // stores no keys at all; per-holder key maps carry them).
+        // Covered ⇒ this holder already holds the exact triple: a
+        // plain duplicate, an alias (their other key), or a refused
+        // move — all observably identical, all non-destructive.
+        if self.chains[chain as usize].covered(pos, holder) {
+            return Ok(Placed::Duplicate);
+        }
+        // Not covered: a move relocates the key first, then join.
+        if let Some(old) = self.state_of(holder).keys.get(&key).copied() {
+            self.remove_membership(holder, old);
+            self.state_of_mut(holder).keys.remove(&key);
+        }
+        self.add_membership(holder, chain, pos);
+        self.state_of_mut(holder).keys.insert(key, (chain, pos));
+        let _ = id;
+        Ok(Placed::Applied)
+    }
+
+    pub fn remove(&mut self, id: HolderId, keys: &[BlockKey]) -> u32 {
+        if self.live(id).is_none() {
+            return 0;
+        }
+        let holder = id.parts().0;
+        let mut removed = 0u32;
+        for &key in keys {
+            let Some(&(chain, pos)) = self.state_of(holder).keys.get(&key) else {
+                continue;
+            };
+            self.state_of_mut(holder).keys.remove(&key);
+            self.remove_membership(holder, (chain, pos));
+            removed += 1;
+        }
+        removed
+    }
+
+    pub fn truncate_tail(&mut self, id: HolderId, keep: u64) -> u64 {
+        if self.live(id).is_none() {
+            return 0;
+        }
+        let holder = id.parts().0;
+        let state = self.state_of(holder);
+        if state.keys.len() as u64 <= keep {
+            return 0;
+        }
+        let mut ordered: Vec<(u32, BlockKey)> =
+            state.keys.iter().map(|(&k, &(_, p))| (p, k)).collect();
+        ordered.sort_unstable();
+        let mut dropped = 0u64;
+        while self.state_of(holder).keys.len() as u64 > keep {
+            let (_, key) = ordered.pop().expect("non-empty");
+            let (chain, pos) = self.state_of(holder).keys[&key];
+            self.state_of_mut(holder).keys.remove(&key);
+            self.remove_membership(holder, (chain, pos));
+            dropped += 1;
+        }
+        dropped
+    }
+
+    pub fn clear(&mut self, id: HolderId) {
+        if self.live(id).is_none() {
+            return;
+        }
+        let holder = id.parts().0;
+        let chains: Vec<u32> = self.state_of(holder).chains.iter().copied().collect();
+        for chain in chains {
+            self.drop_holder_from_chain(holder, chain);
+        }
+        let key_count = self.state_of(holder).keys.len() as u64;
+        self.holder_blocks_total -= key_count;
+        let state = self.state_of_mut(holder);
+        state.keys = FxHashMap::default();
+        state.chains = rustc_hash::FxHashSet::default();
+    }
+
+    // ---- reads ----
+
+    pub fn overlap(
+        &self,
+        chain_query: &[ContentHash],
+        scratch: &mut OverlapScratch,
+        out: &mut Vec<Overlap>,
+    ) {
+        out.clear();
+        if chain_query.is_empty() {
+            return;
+        }
+        let root_lineage = lineage_root(chain_query[0]);
+        let Some(&root) = self.roots.get(&root_lineage) else {
+            return;
+        };
+        // Walk the trie along the query, collecting the matched path
+        // as (chain, from, to) segments.
+        let mut segments: Vec<(u32, u32, u32)> = Vec::new();
+        let mut chain = root;
+        let mut pos = 0u32;
+        let limit = chain_query.len().min(u32::MAX as usize) as u32;
+        'walk: while pos < limit {
+            let cd = &self.chains[chain as usize];
+            let seg_from = pos;
+            while pos < limit && pos < cd.end_pos() {
+                if cd.content_at(pos) != chain_query[pos as usize] {
+                    if pos > seg_from {
+                        segments.push((chain, seg_from, pos));
+                    }
+                    // Divergence: a sibling fork may continue.
+                    if pos == seg_from {
+                        // Diverged immediately at segment start:
+                        // fork search happens at pos-1 on the SAME
+                        // parent chain — handled below via child_at
+                        // when entering; nothing matched here.
+                    }
+                    match (pos > 0)
+                        .then(|| self.fork_of(chain, pos - 1, chain_query[pos as usize]))
+                        .flatten()
+                    {
+                        Some(child) => {
+                            chain = child;
+                            continue 'walk;
+                        }
+                        None => break 'walk,
+                    }
+                }
+                pos += 1;
+            }
+            if pos > seg_from {
+                segments.push((chain, seg_from, pos));
+            }
+            if pos >= limit {
+                break;
+            }
+            // Chain exhausted: follow the child fork at the tip.
+            match self.fork_of(chain, pos - 1, chain_query[pos as usize]) {
+                Some(child) => chain = child,
+                None => break,
+            }
+        }
+        if segments.is_empty() {
+            return;
+        }
+        // Merge holder runs along the matched path (same active-set
+        // logic as the flat walk, but over spans — few per segment).
+        let active = &mut scratch.active;
+        let next = &mut scratch.next;
+        active.clear();
+        next.clear();
+        let mut depth = 0u32;
+        let mut first = true;
+        'runs: for &(c, from, to) in &segments {
+            let cd = &self.chains[c as usize];
+            let mut p = from;
+            while p < to {
+                let (run_holders, run_end) = match cd.span_index(p) {
+                    Some(i) if cd.spans[i].start <= p => {
+                        let s = &cd.spans[i];
+                        (Some(&s.holders), (s.start + s.len).min(to))
+                    }
+                    Some(i) => (None, cd.spans[i].start.min(to)),
+                    None => (None, to),
+                };
+                match run_holders {
+                    None => {
+                        // Uncovered positions: everyone drops here.
+                        for &h in active.iter() {
+                            push_answer3(&self.slots, h, depth, out);
+                        }
+                        active.clear();
+                        break 'runs;
+                    }
+                    Some(set) => {
+                        if first {
+                            active.extend_from_slice(set);
+                            first = false;
+                        } else if !std::ptr::eq(set.as_ptr(), active.as_ptr())
+                            && set.as_ref() != active.as_slice()
+                        {
+                            next.clear();
+                            let mut ai = 0usize;
+                            for &h in set.iter() {
+                                while ai < active.len() && active[ai] < h {
+                                    push_answer3(&self.slots, active[ai], depth, out);
+                                    ai += 1;
+                                }
+                                if ai < active.len() && active[ai] == h {
+                                    next.push(h);
+                                    ai += 1;
+                                }
+                            }
+                            while ai < active.len() {
+                                push_answer3(&self.slots, active[ai], depth, out);
+                                ai += 1;
+                            }
+                            std::mem::swap(active, next);
+                        }
+                        if active.is_empty() {
+                            break 'runs;
+                        }
+                        depth = run_end;
+                    }
+                }
+                p = run_end;
+            }
+        }
+        for &h in active.iter() {
+            push_answer3(&self.slots, h, depth, out);
+        }
+    }
+
+    pub fn enumerate(
+        &self,
+        id: HolderId,
+    ) -> impl Iterator<Item = (u32, BlockKey, ContentHash)> + '_ {
+        let rows = self.live(id).map(|state| {
+            let mut v: Vec<(u32, BlockKey, ContentHash)> = state
+                .keys
+                .iter()
+                .map(|(&k, &(c, p))| (p, k, self.chains[c as usize].content_at(p)))
+                .collect();
+            v.sort_unstable();
+            v
+        });
+        rows.unwrap_or_default().into_iter()
+    }
+
+    pub fn stats(&self) -> Stats {
+        let holders = self.slots.iter().filter(|s| s.state.is_some()).count() as u64;
+        let chain_bytes: u64 = self
+            .chains
+            .iter()
+            .map(|c| {
+                16 * c.contents.len() as u64
+                    + 24 * c.spans.len() as u64
+                    + 16 * c.children.len() as u64
+            })
+            .sum();
+        Stats {
+            holders,
+            holder_blocks: self.holder_blocks_total,
+            distinct_entries: self.distinct_entries,
+            bytes_estimate: chain_bytes + self.holder_blocks_total * 24 + holders * 128,
+        }
+    }
+
+    // ---- internals ----
+
+    fn state_of(&self, holder: u32) -> &HolderState3 {
+        self.slots[holder as usize].state.as_ref().expect("live")
+    }
+    fn state_of_mut(&mut self, holder: u32) -> &mut HolderState3 {
+        self.slots[holder as usize].state.as_mut().expect("live")
+    }
+
+    fn lineage_at(&self, chain: u32, pos: u32) -> u64 {
+        // Roll from the chain's start (parents cached via
+        // start_lineage; positions within a chain need a walk —
+        // used on the STORE path only for the anchor, so bounded by
+        // one chain's length).
+        let cd = &self.chains[chain as usize];
+        let mut l = cd.start_lineage;
+        for p in (cd.base_pos + 1)..=pos {
+            l = lineage_step(l, cd.content_at(p));
+        }
+        l
+    }
+
+    fn fork_of(&self, chain: u32, fork_pos: u32, content: ContentHash) -> Option<u32> {
+        self.chains[chain as usize].child_at(fork_pos, content)
+    }
+
+    fn alloc_chain(&mut self, data: ChainData) -> u32 {
+        if let Some(c) = self.free_chains.pop() {
+            self.chains[c as usize] = data;
+            c
+        } else {
+            self.chains.push(data);
+            (self.chains.len() - 1) as u32
+        }
+    }
+
+    fn new_child(&mut self, parent: u32, fork_pos: u32, content: ContentHash, lineage: u64) -> u32 {
+        let c = self.alloc_chain(ChainData {
+            parent: Some((parent, fork_pos)),
+            base_pos: fork_pos + 1,
+            contents: vec![content],
+            start_lineage: lineage,
+            end_lineage: lineage,
+            spans: Vec::new(),
+            children: Vec::new(),
+        });
+        let pd = &mut self.chains[parent as usize];
+        let at = pd
+            .children
+            .binary_search_by_key(&(fork_pos, content), |&(p, cc, _)| (p, cc))
+            .unwrap_err();
+        pd.children.insert(at, (fork_pos, content, c));
+        c
+    }
+
+    /// Add `holder` to the membership at (chain, pos), renormalizing
+    /// runs canonically.
+    fn add_membership(&mut self, holder: u32, chain: u32, pos: u32) {
+        let mut m = self.take_position_membership(chain, pos);
+        let was_empty = matches!(m, PosSet::Empty);
+        match &mut m {
+            PosSet::Empty => m = PosSet::Set(self.interner.intern(&[holder])),
+            PosSet::Set(set) => {
+                if let Err(at) = set.binary_search(&holder) {
+                    let mut grown = Vec::with_capacity(set.len() + 1);
+                    grown.extend_from_slice(&set[..at]);
+                    grown.push(holder);
+                    grown.extend_from_slice(&set[at..]);
+                    let new = self.interner.intern(&grown);
+                    let old = std::mem::replace(set, new);
+                    self.interner.release(old);
+                }
+            }
+        }
+        self.put_position_membership(chain, pos, m);
+        if was_empty {
+            self.distinct_entries += 1;
+        }
+        self.holder_blocks_total += 1;
+        self.state_of_mut(holder).chains.insert(chain);
+    }
+
+    fn remove_membership(&mut self, holder: u32, at: (u32, u32)) {
+        let (chain, pos) = at;
+        let mut m = self.take_position_membership(chain, pos);
+        let mut now_empty = false;
+        match &mut m {
+            PosSet::Empty => {}
+            PosSet::Set(set) => {
+                if let Ok(idx) = set.binary_search(&holder) {
+                    if set.len() == 1 {
+                        let old = std::mem::replace(set, self.interner.intern(&[]));
+                        self.interner.release(old);
+                        now_empty = true;
+                        m = PosSet::Empty;
+                    } else {
+                        let mut shrunk = Vec::with_capacity(set.len() - 1);
+                        shrunk.extend_from_slice(&set[..idx]);
+                        shrunk.extend_from_slice(&set[idx + 1..]);
+                        let new = self.interner.intern(&shrunk);
+                        let old = std::mem::replace(set, new);
+                        self.interner.release(old);
+                    }
+                }
+            }
+        }
+        self.put_position_membership(chain, pos, m);
+        if now_empty {
+            self.distinct_entries -= 1;
+            self.maybe_gc_chain(chain);
+        }
+        self.holder_blocks_total -= 1;
+        // holder->chains index pruned lazily in drop_holder_from_chain
+        // and audit-tolerated as a superset.
+    }
+
+    /// Remove the holder from every span of one chain (clear path).
+    fn drop_holder_from_chain(&mut self, holder: u32, chain: u32) {
+        let cd = &self.chains[chain as usize];
+        let positions: Vec<u32> = cd
+            .spans
+            .iter()
+            .filter(|s| s.holders.binary_search(&holder).is_ok())
+            .flat_map(|s| s.start..s.start + s.len)
+            .collect();
+        for pos in positions {
+            let mut m = self.take_position_membership(chain, pos);
+            if let PosSet::Set(set) = &mut m {
+                if let Ok(idx) = set.binary_search(&holder) {
+                    if set.len() == 1 {
+                        let old = std::mem::replace(set, self.interner.intern(&[]));
+                        self.interner.release(old);
+                        m = PosSet::Empty;
+                        self.distinct_entries -= 1;
+                    } else {
+                        let mut shrunk = Vec::with_capacity(set.len() - 1);
+                        shrunk.extend_from_slice(&set[..idx]);
+                        shrunk.extend_from_slice(&set[idx + 1..]);
+                        let new = self.interner.intern(&shrunk);
+                        let old = std::mem::replace(set, new);
+                        self.interner.release(old);
+                    }
+                }
+            }
+            self.put_position_membership(chain, pos, m);
+        }
+        self.maybe_gc_chain(chain);
+    }
+
+    /// Extract the membership at one position, splitting its span so
+    /// the position stands alone; `put` re-normalizes neighbors.
+    fn take_position_membership(&mut self, chain: u32, pos: u32) -> PosSet {
+        let cd = &mut self.chains[chain as usize];
+        let Some(i) = cd.span_index(pos) else {
+            return PosSet::Empty;
+        };
+        let s = cd.spans[i].clone();
+        // Split into [start, pos), [pos, pos+1), (pos+1, end)
+        let mut replacement = Vec::with_capacity(3);
+        if pos > s.start {
+            replacement.push(Span {
+                start: s.start,
+                len: pos - s.start,
+                holders: s.holders.clone(),
+            });
+        }
+        let taken = s.holders.clone();
+        if s.start + s.len > pos + 1 {
+            replacement.push(Span {
+                start: pos + 1,
+                len: s.start + s.len - pos - 1,
+                holders: s.holders.clone(),
+            });
+        }
+        // Replace the original span with its fragments; the original
+        // ref is released (fragments and `taken` hold clones).
+        let original = cd.spans[i].clone();
+        cd.spans.splice(i..=i, replacement);
+        self.interner.release(original.holders);
+        PosSet::Set(taken)
+    }
+
+    /// Re-insert the membership at one position and renormalize with
+    /// neighbors (canonical maximal runs).
+    fn put_position_membership(&mut self, chain: u32, pos: u32, m: PosSet) {
+        let cd = &mut self.chains[chain as usize];
+        if let PosSet::Set(set) = m {
+            if !set.is_empty() {
+                let at = cd.spans.partition_point(|s| s.start < pos);
+                cd.spans.insert(
+                    at,
+                    Span {
+                        start: pos,
+                        len: 1,
+                        holders: set,
+                    },
+                );
+            } else {
+                self.interner.release(set);
+            }
+        }
+        // Renormalize around pos: merge adjacent spans with identical
+        // (pointer-equal) sets.
+        let cd = &mut self.chains[chain as usize];
+        let mut i = cd.spans.partition_point(|s| s.start + s.len < pos);
+        i = i.saturating_sub(1);
+        while i + 1 < cd.spans.len() {
+            let (a, b) = (&cd.spans[i], &cd.spans[i + 1]);
+            if a.start + a.len == b.start && std::sync::Arc::ptr_eq(&a.holders, &b.holders) {
+                let merged_len = a.len + b.len;
+                let dropped = cd.spans.remove(i + 1);
+                cd.spans[i].len = merged_len;
+                self.interner.release(dropped.holders);
+            } else if b.start <= pos + 1 {
+                i += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Free a chain when nothing references it.
+    fn maybe_gc_chain(&mut self, chain: u32) {
+        let cd = &self.chains[chain as usize];
+        // Already freed (double-GC guard: reachable via a remove on
+        // one path racing a parent-recursion free on another).
+        if cd.contents.is_empty() {
+            return;
+        }
+        if !cd.spans.is_empty() || !cd.children.is_empty() {
+            return;
+        }
+        // Any key map still pointing here keeps it alive (out-of-
+        // contract survivors); scan is O(holders) worst case but the
+        // common in-contract path hits the fast bail above.
+        // (Correct-but-slow; the audit keeps it honest.)
+        for slot in &self.slots {
+            if let Some(state) = &slot.state {
+                if state.keys.values().any(|&(c, _)| c == chain) {
+                    return;
+                }
+            }
+        }
+        let parent = cd.parent;
+        let start_lineage = cd.start_lineage;
+        let base = cd.base_pos;
+        let first_content = cd.contents.first().copied();
+        self.chains[chain as usize] = ChainData::default();
+        self.free_chains.push(chain);
+        match parent {
+            None => {
+                self.roots.remove(&start_lineage);
+            }
+            Some((p, fork_pos)) => {
+                let content = first_content.expect("chains are non-empty");
+                let pd = &mut self.chains[p as usize];
+                if let Ok(idx) = pd
+                    .children
+                    .binary_search_by_key(&(fork_pos, content), |&(fp, c, _)| (fp, c))
+                {
+                    pd.children.remove(idx);
+                }
+                let _ = base;
+                self.maybe_gc_chain(p);
+            }
+        }
+    }
+
+    // ---- verification ----
+
+    pub fn audit(&self) -> Result<(), String> {
+        use std::collections::HashSet;
+        // Slot/name/free coherence (same rules as the flat core).
+        let mut live = 0u64;
+        for (idx, slot) in self.slots.iter().enumerate() {
+            if let Some(state) = &slot.state {
+                live += 1;
+                if self.by_name.get(&state.name) != Some(&(idx as u32)) {
+                    return Err(format!("by_name incoherent for {}", state.name));
+                }
+            }
+        }
+        if self.by_name.len() as u64 != live {
+            return Err("by_name size mismatch".into());
+        }
+        let mut freed = HashSet::new();
+        for &f in &self.free {
+            if self.slots[f as usize].state.is_some() || !freed.insert(f) {
+                return Err(format!("free-list bad entry {f}"));
+            }
+        }
+        // Chains: shape, spans normalized, children sorted+linked.
+        let mut live_chains = HashSet::new();
+        let freed_chains: HashSet<u32> = self.free_chains.iter().copied().collect();
+        for (ci, cd) in self.chains.iter().enumerate() {
+            let ci = ci as u32;
+            if freed_chains.contains(&ci) {
+                if !cd.contents.is_empty() {
+                    return Err(format!("freed chain {ci} not empty"));
+                }
+                continue;
+            }
+            if cd.contents.is_empty() {
+                // Never-allocated default slots only exist as freed.
+                return Err(format!("live chain {ci} is empty"));
+            }
+            live_chains.insert(ci);
+            let mut prev_end = cd.base_pos;
+            let mut prev_set: Option<&SetRef> = None;
+            for s in &cd.spans {
+                if s.len == 0 || s.holders.is_empty() {
+                    return Err(format!("chain {ci} empty span"));
+                }
+                if s.start < prev_end && prev_set.is_some() {
+                    return Err(format!("chain {ci} overlapping spans"));
+                }
+                if s.start < cd.base_pos || s.start + s.len > cd.end_pos() {
+                    return Err(format!("chain {ci} span out of bounds"));
+                }
+                if let Some(ps) = prev_set {
+                    if s.start == prev_end && std::sync::Arc::ptr_eq(ps, &s.holders) {
+                        return Err(format!("chain {ci} non-maximal adjacent spans"));
+                    }
+                }
+                let mut ph = None;
+                for &h in s.holders.iter() {
+                    if ph.is_some_and(|p: u32| p >= h) {
+                        return Err(format!("chain {ci} unsorted span holders"));
+                    }
+                    ph = Some(h);
+                    if self
+                        .slots
+                        .get(h as usize)
+                        .and_then(|s| s.state.as_ref())
+                        .is_none()
+                    {
+                        return Err(format!("chain {ci} span holds retired holder {h}"));
+                    }
+                }
+                prev_end = s.start + s.len;
+                prev_set = Some(&s.holders);
+            }
+            let mut prev_child = None;
+            for &(fp, c, child) in &cd.children {
+                if prev_child.is_some_and(|p| p >= (fp, c)) {
+                    return Err(format!("chain {ci} unsorted children"));
+                }
+                prev_child = Some((fp, c));
+                if fp < cd.base_pos || fp >= cd.end_pos() {
+                    return Err(format!("chain {ci} child fork out of bounds"));
+                }
+                let ch = &self.chains[child as usize];
+                if ch.parent != Some((ci, fp)) || ch.base_pos != fp + 1 {
+                    return Err(format!("chain {ci} child {child} link broken"));
+                }
+            }
+            match cd.parent {
+                None => {
+                    if cd.base_pos != 0 || self.roots.get(&cd.start_lineage) != Some(&ci) {
+                        return Err(format!("root chain {ci} unindexed"));
+                    }
+                }
+                Some((p, fp)) => {
+                    let pd = &self.chains[p as usize];
+                    if pd.child_at(fp, cd.contents[0]) != Some(ci) {
+                        return Err(format!("chain {ci} not in parent's children"));
+                    }
+                }
+            }
+            // start/end lineage coherence.
+            let mut l = cd.start_lineage;
+            for i in 1..cd.contents.len() {
+                l = lineage_step(l, cd.contents[i]);
+            }
+            if l != cd.end_lineage {
+                return Err(format!("chain {ci} end_lineage stale"));
+            }
+        }
+        for (&l, &c) in &self.roots {
+            let cd = &self.chains[c as usize];
+            if cd.parent.is_some() || cd.start_lineage != l || freed_chains.contains(&c) {
+                return Err(format!("roots entry {l:#x} bad"));
+            }
+        }
+        // Key maps <-> coverage; counters.
+        let mut blocks = 0u64;
+        for (idx, slot) in self.slots.iter().enumerate() {
+            let Some(state) = &slot.state else { continue };
+            blocks += state.keys.len() as u64;
+            for (&k, &(c, p)) in &state.keys {
+                if !live_chains.contains(&c) {
+                    return Err(format!("holder {idx} key {k:#x} points at dead chain {c}"));
+                }
+                let cd = &self.chains[c as usize];
+                if p < cd.base_pos || p >= cd.end_pos() {
+                    return Err(format!("holder {idx} key {k:#x} position out of bounds"));
+                }
+                if !cd.covered(p, idx as u32) {
+                    return Err(format!("holder {idx} key {k:#x} not covered by spans"));
+                }
+            }
+        }
+        if blocks != self.holder_blocks_total {
+            return Err(format!(
+                "holder_blocks_total {} != recount {blocks}",
+                self.holder_blocks_total
+            ));
+        }
+        // Reverse: every covered (position, holder) is backed by at
+        // least one key in that holder's map (keys are per-holder;
+        // build the reverse view once).
+        let mut reverse: HashSet<(u32, u32, u32)> = HashSet::new();
+        for (idx, slot) in self.slots.iter().enumerate() {
+            if let Some(state) = &slot.state {
+                for &(c, p) in state.keys.values() {
+                    reverse.insert((idx as u32, c, p));
+                }
+            }
+        }
+        for &ci in &live_chains {
+            let cd = &self.chains[ci as usize];
+            for s in &cd.spans {
+                for pos in s.start..s.start + s.len {
+                    for &h in s.holders.iter() {
+                        if !reverse.contains(&(h, ci, pos)) {
+                            return Err(format!(
+                                "span coverage (chain {ci}, pos {pos}, holder {h}) has no key map entry"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        let mut distinct = 0u64;
+        for &ci in &live_chains {
+            for s in &self.chains[ci as usize].spans {
+                distinct += s.len as u64;
+            }
+        }
+        if distinct != self.distinct_entries {
+            return Err(format!(
+                "distinct_entries {} != recount {distinct}",
+                self.distinct_entries
+            ));
+        }
+        Ok(())
+    }
+}
+
+enum PosSet {
+    Empty,
+    Set(SetRef),
+}
+
+enum Placed {
+    Applied,
+    Duplicate,
+}
+
+fn push_answer3(slots: &[Slot3], holder: u32, depth: u32, out: &mut Vec<Overlap>) {
+    if depth == 0 {
+        return;
+    }
+    let slot = &slots[holder as usize];
+    let Some(state) = slot.state.as_ref() else {
+        return;
+    };
+    out.push(Overlap {
+        holder: HolderId::assemble(holder, slot.generation),
+        depth,
+        total_blocks: state.keys.len() as u64,
+    });
+    let _ = &state.name;
+}

--- a/crates/radix_tree/src/core3.rs
+++ b/crates/radix_tree/src/core3.rs
@@ -84,8 +84,12 @@ pub struct RadixTree3 {
     cfg: Config,
     chains: Vec<ChainData>,
     free_chains: Vec<u32>,
-    /// Root chains by their start lineage (single query entry probe).
-    roots: FxHashMap<u64, u32>,
+    /// Root chains by their start lineage. The value is a collision
+    /// list (essentially always length 1): entries are CONTENT-
+    /// verified on every resolution, which makes R3 immune to
+    /// fingerprint collisions — the flat core cannot verify (it
+    /// stores no contents), R3 always can.
+    roots: FxHashMap<u64, Vec<u32>>,
     slots: Vec<Slot3>,
     by_name: FxHashMap<String, u32>,
     free: Vec<u32>,
@@ -244,9 +248,16 @@ impl RadixTree3 {
         // Resolve the target (chain, pos) for this block canonically.
         let target: (u32, u32) = match *cursor {
             None => {
-                // Root anchor: canonical root chain by root lineage.
-                match self.roots.get(&lineage) {
-                    Some(&c) => (c, 0),
+                // Root anchor: canonical root chain by root lineage,
+                // CONTENT-verified (a colliding lineage with a
+                // different first content gets its own chain).
+                let existing = self.roots.get(&lineage).and_then(|list| {
+                    list.iter()
+                        .copied()
+                        .find(|&c| self.chains[c as usize].contents[0] == content)
+                });
+                match existing {
+                    Some(c) => (c, 0),
                     None => {
                         let c = self.alloc_chain(ChainData {
                             parent: None,
@@ -257,7 +268,7 @@ impl RadixTree3 {
                             spans: Vec::new(),
                             children: Vec::new(),
                         });
-                        self.roots.insert(lineage, c);
+                        self.roots.entry(lineage).or_default().push(c);
                         (c, 0)
                     }
                 }
@@ -404,7 +415,11 @@ impl RadixTree3 {
             return;
         }
         let root_lineage = lineage_root(chain_query[0]);
-        let Some(&root) = self.roots.get(&root_lineage) else {
+        let Some(root) = self.roots.get(&root_lineage).and_then(|list| {
+            list.iter()
+                .copied()
+                .find(|&c| self.chains[c as usize].contents[0] == chain_query[0])
+        }) else {
             return;
         };
         // Walk the trie along the query, collecting the matched path
@@ -810,7 +825,12 @@ impl RadixTree3 {
         self.free_chains.push(chain);
         match parent {
             None => {
-                self.roots.remove(&start_lineage);
+                if let Some(list) = self.roots.get_mut(&start_lineage) {
+                    list.retain(|&c| c != chain);
+                    if list.is_empty() {
+                        self.roots.remove(&start_lineage);
+                    }
+                }
             }
             Some((p, fork_pos)) => {
                 let content = first_content.expect("chains are non-empty");
@@ -917,7 +937,11 @@ impl RadixTree3 {
             }
             match cd.parent {
                 None => {
-                    if cd.base_pos != 0 || self.roots.get(&cd.start_lineage) != Some(&ci) {
+                    let listed = self
+                        .roots
+                        .get(&cd.start_lineage)
+                        .is_some_and(|l| l.contains(&ci));
+                    if cd.base_pos != 0 || !listed {
                         return Err(format!("root chain {ci} unindexed"));
                     }
                 }
@@ -937,10 +961,19 @@ impl RadixTree3 {
                 return Err(format!("chain {ci} end_lineage stale"));
             }
         }
-        for (&l, &c) in &self.roots {
-            let cd = &self.chains[c as usize];
-            if cd.parent.is_some() || cd.start_lineage != l || freed_chains.contains(&c) {
-                return Err(format!("roots entry {l:#x} bad"));
+        for (&l, list) in &self.roots {
+            if list.is_empty() {
+                return Err(format!("roots entry {l:#x} empty list"));
+            }
+            let mut contents_seen = HashSet::new();
+            for &c in list {
+                let cd = &self.chains[c as usize];
+                if cd.parent.is_some() || cd.start_lineage != l || freed_chains.contains(&c) {
+                    return Err(format!("roots entry {l:#x} bad chain {c}"));
+                }
+                if !contents_seen.insert(cd.contents[0]) {
+                    return Err(format!("roots entry {l:#x} duplicate first content"));
+                }
             }
         }
         // Key maps <-> coverage; counters.

--- a/crates/radix_tree/src/core3.rs
+++ b/crates/radix_tree/src/core3.rs
@@ -336,9 +336,16 @@ impl RadixTree3 {
             return Ok(Placed::Duplicate);
         }
         // Not covered: a move relocates the key first, then join.
+        // Key BEFORE membership (chain GC scans key maps; the
+        // reverse order makes GC see our own dying reference and
+        // leak the chain — the audit's orphan rule caught this).
+        // The CURSOR chain is pinned against GC for the gap between
+        // this removal and the add just below: an in-batch move can
+        // otherwise free the chain the batch is standing on, and the
+        // next block would write into a freed slot (chaos seed 2).
         if let Some(old) = self.state_of(holder).keys.get(&key).copied() {
-            self.remove_membership(holder, old);
             self.state_of_mut(holder).keys.remove(&key);
+            self.remove_membership_pinned(holder, old, Some(chain));
         }
         self.add_membership(holder, chain, pos);
         self.state_of_mut(holder).keys.insert(key, (chain, pos));
@@ -391,15 +398,18 @@ impl RadixTree3 {
             return;
         }
         let holder = id.parts().0;
-        let chains: Vec<u32> = self.state_of(holder).chains.iter().copied().collect();
+        // Wipe the key map FIRST: chain GC scans key maps for
+        // references, so clearing spans before keys made the GC see
+        // the holder's own keys and bail — every retire leaked its
+        // chains (caught by the churn-boundedness gate on the swap).
+        let state = self.state_of_mut(holder);
+        let key_count = state.keys.len() as u64;
+        state.keys = FxHashMap::default();
+        let chains: Vec<u32> = std::mem::take(&mut state.chains).into_iter().collect();
+        self.holder_blocks_total -= key_count;
         for chain in chains {
             self.drop_holder_from_chain(holder, chain);
         }
-        let key_count = self.state_of(holder).keys.len() as u64;
-        self.holder_blocks_total -= key_count;
-        let state = self.state_of_mut(holder);
-        state.keys = FxHashMap::default();
-        state.chains = rustc_hash::FxHashSet::default();
     }
 
     // ---- reads ----
@@ -657,6 +667,10 @@ impl RadixTree3 {
     }
 
     fn remove_membership(&mut self, holder: u32, at: (u32, u32)) {
+        self.remove_membership_pinned(holder, at, None);
+    }
+
+    fn remove_membership_pinned(&mut self, holder: u32, at: (u32, u32), pinned: Option<u32>) {
         let (chain, pos) = at;
         let mut m = self.take_position_membership(chain, pos);
         let mut now_empty = false;
@@ -683,7 +697,7 @@ impl RadixTree3 {
         self.put_position_membership(chain, pos, m);
         if now_empty {
             self.distinct_entries -= 1;
-            self.maybe_gc_chain(chain);
+            self.maybe_gc_chain_pinned(chain, pinned);
         }
         self.holder_blocks_total -= 1;
         // holder->chains index pruned lazily in drop_holder_from_chain
@@ -797,6 +811,13 @@ impl RadixTree3 {
 
     /// Free a chain when nothing references it.
     fn maybe_gc_chain(&mut self, chain: u32) {
+        self.maybe_gc_chain_pinned(chain, None);
+    }
+
+    fn maybe_gc_chain_pinned(&mut self, chain: u32, pinned: Option<u32>) {
+        if pinned == Some(chain) {
+            return;
+        }
         let cd = &self.chains[chain as usize];
         // Already freed (double-GC guard: reachable via a remove on
         // one path racing a parent-recursion free on another).
@@ -842,7 +863,7 @@ impl RadixTree3 {
                     pd.children.remove(idx);
                 }
                 let _ = base;
-                self.maybe_gc_chain(p);
+                self.maybe_gc_chain_pinned(p, pinned);
             }
         }
     }
@@ -1023,6 +1044,23 @@ impl RadixTree3 {
                         }
                     }
                 }
+            }
+        }
+        // GC coherence: a live chain must be referenced by spans,
+        // children, or at least one key map (otherwise the GC missed
+        // it — the leak class the churn gate caught).
+        let mut key_ref_chains: HashSet<u32> = HashSet::new();
+        for slot in &self.slots {
+            if let Some(state) = &slot.state {
+                for &(c, _) in state.keys.values() {
+                    key_ref_chains.insert(c);
+                }
+            }
+        }
+        for &ci in &live_chains {
+            let cd = &self.chains[ci as usize];
+            if cd.spans.is_empty() && cd.children.is_empty() && !key_ref_chains.contains(&ci) {
+                return Err(format!("live chain {ci} is orphaned (GC leak)"));
             }
         }
         let mut distinct = 0u64;

--- a/crates/radix_tree/src/core3.rs
+++ b/crates/radix_tree/src/core3.rs
@@ -868,6 +868,48 @@ impl RadixTree3 {
         }
     }
 
+    /// Internal structure sizes for leak hunting (soak diagnostics).
+    pub fn debug_footprint(&self) -> String {
+        let live_chains = self
+            .chains
+            .iter()
+            .filter(|c| !c.contents.is_empty())
+            .count();
+        let span_total: usize = self.chains.iter().map(|c| c.spans.len()).sum();
+        let span_cap: usize = self.chains.iter().map(|c| c.spans.capacity()).sum();
+        let content_cap: usize = self.chains.iter().map(|c| c.contents.capacity()).sum();
+        let child_total: usize = self.chains.iter().map(|c| c.children.len()).sum();
+        let intern_sets: usize = self.interner.table.values().map(|v| v.len()).sum();
+        let key_total: usize = self
+            .slots
+            .iter()
+            .filter_map(|s| s.state.as_ref())
+            .map(|s| s.keys.len())
+            .sum();
+        let key_cap: usize = self
+            .slots
+            .iter()
+            .filter_map(|s| s.state.as_ref())
+            .map(|s| s.keys.capacity())
+            .sum();
+        format!(
+            "chains {} (vec {}, free {}) contents_cap {} spans {} (cap {}) children {} roots {} intern {} ({} sets) slots {} keys {} (cap {})",
+            live_chains,
+            self.chains.len(),
+            self.free_chains.len(),
+            content_cap,
+            span_total,
+            span_cap,
+            child_total,
+            self.roots.len(),
+            self.interner.table.len(),
+            intern_sets,
+            self.slots.len(),
+            key_total,
+            key_cap,
+        )
+    }
+
     // ---- verification ----
 
     pub fn audit(&self) -> Result<(), String> {

--- a/crates/radix_tree/src/lib.rs
+++ b/crates/radix_tree/src/lib.rs
@@ -309,6 +309,19 @@ impl Membership {
         }
     }
 
+    /// Is this exact (lineage, holder) pair present?
+    fn contains(&self, lineage: u64, holder: u32) -> bool {
+        match self {
+            Membership::One {
+                lineage: l,
+                holder: h,
+            } => *l == lineage && *h == holder,
+            Membership::Many(buckets) => buckets
+                .binary_search_by_key(&lineage, |&(l, _)| l)
+                .is_ok_and(|bi| buckets[bi].1.binary_search(&holder).is_ok()),
+        }
+    }
+
     /// Does any OTHER holder share (lineage) here?
     fn lineage_shared_beyond(&self, lineage: u64, holder: u32) -> bool {
         match self {
@@ -484,42 +497,55 @@ impl RadixTree {
                     duplicates += 1;
                     continue;
                 }
-                Some(&existing) => {
-                    // §4: re-registration MOVES the block. The old
-                    // placement is unindexed and the key removed; it
-                    // is re-registered below only if the destination
-                    // accepts it.
-                    Self::unindex(
-                        &mut self.entries,
-                        &mut self.interner,
-                        &mut self.distinct_lineage_entries,
-                        id.index,
-                        existing,
-                    );
-                    self.slots[id.index as usize]
-                        .state
-                        .as_mut()
-                        .expect("checked live")
-                        .registry
-                        .remove(&key);
-                    self.holder_blocks_total -= 1;
-                }
-                None => {}
+                _ => {}
             }
-            if self.index_block(id.index, info) {
-                let state = self.slots[id.index as usize]
+            // §4 alias pre-check, BEFORE any mutation: if the holder
+            // already holds this exact (position, content, lineage)
+            // under another key, the store is a duplicate — and a
+            // would-be MOVE is refused NON-destructively (the old
+            // placement stays; review finding: the earlier order
+            // unindexed first and destroyed a block while reporting
+            // a no-op).
+            let dest_taken = self
+                .entries
+                .get(&(info.pos, info.content))
+                .is_some_and(|m| m.contains(info.lineage, id.index));
+            if dest_taken {
+                duplicates += 1;
+                continue;
+            }
+            if let Some(&existing) = self.slots[id.index as usize]
+                .state
+                .as_ref()
+                .expect("checked live")
+                .registry
+                .get(&key)
+            {
+                // §4: re-registration MOVES the block.
+                Self::unindex(
+                    &mut self.entries,
+                    &mut self.interner,
+                    &mut self.distinct_lineage_entries,
+                    id.index,
+                    existing,
+                );
+                self.slots[id.index as usize]
                     .state
                     .as_mut()
-                    .expect("checked live");
-                state.registry.insert(key, info);
-                self.holder_blocks_total += 1;
-                applied += 1;
-            } else {
-                // Same holder already holds this exact (position,
-                // content, lineage) under another key: a duplicate in
-                // every observable sense.
-                duplicates += 1;
+                    .expect("checked live")
+                    .registry
+                    .remove(&key);
+                self.holder_blocks_total -= 1;
             }
+            let inserted = self.index_block(id.index, info);
+            debug_assert!(inserted, "alias pre-check guarantees insertion");
+            let state = self.slots[id.index as usize]
+                .state
+                .as_mut()
+                .expect("checked live");
+            state.registry.insert(key, info);
+            self.holder_blocks_total += 1;
+            applied += 1;
         }
         Ok(StoreOutcome {
             applied,
@@ -688,6 +714,9 @@ impl RadixTree {
                     }
                 }
                 None => break,
+            }
+            if matches!(probes.last(), Some(RunProbe::Miss)) {
+                break;
             }
         }
         // Phase 2: sequential merge over dense holder runs.

--- a/crates/radix_tree/src/lib.rs
+++ b/crates/radix_tree/src/lib.rs
@@ -160,17 +160,30 @@ enum Membership {
     Many(Vec<(u64, Vec<u32>)>),
 }
 
+/// What [`Membership::insert`] did — drives both counter maintenance
+/// and the out-of-contract same-triple dedup in `store`.
+#[derive(PartialEq, Eq)]
+enum Inserted {
+    /// The (lineage, holder) pair was already present: the holder
+    /// already holds a block at this exact (position, content,
+    /// lineage) under a DIFFERENT key. Out-of-contract; the caller
+    /// treats it as a duplicate and does not register the new key.
+    Existing,
+    AddedToExistingLineage,
+    AddedNewLineage,
+}
+
 impl Membership {
-    /// Insert; true when newly added.
-    fn insert(&mut self, lineage: u64, holder: u32) -> bool {
+    fn insert(&mut self, lineage: u64, holder: u32) -> Inserted {
         match self {
             Membership::One {
                 lineage: l,
                 holder: h,
             } => {
                 if *l == lineage && *h == holder {
-                    false
+                    Inserted::Existing
                 } else {
+                    let same_lineage = *l == lineage;
                     let mut buckets = vec![(*l, vec![*h])];
                     match buckets[0].0.cmp(&lineage) {
                         std::cmp::Ordering::Equal => {
@@ -181,21 +194,25 @@ impl Membership {
                         std::cmp::Ordering::Greater => buckets.insert(0, (lineage, vec![holder])),
                     }
                     *self = Membership::Many(buckets);
-                    true
+                    if same_lineage {
+                        Inserted::AddedToExistingLineage
+                    } else {
+                        Inserted::AddedNewLineage
+                    }
                 }
             }
             Membership::Many(buckets) => {
                 match buckets.binary_search_by_key(&lineage, |&(l, _)| l) {
                     Ok(bi) => match buckets[bi].1.binary_search(&holder) {
-                        Ok(_) => false,
+                        Ok(_) => Inserted::Existing,
                         Err(at) => {
                             buckets[bi].1.insert(at, holder);
-                            true
+                            Inserted::AddedToExistingLineage
                         }
                     },
                     Err(bi) => {
                         buckets.insert(bi, (lineage, vec![holder]));
-                        true
+                        Inserted::AddedNewLineage
                     }
                 }
             }
@@ -392,25 +409,40 @@ impl RadixTree {
                     continue;
                 }
                 Some(&existing) => {
-                    // §4: re-registration MOVES the block.
+                    // §4: re-registration MOVES the block. The old
+                    // placement is unindexed and the key removed; it
+                    // is re-registered below only if the destination
+                    // accepts it.
                     Self::unindex(
                         &mut self.entries,
                         &mut self.distinct_lineage_entries,
                         id.index,
                         existing,
                     );
+                    self.slots[id.index as usize]
+                        .state
+                        .as_mut()
+                        .expect("checked live")
+                        .registry
+                        .remove(&key);
                     self.holder_blocks_total -= 1;
                 }
                 None => {}
             }
-            let state = self.slots[id.index as usize]
-                .state
-                .as_mut()
-                .expect("checked live");
-            state.registry.insert(key, info);
-            self.holder_blocks_total += 1;
-            self.index_block(id.index, info);
-            applied += 1;
+            if self.index_block(id.index, info) {
+                let state = self.slots[id.index as usize]
+                    .state
+                    .as_mut()
+                    .expect("checked live");
+                state.registry.insert(key, info);
+                self.holder_blocks_total += 1;
+                applied += 1;
+            } else {
+                // Same holder already holds this exact (position,
+                // content, lineage) under another key: a duplicate in
+                // every observable sense.
+                duplicates += 1;
+            }
         }
         Ok(StoreOutcome {
             applied,
@@ -665,6 +697,166 @@ impl RadixTree {
         }
     }
 
+    // ---- verification (campaign C2) ----
+
+    /// Full-state consistency audit: recomputes every counter and
+    /// cross-checks every structure from first principles. O(state);
+    /// meant for the fuzz harness and debug assertions, not the hot
+    /// path. Returns the first violation found.
+    pub fn audit(&self) -> Result<(), String> {
+        use std::collections::HashSet;
+        // Slot / name / free-list coherence.
+        let mut live = 0u64;
+        for (idx, slot) in self.slots.iter().enumerate() {
+            if let Some(state) = &slot.state {
+                live += 1;
+                match self.by_name.get(&state.name) {
+                    Some(&i) if i as usize == idx => {}
+                    other => {
+                        return Err(format!(
+                            "by_name[{}] = {:?}, expected {}",
+                            state.name, other, idx
+                        ))
+                    }
+                }
+            }
+        }
+        if self.by_name.len() as u64 != live {
+            return Err(format!(
+                "by_name has {} entries, {} live slots",
+                self.by_name.len(),
+                live
+            ));
+        }
+        let mut seen_free = HashSet::new();
+        for &f in &self.free {
+            if f as usize >= self.slots.len() {
+                return Err(format!("free-list index {f} out of range"));
+            }
+            if self.slots[f as usize].state.is_some() {
+                return Err(format!("free-list index {f} is live"));
+            }
+            if !seen_free.insert(f) {
+                return Err(format!("free-list duplicate {f}"));
+            }
+        }
+        // Counters + forward containment (registry -> entries).
+        let mut blocks = 0u64;
+        for (idx, slot) in self.slots.iter().enumerate() {
+            let Some(state) = &slot.state else { continue };
+            blocks += state.registry.len() as u64;
+            for (&key, info) in &state.registry {
+                let Some(m) = self.entries.get(&(info.pos, info.content)) else {
+                    return Err(format!(
+                        "registry block {key:#x} of holder {idx} at ({},{:#x}) has no entry",
+                        info.pos, info.content
+                    ));
+                };
+                let mut found = false;
+                match m {
+                    Membership::One { lineage, holder } => {
+                        found = *lineage == info.lineage && *holder as usize == idx;
+                    }
+                    Membership::Many(buckets) => {
+                        if let Ok(bi) = buckets.binary_search_by_key(&info.lineage, |&(l, _)| l) {
+                            found = buckets[bi].1.binary_search(&(idx as u32)).is_ok();
+                        }
+                    }
+                }
+                if !found {
+                    return Err(format!(
+                        "membership missing for holder {idx} block {key:#x} at ({},{:#x}) lineage {:#x}",
+                        info.pos, info.content, info.lineage
+                    ));
+                }
+            }
+        }
+        if blocks != self.holder_blocks_total {
+            return Err(format!(
+                "holder_blocks_total {} != recount {}",
+                self.holder_blocks_total, blocks
+            ));
+        }
+        // Reverse containment (entries -> registries) + shape + distinct.
+        let mut holder_triples: Vec<HashSet<(u32, u64, u64)>> =
+            vec![HashSet::new(); self.slots.len()];
+        for (idx, slot) in self.slots.iter().enumerate() {
+            if let Some(state) = &slot.state {
+                for info in state.registry.values() {
+                    holder_triples[idx].insert((info.pos, info.content, info.lineage));
+                }
+            }
+        }
+        let mut distinct = 0u64;
+        for (&(pos, content), m) in &self.entries {
+            match m {
+                Membership::One { lineage, holder } => {
+                    distinct += 1;
+                    if self
+                        .slots
+                        .get(*holder as usize)
+                        .and_then(|s| s.state.as_ref())
+                        .is_none()
+                    {
+                        return Err(format!(
+                            "entry ({pos},{content:#x}) holds retired holder {holder}"
+                        ));
+                    }
+                    if !holder_triples[*holder as usize].contains(&(pos, content, *lineage)) {
+                        return Err(format!(
+                            "entry ({pos},{content:#x}) lineage {lineage:#x} not in holder {holder}'s registry"
+                        ));
+                    }
+                }
+                Membership::Many(buckets) => {
+                    if buckets.is_empty() {
+                        return Err(format!("empty Many at ({pos},{content:#x})"));
+                    }
+                    let mut prev_l = None;
+                    for (l, holders) in buckets {
+                        distinct += 1;
+                        if holders.is_empty() {
+                            return Err(format!("empty bucket at ({pos},{content:#x})"));
+                        }
+                        if prev_l.is_some_and(|p: u64| p >= *l) {
+                            return Err(format!("unsorted buckets at ({pos},{content:#x})"));
+                        }
+                        prev_l = Some(*l);
+                        let mut prev_h = None;
+                        for &h in holders {
+                            if prev_h.is_some_and(|p: u32| p >= h) {
+                                return Err(format!("unsorted holders at ({pos},{content:#x})"));
+                            }
+                            prev_h = Some(h);
+                            if self
+                                .slots
+                                .get(h as usize)
+                                .and_then(|s| s.state.as_ref())
+                                .is_none()
+                            {
+                                return Err(format!(
+                                    "entry ({pos},{content:#x}) holds retired holder {h}"
+                                ));
+                            }
+                            if !holder_triples[h as usize].contains(&(pos, content, *l)) {
+                                return Err(format!(
+                                    "entry ({pos},{content:#x}) lineage {l:#x} not in holder {h}'s registry"
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if distinct != self.distinct_lineage_entries {
+            return Err(format!(
+                "distinct_lineage_entries {} != recount {}",
+                self.distinct_lineage_entries, distinct
+            ));
+        }
+        Ok(())
+    }
+
     // ---- internals ----
 
     fn live(&self, id: HolderId) -> Option<&HolderState> {
@@ -693,7 +885,12 @@ impl RadixTree {
         });
     }
 
-    fn index_block(&mut self, holder: u32, info: BlockInfo) {
+    /// Add the (lineage, holder) membership for a block. Returns
+    /// false for the out-of-contract case where the holder ALREADY
+    /// holds this exact (position, content, lineage) under another
+    /// key — the caller then treats the store as a duplicate and the
+    /// new key is never registered (deterministic; audited).
+    fn index_block(&mut self, holder: u32, info: BlockInfo) -> bool {
         match self.entries.entry((info.pos, info.content)) {
             std::collections::hash_map::Entry::Vacant(vacant) => {
                 vacant.insert(Membership::One {
@@ -701,13 +898,16 @@ impl RadixTree {
                     holder,
                 });
                 self.distinct_lineage_entries += 1;
+                true
             }
             std::collections::hash_map::Entry::Occupied(mut occupied) => {
-                let had_lineage = occupied.get().lineage_shared_beyond(info.lineage, holder)
-                    || matches!(occupied.get(), Membership::One { lineage, holder: h }
-                        if *lineage == info.lineage && *h == holder);
-                if occupied.get_mut().insert(info.lineage, holder) && !had_lineage {
-                    self.distinct_lineage_entries += 1;
+                match occupied.get_mut().insert(info.lineage, holder) {
+                    Inserted::Existing => false,
+                    Inserted::AddedToExistingLineage => true,
+                    Inserted::AddedNewLineage => {
+                        self.distinct_lineage_entries += 1;
+                        true
+                    }
                 }
             }
         }

--- a/crates/radix_tree/src/lib.rs
+++ b/crates/radix_tree/src/lib.rs
@@ -11,6 +11,14 @@
 #![forbid(unsafe_code)]
 
 mod core3;
+/// The chain-native core is the crate's PRIMARY type: every original
+/// performance gate passed on it (26.9 B/holder-block, exact-match
+/// gate cell p99 7.6 us, scale-stable at 128M blocks) with the full
+/// referee equal. The flat core remains as [`FlatTree`] — a second,
+/// independently-verified implementation the dual-core harness keeps
+/// asserting against the model, and the substrate the chain core's
+/// interner came from.
+pub use core3::RadixTree3 as RadixTree;
 pub use core3::RadixTree3;
 use rustc_hash::FxHashMap;
 
@@ -354,7 +362,7 @@ pub struct OverlapScratch {
     lineages: Vec<u64>,
 }
 
-pub struct RadixTree {
+pub struct FlatTree {
     cfg: Config,
     entries: FxHashMap<(u32, ContentHash), Membership>,
     slots: Vec<HolderSlot>,
@@ -365,7 +373,7 @@ pub struct RadixTree {
     interner: SetInterner,
 }
 
-impl RadixTree {
+impl FlatTree {
     pub fn new(cfg: Config) -> Self {
         Self {
             cfg,

--- a/crates/radix_tree/src/lib.rs
+++ b/crates/radix_tree/src/lib.rs
@@ -1,8 +1,733 @@
-//! Generic prefix-membership index — SPEC STAGE.
+//! Generic prefix-membership index — the R1 flat core.
 //!
-//! The contract lives in `SPEC.md`. Per its §12, no core code lands
-//! before the verification harness exists: `tests/` holds the
-//! model-referee differential harness (a trivially-correct model of
-//! the §6/§7 contract, the `kv_index` oracle behind the engine's
-//! replicated glue, and the seeded workload generator). The R1 flat
-//! core will be implemented against that harness.
+//! The contract lives in `SPEC.md`; the referee lives in
+//! `tests/differential.rs` (this implementation must equal the model
+//! there, always). Shape per §9: a flat positional entry map keyed by
+//! `(position, content)` with lineage-disambiguated membership, plus
+//! an internal per-holder registry — order-insensitive set semantics,
+//! so §7 convergence holds by construction. Single-writer (§8): no
+//! locks, no atomics, no shards.
+
+#![forbid(unsafe_code)]
+
+use rustc_hash::FxHashMap;
+
+/// Position-independent content identity (the matching currency).
+pub type ContentHash = u64;
+/// The publisher's removal key (backend block hash / placement chain
+/// hash). Opaque to matching.
+pub type BlockKey = u64;
+
+/// Generational holder id (§5): operations through a retired id fail
+/// loudly, never alias a recycled slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HolderId {
+    index: u32,
+    generation: u32,
+}
+
+impl HolderId {
+    /// Raw (index, generation) — for callers keeping side tables
+    /// keyed by holder. Stale ids stay detectable through the
+    /// generation.
+    pub fn parts(self) -> (u32, u32) {
+        (self.index, self.generation)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Hard bound on chain length; a store extending past it is
+    /// rejected whole (`StoreError::ChainTooLong`).
+    pub max_chain_len: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            max_chain_len: 65_536,
+        }
+    }
+}
+
+/// Advisory (§4): outside the convergence contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StoreOutcome {
+    pub applied: u32,
+    pub duplicates: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreError {
+    /// Unknown or stale-generation holder id.
+    UnknownHolder,
+    /// Parent key not registered; the ONLY error whose sanctioned
+    /// recovery is re-anchoring at position 0 (§4).
+    ParentNotFound,
+    /// Batch would extend past `max_chain_len`; terminal, do not
+    /// re-anchor.
+    ChainTooLong,
+}
+
+/// One query answer row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Overlap {
+    pub holder: HolderId,
+    pub depth: u32,
+    pub total_blocks: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Stats {
+    pub holders: u64,
+    /// Sum of per-holder block counts (capacity arithmetic).
+    pub holder_blocks: u64,
+    /// Unique (position, content, lineage) memberships-bearing
+    /// entries — the oracle-parity metric (§4).
+    pub distinct_entries: u64,
+    /// Rough resident estimate; drift-tolerant, monotone with state.
+    pub bytes_estimate: u64,
+}
+
+/// A block's placement inside its holder: position, content, and the
+/// lineage fingerprint of the chain prefix it was stored under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BlockInfo {
+    pos: u32,
+    content: ContentHash,
+    lineage: u64,
+}
+
+#[derive(Debug, Default)]
+struct HolderState {
+    name: String,
+    /// BlockKey -> placement. Internal — never caller-owned (§4).
+    /// Deliberately the ONLY per-block holder structure: position
+    /// order (truncate_tail/enumerate — cold capacity/snapshot
+    /// paths) is derived from it on demand, costing those calls an
+    /// O(n log n) scan instead of costing every block 16 resident
+    /// bytes of standing order log.
+    registry: FxHashMap<BlockKey, BlockInfo>,
+}
+
+impl HolderState {
+    /// (position, key) pairs in ascending order, derived on demand.
+    fn ordered(&self) -> Vec<(u32, BlockKey)> {
+        let mut v: Vec<(u32, BlockKey)> = self.registry.iter().map(|(&k, i)| (i.pos, k)).collect();
+        v.sort_unstable();
+        v
+    }
+}
+
+#[derive(Debug)]
+struct HolderSlot {
+    generation: u32,
+    /// `None` = retired slot awaiting reuse.
+    state: Option<HolderState>,
+}
+
+/// Lineage fingerprint chain: an INTERNAL rolling 64-bit mix — not
+/// the wire hash scheme (the crate is hash-agnostic, §2).
+#[inline]
+fn lineage_root(content: ContentHash) -> u64 {
+    splitmix(0xA0761D6478BD642F ^ content)
+}
+
+#[inline]
+fn lineage_step(prev: u64, content: ContentHash) -> u64 {
+    splitmix(prev.rotate_left(23) ^ content.wrapping_mul(0x9E3779B97F4A7C15))
+}
+
+#[inline]
+fn splitmix(mut z: u64) -> u64 {
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+    z ^ (z >> 31)
+}
+
+/// Membership at one (position, content) entry, lineage-disambiguated.
+/// The common case — one holder, one lineage — is inline and
+/// allocation-free (§9). Shared entries hold one dense sorted holder
+/// array per lineage: 4 B/holder, slice-comparable, streamed by the
+/// query merge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Membership {
+    One {
+        lineage: u64,
+        holder: u32,
+    },
+    /// Buckets sorted by lineage; holders sorted ascending within.
+    Many(Vec<(u64, Vec<u32>)>),
+}
+
+impl Membership {
+    /// Insert; true when newly added.
+    fn insert(&mut self, lineage: u64, holder: u32) -> bool {
+        match self {
+            Membership::One {
+                lineage: l,
+                holder: h,
+            } => {
+                if *l == lineage && *h == holder {
+                    false
+                } else {
+                    let mut buckets = vec![(*l, vec![*h])];
+                    match buckets[0].0.cmp(&lineage) {
+                        std::cmp::Ordering::Equal => {
+                            buckets[0].1.push(holder);
+                            buckets[0].1.sort_unstable();
+                        }
+                        std::cmp::Ordering::Less => buckets.push((lineage, vec![holder])),
+                        std::cmp::Ordering::Greater => buckets.insert(0, (lineage, vec![holder])),
+                    }
+                    *self = Membership::Many(buckets);
+                    true
+                }
+            }
+            Membership::Many(buckets) => {
+                match buckets.binary_search_by_key(&lineage, |&(l, _)| l) {
+                    Ok(bi) => match buckets[bi].1.binary_search(&holder) {
+                        Ok(_) => false,
+                        Err(at) => {
+                            buckets[bi].1.insert(at, holder);
+                            true
+                        }
+                    },
+                    Err(bi) => {
+                        buckets.insert(bi, (lineage, vec![holder]));
+                        true
+                    }
+                }
+            }
+        }
+    }
+
+    /// Remove; true when the whole membership is now empty.
+    fn remove(&mut self, lineage: u64, holder: u32) -> bool {
+        match self {
+            Membership::One {
+                lineage: l,
+                holder: h,
+            } => *l == lineage && *h == holder,
+            Membership::Many(buckets) => {
+                if let Ok(bi) = buckets.binary_search_by_key(&lineage, |&(l, _)| l) {
+                    if let Ok(at) = buckets[bi].1.binary_search(&holder) {
+                        buckets[bi].1.remove(at);
+                        if buckets[bi].1.is_empty() {
+                            buckets.remove(bi);
+                        }
+                    }
+                }
+                buckets.is_empty()
+            }
+        }
+    }
+
+    /// Does any OTHER holder share (lineage) here?
+    fn lineage_shared_beyond(&self, lineage: u64, holder: u32) -> bool {
+        match self {
+            Membership::One {
+                lineage: l,
+                holder: h,
+            } => *l == lineage && *h != holder,
+            Membership::Many(buckets) => {
+                match buckets.binary_search_by_key(&lineage, |&(l, _)| l) {
+                    Ok(bi) => buckets[bi].1.iter().any(|&h| h != holder),
+                    Err(_) => false,
+                }
+            }
+        }
+    }
+}
+
+pub struct RadixTree {
+    cfg: Config,
+    entries: FxHashMap<(u32, ContentHash), Membership>,
+    slots: Vec<HolderSlot>,
+    by_name: FxHashMap<String, u32>,
+    free: Vec<u32>,
+    holder_blocks_total: u64,
+    distinct_lineage_entries: u64,
+    /// Scratch for the query walk (kept to stay allocation-free on
+    /// the hot path once warm).
+    scratch_active: Vec<u32>,
+    scratch_next: Vec<u32>,
+    scratch_lineages: Vec<u64>,
+}
+
+impl RadixTree {
+    pub fn new(cfg: Config) -> Self {
+        Self {
+            cfg,
+            entries: FxHashMap::default(),
+            slots: Vec::new(),
+            by_name: FxHashMap::default(),
+            free: Vec::new(),
+            holder_blocks_total: 0,
+            distinct_lineage_entries: 0,
+            scratch_active: Vec::new(),
+            scratch_next: Vec::new(),
+            scratch_lineages: Vec::new(),
+        }
+    }
+
+    // ---- holder lifecycle (§5) ----
+
+    /// Create (or return the live holder of this name). Recycles
+    /// retired slots; the returned id's generation detects staleness.
+    pub fn create_holder(&mut self, name: &str) -> HolderId {
+        if let Some(&index) = self.by_name.get(name) {
+            return HolderId {
+                index,
+                generation: self.slots[index as usize].generation,
+            };
+        }
+        let state = HolderState {
+            name: name.to_string(),
+            ..HolderState::default()
+        };
+        let index = if let Some(index) = self.free.pop() {
+            let slot = &mut self.slots[index as usize];
+            slot.state = Some(state);
+            index
+        } else {
+            self.slots.push(HolderSlot {
+                generation: 0,
+                state: Some(state),
+            });
+            (self.slots.len() - 1) as u32
+        };
+        self.by_name.insert(name.to_string(), index);
+        HolderId {
+            index,
+            generation: self.slots[index as usize].generation,
+        }
+    }
+
+    pub fn holder_name(&self, id: HolderId) -> Option<&str> {
+        self.live(id).map(|s| s.name.as_str())
+    }
+
+    /// Release every byte attributable to the holder; the id becomes
+    /// stale (generation bumped) and the slot reusable.
+    pub fn retire_holder(&mut self, id: HolderId) {
+        if self.live(id).is_none() {
+            return;
+        }
+        self.clear(id);
+        let slot = &mut self.slots[id.index as usize];
+        let state = slot.state.take().expect("checked live");
+        self.by_name.remove(&state.name);
+        slot.generation = slot.generation.wrapping_add(1);
+        self.free.push(id.index);
+    }
+
+    /// O(1).
+    pub fn holder_blocks(&self, id: HolderId) -> u64 {
+        self.live(id).map_or(0, |s| s.registry.len() as u64)
+    }
+
+    // ---- writes (§4) ----
+
+    /// All-or-nothing on error; see `StoreError` for the recovery
+    /// contract per variant.
+    pub fn store(
+        &mut self,
+        id: HolderId,
+        parent: Option<BlockKey>,
+        blocks: &[(BlockKey, ContentHash)],
+    ) -> Result<StoreOutcome, StoreError> {
+        if self.live(id).is_none() {
+            return Err(StoreError::UnknownHolder);
+        }
+        if blocks.is_empty() {
+            return Ok(StoreOutcome {
+                applied: 0,
+                duplicates: 0,
+            });
+        }
+        let state = self.slots[id.index as usize]
+            .state
+            .as_ref()
+            .expect("checked live");
+        // Resolve the anchor BEFORE any mutation (all-or-nothing).
+        let (start_pos, mut lineage_prev) = match parent {
+            Some(parent_key) => match state.registry.get(&parent_key) {
+                None => return Err(StoreError::ParentNotFound),
+                Some(info) => (info.pos + 1, Some(info.lineage)),
+            },
+            None => {
+                // Re-publish dedup: a parent-None batch whose first
+                // key already anchors a chain at position 0 extends
+                // that chain (the model's rule; in-contract the fresh
+                // lineage recomputation matches the stored one).
+                (0, None)
+            }
+        };
+        if start_pos as u64 + blocks.len() as u64 > self.cfg.max_chain_len as u64 {
+            return Err(StoreError::ChainTooLong);
+        }
+
+        let mut applied = 0u32;
+        let mut duplicates = 0u32;
+        for (i, &(key, content)) in blocks.iter().enumerate() {
+            let pos = start_pos + i as u32;
+            let lineage = match lineage_prev {
+                None => lineage_root(content),
+                Some(prev) => lineage_step(prev, content),
+            };
+            lineage_prev = Some(lineage);
+            let info = BlockInfo {
+                pos,
+                content,
+                lineage,
+            };
+            let state = self.slots[id.index as usize]
+                .state
+                .as_mut()
+                .expect("checked live");
+            match state.registry.get(&key) {
+                Some(existing) if *existing == info => {
+                    duplicates += 1;
+                    continue;
+                }
+                Some(&existing) => {
+                    // §4: re-registration MOVES the block.
+                    Self::unindex(
+                        &mut self.entries,
+                        &mut self.distinct_lineage_entries,
+                        id.index,
+                        existing,
+                    );
+                    self.holder_blocks_total -= 1;
+                }
+                None => {}
+            }
+            let state = self.slots[id.index as usize]
+                .state
+                .as_mut()
+                .expect("checked live");
+            state.registry.insert(key, info);
+            self.holder_blocks_total += 1;
+            self.index_block(id.index, info);
+            applied += 1;
+        }
+        Ok(StoreOutcome {
+            applied,
+            duplicates,
+        })
+    }
+
+    /// Idempotent; returns blocks actually removed (advisory).
+    pub fn remove(&mut self, id: HolderId, keys: &[BlockKey]) -> u32 {
+        if self.live(id).is_none() {
+            return 0;
+        }
+        let mut removed = 0u32;
+        for &key in keys {
+            let state = self.slots[id.index as usize]
+                .state
+                .as_mut()
+                .expect("checked live");
+            let Some(info) = state.registry.remove(&key) else {
+                continue;
+            };
+            self.holder_blocks_total -= 1;
+            Self::unindex(
+                &mut self.entries,
+                &mut self.distinct_lineage_entries,
+                id.index,
+                info,
+            );
+            removed += 1;
+        }
+        removed
+    }
+
+    /// Forest-wide prefix-closed eviction (§4): drop blocks in
+    /// strictly decreasing position order, ties by key, until `keep`
+    /// remain. Returns dropped count.
+    pub fn truncate_tail(&mut self, id: HolderId, keep: u64) -> u64 {
+        if self.live(id).is_none() {
+            return 0;
+        }
+        let state = self.slots[id.index as usize]
+            .state
+            .as_mut()
+            .expect("checked live");
+        if state.registry.len() as u64 <= keep {
+            return 0;
+        }
+        let mut ordered = state.ordered();
+        let mut dropped = 0u64;
+        while ordered.len() as u64 > keep {
+            let (pos, key) = ordered.pop().expect("non-empty");
+            let state = self.slots[id.index as usize]
+                .state
+                .as_mut()
+                .expect("checked live");
+            let info = state.registry.remove(&key).expect("derived from registry");
+            debug_assert_eq!(info.pos, pos);
+            self.holder_blocks_total -= 1;
+            Self::unindex(
+                &mut self.entries,
+                &mut self.distinct_lineage_entries,
+                id.index,
+                info,
+            );
+            dropped += 1;
+        }
+        dropped
+    }
+
+    /// Drop all blocks; the holder (id, name, epoch posture at the
+    /// caller) survives — this is the epoch-bump primitive (§2).
+    pub fn clear(&mut self, id: HolderId) {
+        if self.live(id).is_none() {
+            return;
+        }
+        let state = self.slots[id.index as usize]
+            .state
+            .as_mut()
+            .expect("checked live");
+        let registry = std::mem::take(&mut state.registry);
+        self.holder_blocks_total -= registry.len() as u64;
+        for (_, info) in registry {
+            Self::unindex(
+                &mut self.entries,
+                &mut self.distinct_lineage_entries,
+                id.index,
+                info,
+            );
+        }
+    }
+
+    // ---- reads ----
+
+    /// §6 exact overlap: lineage-true consecutive depth per holder.
+    /// `out` is cleared and filled (holders at depth 0 absent).
+    ///
+    /// Two-phase walk: probing each position's entry has no data
+    /// dependency on its neighbors (lineages are a pure rolling
+    /// function of the QUERY), so phase 1 issues all map probes
+    /// back-to-back — the CPU overlaps their cache misses — and only
+    /// phase 2's cheap merge is sequential. This is what makes exact
+    /// matching latency-competitive without the oracle's unsound
+    /// skip heuristics.
+    pub fn overlap(&mut self, chain: &[ContentHash], out: &mut Vec<Overlap>) {
+        out.clear();
+        if chain.is_empty() {
+            return;
+        }
+        // Phase 0: lineages up front.
+        let mut lineages = std::mem::take(&mut self.scratch_lineages);
+        lineages.clear();
+        let mut lineage = 0u64;
+        for (p, &content) in chain.iter().enumerate() {
+            lineage = if p == 0 {
+                lineage_root(content)
+            } else {
+                lineage_step(lineage, content)
+            };
+            lineages.push(lineage);
+        }
+        // Phase 1: independent probes resolving each position's
+        // dense holder run, endpoints touched so the run data rides
+        // the same overlapped misses. Stops at the first absent
+        // entry (no deeper position can matter).
+        enum RunProbe<'a> {
+            One(u32),
+            Slice(&'a [u32]),
+            Miss,
+        }
+        let mut probes: Vec<RunProbe> = Vec::with_capacity(chain.len().min(1024));
+        for (p, &content) in chain.iter().enumerate() {
+            match self.entries.get(&(p as u32, content)) {
+                Some(Membership::One { lineage, holder }) => {
+                    probes.push(if *lineage == lineages[p] {
+                        RunProbe::One(*holder)
+                    } else {
+                        RunProbe::Miss
+                    })
+                }
+                Some(Membership::Many(buckets)) => {
+                    let run = if buckets.len() == 1 {
+                        (buckets[0].0 == lineages[p]).then(|| buckets[0].1.as_slice())
+                    } else {
+                        buckets
+                            .binary_search_by_key(&lineages[p], |&(l, _)| l)
+                            .ok()
+                            .map(|bi| buckets[bi].1.as_slice())
+                    };
+                    match run {
+                        Some(run) => {
+                            // Endpoint touches: pull the run's first
+                            // and last cache lines now, overlapped.
+                            std::hint::black_box(run[0]);
+                            std::hint::black_box(run[run.len() - 1]);
+                            probes.push(RunProbe::Slice(run));
+                        }
+                        None => probes.push(RunProbe::Miss),
+                    }
+                }
+                None => break,
+            }
+        }
+        // Phase 2: sequential merge over dense holder runs.
+        let mut active = std::mem::take(&mut self.scratch_active);
+        let mut next = std::mem::take(&mut self.scratch_next);
+        active.clear();
+        next.clear();
+        let mut survivors_depth = 0u32;
+        let mut one_hold = [0u32; 1];
+        for (p, probe) in probes.iter().enumerate() {
+            let run: &[u32] = match probe {
+                RunProbe::One(h) => {
+                    one_hold[0] = *h;
+                    &one_hold[..]
+                }
+                RunProbe::Slice(r) => r,
+                RunProbe::Miss => &[],
+            };
+            if p == 0 {
+                if run.is_empty() {
+                    break;
+                }
+                active.extend_from_slice(run);
+            } else {
+                if run == active.as_slice() {
+                    // Unchanged membership (the common shared-run
+                    // case): one memcmp, no rebuild.
+                } else {
+                    // Merge-intersect two sorted runs; dropped
+                    // holders get depth p in the same pass.
+                    next.clear();
+                    let mut ai = 0usize;
+                    for &h in run {
+                        while ai < active.len() && active[ai] < h {
+                            self.push_answer(active[ai], p as u32, out);
+                            ai += 1;
+                        }
+                        if ai < active.len() && active[ai] == h {
+                            next.push(h);
+                            ai += 1;
+                        }
+                    }
+                    while ai < active.len() {
+                        self.push_answer(active[ai], p as u32, out);
+                        ai += 1;
+                    }
+                    std::mem::swap(&mut active, &mut next);
+                }
+            }
+            if active.is_empty() {
+                break;
+            }
+            survivors_depth = p as u32 + 1;
+        }
+        // Holders still active survived every visited position.
+        for &h in active.iter() {
+            self.push_answer(h, survivors_depth, out);
+        }
+        drop(probes);
+        self.scratch_active = active;
+        self.scratch_next = next;
+        self.scratch_lineages = lineages;
+    }
+
+    /// Position-ordered enumeration (snapshot/Pull; §4). Order is
+    /// derived on demand — snapshot is a cold path.
+    pub fn enumerate(
+        &self,
+        id: HolderId,
+    ) -> impl Iterator<Item = (u32, BlockKey, ContentHash)> + '_ {
+        let state = self.live(id);
+        let ordered = state.map(|s| s.ordered()).unwrap_or_default();
+        ordered.into_iter().map(move |(pos, key)| {
+            let info = state
+                .expect("ordered non-empty implies live")
+                .registry
+                .get(&key)
+                .expect("derived from registry");
+            (pos, key, info.content)
+        })
+    }
+
+    pub fn stats(&self) -> Stats {
+        let holders = self.slots.iter().filter(|s| s.state.is_some()).count() as u64;
+        // Rough model: entry map + memberships + registries.
+        let bytes = self.entries.len() as u64 * 48 + self.holder_blocks_total * 72 + holders * 128;
+        Stats {
+            holders,
+            holder_blocks: self.holder_blocks_total,
+            distinct_entries: self.distinct_lineage_entries,
+            bytes_estimate: bytes,
+        }
+    }
+
+    // ---- internals ----
+
+    fn live(&self, id: HolderId) -> Option<&HolderState> {
+        let slot = self.slots.get(id.index as usize)?;
+        if slot.generation != id.generation {
+            return None;
+        }
+        slot.state.as_ref()
+    }
+
+    fn push_answer(&self, holder: u32, depth: u32, out: &mut Vec<Overlap>) {
+        if depth == 0 {
+            return;
+        }
+        let slot = &self.slots[holder as usize];
+        let Some(state) = slot.state.as_ref() else {
+            return;
+        };
+        out.push(Overlap {
+            holder: HolderId {
+                index: holder,
+                generation: slot.generation,
+            },
+            depth,
+            total_blocks: state.registry.len() as u64,
+        });
+    }
+
+    fn index_block(&mut self, holder: u32, info: BlockInfo) {
+        match self.entries.entry((info.pos, info.content)) {
+            std::collections::hash_map::Entry::Vacant(vacant) => {
+                vacant.insert(Membership::One {
+                    lineage: info.lineage,
+                    holder,
+                });
+                self.distinct_lineage_entries += 1;
+            }
+            std::collections::hash_map::Entry::Occupied(mut occupied) => {
+                let had_lineage = occupied.get().lineage_shared_beyond(info.lineage, holder)
+                    || matches!(occupied.get(), Membership::One { lineage, holder: h }
+                        if *lineage == info.lineage && *h == holder);
+                if occupied.get_mut().insert(info.lineage, holder) && !had_lineage {
+                    self.distinct_lineage_entries += 1;
+                }
+            }
+        }
+    }
+
+    fn unindex(
+        entries: &mut FxHashMap<(u32, ContentHash), Membership>,
+        distinct: &mut u64,
+        holder: u32,
+        info: BlockInfo,
+    ) {
+        let Some(membership) = entries.get_mut(&(info.pos, info.content)) else {
+            return;
+        };
+        let shared = membership.lineage_shared_beyond(info.lineage, holder);
+        if membership.remove(info.lineage, holder) {
+            entries.remove(&(info.pos, info.content));
+        }
+        if !shared {
+            *distinct -= 1;
+        }
+    }
+}

--- a/crates/radix_tree/src/lib.rs
+++ b/crates/radix_tree/src/lib.rs
@@ -23,14 +23,14 @@ pub type BlockKey = u64;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HolderId {
     index: u32,
-    generation: u32,
+    generation: u64,
 }
 
 impl HolderId {
     /// Raw (index, generation) — for callers keeping side tables
     /// keyed by holder. Stale ids stay detectable through the
     /// generation.
-    pub fn parts(self) -> (u32, u32) {
+    pub fn parts(self) -> (u32, u64) {
         (self.index, self.generation)
     }
 }
@@ -121,7 +121,7 @@ impl HolderState {
 
 #[derive(Debug)]
 struct HolderSlot {
-    generation: u32,
+    generation: u64,
     /// `None` = retired slot awaiting reuse.
     state: Option<HolderState>,
 }
@@ -145,6 +145,61 @@ fn splitmix(mut z: u64) -> u64 {
     z ^ (z >> 31)
 }
 
+/// Interned, immutable, sorted holder set. Consecutive positions of a
+/// shared chain hold IDENTICAL sets; hash-consing them means (a) the
+/// query walk proves "membership unchanged since the previous
+/// position" by POINTER EQUALITY — a sound O(1) run-skip, unlike the
+/// oracle's count heuristic — and (b) the per-position duplication of
+/// holder arrays collapses to one allocation per distinct set (the
+/// run-compression memory win, without a linked tree).
+type SetRef = std::sync::Arc<[u32]>;
+
+#[derive(Debug, Default)]
+struct SetInterner {
+    /// set-content hash -> interned sets with that hash.
+    table: FxHashMap<u64, Vec<SetRef>>,
+}
+
+impl SetInterner {
+    fn hash_of(set: &[u32]) -> u64 {
+        let mut h = 0x51_7C_C1_B7_27_22_0A_95u64 ^ (set.len() as u64);
+        for &x in set {
+            h = splitmix(h ^ (x as u64).wrapping_mul(0x9E3779B97F4A7C15));
+        }
+        h
+    }
+
+    /// Intern a sorted holder array (consumes the scratch build).
+    fn intern(&mut self, set: &[u32]) -> SetRef {
+        let h = Self::hash_of(set);
+        let bucket = self.table.entry(h).or_default();
+        for existing in bucket.iter() {
+            if existing.as_ref() == set {
+                return existing.clone();
+            }
+        }
+        let arc: SetRef = set.into();
+        bucket.push(arc.clone());
+        arc
+    }
+
+    /// Release a reference that a membership is dropping. When only
+    /// the table still holds the set, it is removed (single-writer,
+    /// so the count is exact here).
+    fn release(&mut self, set: SetRef) {
+        let h = Self::hash_of(&set);
+        // The caller's clone + the table's = 2 when orphaned.
+        if std::sync::Arc::strong_count(&set) == 2 {
+            if let Some(bucket) = self.table.get_mut(&h) {
+                bucket.retain(|s| !std::sync::Arc::ptr_eq(s, &set));
+                if bucket.is_empty() {
+                    self.table.remove(&h);
+                }
+            }
+        }
+    }
+}
+
 /// Membership at one (position, content) entry, lineage-disambiguated.
 /// The common case — one holder, one lineage — is inline and
 /// allocation-free (§9). Shared entries hold one dense sorted holder
@@ -156,8 +211,8 @@ enum Membership {
         lineage: u64,
         holder: u32,
     },
-    /// Buckets sorted by lineage; holders sorted ascending within.
-    Many(Vec<(u64, Vec<u32>)>),
+    /// Buckets sorted by lineage; holders are interned sorted sets.
+    Many(Vec<(u64, SetRef)>),
 }
 
 /// What [`Membership::insert`] did — drives both counter maintenance
@@ -174,7 +229,7 @@ enum Inserted {
 }
 
 impl Membership {
-    fn insert(&mut self, lineage: u64, holder: u32) -> Inserted {
+    fn insert(&mut self, lineage: u64, holder: u32, interner: &mut SetInterner) -> Inserted {
         match self {
             Membership::One {
                 lineage: l,
@@ -182,36 +237,42 @@ impl Membership {
             } => {
                 if *l == lineage && *h == holder {
                     Inserted::Existing
-                } else {
-                    let same_lineage = *l == lineage;
-                    let mut buckets = vec![(*l, vec![*h])];
-                    match buckets[0].0.cmp(&lineage) {
-                        std::cmp::Ordering::Equal => {
-                            buckets[0].1.push(holder);
-                            buckets[0].1.sort_unstable();
-                        }
-                        std::cmp::Ordering::Less => buckets.push((lineage, vec![holder])),
-                        std::cmp::Ordering::Greater => buckets.insert(0, (lineage, vec![holder])),
-                    }
-                    *self = Membership::Many(buckets);
-                    if same_lineage {
-                        Inserted::AddedToExistingLineage
+                } else if *l == lineage {
+                    let set = if *h < holder {
+                        [*h, holder]
                     } else {
-                        Inserted::AddedNewLineage
-                    }
+                        [holder, *h]
+                    };
+                    *self = Membership::Many(vec![(lineage, interner.intern(&set))]);
+                    Inserted::AddedToExistingLineage
+                } else {
+                    let mut buckets = vec![(*l, interner.intern(&[*h]))];
+                    let pos = usize::from(*l < lineage);
+                    buckets.insert(pos, (lineage, interner.intern(&[holder])));
+                    *self = Membership::Many(buckets);
+                    Inserted::AddedNewLineage
                 }
             }
             Membership::Many(buckets) => {
                 match buckets.binary_search_by_key(&lineage, |&(l, _)| l) {
-                    Ok(bi) => match buckets[bi].1.binary_search(&holder) {
-                        Ok(_) => Inserted::Existing,
-                        Err(at) => {
-                            buckets[bi].1.insert(at, holder);
-                            Inserted::AddedToExistingLineage
+                    Ok(bi) => {
+                        let set = &buckets[bi].1;
+                        match set.binary_search(&holder) {
+                            Ok(_) => Inserted::Existing,
+                            Err(at) => {
+                                let mut grown = Vec::with_capacity(set.len() + 1);
+                                grown.extend_from_slice(&set[..at]);
+                                grown.push(holder);
+                                grown.extend_from_slice(&set[at..]);
+                                let old =
+                                    std::mem::replace(&mut buckets[bi].1, interner.intern(&grown));
+                                interner.release(old);
+                                Inserted::AddedToExistingLineage
+                            }
                         }
-                    },
+                    }
                     Err(bi) => {
-                        buckets.insert(bi, (lineage, vec![holder]));
+                        buckets.insert(bi, (lineage, interner.intern(&[holder])));
                         Inserted::AddedNewLineage
                     }
                 }
@@ -220,7 +281,7 @@ impl Membership {
     }
 
     /// Remove; true when the whole membership is now empty.
-    fn remove(&mut self, lineage: u64, holder: u32) -> bool {
+    fn remove(&mut self, lineage: u64, holder: u32, interner: &mut SetInterner) -> bool {
         match self {
             Membership::One {
                 lineage: l,
@@ -228,10 +289,18 @@ impl Membership {
             } => *l == lineage && *h == holder,
             Membership::Many(buckets) => {
                 if let Ok(bi) = buckets.binary_search_by_key(&lineage, |&(l, _)| l) {
-                    if let Ok(at) = buckets[bi].1.binary_search(&holder) {
-                        buckets[bi].1.remove(at);
-                        if buckets[bi].1.is_empty() {
-                            buckets.remove(bi);
+                    let set = &buckets[bi].1;
+                    if let Ok(at) = set.binary_search(&holder) {
+                        if set.len() == 1 {
+                            let (_, old) = buckets.remove(bi);
+                            interner.release(old);
+                        } else {
+                            let mut shrunk = Vec::with_capacity(set.len() - 1);
+                            shrunk.extend_from_slice(&set[..at]);
+                            shrunk.extend_from_slice(&set[at + 1..]);
+                            let old =
+                                std::mem::replace(&mut buckets[bi].1, interner.intern(&shrunk));
+                            interner.release(old);
                         }
                     }
                 }
@@ -257,6 +326,15 @@ impl Membership {
     }
 }
 
+/// Caller-owned query scratch: keeps `overlap` allocation-free once
+/// warm while the tree itself stays `&self` on the read path (§8).
+#[derive(Debug, Default)]
+pub struct OverlapScratch {
+    active: Vec<u32>,
+    next: Vec<u32>,
+    lineages: Vec<u64>,
+}
+
 pub struct RadixTree {
     cfg: Config,
     entries: FxHashMap<(u32, ContentHash), Membership>,
@@ -265,11 +343,7 @@ pub struct RadixTree {
     free: Vec<u32>,
     holder_blocks_total: u64,
     distinct_lineage_entries: u64,
-    /// Scratch for the query walk (kept to stay allocation-free on
-    /// the hot path once warm).
-    scratch_active: Vec<u32>,
-    scratch_next: Vec<u32>,
-    scratch_lineages: Vec<u64>,
+    interner: SetInterner,
 }
 
 impl RadixTree {
@@ -282,9 +356,7 @@ impl RadixTree {
             free: Vec::new(),
             holder_blocks_total: 0,
             distinct_lineage_entries: 0,
-            scratch_active: Vec::new(),
-            scratch_next: Vec::new(),
-            scratch_lineages: Vec::new(),
+            interner: SetInterner::default(),
         }
     }
 
@@ -308,6 +380,10 @@ impl RadixTree {
             slot.state = Some(state);
             index
         } else {
+            assert!(
+                self.slots.len() < u32::MAX as usize,
+                "holder slot space exhausted (u32 indices)"
+            );
             self.slots.push(HolderSlot {
                 generation: 0,
                 state: Some(state),
@@ -415,6 +491,7 @@ impl RadixTree {
                     // accepts it.
                     Self::unindex(
                         &mut self.entries,
+                        &mut self.interner,
                         &mut self.distinct_lineage_entries,
                         id.index,
                         existing,
@@ -467,6 +544,7 @@ impl RadixTree {
             self.holder_blocks_total -= 1;
             Self::unindex(
                 &mut self.entries,
+                &mut self.interner,
                 &mut self.distinct_lineage_entries,
                 id.index,
                 info,
@@ -503,6 +581,7 @@ impl RadixTree {
             self.holder_blocks_total -= 1;
             Self::unindex(
                 &mut self.entries,
+                &mut self.interner,
                 &mut self.distinct_lineage_entries,
                 id.index,
                 info,
@@ -527,6 +606,7 @@ impl RadixTree {
         for (_, info) in registry {
             Self::unindex(
                 &mut self.entries,
+                &mut self.interner,
                 &mut self.distinct_lineage_entries,
                 id.index,
                 info,
@@ -546,13 +626,18 @@ impl RadixTree {
     /// phase 2's cheap merge is sequential. This is what makes exact
     /// matching latency-competitive without the oracle's unsound
     /// skip heuristics.
-    pub fn overlap(&mut self, chain: &[ContentHash], out: &mut Vec<Overlap>) {
+    pub fn overlap(
+        &self,
+        chain: &[ContentHash],
+        scratch: &mut OverlapScratch,
+        out: &mut Vec<Overlap>,
+    ) {
         out.clear();
         if chain.is_empty() {
             return;
         }
         // Phase 0: lineages up front.
-        let mut lineages = std::mem::take(&mut self.scratch_lineages);
+        let lineages = &mut scratch.lineages;
         lineages.clear();
         let mut lineage = 0u64;
         for (p, &content) in chain.iter().enumerate() {
@@ -584,12 +669,12 @@ impl RadixTree {
                 }
                 Some(Membership::Many(buckets)) => {
                     let run = if buckets.len() == 1 {
-                        (buckets[0].0 == lineages[p]).then(|| buckets[0].1.as_slice())
+                        (buckets[0].0 == lineages[p]).then(|| &*buckets[0].1)
                     } else {
                         buckets
                             .binary_search_by_key(&lineages[p], |&(l, _)| l)
                             .ok()
-                            .map(|bi| buckets[bi].1.as_slice())
+                            .map(|bi| &*buckets[bi].1)
                     };
                     match run {
                         Some(run) => {
@@ -606,12 +691,17 @@ impl RadixTree {
             }
         }
         // Phase 2: sequential merge over dense holder runs.
-        let mut active = std::mem::take(&mut self.scratch_active);
-        let mut next = std::mem::take(&mut self.scratch_next);
+        let mut active = std::mem::take(&mut scratch.active);
+        let mut next = std::mem::take(&mut scratch.next);
         active.clear();
         next.clear();
         let mut survivors_depth = 0u32;
         let mut one_hold = [0u32; 1];
+        // The interned-set identity `active` currently equals, when it
+        // exactly equals one: pointer equality against a position's
+        // run then proves "membership unchanged" in O(1), soundly
+        // (interning guarantees identical sets share one allocation).
+        let mut active_src: Option<*const u32> = None;
         for (p, probe) in probes.iter().enumerate() {
             let run: &[u32] = match probe {
                 RunProbe::One(h) => {
@@ -626,10 +716,18 @@ impl RadixTree {
                     break;
                 }
                 active.extend_from_slice(run);
+                if matches!(probe, RunProbe::Slice(_)) {
+                    active_src = Some(run.as_ptr());
+                }
             } else {
-                if run == active.as_slice() {
-                    // Unchanged membership (the common shared-run
-                    // case): one memcmp, no rebuild.
+                if active_src.is_some_and(|src| std::ptr::eq(src, run.as_ptr())) {
+                    // O(1) sound run-skip: same interned set object.
+                } else if run == active.as_slice() {
+                    // Content-equal after a hand-built subset: resync
+                    // to the interned identity.
+                    if matches!(probe, RunProbe::Slice(_)) {
+                        active_src = Some(run.as_ptr());
+                    }
                 } else {
                     // Merge-intersect two sorted runs; dropped
                     // holders get depth p in the same pass.
@@ -650,6 +748,13 @@ impl RadixTree {
                         ai += 1;
                     }
                     std::mem::swap(&mut active, &mut next);
+                    // next ⊆ run; equal lengths ⟹ equal sets.
+                    active_src = if active.len() == run.len() && matches!(probe, RunProbe::Slice(_))
+                    {
+                        Some(run.as_ptr())
+                    } else {
+                        None
+                    };
                 }
             }
             if active.is_empty() {
@@ -662,9 +767,8 @@ impl RadixTree {
             self.push_answer(h, survivors_depth, out);
         }
         drop(probes);
-        self.scratch_active = active;
-        self.scratch_next = next;
-        self.scratch_lineages = lineages;
+        scratch.active = active;
+        scratch.next = next;
     }
 
     /// Position-ordered enumeration (snapshot/Pull; §4). Order is
@@ -823,7 +927,7 @@ impl RadixTree {
                         }
                         prev_l = Some(*l);
                         let mut prev_h = None;
-                        for &h in holders {
+                        for &h in holders.iter() {
                             if prev_h.is_some_and(|p: u32| p >= h) {
                                 return Err(format!("unsorted holders at ({pos},{content:#x})"));
                             }
@@ -853,6 +957,34 @@ impl RadixTree {
                 "distinct_lineage_entries {} != recount {}",
                 self.distinct_lineage_entries, distinct
             ));
+        }
+        // Interner coherence: every bucket's set is findable in the
+        // table under its content hash, and the table holds no orphan
+        // sets (kept alive by nothing but the table = a leak).
+        for m in self.entries.values() {
+            if let Membership::Many(buckets) = m {
+                for (_, set) in buckets {
+                    let h = SetInterner::hash_of(set);
+                    let found = self
+                        .interner
+                        .table
+                        .get(&h)
+                        .is_some_and(|v| v.iter().any(|s| std::sync::Arc::ptr_eq(s, set)));
+                    if !found {
+                        return Err(format!("interned set {:?} missing from table", &set[..]));
+                    }
+                }
+            }
+        }
+        for (h, sets) in &self.interner.table {
+            for set in sets {
+                if std::sync::Arc::strong_count(set) == 1 {
+                    return Err(format!(
+                        "orphan interned set under hash {h:#x}: {:?}",
+                        &set[..]
+                    ));
+                }
+            }
         }
         Ok(())
     }
@@ -891,6 +1023,7 @@ impl RadixTree {
     /// key — the caller then treats the store as a duplicate and the
     /// new key is never registered (deterministic; audited).
     fn index_block(&mut self, holder: u32, info: BlockInfo) -> bool {
+        let interner = &mut self.interner;
         match self.entries.entry((info.pos, info.content)) {
             std::collections::hash_map::Entry::Vacant(vacant) => {
                 vacant.insert(Membership::One {
@@ -901,7 +1034,7 @@ impl RadixTree {
                 true
             }
             std::collections::hash_map::Entry::Occupied(mut occupied) => {
-                match occupied.get_mut().insert(info.lineage, holder) {
+                match occupied.get_mut().insert(info.lineage, holder, interner) {
                     Inserted::Existing => false,
                     Inserted::AddedToExistingLineage => true,
                     Inserted::AddedNewLineage => {
@@ -915,6 +1048,7 @@ impl RadixTree {
 
     fn unindex(
         entries: &mut FxHashMap<(u32, ContentHash), Membership>,
+        interner: &mut SetInterner,
         distinct: &mut u64,
         holder: u32,
         info: BlockInfo,
@@ -923,7 +1057,7 @@ impl RadixTree {
             return;
         };
         let shared = membership.lineage_shared_beyond(info.lineage, holder);
-        if membership.remove(info.lineage, holder) {
+        if membership.remove(info.lineage, holder, interner) {
             entries.remove(&(info.pos, info.content));
         }
         if !shared {

--- a/crates/radix_tree/src/lib.rs
+++ b/crates/radix_tree/src/lib.rs
@@ -1,25 +1,26 @@
-//! Generic prefix-membership index — the R1 flat core.
+//! Generic prefix-membership index.
 //!
 //! The contract lives in `SPEC.md`; the referee lives in
-//! `tests/differential.rs` (this implementation must equal the model
-//! there, always). Shape per §9: a flat positional entry map keyed by
-//! `(position, content)` with lineage-disambiguated membership, plus
-//! an internal per-holder registry — order-insensitive set semantics,
-//! so §7 convergence holds by construction. Single-writer (§8): no
-//! locks, no atomics, no shards.
+//! `tests/differential.rs` (every implementation must equal the
+//! reference model there, always). Two cores share the contract:
+//! [`RadixTree`] (the chain-native primary, `chain.rs`) and
+//! [`FlatTree`] (below in this file) — a flat positional entry map
+//! keyed by `(position, content)` with lineage-disambiguated
+//! membership and an internal per-holder registry;
+//! order-insensitive set semantics make convergence hold by
+//! construction. Both are single-writer: no locks, no atomics, no
+//! shards (§8).
 
 #![forbid(unsafe_code)]
 
-mod core3;
-/// The chain-native core is the crate's PRIMARY type: every original
-/// performance gate passed on it (26.9 B/holder-block, exact-match
-/// gate cell p99 7.6 us, scale-stable at 128M blocks) with the full
-/// referee equal. The flat core remains as [`FlatTree`] — a second,
-/// independently-verified implementation the dual-core harness keeps
-/// asserting against the model, and the substrate the chain core's
-/// interner came from.
-pub use core3::RadixTree3 as RadixTree;
-pub use core3::RadixTree3;
+mod chain;
+/// The chain-native core is the crate's primary type: chains stored
+/// as contiguous data shared by every holder, membership as maximal
+/// runs over interned holder sets, one entry probe per query. The
+/// flat core remains as [`FlatTree`] — a second, independently
+/// verified implementation the dual-core harness keeps asserting
+/// against the model.
+pub use chain::RadixTree;
 use rustc_hash::FxHashMap;
 
 /// Position-independent content identity (the matching currency).
@@ -844,7 +845,7 @@ impl FlatTree {
         }
     }
 
-    // ---- verification (campaign C2) ----
+    // ---- verification ----
 
     /// Full-state consistency audit: recomputes every counter and
     /// cross-checks every structure from first principles. O(state);

--- a/crates/radix_tree/src/lib.rs
+++ b/crates/radix_tree/src/lib.rs
@@ -10,6 +10,8 @@
 
 #![forbid(unsafe_code)]
 
+mod core3;
+pub use core3::RadixTree3;
 use rustc_hash::FxHashMap;
 
 /// Position-independent content identity (the matching currency).
@@ -32,6 +34,10 @@ impl HolderId {
     /// generation.
     pub fn parts(self) -> (u32, u64) {
         (self.index, self.generation)
+    }
+
+    pub(crate) fn assemble(index: u32, generation: u64) -> Self {
+        Self { index, generation }
     }
 }
 

--- a/crates/radix_tree/src/lib.rs
+++ b/crates/radix_tree/src/lib.rs
@@ -1,0 +1,8 @@
+//! Generic prefix-membership index — SPEC STAGE.
+//!
+//! The contract lives in `SPEC.md`. Per its §12, no core code lands
+//! before the verification harness exists: `tests/` holds the
+//! model-referee differential harness (a trivially-correct model of
+//! the §6/§7 contract, the `kv_index` oracle behind the engine's
+//! replicated glue, and the seeded workload generator). The R1 flat
+//! core will be implemented against that harness.

--- a/crates/radix_tree/tests/alloc_gate.rs
+++ b/crates/radix_tree/tests/alloc_gate.rs
@@ -8,7 +8,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use radix_tree::{Config, RadixTree, RadixTree3};
+use radix_tree::{Config, FlatTree, RadixTree3};
 
 struct Counting;
 
@@ -38,7 +38,7 @@ fn fresh_single_holder_stores_amortize_to_map_growth() {
 }
 
 fn run_flat() {
-    let mut tree = RadixTree::new(Config::default());
+    let mut tree = FlatTree::new(Config::default());
     let h = tree.create_holder("h");
     // Warm: one chain so first-touch allocations (scratch, maps) are
     // out of the measured window.

--- a/crates/radix_tree/tests/alloc_gate.rs
+++ b/crates/radix_tree/tests/alloc_gate.rs
@@ -8,7 +8,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use radix_tree::{Config, RadixTree};
+use radix_tree::{Config, RadixTree, RadixTree3};
 
 struct Counting;
 
@@ -33,6 +33,11 @@ static A: Counting = Counting;
 
 #[test]
 fn fresh_single_holder_stores_amortize_to_map_growth() {
+    run_flat();
+    run_chain();
+}
+
+fn run_flat() {
     let mut tree = RadixTree::new(Config::default());
     let h = tree.create_holder("h");
     // Warm: one chain so first-touch allocations (scratch, maps) are
@@ -76,6 +81,46 @@ fn fresh_single_holder_stores_amortize_to_map_growth() {
     // (a heap set per block would cost >= 1.0).
     assert!(
         per_block < 0.5,
-        "allocation regression: {per_block:.4} allocs/block (gate: < 0.5)"
+        "flat allocation regression: {per_block:.4} allocs/block (gate: < 0.5)"
+    );
+}
+
+/// Same gate for the chain-native core: contents-Vec growth and span
+/// bookkeeping must amortize, never per-block allocate.
+fn run_chain() {
+    let mut tree = RadixTree3::new(Config::default());
+    let h = tree.create_holder("h");
+    let warm: Vec<(u64, u64)> = (1..=64u64).map(|i| (i, i ^ 0xABCD)).collect();
+    tree.store(h, None, &warm).expect("warm");
+    const BLOCKS: u64 = 100_000;
+    const CHAIN_LEN: u64 = 512;
+    let mut batch = Vec::with_capacity(8);
+    let before = ALLOCS.load(Ordering::Relaxed);
+    let mut key = 10_000_000u64;
+    let mut stored = 0u64;
+    'outer: loop {
+        let mut parent = None;
+        let mut in_chain = 0u64;
+        while in_chain < CHAIN_LEN {
+            batch.clear();
+            for _ in 0..8 {
+                key += 1;
+                batch.push((key, key.wrapping_mul(0x9E3779B97F4A7C15) | 1));
+            }
+            tree.store(h, parent, &batch).expect("store");
+            parent = Some(key);
+            stored += 8;
+            in_chain += 8;
+            if stored >= BLOCKS {
+                break 'outer;
+            }
+        }
+    }
+    let allocs = ALLOCS.load(Ordering::Relaxed) - before;
+    let per_block = allocs as f64 / stored as f64;
+    println!("chain core: {allocs} allocations for {stored} blocks = {per_block:.4}/block");
+    assert!(
+        per_block < 0.5,
+        "chain allocation regression: {per_block:.4} allocs/block (gate: < 0.5)"
     );
 }

--- a/crates/radix_tree/tests/alloc_gate.rs
+++ b/crates/radix_tree/tests/alloc_gate.rs
@@ -1,0 +1,81 @@
+//! §11 allocation gate: storing fresh single-holder blocks performs
+//! zero heap allocations amortized beyond map growth. The relative
+//! RSS gate cannot catch a regression to per-block heap sets (the
+//! §13.4 risk), so this counts allocations directly.
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use radix_tree::{Config, RadixTree};
+
+struct Counting;
+
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        System.alloc(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static A: Counting = Counting;
+
+#[test]
+fn fresh_single_holder_stores_amortize_to_map_growth() {
+    let mut tree = RadixTree::new(Config::default());
+    let h = tree.create_holder("h");
+    // Warm: one chain so first-touch allocations (scratch, maps) are
+    // out of the measured window.
+    let warm: Vec<(u64, u64)> = (1..=64u64).map(|i| (i, i ^ 0xABCD)).collect();
+    tree.store(h, None, &warm).expect("warm");
+
+    // Many realistic-length chains (512 blocks), fresh single-holder
+    // blocks throughout — never near max_chain_len.
+    const BLOCKS: u64 = 100_000;
+    const CHAIN_LEN: u64 = 512;
+    let mut batch = Vec::with_capacity(8);
+    let before = ALLOCS.load(Ordering::Relaxed);
+    let mut key = 1000u64;
+    let mut stored = 0u64;
+    'outer: loop {
+        let mut parent = None;
+        let mut in_chain = 0u64;
+        while in_chain < CHAIN_LEN {
+            batch.clear();
+            for _ in 0..8 {
+                key += 1;
+                batch.push((key, key.wrapping_mul(0x9E3779B97F4A7C15) | 1));
+            }
+            tree.store(h, parent, &batch).expect("store");
+            parent = Some(key);
+            stored += 8;
+            in_chain += 8;
+            if stored >= BLOCKS {
+                break 'outer;
+            }
+        }
+    }
+    let allocs = ALLOCS.load(Ordering::Relaxed) - before;
+    let per_block = allocs as f64 / stored as f64;
+    println!("{allocs} allocations for {stored} single-holder blocks = {per_block:.4}/block");
+    // Membership::One is inline (zero per-block); what remains is
+    // amortized structure growth: BTreeSet nodes (~1 per 11 inserts)
+    // and hash-map doublings. 0.5/block is generous headroom over
+    // that floor while still failing any per-block heap regression
+    // (a heap set per block would cost >= 1.0).
+    assert!(
+        per_block < 0.5,
+        "allocation regression: {per_block:.4} allocs/block (gate: < 0.5)"
+    );
+}

--- a/crates/radix_tree/tests/alloc_gate.rs
+++ b/crates/radix_tree/tests/alloc_gate.rs
@@ -8,7 +8,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use radix_tree::{Config, FlatTree, RadixTree3};
+use radix_tree::{Config, FlatTree, RadixTree};
 
 struct Counting;
 
@@ -88,7 +88,7 @@ fn run_flat() {
 /// Same gate for the chain-native core: contents-Vec growth and span
 /// bookkeeping must amortize, never per-block allocate.
 fn run_chain() {
-    let mut tree = RadixTree3::new(Config::default());
+    let mut tree = RadixTree::new(Config::default());
     let h = tree.create_holder("h");
     let warm: Vec<(u64, u64)> = (1..=64u64).map(|i| (i, i ^ 0xABCD)).collect();
     tree.store(h, None, &warm).expect("warm");

--- a/crates/radix_tree/tests/api.rs
+++ b/crates/radix_tree/tests/api.rs
@@ -2,7 +2,7 @@
 //! differential harness can't reach because the model deliberately
 //! has no ids, config bounds, or lifecycle.
 
-use radix_tree::{Config, RadixTree, StoreError};
+use radix_tree::{Config, OverlapScratch, RadixTree, StoreError};
 
 fn tree() -> RadixTree {
     RadixTree::new(Config::default())
@@ -75,10 +75,11 @@ fn truncate_tail_is_forest_wide_prefix_closed_and_deterministic() {
     // p-1 present on the same chain (A kept 0,1; B kept 0).
     // Queries still answer the kept prefixes exactly.
     let mut out = Vec::new();
-    t.overlap(&[1, 2, 3], &mut out);
+    let mut sc = OverlapScratch::default();
+    t.overlap(&[1, 2, 3], &mut sc, &mut out);
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].depth, 2);
-    t.overlap(&[5, 6], &mut out);
+    t.overlap(&[5, 6], &mut sc, &mut out);
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].depth, 1);
 }
@@ -120,14 +121,15 @@ fn lineage_exactness_content_coincidence_never_over_matches() {
     t.store(h, None, &[(1, 7), (2, 8)]).expect("X");
     t.store(h, None, &[(3, 9), (4, 8)]).expect("Y");
     let mut out = Vec::new();
+    let mut sc = OverlapScratch::default();
     // Query [7, 8]: depth 2 via X only.
-    t.overlap(&[7, 8], &mut out);
+    t.overlap(&[7, 8], &mut sc, &mut out);
     assert_eq!((out[0].holder, out[0].depth), (h, 2));
     // Query [9, 8]: depth 2 via Y only.
-    t.overlap(&[9, 8], &mut out);
+    t.overlap(&[9, 8], &mut sc, &mut out);
     assert_eq!((out[0].holder, out[0].depth), (h, 2));
     // Query [5, 8]: content 8 exists at position 1 (twice!) but no
     // chain has lineage [5] -> depth 0, no answer at all.
-    t.overlap(&[5, 8], &mut out);
+    t.overlap(&[5, 8], &mut sc, &mut out);
     assert!(out.is_empty(), "lineage-blind positional match leaked");
 }

--- a/crates/radix_tree/tests/api.rs
+++ b/crates/radix_tree/tests/api.rs
@@ -1,0 +1,133 @@
+//! Targeted API contract tests (SPEC.md §4/§5): the behaviors the
+//! differential harness can't reach because the model deliberately
+//! has no ids, config bounds, or lifecycle.
+
+use radix_tree::{Config, RadixTree, StoreError};
+
+fn tree() -> RadixTree {
+    RadixTree::new(Config::default())
+}
+
+#[test]
+fn stale_id_fails_loudly_never_aliases() {
+    let mut t = tree();
+    let a = t.create_holder("a");
+    t.store(a, None, &[(1, 10), (2, 20)]).expect("store");
+    t.retire_holder(a);
+    // Slot recycled by a different holder.
+    let b = t.create_holder("b");
+    t.store(b, None, &[(3, 30)]).expect("store");
+    assert_eq!(a.parts().0, b.parts().0, "test premise: slot reused");
+    // Every operation through the stale id is a loud no-op.
+    assert_eq!(t.store(a, None, &[(4, 40)]), Err(StoreError::UnknownHolder));
+    assert_eq!(t.remove(a, &[3]), 0);
+    assert_eq!(t.holder_blocks(a), 0);
+    assert_eq!(t.holder_name(a), None);
+    assert_eq!(t.enumerate(a).count(), 0);
+    assert_eq!(t.truncate_tail(a, 0), 0);
+    // The recycled holder was never touched.
+    assert_eq!(t.holder_blocks(b), 1);
+    assert_eq!(t.holder_name(b), Some("b"));
+}
+
+#[test]
+fn retire_releases_everything_bounded_under_churn() {
+    let mut t = tree();
+    let mut baseline = None;
+    for cycle in 0..200u64 {
+        let h = t.create_holder(&format!("pod-{cycle}"));
+        let blocks: Vec<(u64, u64)> = (0..64)
+            .map(|i| (cycle * 1000 + i + 1, cycle * 2000 + i + 1))
+            .collect();
+        t.store(h, None, &blocks).expect("store");
+        t.retire_holder(h);
+        let est = t.stats().bytes_estimate;
+        match baseline {
+            None => baseline = Some(est),
+            Some(b) => assert!(
+                est <= b,
+                "state grew under churn: cycle {cycle}, {est} > {b}"
+            ),
+        }
+        assert_eq!(t.stats().holders, 0);
+        assert_eq!(t.stats().holder_blocks, 0);
+        assert_eq!(t.stats().distinct_entries, 0);
+    }
+}
+
+#[test]
+fn truncate_tail_is_forest_wide_prefix_closed_and_deterministic() {
+    let mut t = tree();
+    let h = t.create_holder("h");
+    // Two chains: positions 0..4 and 0..2.
+    t.store(h, None, &[(10, 1), (11, 2), (12, 3), (13, 4)])
+        .expect("chain A");
+    t.store(h, None, &[(20, 5), (21, 6)]).expect("chain B");
+    assert_eq!(t.holder_blocks(h), 6);
+    // keep=3: drops A@3, A@2, then the position-1 tie (A@1 key 11 vs
+    // B@1 key 21) resolved by HIGHEST key first per the (pos, key)
+    // order -> 21 goes first.
+    let dropped = t.truncate_tail(h, 3);
+    assert_eq!(dropped, 3);
+    let left: Vec<(u32, u64, u64)> = t.enumerate(h).collect();
+    assert_eq!(left, vec![(0, 10, 1), (0, 20, 5), (1, 11, 2)]);
+    // Prefix-closed: every remaining position p>0 has its position
+    // p-1 present on the same chain (A kept 0,1; B kept 0).
+    // Queries still answer the kept prefixes exactly.
+    let mut out = Vec::new();
+    t.overlap(&[1, 2, 3], &mut out);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].depth, 2);
+    t.overlap(&[5, 6], &mut out);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].depth, 1);
+}
+
+#[test]
+fn chain_too_long_is_terminal_and_atomic() {
+    let mut t = RadixTree::new(Config { max_chain_len: 4 });
+    let h = t.create_holder("h");
+    t.store(h, None, &[(1, 1), (2, 2), (3, 3)]).expect("fits");
+    // Extending 3 + 2 > 4: rejected whole.
+    assert_eq!(
+        t.store(h, Some(3), &[(4, 4), (5, 5)]),
+        Err(StoreError::ChainTooLong)
+    );
+    assert_eq!(t.holder_blocks(h), 3);
+    // Exactly at the bound is fine.
+    t.store(h, Some(3), &[(4, 4)]).expect("at bound");
+    assert_eq!(t.holder_blocks(h), 4);
+}
+
+#[test]
+fn create_holder_is_idempotent_per_live_name() {
+    let mut t = tree();
+    let a1 = t.create_holder("a");
+    let a2 = t.create_holder("a");
+    assert_eq!(a1, a2);
+    t.retire_holder(a1);
+    let a3 = t.create_holder("a");
+    assert_ne!(a1, a3, "new generation after retire");
+    assert_eq!(t.holder_blocks(a3), 0);
+}
+
+#[test]
+fn lineage_exactness_content_coincidence_never_over_matches() {
+    let mut t = tree();
+    let h = t.create_holder("h");
+    // Chain X: contents [7, 8]; chain Y: contents [9, 8] — content 8
+    // appears at position 1 under BOTH lineages.
+    t.store(h, None, &[(1, 7), (2, 8)]).expect("X");
+    t.store(h, None, &[(3, 9), (4, 8)]).expect("Y");
+    let mut out = Vec::new();
+    // Query [7, 8]: depth 2 via X only.
+    t.overlap(&[7, 8], &mut out);
+    assert_eq!((out[0].holder, out[0].depth), (h, 2));
+    // Query [9, 8]: depth 2 via Y only.
+    t.overlap(&[9, 8], &mut out);
+    assert_eq!((out[0].holder, out[0].depth), (h, 2));
+    // Query [5, 8]: content 8 exists at position 1 (twice!) but no
+    // chain has lineage [5] -> depth 0, no answer at all.
+    t.overlap(&[5, 8], &mut out);
+    assert!(out.is_empty(), "lineage-blind positional match leaked");
+}

--- a/crates/radix_tree/tests/common/mod.rs
+++ b/crates/radix_tree/tests/common/mod.rs
@@ -11,6 +11,10 @@
 //!   §7-scoped operation streams with shared prefixes, divergent
 //!   tails, duplicates, gaps, and content coincidence.
 
+// Each integration-test binary compiles this module independently and
+// uses a different slice of it; unused-in-this-binary is expected.
+#![allow(dead_code)]
+
 pub mod model;
 pub mod oracle;
 pub mod workload;

--- a/crates/radix_tree/tests/common/mod.rs
+++ b/crates/radix_tree/tests/common/mod.rs
@@ -1,0 +1,78 @@
+//! The model-referee harness (SPEC.md §10.1).
+//!
+//! Three pieces:
+//! - [`model`]: a trivially-correct implementation of the §6/§7
+//!   contract — per-holder chain forests with literal lineage
+//!   vectors. Slow, obvious, and the referee for everything else.
+//! - [`oracle`]: `kv_index::PositionalIndexer` behind the engine's
+//!   replicated glue (per-holder reverse maps, interning), applied
+//!   through the same operation stream.
+//! - [`workload`]: a seeded deterministic generator producing
+//!   §7-scoped operation streams with shared prefixes, divergent
+//!   tails, duplicates, gaps, and content coincidence.
+
+pub mod model;
+pub mod oracle;
+pub mod workload;
+
+/// One operation in a workload stream. Holder identity is a dense
+/// index (the harness maps it to names/ids per implementation).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Op {
+    Store {
+        holder: usize,
+        /// `None` anchors a new chain at position 0.
+        parent: Option<u64>,
+        /// (BlockKey, ContentHash) pairs, consecutive positions.
+        blocks: Vec<(u64, u64)>,
+    },
+    Remove {
+        holder: usize,
+        keys: Vec<u64>,
+    },
+    Clear {
+        holder: usize,
+    },
+}
+
+impl Op {
+    pub fn holder(&self) -> usize {
+        match self {
+            Op::Store { holder, .. } | Op::Remove { holder, .. } | Op::Clear { holder } => *holder,
+        }
+    }
+
+    /// Whether reordering this op against its holder's stores is
+    /// outside the §7 convergence scope. (Used by the R1 convergence
+    /// suite; the R0 reinterleaver conservatively keeps all order.)
+    #[allow(dead_code)]
+    pub fn orders_holder(&self) -> bool {
+        matches!(self, Op::Remove { .. } | Op::Clear { .. })
+    }
+}
+
+/// SplitMix64: tiny deterministic RNG so the harness has zero deps
+/// and identical streams on every platform.
+#[derive(Debug, Clone)]
+pub struct Rng(pub u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+    pub fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+    /// Uniform in [0, n).
+    pub fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+    /// Bernoulli with probability pct/100.
+    pub fn chance(&mut self, pct: u64) -> bool {
+        self.next() % 100 < pct
+    }
+}

--- a/crates/radix_tree/tests/common/model.rs
+++ b/crates/radix_tree/tests/common/model.rs
@@ -107,6 +107,17 @@ impl Model {
                 chain: chain_idx,
                 pos,
             };
+            // §4 twin-key rule: a DIFFERENT key already occupying this
+            // exact (chain, position) with the same content is the
+            // same block in every observable sense — duplicate, the
+            // new key is never registered.
+            if h.registry.get(&key).is_none_or(|p| *p != placement) {
+                let chain = &h.chains[chain_idx];
+                if chain.present.get(&pos).map(|&(k, c)| (k != key, c)) == Some((true, content)) {
+                    duplicates += 1;
+                    continue;
+                }
+            }
             match h.registry.get(&key) {
                 Some(existing) if *existing == placement => {
                     duplicates += 1;
@@ -196,6 +207,32 @@ impl Model {
             .chains
             .iter()
             .any(|c| c.present.get(&pos).map(|&(_, content)| content) == Some(q))
+    }
+
+    /// Position-ordered (pos, key, content) across the forest —
+    /// the model's answer to `enumerate` (sorted by (pos, key)).
+    pub fn enumerate(&self, holder: usize) -> Vec<(u32, u64, u64)> {
+        let mut v: Vec<(u32, u64, u64)> = self.holders[holder]
+            .chains
+            .iter()
+            .flat_map(|c| c.present.iter().map(|(&p, &(k, content))| (p, k, content)))
+            .collect();
+        v.sort_unstable();
+        v
+    }
+
+    /// Distinct (position, content, lineage-prefix) across all
+    /// holders — the model's answer to stats().distinct_entries.
+    pub fn distinct_entries(&self) -> u64 {
+        let mut set = std::collections::HashSet::new();
+        for h in &self.holders {
+            for c in &h.chains {
+                for (&p, &(_, content)) in &c.present {
+                    set.insert((p, content, c.lineage[..=p as usize].to_vec()));
+                }
+            }
+        }
+        set.len() as u64
     }
 
     /// Does `holder` hold a LINEAGE-TRUE block at `pos` for this query

--- a/crates/radix_tree/tests/common/model.rs
+++ b/crates/radix_tree/tests/common/model.rs
@@ -1,0 +1,212 @@
+//! The trivially-correct model of SPEC.md §6/§7.
+//!
+//! Chosen for obviousness over speed: chains store their lineage as
+//! literal content vectors, depth is computed by scanning every chain
+//! of every holder, and nothing is amortized. If this model and an
+//! implementation disagree, the implementation is wrong (or the spec
+//! is — either way, loudly).
+
+use std::collections::{BTreeMap, HashMap};
+
+use super::Op;
+
+/// A stored block's placement inside one holder's forest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Placement {
+    chain: usize,
+    pos: u32,
+}
+
+#[derive(Debug, Clone, Default)]
+struct Chain {
+    /// Positions currently present: pos -> (key, content).
+    present: BTreeMap<u32, (u64, u64)>,
+    /// Append-only lineage: content by position AS STORED. Removal
+    /// leaves lineage intact (a block's identity includes the prefix
+    /// it was stored under, §3), so re-parented children keep
+    /// matching their original chain.
+    lineage: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct Holder {
+    chains: Vec<Chain>,
+    registry: HashMap<u64, Placement>,
+}
+
+/// Model-level store outcome, mirroring the §4 error surface the
+/// generator and (later) the R1 core must agree on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreResult {
+    Applied { applied: u32, duplicates: u32 },
+    ParentNotFound,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Model {
+    holders: Vec<Holder>,
+}
+
+impl Model {
+    pub fn new(holder_count: usize) -> Self {
+        Self {
+            holders: vec![Holder::default(); holder_count],
+        }
+    }
+
+    pub fn apply(&mut self, op: &Op) -> Option<StoreResult> {
+        match op {
+            Op::Store {
+                holder,
+                parent,
+                blocks,
+            } => Some(self.store(*holder, *parent, blocks)),
+            Op::Remove { holder, keys } => {
+                self.remove(*holder, keys);
+                None
+            }
+            Op::Clear { holder } => {
+                self.clear(*holder);
+                None
+            }
+        }
+    }
+
+    fn store(&mut self, holder: usize, parent: Option<u64>, blocks: &[(u64, u64)]) -> StoreResult {
+        if blocks.is_empty() {
+            return StoreResult::Applied {
+                applied: 0,
+                duplicates: 0,
+            };
+        }
+        let h = &mut self.holders[holder];
+        let (chain_idx, start_pos) = match parent {
+            None => {
+                // A parent-None batch whose first block is already
+                // registered at position 0 extends/duplicates that
+                // chain rather than opening a twin (placement
+                // re-publish is the common case).
+                match h.registry.get(&blocks[0].0) {
+                    Some(p) if p.pos == 0 => (p.chain, 0),
+                    _ => {
+                        h.chains.push(Chain::default());
+                        (h.chains.len() - 1, 0)
+                    }
+                }
+            }
+            Some(parent_key) => match h.registry.get(&parent_key) {
+                None => return StoreResult::ParentNotFound,
+                Some(p) => (p.chain, p.pos + 1),
+            },
+        };
+        let mut applied = 0u32;
+        let mut duplicates = 0u32;
+        for (i, &(key, content)) in blocks.iter().enumerate() {
+            let pos = start_pos + i as u32;
+            let placement = Placement {
+                chain: chain_idx,
+                pos,
+            };
+            match h.registry.get(&key) {
+                Some(existing) if *existing == placement => {
+                    duplicates += 1;
+                    continue;
+                }
+                Some(&existing) => {
+                    // §4: re-registering at a different placement MOVES
+                    // the block (out of chain-consistent scope, but
+                    // deterministic under per-holder order).
+                    h.chains[existing.chain].present.remove(&existing.pos);
+                }
+                None => {}
+            }
+            let chain = &mut h.chains[chain_idx];
+            if chain.lineage.len() <= pos as usize {
+                chain.lineage.resize(pos as usize + 1, 0);
+            }
+            chain.lineage[pos as usize] = content;
+            chain.present.insert(pos, (key, content));
+            h.registry.insert(key, placement);
+            applied += 1;
+        }
+        StoreResult::Applied {
+            applied,
+            duplicates,
+        }
+    }
+
+    fn remove(&mut self, holder: usize, keys: &[u64]) -> u32 {
+        let h = &mut self.holders[holder];
+        let mut removed = 0;
+        for key in keys {
+            if let Some(p) = h.registry.remove(key) {
+                h.chains[p.chain].present.remove(&p.pos);
+                removed += 1;
+            }
+        }
+        removed
+    }
+
+    fn clear(&mut self, holder: usize) {
+        self.holders[holder] = Holder::default();
+    }
+
+    /// §6 depth: the largest `d` such that ONE chain holds every
+    /// position `p < d` with content `query[p]` AND lineage exactly
+    /// `query[0..p]`. Lineage prefix equality plus presence.
+    pub fn depth(&self, holder: usize, query: &[u64]) -> u32 {
+        let mut best = 0u32;
+        for chain in &self.holders[holder].chains {
+            let mut d = 0u32;
+            for (p, &q) in query.iter().enumerate() {
+                let lineage_true = chain.lineage.get(p) == Some(&q);
+                let present_true = chain.present.get(&(p as u32)).map(|&(_, c)| c) == Some(q);
+                if lineage_true && present_true {
+                    d = p as u32 + 1;
+                } else {
+                    break;
+                }
+            }
+            best = best.max(d);
+        }
+        best
+    }
+
+    /// Full holder->depth map for one query (§10.1: map equality,
+    /// never a depth multiset). Depth-0 holders are absent.
+    pub fn overlap(&self, query: &[u64]) -> BTreeMap<usize, u32> {
+        let mut out = BTreeMap::new();
+        for holder in 0..self.holders.len() {
+            let d = self.depth(holder, query);
+            if d > 0 {
+                out.insert(holder, d);
+            }
+        }
+        out
+    }
+
+    pub fn holder_blocks(&self, holder: usize) -> u64 {
+        self.holders[holder].registry.len() as u64
+    }
+
+    /// Does `holder` hold content `q` anywhere at `pos` (any lineage)?
+    /// The divergence classifier's discriminator (§6 quirk classes).
+    pub fn holds_content_at(&self, holder: usize, pos: u32, q: u64) -> bool {
+        self.holders[holder]
+            .chains
+            .iter()
+            .any(|c| c.present.get(&pos).map(|&(_, content)| content) == Some(q))
+    }
+
+    /// Does `holder` hold a LINEAGE-TRUE block at `pos` for this query
+    /// (present, right content, lineage == query[0..pos]) — i.e. the
+    /// only reason model depth stopped short of it is a missing
+    /// EARLIER position (a gap)?
+    pub fn holds_lineage_true_at(&self, holder: usize, pos: u32, query: &[u64]) -> bool {
+        self.holders[holder].chains.iter().any(|c| {
+            c.present.get(&pos).map(|&(_, content)| content) == Some(query[pos as usize])
+                && c.lineage.len() > pos as usize
+                && c.lineage[..=pos as usize] == query[..=pos as usize]
+        })
+    }
+}

--- a/crates/radix_tree/tests/common/model.rs
+++ b/crates/radix_tree/tests/common/model.rs
@@ -1,56 +1,65 @@
-//! The trivially-correct model of SPEC.md §6/§7.
+//! The trivially-correct model of SPEC.md §4/§6/§7.
 //!
-//! Chosen for obviousness over speed: chains store their lineage as
-//! literal content vectors, depth is computed by scanning every chain
-//! of every holder, and nothing is amortized. If this model and an
-//! implementation disagree, the implementation is wrong (or the spec
-//! is — either way, loudly).
+//! Representationally complete: every block carries its OWN literal
+//! lineage (the content prefix it was stored under, including
+//! itself), exactly mirroring the subject's registry of
+//! (position, content, lineage-fingerprint) — with the fingerprint
+//! replaced by the literal vector, so no hashing and no collisions.
+//! This makes the model defined on ARBITRARY inputs (aliases, moves,
+//! twin keys), which lets the chaos fuzz use it as referee too.
+//!
+//! §4 alias semantics, mirrored exactly:
+//! - same key, same (pos, content, lineage): duplicate;
+//! - different key, same (pos, content, lineage) already held: the
+//!   new key is a duplicate and is NEVER registered — and when that
+//!   key was previously registered elsewhere (a refused MOVE), its
+//!   old placement stays intact;
+//! - same key, different placement: MOVE (old placement removed).
 
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    rc::Rc,
+};
 
 use super::Op;
 
-/// A stored block's placement inside one holder's forest.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct Placement {
-    chain: usize,
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BlockRec {
     pos: u32,
-}
-
-#[derive(Debug, Clone, Default)]
-struct Chain {
-    /// Positions currently present: pos -> (key, content).
-    present: BTreeMap<u32, (u64, u64)>,
-    /// Append-only lineage: content by position AS STORED. Removal
-    /// leaves lineage intact (a block's identity includes the prefix
-    /// it was stored under, §3), so re-parented children keep
-    /// matching their original chain.
-    lineage: Vec<u64>,
+    content: u64,
+    /// Literal lineage: contents at positions 0..=pos as stored.
+    lineage: Rc<Vec<u64>>,
 }
 
 #[derive(Debug, Clone, Default)]
 struct Holder {
-    chains: Vec<Chain>,
-    registry: HashMap<u64, Placement>,
+    registry: HashMap<u64, BlockRec>,
 }
 
-/// Model-level store outcome, mirroring the §4 error surface the
-/// generator and (later) the R1 core must agree on.
+/// Model-level store outcome, mirroring the §4 error surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StoreResult {
     Applied { applied: u32, duplicates: u32 },
     ParentNotFound,
+    ChainTooLong,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct Model {
     holders: Vec<Holder>,
+    max_chain_len: u32,
 }
 
 impl Model {
     pub fn new(holder_count: usize) -> Self {
+        Self::with_max(holder_count, 65_536)
+    }
+
+    /// Mirror a subject configured with a specific max_chain_len.
+    pub fn with_max(holder_count: usize, max_chain_len: u32) -> Self {
         Self {
             holders: vec![Holder::default(); holder_count],
+            max_chain_len,
         }
     }
 
@@ -72,7 +81,12 @@ impl Model {
         }
     }
 
-    fn store(&mut self, holder: usize, parent: Option<u64>, blocks: &[(u64, u64)]) -> StoreResult {
+    pub fn store(
+        &mut self,
+        holder: usize,
+        parent: Option<u64>,
+        blocks: &[(u64, u64)],
+    ) -> StoreResult {
         if blocks.is_empty() {
             return StoreResult::Applied {
                 applied: 0,
@@ -80,64 +94,43 @@ impl Model {
             };
         }
         let h = &mut self.holders[holder];
-        let (chain_idx, start_pos) = match parent {
-            None => {
-                // A parent-None batch whose first block is already
-                // registered at position 0 extends/duplicates that
-                // chain rather than opening a twin (placement
-                // re-publish is the common case).
-                match h.registry.get(&blocks[0].0) {
-                    Some(p) if p.pos == 0 => (p.chain, 0),
-                    _ => {
-                        h.chains.push(Chain::default());
-                        (h.chains.len() - 1, 0)
-                    }
-                }
-            }
+        let (start_pos, mut prefix) = match parent {
+            None => (0u32, Vec::new()),
             Some(parent_key) => match h.registry.get(&parent_key) {
                 None => return StoreResult::ParentNotFound,
-                Some(p) => (p.chain, p.pos + 1),
+                Some(rec) => (rec.pos + 1, rec.lineage.as_ref().clone()),
             },
         };
+        if start_pos as u64 + blocks.len() as u64 > self.max_chain_len as u64 {
+            return StoreResult::ChainTooLong;
+        }
         let mut applied = 0u32;
         let mut duplicates = 0u32;
         for (i, &(key, content)) in blocks.iter().enumerate() {
             let pos = start_pos + i as u32;
-            let placement = Placement {
-                chain: chain_idx,
+            prefix.push(content);
+            let candidate = BlockRec {
                 pos,
+                content,
+                lineage: Rc::new(prefix.clone()),
             };
-            // §4 twin-key rule: a DIFFERENT key already occupying this
-            // exact (chain, position) with the same content is the
-            // same block in every observable sense — duplicate, the
-            // new key is never registered.
-            if h.registry.get(&key).is_none_or(|p| *p != placement) {
-                let chain = &h.chains[chain_idx];
-                if chain.present.get(&pos).map(|&(k, c)| (k != key, c)) == Some((true, content)) {
-                    duplicates += 1;
-                    continue;
-                }
+            if h.registry.get(&key) == Some(&candidate) {
+                duplicates += 1;
+                continue;
             }
-            match h.registry.get(&key) {
-                Some(existing) if *existing == placement => {
-                    duplicates += 1;
-                    continue;
-                }
-                Some(&existing) => {
-                    // §4: re-registering at a different placement MOVES
-                    // the block (out of chain-consistent scope, but
-                    // deterministic under per-holder order).
-                    h.chains[existing.chain].present.remove(&existing.pos);
-                }
-                None => {}
+            // Alias: any OTHER key already at this exact triple?
+            let aliased = h
+                .registry
+                .iter()
+                .any(|(&k, rec)| k != key && *rec == candidate);
+            if aliased {
+                // Duplicate in every observable sense; a would-be MOVE
+                // is refused non-destructively (old placement stays).
+                duplicates += 1;
+                continue;
             }
-            let chain = &mut h.chains[chain_idx];
-            if chain.lineage.len() <= pos as usize {
-                chain.lineage.resize(pos as usize + 1, 0);
-            }
-            chain.lineage[pos as usize] = content;
-            chain.present.insert(pos, (key, content));
-            h.registry.insert(key, placement);
+            // MOVE or fresh insert: (re)register.
+            h.registry.insert(key, candidate);
             applied += 1;
         }
         StoreResult::Applied {
@@ -146,45 +139,61 @@ impl Model {
         }
     }
 
-    fn remove(&mut self, holder: usize, keys: &[u64]) -> u32 {
+    pub fn remove(&mut self, holder: usize, keys: &[u64]) -> u32 {
         let h = &mut self.holders[holder];
         let mut removed = 0;
         for key in keys {
-            if let Some(p) = h.registry.remove(key) {
-                h.chains[p.chain].present.remove(&p.pos);
+            if h.registry.remove(key).is_some() {
                 removed += 1;
             }
         }
         removed
     }
 
-    fn clear(&mut self, holder: usize) {
+    pub fn clear(&mut self, holder: usize) {
         self.holders[holder] = Holder::default();
     }
 
-    /// §6 depth: the largest `d` such that ONE chain holds every
-    /// position `p < d` with content `query[p]` AND lineage exactly
-    /// `query[0..p]`. Lineage prefix equality plus presence.
-    pub fn depth(&self, holder: usize, query: &[u64]) -> u32 {
-        let mut best = 0u32;
-        for chain in &self.holders[holder].chains {
-            let mut d = 0u32;
-            for (p, &q) in query.iter().enumerate() {
-                let lineage_true = chain.lineage.get(p) == Some(&q);
-                let present_true = chain.present.get(&(p as u32)).map(|&(_, c)| c) == Some(q);
-                if lineage_true && present_true {
-                    d = p as u32 + 1;
-                } else {
-                    break;
-                }
-            }
-            best = best.max(d);
+    /// Forest-wide §4 truncate: strictly decreasing positions, ties
+    /// by key, until `keep` remain.
+    pub fn truncate_tail(&mut self, holder: usize, keep: u64) -> u64 {
+        let h = &mut self.holders[holder];
+        if h.registry.len() as u64 <= keep {
+            return 0;
         }
-        best
+        let mut ordered: Vec<(u32, u64)> = h.registry.iter().map(|(&k, r)| (r.pos, k)).collect();
+        ordered.sort_unstable();
+        let mut dropped = 0u64;
+        while h.registry.len() as u64 > keep {
+            let (_, key) = ordered.pop().expect("non-empty");
+            h.registry.remove(&key);
+            dropped += 1;
+        }
+        dropped
     }
 
-    /// Full holder->depth map for one query (§10.1: map equality,
-    /// never a depth multiset). Depth-0 holders are absent.
+    /// §6 depth: largest d such that for every p < d the holder has a
+    /// block at position p whose content is query[p] and whose
+    /// LITERAL lineage equals query[0..=p].
+    pub fn depth(&self, holder: usize, query: &[u64]) -> u32 {
+        let mut d = 0u32;
+        'outer: for (p, &q) in query.iter().enumerate() {
+            for rec in self.holders[holder].registry.values() {
+                if rec.pos == p as u32
+                    && rec.content == q
+                    && rec.lineage.len() == p + 1
+                    && rec.lineage[..] == query[..=p]
+                {
+                    d = p as u32 + 1;
+                    continue 'outer;
+                }
+            }
+            break;
+        }
+        d
+    }
+
+    /// Full holder->depth map (§10.1: map equality, depth-0 absent).
     pub fn overlap(&self, query: &[u64]) -> BTreeMap<usize, u32> {
         let mut out = BTreeMap::new();
         for holder in 0..self.holders.len() {
@@ -200,50 +209,49 @@ impl Model {
         self.holders[holder].registry.len() as u64
     }
 
-    /// Does `holder` hold content `q` anywhere at `pos` (any lineage)?
-    /// The divergence classifier's discriminator (§6 quirk classes).
-    pub fn holds_content_at(&self, holder: usize, pos: u32, q: u64) -> bool {
-        self.holders[holder]
-            .chains
-            .iter()
-            .any(|c| c.present.get(&pos).map(|&(_, content)| content) == Some(q))
-    }
-
-    /// Position-ordered (pos, key, content) across the forest —
-    /// the model's answer to `enumerate` (sorted by (pos, key)).
+    /// Position-ordered (pos, key, content) — the model's `enumerate`.
     pub fn enumerate(&self, holder: usize) -> Vec<(u32, u64, u64)> {
         let mut v: Vec<(u32, u64, u64)> = self.holders[holder]
-            .chains
+            .registry
             .iter()
-            .flat_map(|c| c.present.iter().map(|(&p, &(k, content))| (p, k, content)))
+            .map(|(&k, r)| (r.pos, k, r.content))
             .collect();
         v.sort_unstable();
         v
     }
 
-    /// Distinct (position, content, lineage-prefix) across all
-    /// holders — the model's answer to stats().distinct_entries.
+    /// Distinct (position, content, lineage) across all holders — the
+    /// model's stats().distinct_entries.
     pub fn distinct_entries(&self) -> u64 {
         let mut set = std::collections::HashSet::new();
         for h in &self.holders {
-            for c in &h.chains {
-                for (&p, &(_, content)) in &c.present {
-                    set.insert((p, content, c.lineage[..=p as usize].to_vec()));
-                }
+            for rec in h.registry.values() {
+                set.insert((rec.pos, rec.content, rec.lineage.clone()));
             }
         }
         set.len() as u64
     }
 
-    /// Does `holder` hold a LINEAGE-TRUE block at `pos` for this query
-    /// (present, right content, lineage == query[0..pos]) — i.e. the
-    /// only reason model depth stopped short of it is a missing
-    /// EARLIER position (a gap)?
+    /// Census discriminator: content match at pos under ANY lineage.
+    pub fn holds_content_at(&self, holder: usize, pos: u32, q: u64) -> bool {
+        self.holders[holder]
+            .registry
+            .values()
+            .any(|r| r.pos == pos && r.content == q)
+    }
+
+    /// Census discriminator: lineage-true block at pos for this query
+    /// (model depth stopped earlier only because of a gap).
     pub fn holds_lineage_true_at(&self, holder: usize, pos: u32, query: &[u64]) -> bool {
-        self.holders[holder].chains.iter().any(|c| {
-            c.present.get(&pos).map(|&(_, content)| content) == Some(query[pos as usize])
-                && c.lineage.len() > pos as usize
-                && c.lineage[..=pos as usize] == query[..=pos as usize]
+        self.holders[holder].registry.values().any(|r| {
+            r.pos == pos
+                && r.content == query[pos as usize]
+                && r.lineage.len() == pos as usize + 1
+                && r.lineage[..] == query[..=pos as usize]
         })
     }
+
+    /// Keep the compiler honest about BTreeMap being intentional.
+    #[allow(dead_code)]
+    fn _uses(_: &BTreeMap<usize, u32>) {}
 }

--- a/crates/radix_tree/tests/common/oracle.rs
+++ b/crates/radix_tree/tests/common/oracle.rs
@@ -1,0 +1,89 @@
+//! The differential oracle: `kv_index::PositionalIndexer` behind the
+//! same glue the service engine holds today (per-holder caller-owned
+//! reverse maps, worker interning, id->holder resolution), driven by
+//! the harness's operation stream.
+
+use std::collections::BTreeMap;
+
+use kv_index::{ContentHash, PositionalIndexer, SequenceHash, StoredBlock, WorkerBlockMap};
+
+use super::Op;
+
+pub struct Oracle {
+    index: PositionalIndexer,
+    /// worker_id by holder index (dense).
+    ids: Vec<u32>,
+    /// The engine-side caller-owned reverse maps, one per holder.
+    blocks: Vec<WorkerBlockMap>,
+}
+
+impl Oracle {
+    pub fn new(holder_count: usize) -> Self {
+        let index = PositionalIndexer::new(64);
+        let mut ids = Vec::with_capacity(holder_count);
+        let mut blocks = Vec::with_capacity(holder_count);
+        for h in 0..holder_count {
+            let id = index
+                .intern_worker(&format!("holder-{h}"))
+                .expect("id space");
+            ids.push(id);
+            blocks.push(WorkerBlockMap::default());
+        }
+        Self { index, ids, blocks }
+    }
+
+    /// Apply one op the way the engine does. Returns false when the
+    /// oracle rejected a store (parent not found / not tracked) — the
+    /// model must have rejected it too.
+    pub fn apply(&mut self, op: &Op) -> bool {
+        match op {
+            Op::Store {
+                holder,
+                parent,
+                blocks,
+            } => {
+                let stored: Vec<StoredBlock> = blocks
+                    .iter()
+                    .map(|&(key, content)| StoredBlock {
+                        seq_hash: SequenceHash(key),
+                        content_hash: ContentHash(content),
+                    })
+                    .collect();
+                self.index
+                    .apply_stored(
+                        self.ids[*holder],
+                        &stored,
+                        parent.map(SequenceHash),
+                        &mut self.blocks[*holder],
+                    )
+                    .is_ok()
+            }
+            Op::Remove { holder, keys } => {
+                let seqs: Vec<SequenceHash> = keys.iter().copied().map(SequenceHash).collect();
+                self.index
+                    .apply_removed(self.ids[*holder], &seqs, &mut self.blocks[*holder]);
+                true
+            }
+            Op::Clear { holder } => {
+                self.index
+                    .apply_cleared(self.ids[*holder], &mut self.blocks[*holder]);
+                true
+            }
+        }
+    }
+
+    /// Full holder->depth map for one query (depth-0 absent).
+    pub fn overlap(&self, query: &[u64]) -> BTreeMap<usize, u32> {
+        let hashes: Vec<ContentHash> = query.iter().copied().map(ContentHash).collect();
+        let scores = self.index.find_matches(&hashes, false);
+        let mut out = BTreeMap::new();
+        for (holder, &id) in self.ids.iter().enumerate() {
+            if let Some(&depth) = scores.scores.get(&id) {
+                if depth > 0 {
+                    out.insert(holder, depth);
+                }
+            }
+        }
+        out
+    }
+}

--- a/crates/radix_tree/tests/common/workload.rs
+++ b/crates/radix_tree/tests/common/workload.rs
@@ -115,13 +115,20 @@ pub fn generate(seed: u64, cfg: &Config) -> Workload {
     }
 
     // Assignment + per-holder scripts (sequences that MUST keep their
-    // relative order for that holder).
+    // relative order for that holder). A repeat assignment of the
+    // same family to the same holder re-stores the shared chain
+    // (pure duplicates) but must NOT grow a second divergent tail:
+    // two different keys at one chain position is outside the §7
+    // chain-consistent scope this generator promises (caught by the
+    // enumerate parity check).
     let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); cfg.holders];
+    let mut tailed: std::collections::HashSet<(usize, usize)> = std::collections::HashSet::new();
     for (fi, family) in families.iter().enumerate() {
         let count = cfg.holders_per_family.0
             + rng.below(cfg.holders_per_family.1 - cfg.holders_per_family.0 + 1);
         for _ in 0..count {
             let holder = rng.below(cfg.holders);
+            let first_assignment = tailed.insert((holder, fi));
             // Base chain in parent-linked batches.
             let mut parent = None;
             let mut batches = Vec::new();
@@ -133,27 +140,30 @@ pub fn generate(seed: u64, cfg: &Config) -> Workload {
                 });
                 parent = Some(batch.last().expect("non-empty").0);
             }
-            // Divergent tail: unique contents, keys mixed with holder
-            // and family so tails never collide.
-            let tail_len = cfg.tail_len.0 + rng.below(cfg.tail_len.1 - cfg.tail_len.0 + 1);
-            let mut tail = Vec::with_capacity(tail_len);
-            let mut prev_key = parent.expect("family non-empty");
-            for _ in 0..tail_len {
-                let content = fresh_content(&mut rng, &mut content_pool, 0);
-                let key = (prev_key ^ content.rotate_left(29))
-                    .wrapping_mul(0x9E3779B97F4A7C15)
-                    .wrapping_add(holder as u64 ^ (fi as u64) << 32)
-                    | 1;
-                tail.push((key, content));
-                prev_key = key;
-            }
-            for batch in tail.chunks(cfg.store_batch) {
-                batches.push(Op::Store {
-                    holder,
-                    parent,
-                    blocks: batch.to_vec(),
-                });
-                parent = Some(batch.last().expect("non-empty").0);
+            // Divergent tail (first assignment only): unique
+            // contents, keys mixed with holder and family so tails
+            // never collide.
+            if first_assignment {
+                let tail_len = cfg.tail_len.0 + rng.below(cfg.tail_len.1 - cfg.tail_len.0 + 1);
+                let mut tail = Vec::with_capacity(tail_len);
+                let mut prev_key = parent.expect("family non-empty");
+                for _ in 0..tail_len {
+                    let content = fresh_content(&mut rng, &mut content_pool, 0);
+                    let key = (prev_key ^ content.rotate_left(29))
+                        .wrapping_mul(0x9E3779B97F4A7C15)
+                        .wrapping_add(holder as u64 ^ (fi as u64) << 32)
+                        | 1;
+                    tail.push((key, content));
+                    prev_key = key;
+                }
+                for batch in tail.chunks(cfg.store_batch) {
+                    batches.push(Op::Store {
+                        holder,
+                        parent,
+                        blocks: batch.to_vec(),
+                    });
+                    parent = Some(batch.last().expect("non-empty").0);
+                }
             }
             // Duplicates: re-send some batches verbatim (later in the
             // holder's script — legal §7 duplication).

--- a/crates/radix_tree/tests/common/workload.rs
+++ b/crates/radix_tree/tests/common/workload.rs
@@ -123,16 +123,27 @@ pub fn generate(seed: u64, cfg: &Config) -> Workload {
     // enumerate parity check).
     let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); cfg.holders];
     let mut tailed: std::collections::HashSet<(usize, usize)> = std::collections::HashSet::new();
+    let mut tails: Vec<(usize, u32, Vec<(u64, u64)>)> = Vec::new();
     for (fi, family) in families.iter().enumerate() {
         let count = cfg.holders_per_family.0
             + rng.below(cfg.holders_per_family.1 - cfg.holders_per_family.0 + 1);
         for _ in 0..count {
             let holder = rng.below(cfg.holders);
             let first_assignment = tailed.insert((holder, fi));
-            // Base chain in parent-linked batches.
+            // A third of members store only a PREFIX of the family,
+            // so membership decays with depth (the run-boundary
+            // structure real fleets produce; audit finding: constant
+            // membership along every spine left split/merge
+            // maintenance under-exercised).
+            let span = if rng.chance(33) && family.len() > 2 {
+                1 + rng.below(family.len() - 1)
+            } else {
+                family.len()
+            };
+            let stored_spine = &family[..span];
             let mut parent = None;
             let mut batches = Vec::new();
-            for batch in family.chunks(cfg.store_batch) {
+            for batch in stored_spine.chunks(cfg.store_batch) {
                 batches.push(Op::Store {
                     holder,
                     parent,
@@ -142,11 +153,19 @@ pub fn generate(seed: u64, cfg: &Config) -> Workload {
             }
             // Divergent tail (first assignment only): unique
             // contents, keys mixed with holder and family so tails
-            // never collide.
+            // never collide. A third of tails fork MID-CHAIN (audit
+            // finding: tip-only forks left interior branch handling
+            // untested in-contract).
             if first_assignment {
+                let fork_at = if rng.chance(33) && span > 2 {
+                    1 + rng.below(span - 1)
+                } else {
+                    span
+                };
+                let fork_parent = stored_spine[fork_at - 1].0;
                 let tail_len = cfg.tail_len.0 + rng.below(cfg.tail_len.1 - cfg.tail_len.0 + 1);
                 let mut tail = Vec::with_capacity(tail_len);
-                let mut prev_key = parent.expect("family non-empty");
+                let mut prev_key = fork_parent;
                 for _ in 0..tail_len {
                     let content = fresh_content(&mut rng, &mut content_pool, 0);
                     let key = (prev_key ^ content.rotate_left(29))
@@ -156,14 +175,17 @@ pub fn generate(seed: u64, cfg: &Config) -> Workload {
                     tail.push((key, content));
                     prev_key = key;
                 }
+                let mut tail_parent = Some(fork_parent);
                 for batch in tail.chunks(cfg.store_batch) {
                     batches.push(Op::Store {
                         holder,
-                        parent,
+                        parent: tail_parent,
                         blocks: batch.to_vec(),
                     });
-                    parent = Some(batch.last().expect("non-empty").0);
+                    tail_parent = Some(batch.last().expect("non-empty").0);
                 }
+                // Record the tail for query generation.
+                tails.push((fi, fork_at as u32, tail));
             }
             // Duplicates: re-send some batches verbatim (later in the
             // holder's script — legal §7 duplication).
@@ -217,13 +239,32 @@ pub fn generate(seed: u64, cfg: &Config) -> Workload {
     // both sides must reject those identically (ParentNotFound), so
     // they stay in the stream on purpose.
 
-    // Queries: family prefixes at random depths (+tails), plus misses.
+    // Queries: spine prefixes, TAIL-EXTENDING (into one holder's
+    // divergent tail — distinguishes that holder's deeper answer),
+    // MID-DIVERGING (match d blocks then differ in content), and
+    // pure misses. The first shape set alone let off-query-path
+    // corruption hide (audit finding).
     let mut queries = Vec::new();
     for family in &families {
-        for _ in 0..4 {
+        for _ in 0..3 {
             let d = 1 + rng.below(family.len());
-            queries.push(family[..d].iter().map(|&(_, c)| c).collect());
+            queries.push(family[..d].iter().map(|&(_, c)| c).collect::<Vec<u64>>());
         }
+        // Mid-diverging: real prefix then foreign content.
+        let d = 1 + rng.below(family.len());
+        let mut q: Vec<u64> = family[..d].iter().map(|&(_, c)| c).collect();
+        q.extend((0..1 + rng.below(8)).map(|_| rng.next() | 1));
+        queries.push(q);
+    }
+    for (fi, fork_at, tail) in &tails {
+        if queries.len() > families.len() * 8 {
+            break;
+        }
+        let spine = &families[*fi];
+        let mut q: Vec<u64> = spine[..*fork_at as usize].iter().map(|&(_, c)| c).collect();
+        let take = 1 + rng.below(tail.len());
+        q.extend(tail[..take].iter().map(|&(_, c)| c));
+        queries.push(q);
     }
     for _ in 0..families.len() {
         let miss: Vec<u64> = (0..1 + rng.below(24)).map(|_| rng.next() | 1).collect();
@@ -236,14 +277,101 @@ pub fn generate(seed: u64, cfg: &Config) -> Workload {
     }
 }
 
-/// Reorder a stream within §7 scope: per-holder order preserved for
-/// order-bearing scripts, arbitrary cross-holder interleaving, using
-/// a different seed. (Store-only holders could legally reorder
-/// further; keeping their order too stays within scope.)
+/// Reorder a stream within the FULL §7 scope: arbitrary cross-holder
+/// interleaving always; and for holders whose scripts carry no
+/// remove/clear, their OWN store order is also shuffled arbitrarily
+/// (the stronger half of the guarantee — audit finding: it was never
+/// exercised). Order-bearing holders keep their sequence.
 pub fn reinterleave(seed: u64, ops: &[Op], holders: usize) -> Vec<Op> {
     let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); holders];
     for op in ops {
         per_holder[op.holder()].push(op.clone());
+    }
+    let mut rng0 = Rng::new(seed ^ 0x5EED);
+    for script in per_holder.iter_mut() {
+        if !script.iter().any(|op| op.orders_holder()) && script.len() > 1 {
+            // Fisher-Yates over the store-only script. Parent links
+            // may now arrive before their anchor: §7 excludes
+            // ParentNotFound compensation from the guarantee, so the
+            // comparison target must apply the SAME order — callers
+            // compare two subjects on one order, or model-vs-subject
+            // on the same order, never across orders with rejects.
+            // We keep it in-contract instead: shuffle only WHOLE
+            // parent-linked chains (contiguous runs where each op's
+            // parent is the previous op's last key).
+            let mut runs: Vec<Vec<Op>> = Vec::new();
+            let mut current: Vec<Op> = Vec::new();
+            let mut last_key: Option<u64> = None;
+            for op in script.drain(..) {
+                let anchors_prev = matches!(
+                    (&op, last_key),
+                    (Op::Store { parent: Some(p), .. }, Some(k)) if *p == k
+                );
+                if !anchors_prev && !current.is_empty() {
+                    runs.push(std::mem::take(&mut current));
+                }
+                last_key = match &op {
+                    Op::Store { blocks, .. } => blocks.last().map(|&(k, _)| k),
+                    _ => None,
+                };
+                current.push(op);
+            }
+            if !current.is_empty() {
+                runs.push(current);
+            }
+            // Random TOPOLOGICAL order: a run whose anchor parent
+            // key is produced by another run must stay after it —
+            // literal arbitrary order would change which stores get
+            // ACCEPTED (ParentNotFound), which is outside §7's
+            // chain-consistent scope (rejected stores leave the
+            // multiset). Within the dependency partial order, the
+            // shuffle is free.
+            let produced: Vec<std::collections::HashSet<u64>> = runs
+                .iter()
+                .map(|run| {
+                    run.iter()
+                        .flat_map(|op| match op {
+                            Op::Store { blocks, .. } => {
+                                blocks.iter().map(|&(k, _)| k).collect::<Vec<_>>()
+                            }
+                            _ => Vec::new(),
+                        })
+                        .collect()
+                })
+                .collect();
+            let needs: Vec<Option<u64>> = runs
+                .iter()
+                .map(|run| match run.first() {
+                    Some(Op::Store { parent, .. }) => *parent,
+                    _ => None,
+                })
+                .collect();
+            let n = runs.len();
+            let mut placed = vec![false; n];
+            let mut ordered: Vec<Vec<Op>> = Vec::with_capacity(n);
+            let mut produced_so_far: std::collections::HashSet<u64> =
+                std::collections::HashSet::new();
+            while ordered.len() < n {
+                let ready: Vec<usize> = (0..n)
+                    .filter(|&i| {
+                        !placed[i] && needs[i].is_none_or(|k| produced_so_far.contains(&k))
+                    })
+                    .collect();
+                // Runs whose parent was never produced in this script
+                // (anchored on another assignment's spine already
+                // present) are always ready.
+                let ready = if ready.is_empty() {
+                    (0..n).filter(|&i| !placed[i]).collect()
+                } else {
+                    ready
+                };
+                let pick = ready[rng0.below(ready.len())];
+                placed[pick] = true;
+                produced_so_far.extend(produced[pick].iter().copied());
+                ordered.push(std::mem::take(&mut runs[pick]));
+            }
+            *script = ordered.into_iter().flatten().collect();
+        }
     }
     let mut rng = Rng::new(seed);
     let mut cursors = vec![0usize; holders];

--- a/crates/radix_tree/tests/common/workload.rs
+++ b/crates/radix_tree/tests/common/workload.rs
@@ -1,0 +1,253 @@
+//! Seeded workload generator producing §7-scoped operation streams.
+//!
+//! Shape (mirrors SPEC.md §11's pinned-workload structure at test
+//! scale): prefix FAMILIES — shared base chains that several holders
+//! store identically (same keys, same contents: exactly what the
+//! placement feed produces) — plus per-holder divergent tails,
+//! duplicate re-stores, gap-punching removes, rare clears, and
+//! optional cross-family content coincidence to arm the oracle's
+//! Single-entry lineage skip.
+//!
+//! Ordering scope: the emitted stream preserves each holder's own
+//! order (ops interleave only ACROSS holders), matching §7. The
+//! convergence tests additionally reorder within that scope.
+
+use super::{Op, Rng};
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub holders: usize,
+    pub families: usize,
+    /// Blocks per family base chain: uniform in [min, max].
+    pub family_len: (usize, usize),
+    /// Holders per family: uniform in [min, max].
+    pub holders_per_family: (usize, usize),
+    /// Divergent tail blocks per holder per family: uniform [min, max].
+    pub tail_len: (usize, usize),
+    pub store_batch: usize,
+    /// Percent of batches re-sent verbatim later (duplicates).
+    pub duplicate_pct: u64,
+    /// Percent of (holder, family) pairs that lose a mid-chain block
+    /// (gap injection via remove).
+    pub gap_pct: u64,
+    /// Percent of holders cleared once mid-stream.
+    pub clear_pct: u64,
+    /// Reuse content values across families at this percent per
+    /// block, arming content coincidence (oracle quirk class 3).
+    pub coincidence_pct: u64,
+}
+
+impl Config {
+    pub fn small() -> Self {
+        Self {
+            holders: 24,
+            families: 8,
+            family_len: (8, 96),
+            holders_per_family: (1, 8),
+            tail_len: (2, 16),
+            store_batch: 8,
+            duplicate_pct: 10,
+            gap_pct: 15,
+            clear_pct: 8,
+            coincidence_pct: 0,
+        }
+    }
+
+    pub fn with_coincidence() -> Self {
+        Self {
+            coincidence_pct: 25,
+            ..Self::small()
+        }
+    }
+}
+
+/// The generated workload: an op stream (per-holder order already
+/// legal per §7) plus the query set derived from stored prefixes and
+/// misses.
+#[derive(Debug, Clone)]
+pub struct Workload {
+    pub ops: Vec<Op>,
+    pub queries: Vec<Vec<u64>>,
+    pub holders: usize,
+}
+
+pub fn generate(seed: u64, cfg: &Config) -> Workload {
+    let mut rng = Rng::new(seed);
+    let mut content_pool: Vec<u64> = Vec::new();
+    let fresh_content = |rng: &mut Rng, pool: &mut Vec<u64>, coincidence_pct: u64| -> u64 {
+        if !pool.is_empty() && rng.chance(coincidence_pct) {
+            pool[rng.below(pool.len())]
+        } else {
+            let c = rng.next() | 1; // avoid 0 (the model's lineage filler)
+            pool.push(c);
+            c
+        }
+    };
+
+    // Families: shared (key, content) base chains. Keys are the
+    // deterministic placement chain of the contents — identical
+    // across holders for identical prefixes, as on the wire.
+    let mut families: Vec<Vec<(u64, u64)>> = Vec::new();
+    for _ in 0..cfg.families {
+        let len = cfg.family_len.0 + rng.below(cfg.family_len.1 - cfg.family_len.0 + 1);
+        let mut chain = Vec::with_capacity(len);
+        let mut prev_key = 0u64;
+        for i in 0..len {
+            // Position 0 contents stay unique: pos-0 keys ARE the
+            // content (wire position-0 rule), so coincidence there
+            // would fuse two families into one chain — out of the §7
+            // chain-consistent scope this generator promises.
+            let coincidence = if i == 0 { 0 } else { cfg.coincidence_pct };
+            let content = fresh_content(&mut rng, &mut content_pool, coincidence);
+            // Chain-hash-shaped keys without depending on the wire
+            // scheme: mix prev key and content deterministically.
+            let key = if i == 0 {
+                content
+            } else {
+                let mut k = prev_key ^ content.rotate_left(17);
+                k = k.wrapping_mul(0x2545F4914F6CDD1D) | 1;
+                k
+            };
+            chain.push((key, content));
+            prev_key = key;
+        }
+        families.push(chain);
+    }
+
+    // Assignment + per-holder scripts (sequences that MUST keep their
+    // relative order for that holder).
+    let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); cfg.holders];
+    for (fi, family) in families.iter().enumerate() {
+        let count = cfg.holders_per_family.0
+            + rng.below(cfg.holders_per_family.1 - cfg.holders_per_family.0 + 1);
+        for _ in 0..count {
+            let holder = rng.below(cfg.holders);
+            // Base chain in parent-linked batches.
+            let mut parent = None;
+            let mut batches = Vec::new();
+            for batch in family.chunks(cfg.store_batch) {
+                batches.push(Op::Store {
+                    holder,
+                    parent,
+                    blocks: batch.to_vec(),
+                });
+                parent = Some(batch.last().expect("non-empty").0);
+            }
+            // Divergent tail: unique contents, keys mixed with holder
+            // and family so tails never collide.
+            let tail_len = cfg.tail_len.0 + rng.below(cfg.tail_len.1 - cfg.tail_len.0 + 1);
+            let mut tail = Vec::with_capacity(tail_len);
+            let mut prev_key = parent.expect("family non-empty");
+            for _ in 0..tail_len {
+                let content = fresh_content(&mut rng, &mut content_pool, 0);
+                let key = (prev_key ^ content.rotate_left(29))
+                    .wrapping_mul(0x9E3779B97F4A7C15)
+                    .wrapping_add(holder as u64 ^ (fi as u64) << 32)
+                    | 1;
+                tail.push((key, content));
+                prev_key = key;
+            }
+            for batch in tail.chunks(cfg.store_batch) {
+                batches.push(Op::Store {
+                    holder,
+                    parent,
+                    blocks: batch.to_vec(),
+                });
+                parent = Some(batch.last().expect("non-empty").0);
+            }
+            // Duplicates: re-send some batches verbatim (later in the
+            // holder's script — legal §7 duplication).
+            let mut dups = Vec::new();
+            for b in &batches {
+                if rng.chance(cfg.duplicate_pct) {
+                    dups.push(b.clone());
+                }
+            }
+            // Gap: remove one mid-chain family block.
+            let mut gaps = Vec::new();
+            if rng.chance(cfg.gap_pct) && family.len() > 2 {
+                let victim = family[1 + rng.below(family.len() - 2)].0;
+                gaps.push(Op::Remove {
+                    holder,
+                    keys: vec![victim],
+                });
+            }
+            let script = &mut per_holder[holder];
+            script.extend(batches);
+            script.extend(dups);
+            script.extend(gaps);
+        }
+    }
+    for (holder, script) in per_holder.iter_mut().enumerate() {
+        if rng.chance(cfg.clear_pct) && !script.is_empty() {
+            // Clear mid-script: everything before it is discarded
+            // state; everything after rebuilds. Insert at a random
+            // point rather than the end so post-clear stores exist.
+            let at = rng.below(script.len());
+            script.insert(at, Op::Clear { holder });
+        }
+    }
+
+    // Interleave across holders preserving each holder's order.
+    let mut cursors = vec![0usize; cfg.holders];
+    let mut ops = Vec::new();
+    loop {
+        let live: Vec<usize> = (0..cfg.holders)
+            .filter(|&h| cursors[h] < per_holder[h].len())
+            .collect();
+        if live.is_empty() {
+            break;
+        }
+        let h = live[rng.below(live.len())];
+        ops.push(per_holder[h][cursors[h]].clone());
+        cursors[h] += 1;
+    }
+
+    // Post-clear stores may reference parents wiped by the clear;
+    // both sides must reject those identically (ParentNotFound), so
+    // they stay in the stream on purpose.
+
+    // Queries: family prefixes at random depths (+tails), plus misses.
+    let mut queries = Vec::new();
+    for family in &families {
+        for _ in 0..4 {
+            let d = 1 + rng.below(family.len());
+            queries.push(family[..d].iter().map(|&(_, c)| c).collect());
+        }
+    }
+    for _ in 0..families.len() {
+        let miss: Vec<u64> = (0..1 + rng.below(24)).map(|_| rng.next() | 1).collect();
+        queries.push(miss);
+    }
+    Workload {
+        ops,
+        queries,
+        holders: cfg.holders,
+    }
+}
+
+/// Reorder a stream within §7 scope: per-holder order preserved for
+/// order-bearing scripts, arbitrary cross-holder interleaving, using
+/// a different seed. (Store-only holders could legally reorder
+/// further; keeping their order too stays within scope.)
+pub fn reinterleave(seed: u64, ops: &[Op], holders: usize) -> Vec<Op> {
+    let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); holders];
+    for op in ops {
+        per_holder[op.holder()].push(op.clone());
+    }
+    let mut rng = Rng::new(seed);
+    let mut cursors = vec![0usize; holders];
+    let mut out = Vec::with_capacity(ops.len());
+    loop {
+        let live: Vec<usize> = (0..holders)
+            .filter(|&h| cursors[h] < per_holder[h].len())
+            .collect();
+        if live.is_empty() {
+            break;
+        }
+        let h = live[rng.below(live.len())];
+        out.push(per_holder[h][cursors[h]].clone());
+        cursors[h] += 1;
+    }
+    out
+}

--- a/crates/radix_tree/tests/differential.rs
+++ b/crates/radix_tree/tests/differential.rs
@@ -22,13 +22,13 @@ use common::{
     oracle::Oracle,
     workload, Op,
 };
-use radix_tree::{Config, HolderId, OverlapScratch, RadixTree, RadixTree3, StoreError};
+use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree3, StoreError};
 
 /// The implementations under test (flat R1 and chain-native R3),
 /// driven by the harness Op protocol. Every observable is asserted
 /// for BOTH against the model.
 enum Core {
-    Flat(RadixTree),
+    Flat(FlatTree),
     Chain(RadixTree3),
 }
 
@@ -41,7 +41,7 @@ struct Subject {
 
 impl Subject {
     fn new_flat(holders: usize) -> Self {
-        let mut tree = RadixTree::new(Config::default());
+        let mut tree = FlatTree::new(Config::default());
         let ids = (0..holders)
             .map(|h| tree.create_holder(&format!("holder-{h}")))
             .collect();

--- a/crates/radix_tree/tests/differential.rs
+++ b/crates/radix_tree/tests/differential.rs
@@ -22,24 +22,44 @@ use common::{
     oracle::Oracle,
     workload, Op,
 };
-use radix_tree::{Config, HolderId, OverlapScratch, RadixTree, StoreError};
+use radix_tree::{Config, HolderId, OverlapScratch, RadixTree, RadixTree3, StoreError};
 
-/// The implementation under test, driven by the harness Op protocol.
+/// The implementations under test (flat R1 and chain-native R3),
+/// driven by the harness Op protocol. Every observable is asserted
+/// for BOTH against the model.
+enum Core {
+    Flat(RadixTree),
+    Chain(RadixTree3),
+}
+
 struct Subject {
-    tree: RadixTree,
+    core: Core,
     ids: Vec<HolderId>,
     scratch: Vec<radix_tree::Overlap>,
     qscratch: OverlapScratch,
 }
 
 impl Subject {
-    fn new(holders: usize) -> Self {
+    fn new_flat(holders: usize) -> Self {
         let mut tree = RadixTree::new(Config::default());
         let ids = (0..holders)
             .map(|h| tree.create_holder(&format!("holder-{h}")))
             .collect();
         Self {
-            tree,
+            core: Core::Flat(tree),
+            ids,
+            scratch: Vec::new(),
+            qscratch: OverlapScratch::default(),
+        }
+    }
+
+    fn new_chain(holders: usize) -> Self {
+        let mut tree = RadixTree3::new(Config::default());
+        let ids = (0..holders)
+            .map(|h| tree.create_holder(&format!("holder-{h}")))
+            .collect();
+        Self {
+            core: Core::Chain(tree),
             ids,
             scratch: Vec::new(),
             qscratch: OverlapScratch::default(),
@@ -53,17 +73,29 @@ impl Subject {
                 holder,
                 parent,
                 blocks,
-            } => match self.tree.store(self.ids[*holder], *parent, blocks) {
-                Ok(_) => true,
-                Err(StoreError::ParentNotFound) => false,
-                Err(e) => panic!("unexpected store error {e:?}"),
-            },
+            } => {
+                let r = match &mut self.core {
+                    Core::Flat(t) => t.store(self.ids[*holder], *parent, blocks),
+                    Core::Chain(t) => t.store(self.ids[*holder], *parent, blocks),
+                };
+                match r {
+                    Ok(_) => true,
+                    Err(StoreError::ParentNotFound) => false,
+                    Err(e) => panic!("unexpected store error {e:?}"),
+                }
+            }
             Op::Remove { holder, keys } => {
-                self.tree.remove(self.ids[*holder], keys);
+                match &mut self.core {
+                    Core::Flat(t) => t.remove(self.ids[*holder], keys),
+                    Core::Chain(t) => t.remove(self.ids[*holder], keys),
+                };
                 true
             }
             Op::Clear { holder } => {
-                self.tree.clear(self.ids[*holder]);
+                match &mut self.core {
+                    Core::Flat(t) => t.clear(self.ids[*holder]),
+                    Core::Chain(t) => t.clear(self.ids[*holder]),
+                }
                 true
             }
         }
@@ -71,12 +103,43 @@ impl Subject {
 
     fn overlap(&mut self, query: &[u64]) -> BTreeMap<usize, u32> {
         let scratch = &mut self.scratch;
-        self.tree.overlap(query, &mut self.qscratch, scratch);
+        match &mut self.core {
+            Core::Flat(t) => t.overlap(query, &mut self.qscratch, scratch),
+            Core::Chain(t) => t.overlap(query, &mut self.qscratch, scratch),
+        }
         let mut out = BTreeMap::new();
         for o in scratch.iter() {
             out.insert(o.holder.parts().0 as usize, o.depth);
         }
         out
+    }
+
+    fn holder_blocks(&self, h: usize) -> u64 {
+        match &self.core {
+            Core::Flat(t) => t.holder_blocks(self.ids[h]),
+            Core::Chain(t) => t.holder_blocks(self.ids[h]),
+        }
+    }
+
+    fn enumerate(&self, h: usize) -> Vec<(u32, u64, u64)> {
+        match &self.core {
+            Core::Flat(t) => t.enumerate(self.ids[h]).collect(),
+            Core::Chain(t) => t.enumerate(self.ids[h]).collect(),
+        }
+    }
+
+    fn distinct_entries(&self) -> u64 {
+        match &self.core {
+            Core::Flat(t) => t.stats().distinct_entries,
+            Core::Chain(t) => t.stats().distinct_entries,
+        }
+    }
+
+    fn audit(&self) -> Result<(), String> {
+        match &self.core {
+            Core::Flat(t) => t.audit(),
+            Core::Chain(t) => t.audit(),
+        }
     }
 }
 
@@ -103,7 +166,10 @@ fn run_differential(seed: u64, cfg: &workload::Config) -> Census {
     let wl = workload::generate(seed, cfg);
     let mut model = Model::new(wl.holders);
     let mut oracle = Oracle::new(wl.holders);
-    let mut subject = Subject::new(wl.holders);
+    let mut subjects = [
+        Subject::new_flat(wl.holders),
+        Subject::new_chain(wl.holders),
+    ];
     let mut census = Census {
         queries: 0,
         holder_answers: 0,
@@ -116,17 +182,22 @@ fn run_differential(seed: u64, cfg: &workload::Config) -> Census {
     for (i, op) in wl.ops.iter().enumerate() {
         let model_outcome = model.apply(op);
         let oracle_ok = oracle.apply(op);
-        let subject_ok = subject.apply(op);
         if let Op::Store { .. } = op {
             let model_ok = !matches!(model_outcome, Some(StoreResult::ParentNotFound));
             assert_eq!(
                 model_ok, oracle_ok,
                 "oracle store acceptance diverged at op {i} (seed {seed}): {op:?}"
             );
-            assert_eq!(
-                model_ok, subject_ok,
-                "RadixTree store acceptance diverged at op {i} (seed {seed}): {op:?}"
-            );
+        }
+        for (ci, subject) in subjects.iter_mut().enumerate() {
+            let subject_ok = subject.apply(op);
+            if let Op::Store { .. } = op {
+                let model_ok = !matches!(model_outcome, Some(StoreResult::ParentNotFound));
+                assert_eq!(
+                    model_ok, subject_ok,
+                    "core{ci} store acceptance diverged at op {i} (seed {seed}): {op:?}"
+                );
+            }
         }
         if i % checkpoint_every == 0 || i + 1 == wl.ops.len() {
             checkpoint(
@@ -134,33 +205,33 @@ fn run_differential(seed: u64, cfg: &workload::Config) -> Census {
                 i,
                 &model,
                 &oracle,
-                &mut subject,
+                &mut subjects,
                 &wl.queries,
                 &mut census,
             );
         }
     }
     // Terminal per-holder accounting, enumeration, and distinct-entry
-    // parity (review finding: these observables were never
-    // model-checked).
-    for h in 0..wl.holders {
+    // parity, for BOTH cores.
+    for (ci, subject) in subjects.iter().enumerate() {
+        for h in 0..wl.holders {
+            assert_eq!(
+                subject.holder_blocks(h),
+                model.holder_blocks(h),
+                "core{ci} holder_blocks diverged for holder {h} (seed {seed})"
+            );
+            assert_eq!(
+                subject.enumerate(h),
+                model.enumerate(h),
+                "core{ci} enumerate diverged for holder {h} (seed {seed})"
+            );
+        }
         assert_eq!(
-            subject.tree.holder_blocks(subject.ids[h]),
-            model.holder_blocks(h),
-            "holder_blocks diverged for holder {h} (seed {seed})"
-        );
-        let got: Vec<(u32, u64, u64)> = subject.tree.enumerate(subject.ids[h]).collect();
-        assert_eq!(
-            got,
-            model.enumerate(h),
-            "enumerate diverged for holder {h} (seed {seed})"
+            subject.distinct_entries(),
+            model.distinct_entries(),
+            "core{ci} distinct_entries diverged (seed {seed})"
         );
     }
-    assert_eq!(
-        subject.tree.stats().distinct_entries,
-        model.distinct_entries(),
-        "distinct_entries diverged (seed {seed})"
-    );
     census
 }
 
@@ -169,28 +240,35 @@ fn checkpoint(
     at: usize,
     model: &Model,
     oracle: &Oracle,
-    subject: &mut Subject,
+    subjects: &mut [Subject; 2],
     queries: &[Vec<u64>],
     census: &mut Census,
 ) {
+    for (ci, subject) in subjects.iter().enumerate() {
+        subject
+            .audit()
+            .unwrap_or_else(|e| panic!("core{ci} audit failed (seed {seed}, op {at}): {e}"));
+    }
     for query in queries {
         census.queries += 1;
         let want = model.overlap(query);
-        // THE gate: the implementation equals the model, always.
-        let subject_map = subject.overlap(query);
-        assert_eq!(
-            subject_map,
-            want,
-            "RadixTree != model (seed {seed}, op {at}, query len {})",
-            query.len()
-        );
-        for o in subject.scratch.iter() {
-            let h = o.holder.parts().0 as usize;
+        // THE gate: both implementations equal the model, always.
+        for (ci, subject) in subjects.iter_mut().enumerate() {
+            let subject_map = subject.overlap(query);
             assert_eq!(
-                o.total_blocks,
-                model.holder_blocks(h),
-                "total_blocks diverged for holder {h} (seed {seed}, op {at})"
+                subject_map,
+                want,
+                "core{ci} != model (seed {seed}, op {at}, query len {})",
+                query.len()
             );
+            for o in subject.scratch.iter() {
+                let h = o.holder.parts().0 as usize;
+                assert_eq!(
+                    o.total_blocks,
+                    model.holder_blocks(h),
+                    "core{ci} total_blocks diverged for holder {h} (seed {seed}, op {at})"
+                );
+            }
         }
         let got = oracle.overlap(query);
         // Under-match anywhere = unclassifiable = fail.
@@ -266,10 +344,15 @@ fn model_converges_within_scope() {
         for reorder_seed in [7u64, 8, 9] {
             let ops = workload::reinterleave(reorder_seed, &wl.ops, wl.holders);
             let mut other = Model::new(wl.holders);
-            let mut subject = Subject::new(wl.holders);
+            let mut subjects = [
+                Subject::new_flat(wl.holders),
+                Subject::new_chain(wl.holders),
+            ];
             for op in &ops {
                 other.apply(op);
-                subject.apply(op);
+                for subject in subjects.iter_mut() {
+                    subject.apply(op);
+                }
             }
             for query in &wl.queries {
                 let want = reference.overlap(query);
@@ -278,18 +361,19 @@ fn model_converges_within_scope() {
                     other.overlap(query),
                     "model diverged under scoped reordering (seed {seed}/{reorder_seed})"
                 );
-                assert_eq!(
-                    subject.overlap(query),
-                    want,
-                    "RadixTree diverged under scoped reordering (seed {seed}/{reorder_seed})"
-                );
+                for (ci, subject) in subjects.iter_mut().enumerate() {
+                    assert_eq!(
+                        subject.overlap(query),
+                        want,
+                        "core{ci} diverged under scoped reordering (seed {seed}/{reorder_seed})"
+                    );
+                }
             }
             for h in 0..wl.holders {
                 assert_eq!(reference.holder_blocks(h), other.holder_blocks(h));
-                assert_eq!(
-                    subject.tree.holder_blocks(subject.ids[h]),
-                    reference.holder_blocks(h)
-                );
+                for subject in subjects.iter() {
+                    assert_eq!(subject.holder_blocks(h), reference.holder_blocks(h));
+                }
             }
         }
     }
@@ -300,7 +384,7 @@ fn model_converges_within_scope() {
 fn rejected_store_applies_nothing() {
     let mut model = Model::new(1);
     let mut oracle = Oracle::new(1);
-    let mut subject = Subject::new(1);
+    let mut subjects = [Subject::new_flat(1), Subject::new_chain(1)];
     let seeded = Op::Store {
         holder: 0,
         parent: None,
@@ -308,10 +392,15 @@ fn rejected_store_applies_nothing() {
     };
     model.apply(&seeded);
     oracle.apply(&seeded);
-    subject.apply(&seeded);
+    for subject in subjects.iter_mut() {
+        subject.apply(&seeded);
+    }
     let before_model = model.overlap(&[101, 102]);
     let before_oracle = oracle.overlap(&[101, 102]);
-    let before_subject = subject.overlap(&[101, 102]);
+    let before_subject: Vec<_> = subjects
+        .iter_mut()
+        .map(|s| s.overlap(&[101, 102]))
+        .collect();
     let bad = Op::Store {
         holder: 0,
         parent: Some(999),
@@ -319,10 +408,14 @@ fn rejected_store_applies_nothing() {
     };
     assert_eq!(model.apply(&bad), Some(StoreResult::ParentNotFound));
     assert!(!oracle.apply(&bad));
-    assert!(!subject.apply(&bad));
+    for subject in subjects.iter_mut() {
+        assert!(!subject.apply(&bad));
+    }
     assert_eq!(model.overlap(&[101, 102]), before_model);
     assert_eq!(oracle.overlap(&[101, 102]), before_oracle);
-    assert_eq!(subject.overlap(&[101, 102]), before_subject);
+    for (subject, before) in subjects.iter_mut().zip(&before_subject) {
+        assert_eq!(subject.overlap(&[101, 102]), *before);
+        assert_eq!(subject.holder_blocks(0), 2);
+    }
     assert_eq!(model.holder_blocks(0), 2);
-    assert_eq!(subject.tree.holder_blocks(subject.ids[0]), 2);
 }

--- a/crates/radix_tree/tests/differential.rs
+++ b/crates/radix_tree/tests/differential.rs
@@ -22,14 +22,14 @@ use common::{
     oracle::Oracle,
     workload, Op,
 };
-use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree3, StoreError};
+use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree, StoreError};
 
 /// The implementations under test (flat R1 and chain-native R3),
 /// driven by the harness Op protocol. Every observable is asserted
 /// for BOTH against the model.
 enum Core {
     Flat(FlatTree),
-    Chain(RadixTree3),
+    Chain(RadixTree),
 }
 
 struct Subject {
@@ -54,7 +54,7 @@ impl Subject {
     }
 
     fn new_chain(holders: usize) -> Self {
-        let mut tree = RadixTree3::new(Config::default());
+        let mut tree = RadixTree::new(Config::default());
         let ids = (0..holders)
             .map(|h| tree.create_holder(&format!("holder-{h}")))
             .collect();

--- a/crates/radix_tree/tests/differential.rs
+++ b/crates/radix_tree/tests/differential.rs
@@ -1,0 +1,197 @@
+//! The model-referee differential harness (SPEC.md §10.1), R0 stage:
+//! model vs oracle. When the R1 core exists it joins as the third
+//! side with the HARD assertion `RadixTree == model`; until then this
+//! file proves the model, the oracle adapter, and the generator agree
+//! on the contract's terms:
+//!
+//! - the oracle never under-matches the model (an under-match has no
+//!   quirk explanation and fails the run — §10.1's "unclassifiable");
+//! - every oracle over-match position is tagged into three classes:
+//!   gap-bridged (right block present, an earlier position missing),
+//!   cross-lineage (content coincidence under another chain), or
+//!   absent (pure skip overshoot) — §6's quirk surface, measured;
+//! - both sides accept/reject every store identically;
+//! - the model itself converges under §7-scoped reordering.
+
+mod common;
+
+use common::{
+    model::{Model, StoreResult},
+    oracle::Oracle,
+    workload, Op,
+};
+
+struct Census {
+    queries: usize,
+    holder_answers: usize,
+    over_matches: usize,
+    /// Excess position holds the right block, an EARLIER position is
+    /// missing: the oracle bridged a gap (jump landing / retain
+    /// guard) — the quirk M2 measured as prediction error.
+    excess_gap_bridged: usize,
+    /// Excess position holds the content under a DIFFERENT lineage:
+    /// cross-chain coincidence (Single-entry lineage skip / retain
+    /// guard on coincident content).
+    excess_cross_lineage: usize,
+    /// Excess position holds nothing matching: pure skip overshoot.
+    excess_absent: usize,
+}
+
+/// Drive one workload through both sides with periodic checkpoints.
+fn run_differential(seed: u64, cfg: &workload::Config) -> Census {
+    let wl = workload::generate(seed, cfg);
+    let mut model = Model::new(wl.holders);
+    let mut oracle = Oracle::new(wl.holders);
+    let mut census = Census {
+        queries: 0,
+        holder_answers: 0,
+        over_matches: 0,
+        excess_gap_bridged: 0,
+        excess_cross_lineage: 0,
+        excess_absent: 0,
+    };
+    let checkpoint_every = (wl.ops.len() / 8).max(1);
+    for (i, op) in wl.ops.iter().enumerate() {
+        let model_outcome = model.apply(op);
+        let oracle_ok = oracle.apply(op);
+        if let Op::Store { .. } = op {
+            let model_ok = !matches!(model_outcome, Some(StoreResult::ParentNotFound));
+            assert_eq!(
+                model_ok, oracle_ok,
+                "store acceptance diverged at op {i} (seed {seed}): {op:?}"
+            );
+        }
+        if i % checkpoint_every == 0 || i + 1 == wl.ops.len() {
+            checkpoint(seed, i, &model, &oracle, &wl.queries, &mut census);
+        }
+    }
+    census
+}
+
+fn checkpoint(
+    seed: u64,
+    at: usize,
+    model: &Model,
+    oracle: &Oracle,
+    queries: &[Vec<u64>],
+    census: &mut Census,
+) {
+    for query in queries {
+        census.queries += 1;
+        let want = model.overlap(query);
+        let got = oracle.overlap(query);
+        // Under-match anywhere = unclassifiable = fail.
+        for (&holder, &depth) in &want {
+            let oracle_depth = got.get(&holder).copied().unwrap_or(0);
+            assert!(
+                oracle_depth >= depth,
+                "oracle under-matches model (seed {seed}, op {at}, holder {holder}): \
+                 oracle {oracle_depth} < model {depth} on query len {}",
+                query.len()
+            );
+        }
+        census.holder_answers += want.len();
+        // Over-matches: every excess position must classify.
+        for (&holder, &oracle_depth) in &got {
+            let model_depth = want.get(&holder).copied().unwrap_or(0);
+            if oracle_depth > model_depth {
+                census.over_matches += 1;
+                for p in model_depth..oracle_depth {
+                    if model.holds_lineage_true_at(holder, p, query) {
+                        census.excess_gap_bridged += 1;
+                    } else if model.holds_content_at(holder, p, query[p as usize]) {
+                        census.excess_cross_lineage += 1;
+                    } else {
+                        census.excess_absent += 1;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn model_vs_oracle_content_unique() {
+    let mut total_over = 0usize;
+    for seed in 1..=8u64 {
+        let census = run_differential(seed, &workload::Config::small());
+        total_over += census.over_matches;
+        println!(
+            "seed {seed}: {} queries, {} holder answers, {} over-matches \
+             (excess positions: {} gap-bridged / {} cross-lineage / {} absent)",
+            census.queries,
+            census.holder_answers,
+            census.over_matches,
+            census.excess_gap_bridged,
+            census.excess_cross_lineage,
+            census.excess_absent
+        );
+    }
+    println!("content-unique total over-matches: {total_over}");
+}
+
+#[test]
+fn model_vs_oracle_with_coincidence() {
+    let mut total_over = 0usize;
+    for seed in 100..=107u64 {
+        let census = run_differential(seed, &workload::Config::with_coincidence());
+        total_over += census.over_matches;
+    }
+    println!("coincidence total over-matches: {total_over}");
+}
+
+/// §7: the model's observable state is identical under any
+/// §7-scoped reordering of the same multiset.
+#[test]
+fn model_converges_within_scope() {
+    for seed in 1..=6u64 {
+        let wl = workload::generate(seed, &workload::Config::small());
+        let mut reference = Model::new(wl.holders);
+        for op in &wl.ops {
+            reference.apply(op);
+        }
+        for reorder_seed in [7u64, 8, 9] {
+            let ops = workload::reinterleave(reorder_seed, &wl.ops, wl.holders);
+            let mut other = Model::new(wl.holders);
+            for op in &ops {
+                other.apply(op);
+            }
+            for query in &wl.queries {
+                assert_eq!(
+                    reference.overlap(query),
+                    other.overlap(query),
+                    "model diverged under scoped reordering (seed {seed}/{reorder_seed})"
+                );
+            }
+            for h in 0..wl.holders {
+                assert_eq!(reference.holder_blocks(h), other.holder_blocks(h));
+            }
+        }
+    }
+}
+
+/// §4: a rejected store applies nothing, on both sides.
+#[test]
+fn rejected_store_applies_nothing() {
+    let mut model = Model::new(1);
+    let mut oracle = Oracle::new(1);
+    let seeded = Op::Store {
+        holder: 0,
+        parent: None,
+        blocks: vec![(11, 101), (12, 102)],
+    };
+    model.apply(&seeded);
+    oracle.apply(&seeded);
+    let before_model = model.overlap(&[101, 102]);
+    let before_oracle = oracle.overlap(&[101, 102]);
+    let bad = Op::Store {
+        holder: 0,
+        parent: Some(999),
+        blocks: vec![(13, 103)],
+    };
+    assert_eq!(model.apply(&bad), Some(StoreResult::ParentNotFound));
+    assert!(!oracle.apply(&bad));
+    assert_eq!(model.overlap(&[101, 102]), before_model);
+    assert_eq!(oracle.overlap(&[101, 102]), before_oracle);
+    assert_eq!(model.holder_blocks(0), 2);
+}

--- a/crates/radix_tree/tests/differential.rs
+++ b/crates/radix_tree/tests/differential.rs
@@ -22,13 +22,14 @@ use common::{
     oracle::Oracle,
     workload, Op,
 };
-use radix_tree::{Config, HolderId, RadixTree, StoreError};
+use radix_tree::{Config, HolderId, OverlapScratch, RadixTree, StoreError};
 
 /// The implementation under test, driven by the harness Op protocol.
 struct Subject {
     tree: RadixTree,
     ids: Vec<HolderId>,
     scratch: Vec<radix_tree::Overlap>,
+    qscratch: OverlapScratch,
 }
 
 impl Subject {
@@ -41,6 +42,7 @@ impl Subject {
             tree,
             ids,
             scratch: Vec::new(),
+            qscratch: OverlapScratch::default(),
         }
     }
 
@@ -69,7 +71,7 @@ impl Subject {
 
     fn overlap(&mut self, query: &[u64]) -> BTreeMap<usize, u32> {
         let scratch = &mut self.scratch;
-        self.tree.overlap(query, scratch);
+        self.tree.overlap(query, &mut self.qscratch, scratch);
         let mut out = BTreeMap::new();
         for o in scratch.iter() {
             out.insert(o.holder.parts().0 as usize, o.depth);
@@ -138,14 +140,27 @@ fn run_differential(seed: u64, cfg: &workload::Config) -> Census {
             );
         }
     }
-    // Terminal per-holder accounting parity.
+    // Terminal per-holder accounting, enumeration, and distinct-entry
+    // parity (review finding: these observables were never
+    // model-checked).
     for h in 0..wl.holders {
         assert_eq!(
             subject.tree.holder_blocks(subject.ids[h]),
             model.holder_blocks(h),
             "holder_blocks diverged for holder {h} (seed {seed})"
         );
+        let got: Vec<(u32, u64, u64)> = subject.tree.enumerate(subject.ids[h]).collect();
+        assert_eq!(
+            got,
+            model.enumerate(h),
+            "enumerate diverged for holder {h} (seed {seed})"
+        );
     }
+    assert_eq!(
+        subject.tree.stats().distinct_entries,
+        model.distinct_entries(),
+        "distinct_entries diverged (seed {seed})"
+    );
     census
 }
 

--- a/crates/radix_tree/tests/differential.rs
+++ b/crates/radix_tree/tests/differential.rs
@@ -15,11 +15,68 @@
 
 mod common;
 
+use std::collections::BTreeMap;
+
 use common::{
     model::{Model, StoreResult},
     oracle::Oracle,
     workload, Op,
 };
+use radix_tree::{Config, HolderId, RadixTree, StoreError};
+
+/// The implementation under test, driven by the harness Op protocol.
+struct Subject {
+    tree: RadixTree,
+    ids: Vec<HolderId>,
+    scratch: Vec<radix_tree::Overlap>,
+}
+
+impl Subject {
+    fn new(holders: usize) -> Self {
+        let mut tree = RadixTree::new(Config::default());
+        let ids = (0..holders)
+            .map(|h| tree.create_holder(&format!("holder-{h}")))
+            .collect();
+        Self {
+            tree,
+            ids,
+            scratch: Vec::new(),
+        }
+    }
+
+    /// Returns false when the store was rejected (must match model).
+    fn apply(&mut self, op: &Op) -> bool {
+        match op {
+            Op::Store {
+                holder,
+                parent,
+                blocks,
+            } => match self.tree.store(self.ids[*holder], *parent, blocks) {
+                Ok(_) => true,
+                Err(StoreError::ParentNotFound) => false,
+                Err(e) => panic!("unexpected store error {e:?}"),
+            },
+            Op::Remove { holder, keys } => {
+                self.tree.remove(self.ids[*holder], keys);
+                true
+            }
+            Op::Clear { holder } => {
+                self.tree.clear(self.ids[*holder]);
+                true
+            }
+        }
+    }
+
+    fn overlap(&mut self, query: &[u64]) -> BTreeMap<usize, u32> {
+        let scratch = &mut self.scratch;
+        self.tree.overlap(query, scratch);
+        let mut out = BTreeMap::new();
+        for o in scratch.iter() {
+            out.insert(o.holder.parts().0 as usize, o.depth);
+        }
+        out
+    }
+}
 
 struct Census {
     queries: usize,
@@ -37,11 +94,14 @@ struct Census {
     excess_absent: usize,
 }
 
-/// Drive one workload through both sides with periodic checkpoints.
+/// Drive one workload through all three sides with periodic
+/// checkpoints. RadixTree == model is the HARD gate; the oracle is
+/// the >=-side sanity anchor with the quirk census.
 fn run_differential(seed: u64, cfg: &workload::Config) -> Census {
     let wl = workload::generate(seed, cfg);
     let mut model = Model::new(wl.holders);
     let mut oracle = Oracle::new(wl.holders);
+    let mut subject = Subject::new(wl.holders);
     let mut census = Census {
         queries: 0,
         holder_answers: 0,
@@ -54,16 +114,37 @@ fn run_differential(seed: u64, cfg: &workload::Config) -> Census {
     for (i, op) in wl.ops.iter().enumerate() {
         let model_outcome = model.apply(op);
         let oracle_ok = oracle.apply(op);
+        let subject_ok = subject.apply(op);
         if let Op::Store { .. } = op {
             let model_ok = !matches!(model_outcome, Some(StoreResult::ParentNotFound));
             assert_eq!(
                 model_ok, oracle_ok,
-                "store acceptance diverged at op {i} (seed {seed}): {op:?}"
+                "oracle store acceptance diverged at op {i} (seed {seed}): {op:?}"
+            );
+            assert_eq!(
+                model_ok, subject_ok,
+                "RadixTree store acceptance diverged at op {i} (seed {seed}): {op:?}"
             );
         }
         if i % checkpoint_every == 0 || i + 1 == wl.ops.len() {
-            checkpoint(seed, i, &model, &oracle, &wl.queries, &mut census);
+            checkpoint(
+                seed,
+                i,
+                &model,
+                &oracle,
+                &mut subject,
+                &wl.queries,
+                &mut census,
+            );
         }
+    }
+    // Terminal per-holder accounting parity.
+    for h in 0..wl.holders {
+        assert_eq!(
+            subject.tree.holder_blocks(subject.ids[h]),
+            model.holder_blocks(h),
+            "holder_blocks diverged for holder {h} (seed {seed})"
+        );
     }
     census
 }
@@ -73,12 +154,29 @@ fn checkpoint(
     at: usize,
     model: &Model,
     oracle: &Oracle,
+    subject: &mut Subject,
     queries: &[Vec<u64>],
     census: &mut Census,
 ) {
     for query in queries {
         census.queries += 1;
         let want = model.overlap(query);
+        // THE gate: the implementation equals the model, always.
+        let subject_map = subject.overlap(query);
+        assert_eq!(
+            subject_map,
+            want,
+            "RadixTree != model (seed {seed}, op {at}, query len {})",
+            query.len()
+        );
+        for o in subject.scratch.iter() {
+            let h = o.holder.parts().0 as usize;
+            assert_eq!(
+                o.total_blocks,
+                model.holder_blocks(h),
+                "total_blocks diverged for holder {h} (seed {seed}, op {at})"
+            );
+        }
         let got = oracle.overlap(query);
         // Under-match anywhere = unclassifiable = fail.
         for (&holder, &depth) in &want {
@@ -153,18 +251,30 @@ fn model_converges_within_scope() {
         for reorder_seed in [7u64, 8, 9] {
             let ops = workload::reinterleave(reorder_seed, &wl.ops, wl.holders);
             let mut other = Model::new(wl.holders);
+            let mut subject = Subject::new(wl.holders);
             for op in &ops {
                 other.apply(op);
+                subject.apply(op);
             }
             for query in &wl.queries {
+                let want = reference.overlap(query);
                 assert_eq!(
-                    reference.overlap(query),
+                    want,
                     other.overlap(query),
                     "model diverged under scoped reordering (seed {seed}/{reorder_seed})"
+                );
+                assert_eq!(
+                    subject.overlap(query),
+                    want,
+                    "RadixTree diverged under scoped reordering (seed {seed}/{reorder_seed})"
                 );
             }
             for h in 0..wl.holders {
                 assert_eq!(reference.holder_blocks(h), other.holder_blocks(h));
+                assert_eq!(
+                    subject.tree.holder_blocks(subject.ids[h]),
+                    reference.holder_blocks(h)
+                );
             }
         }
     }
@@ -175,6 +285,7 @@ fn model_converges_within_scope() {
 fn rejected_store_applies_nothing() {
     let mut model = Model::new(1);
     let mut oracle = Oracle::new(1);
+    let mut subject = Subject::new(1);
     let seeded = Op::Store {
         holder: 0,
         parent: None,
@@ -182,8 +293,10 @@ fn rejected_store_applies_nothing() {
     };
     model.apply(&seeded);
     oracle.apply(&seeded);
+    subject.apply(&seeded);
     let before_model = model.overlap(&[101, 102]);
     let before_oracle = oracle.overlap(&[101, 102]);
+    let before_subject = subject.overlap(&[101, 102]);
     let bad = Op::Store {
         holder: 0,
         parent: Some(999),
@@ -191,7 +304,10 @@ fn rejected_store_applies_nothing() {
     };
     assert_eq!(model.apply(&bad), Some(StoreResult::ParentNotFound));
     assert!(!oracle.apply(&bad));
+    assert!(!subject.apply(&bad));
     assert_eq!(model.overlap(&[101, 102]), before_model);
     assert_eq!(oracle.overlap(&[101, 102]), before_oracle);
+    assert_eq!(subject.overlap(&[101, 102]), before_subject);
     assert_eq!(model.holder_blocks(0), 2);
+    assert_eq!(subject.tree.holder_blocks(subject.ids[0]), 2);
 }

--- a/crates/radix_tree/tests/fuzz_differential.rs
+++ b/crates/radix_tree/tests/fuzz_differential.rs
@@ -1,0 +1,352 @@
+//! Campaign C1/C3/C4: wide-config differential fuzz plus
+//! out-of-contract chaos.
+//!
+//! In-contract mode: randomized workload configs far beyond the
+//! normative shapes, RadixTree == model at every checkpoint, full
+//! `audit()` at every checkpoint (and after EVERY op on small
+//! workloads).
+//!
+//! Chaos mode: deliberately violates every §7 precondition — random
+//! parents (including keys inside the same batch and never-seen
+//! keys), keys reused across positions and chains, interleaved
+//! retires/recreates, operations through stale ids, truncates at
+//! random keeps. The contract here is: NO panics, `audit()` holds
+//! after EVERY op, stale ids are loud no-ops, and a bit-for-bit
+//! replay of the same sequence lands in an identical observable
+//! state (determinism).
+//!
+//! `fuzz_quick` (32+8 seeds) always runs. The campaign entry point:
+//!   RADIX_FUZZ_SEEDS=10000 cargo test -p radix-tree --release \
+//!     --test fuzz_differential -- --ignored --nocapture
+
+mod common;
+
+use std::collections::BTreeMap;
+
+use common::{
+    model::{Model, StoreResult},
+    workload::{self, Config as WlConfig},
+    Op, Rng,
+};
+use radix_tree::{Config, HolderId, RadixTree, StoreError};
+
+fn random_config(rng: &mut Rng) -> WlConfig {
+    let holders = 2 + rng.below(255);
+    WlConfig {
+        holders,
+        families: 1 + rng.below(64),
+        family_len: {
+            let lo = 1 + rng.below(64);
+            (lo, lo + 1 + rng.below(448))
+        },
+        holders_per_family: {
+            let lo = 1 + rng.below(4);
+            (lo, lo + rng.below(holders.min(24)))
+        },
+        tail_len: (1 + rng.below(8), 9 + rng.below(56)),
+        store_batch: 1 + rng.below(16),
+        duplicate_pct: rng.below(41) as u64,
+        gap_pct: rng.below(41) as u64,
+        clear_pct: rng.below(31) as u64,
+        coincidence_pct: rng.below(51) as u64,
+    }
+}
+
+struct Subject {
+    tree: RadixTree,
+    ids: Vec<HolderId>,
+    scratch: Vec<radix_tree::Overlap>,
+}
+
+impl Subject {
+    fn new(holders: usize) -> Self {
+        let mut tree = RadixTree::new(Config::default());
+        let ids = (0..holders)
+            .map(|h| tree.create_holder(&format!("holder-{h}")))
+            .collect();
+        Self {
+            tree,
+            ids,
+            scratch: Vec::new(),
+        }
+    }
+    fn apply(&mut self, op: &Op) -> bool {
+        match op {
+            Op::Store {
+                holder,
+                parent,
+                blocks,
+            } => match self.tree.store(self.ids[*holder], *parent, blocks) {
+                Ok(_) => true,
+                Err(StoreError::ParentNotFound) => false,
+                Err(e) => panic!("unexpected store error {e:?}"),
+            },
+            Op::Remove { holder, keys } => {
+                self.tree.remove(self.ids[*holder], keys);
+                true
+            }
+            Op::Clear { holder } => {
+                self.tree.clear(self.ids[*holder]);
+                true
+            }
+        }
+    }
+    fn overlap(&mut self, query: &[u64]) -> BTreeMap<usize, u32> {
+        let scratch = &mut self.scratch;
+        self.tree.overlap(query, scratch);
+        let mut out = BTreeMap::new();
+        for o in scratch.iter() {
+            out.insert(o.holder.parts().0 as usize, o.depth);
+        }
+        out
+    }
+}
+
+fn run_one_in_contract(seed: u64) {
+    let mut rng = Rng::new(seed ^ 0xF00D);
+    let cfg = random_config(&mut rng);
+    let wl = workload::generate(seed, &cfg);
+    let audit_every_op = wl.ops.len() < 4000;
+    let mut model = Model::new(wl.holders);
+    let mut subject = Subject::new(wl.holders);
+    let checkpoint_every = (wl.ops.len() / 6).max(1);
+    for (i, op) in wl.ops.iter().enumerate() {
+        let model_outcome = model.apply(op);
+        let subject_ok = subject.apply(op);
+        if let Op::Store { .. } = op {
+            let model_ok = !matches!(model_outcome, Some(StoreResult::ParentNotFound));
+            assert_eq!(
+                model_ok, subject_ok,
+                "acceptance diverged: seed {seed} op {i}"
+            );
+        }
+        if audit_every_op {
+            subject
+                .tree
+                .audit()
+                .unwrap_or_else(|e| panic!("audit failed: seed {seed} op {i}: {e}"));
+        }
+        if i % checkpoint_every == 0 || i + 1 == wl.ops.len() {
+            if !audit_every_op {
+                subject
+                    .tree
+                    .audit()
+                    .unwrap_or_else(|e| panic!("audit failed: seed {seed} op {i}: {e}"));
+            }
+            for query in &wl.queries {
+                assert_eq!(
+                    subject.overlap(query),
+                    model.overlap(query),
+                    "subject != model: seed {seed} op {i}"
+                );
+            }
+        }
+    }
+    for h in 0..wl.holders {
+        assert_eq!(
+            subject.tree.holder_blocks(subject.ids[h]),
+            model.holder_blocks(h),
+            "holder_blocks diverged: seed {seed} holder {h}"
+        );
+    }
+}
+
+/// Chaos: arbitrary op soup. Contract: no panic, audit always green,
+/// stale-id ops are loud no-ops, replay is deterministic.
+fn run_one_chaos(seed: u64) {
+    #[derive(Clone, Debug)]
+    enum COp {
+        Store {
+            slot: usize,
+            parent_pick: u64,
+            blocks: Vec<(u64, u64)>,
+        },
+        Remove {
+            slot: usize,
+            keys: Vec<u64>,
+        },
+        Clear {
+            slot: usize,
+        },
+        Truncate {
+            slot: usize,
+            keep: u64,
+        },
+        Retire {
+            slot: usize,
+        },
+        Recreate {
+            slot: usize,
+        },
+        StaleProbe {
+            slot: usize,
+        },
+        Query {
+            probe: Vec<u64>,
+        },
+    }
+    let mut rng = Rng::new(seed ^ 0xC4A05);
+    let slots = 2 + rng.below(12);
+    let ops_count = 400 + rng.below(1200);
+    // Key pool encourages collisions across positions and holders.
+    let key_pool: Vec<u64> = (0..64).map(|_| rng.next() | 1).collect();
+    let content_pool: Vec<u64> = (0..48).map(|_| rng.next() | 1).collect();
+    let mut script = Vec::with_capacity(ops_count);
+    for _ in 0..ops_count {
+        let slot = rng.below(slots);
+        script.push(match rng.below(100) {
+            0..=44 => {
+                let len = 1 + rng.below(12);
+                let blocks: Vec<(u64, u64)> = (0..len)
+                    .map(|_| {
+                        (
+                            key_pool[rng.below(key_pool.len())],
+                            content_pool[rng.below(content_pool.len())],
+                        )
+                    })
+                    .collect();
+                COp::Store {
+                    slot,
+                    parent_pick: rng.next(),
+                    blocks,
+                }
+            }
+            45..=59 => COp::Remove {
+                slot,
+                keys: (0..1 + rng.below(6))
+                    .map(|_| key_pool[rng.below(key_pool.len())])
+                    .collect(),
+            },
+            60..=66 => COp::Clear { slot },
+            67..=74 => COp::Truncate {
+                slot,
+                keep: rng.below(40) as u64,
+            },
+            75..=81 => COp::Retire { slot },
+            82..=88 => COp::Recreate { slot },
+            89..=92 => COp::StaleProbe { slot },
+            _ => COp::Query {
+                probe: (0..1 + rng.below(16))
+                    .map(|_| content_pool[rng.below(content_pool.len())])
+                    .collect(),
+            },
+        });
+    }
+
+    let run = |script: &[COp]| -> (Vec<BTreeMap<usize, u32>>, u64, u64) {
+        let mut tree = RadixTree::new(Config { max_chain_len: 64 });
+        let mut ids: Vec<Option<HolderId>> = (0..slots)
+            .map(|s| Some(tree.create_holder(&format!("chaos-{s}"))))
+            .collect();
+        let mut stale: Vec<HolderId> = Vec::new();
+        let mut answers = Vec::new();
+        let mut scratch = Vec::new();
+        for (i, op) in script.iter().enumerate() {
+            match op {
+                COp::Store {
+                    slot,
+                    parent_pick,
+                    blocks,
+                } => {
+                    if let Some(id) = ids[*slot] {
+                        // Parent: none / a pooled key / a never-seen key.
+                        let parent = match parent_pick % 3 {
+                            0 => None,
+                            1 => Some(key_pool[(*parent_pick as usize / 3) % key_pool.len()]),
+                            _ => Some(parent_pick | 1),
+                        };
+                        let _ = tree.store(id, parent, blocks);
+                    }
+                }
+                COp::Remove { slot, keys } => {
+                    if let Some(id) = ids[*slot] {
+                        tree.remove(id, keys);
+                    }
+                }
+                COp::Clear { slot } => {
+                    if let Some(id) = ids[*slot] {
+                        tree.clear(id);
+                    }
+                }
+                COp::Truncate { slot, keep } => {
+                    if let Some(id) = ids[*slot] {
+                        tree.truncate_tail(id, *keep);
+                    }
+                }
+                COp::Retire { slot } => {
+                    if let Some(id) = ids[*slot].take() {
+                        tree.retire_holder(id);
+                        stale.push(id);
+                    }
+                }
+                COp::Recreate { slot } => {
+                    if ids[*slot].is_none() {
+                        ids[*slot] = Some(tree.create_holder(&format!("chaos-{slot}-re{i}")));
+                    }
+                }
+                COp::StaleProbe { slot } => {
+                    // Every stale id must be a loud no-op forever.
+                    if let Some(&old) = stale.last() {
+                        assert_eq!(
+                            tree.store(old, None, &[(1, 1)]),
+                            Err(StoreError::UnknownHolder),
+                            "stale id accepted a store (seed {seed} op {i} slot {slot})"
+                        );
+                        assert_eq!(tree.remove(old, &[1]), 0);
+                        assert_eq!(tree.holder_blocks(old), 0);
+                        assert_eq!(tree.holder_name(old), None);
+                    }
+                }
+                COp::Query { probe } => {
+                    tree.overlap(probe, &mut scratch);
+                    let mut m = BTreeMap::new();
+                    for o in scratch.iter() {
+                        m.insert(o.holder.parts().0 as usize, o.depth);
+                    }
+                    answers.push(m);
+                }
+            }
+            tree.audit()
+                .unwrap_or_else(|e| panic!("chaos audit failed: seed {seed} op {i}: {e}"));
+        }
+        let stats = tree.stats();
+        (answers, stats.holder_blocks, stats.distinct_entries)
+    };
+    // Determinism: two independent executions of the same soup agree.
+    let a = run(&script);
+    let b = run(&script);
+    assert_eq!(a, b, "chaos replay diverged (seed {seed})");
+}
+
+#[test]
+fn fuzz_quick() {
+    for seed in 1..=32u64 {
+        run_one_in_contract(seed);
+    }
+    for seed in 1..=8u64 {
+        run_one_chaos(seed);
+    }
+}
+
+#[test]
+#[ignore = "campaign entry point; set RADIX_FUZZ_SEEDS"]
+fn fuzz_campaign() {
+    let seeds: u64 = std::env::var("RADIX_FUZZ_SEEDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1000);
+    let start: u64 = std::env::var("RADIX_FUZZ_START")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1000);
+    for seed in start..start + seeds {
+        run_one_in_contract(seed);
+        if seed % 3 == 0 {
+            run_one_chaos(seed);
+        }
+        if (seed - start) % 250 == 249 {
+            println!("fuzz: {} seeds green", seed - start + 1);
+        }
+    }
+    println!("fuzz campaign: {seeds} seeds green");
+}

--- a/crates/radix_tree/tests/fuzz_differential.rs
+++ b/crates/radix_tree/tests/fuzz_differential.rs
@@ -237,6 +237,10 @@ fn run_one_chaos(seed: u64) {
 
     let run = |script: &[COp]| -> (Vec<BTreeMap<usize, u32>>, u64, u64) {
         let mut tree = RadixTree::new(Config { max_chain_len: 64 });
+        // The model is total (defined on arbitrary inputs), so chaos
+        // now runs under the same hard referee gate as the
+        // in-contract fuzz — keyed by chaos slot.
+        let mut model = Model::with_max(slots, 64);
         let mut ids: Vec<Option<HolderId>> = (0..slots)
             .map(|s| Some(tree.create_holder(&format!("chaos-{s}"))))
             .collect();
@@ -258,27 +262,45 @@ fn run_one_chaos(seed: u64) {
                             1 => Some(key_pool[(*parent_pick as usize / 3) % key_pool.len()]),
                             _ => Some(parent_pick | 1),
                         };
-                        let _ = tree.store(id, parent, blocks);
+                        let subject = tree.store(id, parent, blocks);
+                        let modeled = model.store(*slot, parent, blocks);
+                        let pair = (
+                            subject.is_ok(),
+                            !matches!(
+                                modeled,
+                                StoreResult::ParentNotFound | StoreResult::ChainTooLong
+                            ),
+                        );
+                        assert!(
+                            pair.0 == pair.1,
+                            "store acceptance diverged (seed {seed} op {i}): {subject:?} vs {modeled:?}"
+                        );
                     }
                 }
                 COp::Remove { slot, keys } => {
                     if let Some(id) = ids[*slot] {
-                        tree.remove(id, keys);
+                        let a = tree.remove(id, keys);
+                        let b = model.remove(*slot, keys);
+                        assert_eq!(a, b, "remove count diverged (seed {seed} op {i})");
                     }
                 }
                 COp::Clear { slot } => {
                     if let Some(id) = ids[*slot] {
                         tree.clear(id);
+                        model.clear(*slot);
                     }
                 }
                 COp::Truncate { slot, keep } => {
                     if let Some(id) = ids[*slot] {
-                        tree.truncate_tail(id, *keep);
+                        let a = tree.truncate_tail(id, *keep);
+                        let b = model.truncate_tail(*slot, *keep);
+                        assert_eq!(a, b, "truncate count diverged (seed {seed} op {i})");
                     }
                 }
                 COp::Retire { slot } => {
                     if let Some(id) = ids[*slot].take() {
                         tree.retire_holder(id);
+                        model.clear(*slot);
                         stale.push(id);
                     }
                 }
@@ -302,17 +324,44 @@ fn run_one_chaos(seed: u64) {
                 }
                 COp::Query { probe } => {
                     tree.overlap(probe, &mut qscratch, &mut scratch);
-                    let mut m = BTreeMap::new();
+                    let mut by_slot = BTreeMap::new();
                     for o in scratch.iter() {
-                        m.insert(o.holder.parts().0 as usize, o.depth);
+                        // Map subject holder ids back to chaos slots;
+                        // an unmapped id would be a stale-holder leak.
+                        let slot = ids
+                            .iter()
+                            .position(|x| *x == Some(o.holder))
+                            .unwrap_or_else(|| {
+                                panic!("answer for unknown holder (seed {seed} op {i})")
+                            });
+                        by_slot.insert(slot, o.depth);
                     }
-                    answers.push(m);
+                    assert_eq!(
+                        by_slot,
+                        model.overlap(probe),
+                        "chaos subject != model (seed {seed} op {i})"
+                    );
+                    answers.push(by_slot);
                 }
             }
             tree.audit()
                 .unwrap_or_else(|e| panic!("chaos audit failed: seed {seed} op {i}: {e}"));
+            for (slot, id) in ids.iter().enumerate() {
+                if let Some(id) = id {
+                    assert_eq!(
+                        tree.holder_blocks(*id),
+                        model.holder_blocks(slot),
+                        "chaos holder_blocks diverged (seed {seed} op {i} slot {slot})"
+                    );
+                }
+            }
         }
         let stats = tree.stats();
+        assert_eq!(
+            stats.distinct_entries,
+            model.distinct_entries(),
+            "chaos distinct_entries diverged (seed {seed})"
+        );
         (answers, stats.holder_blocks, stats.distinct_entries)
     };
     // Determinism: two independent executions of the same soup agree.

--- a/crates/radix_tree/tests/fuzz_differential.rs
+++ b/crates/radix_tree/tests/fuzz_differential.rs
@@ -28,7 +28,7 @@ use common::{
     workload::{self, Config as WlConfig},
     Op, Rng,
 };
-use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree3, StoreError};
+use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree, StoreError};
 
 fn random_config(rng: &mut Rng) -> WlConfig {
     let holders = 2 + rng.below(255);
@@ -54,7 +54,7 @@ fn random_config(rng: &mut Rng) -> WlConfig {
 
 enum Core {
     Flat(FlatTree),
-    Chain(RadixTree3),
+    Chain(RadixTree),
 }
 
 struct Subject {
@@ -78,7 +78,7 @@ impl Subject {
         }
     }
     fn new_chain(holders: usize) -> Self {
-        let mut tree = RadixTree3::new(Config::default());
+        let mut tree = RadixTree::new(Config::default());
         let ids = (0..holders)
             .map(|h| tree.create_holder(&format!("holder-{h}")))
             .collect();
@@ -274,7 +274,7 @@ macro_rules! impl_core_api {
     };
 }
 impl_core_api!(FlatTree);
-impl_core_api!(RadixTree3);
+impl_core_api!(RadixTree);
 
 /// Chaos: arbitrary op soup. Contract: no panic, audit always green,
 /// stale-id ops are loud no-ops, replay is deterministic — for BOTH
@@ -514,7 +514,7 @@ fn run_one_chaos(seed: u64) {
         slots,
         &key_pool,
         &script,
-        RadixTree3::new(Config { max_chain_len: 64 }),
+        RadixTree::new(Config { max_chain_len: 64 }),
     );
     assert_eq!(
         flat_a, chain_a,

--- a/crates/radix_tree/tests/fuzz_differential.rs
+++ b/crates/radix_tree/tests/fuzz_differential.rs
@@ -30,8 +30,14 @@ use common::{
 };
 use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree, StoreError};
 
-fn random_config(rng: &mut Rng) -> WlConfig {
+/// `wide` raises the sharing cap to the bench's H=64 width — model
+/// scans at that width are too slow for the always-on debug quick
+/// suite, so wide configs belong to the release campaign entry point
+/// (audit finding: correctness past ~27 holders/block was previously
+/// never model-gated ANYWHERE).
+fn random_config(rng: &mut Rng, wide: bool) -> WlConfig {
     let holders = 2 + rng.below(255);
+    let share_cap = if wide { 64 } else { 24 };
     WlConfig {
         holders,
         families: 1 + rng.below(64),
@@ -41,7 +47,7 @@ fn random_config(rng: &mut Rng) -> WlConfig {
         },
         holders_per_family: {
             let lo = 1 + rng.below(4);
-            (lo, lo + rng.below(holders.min(24)))
+            (lo, lo + rng.below(holders.min(share_cap)))
         },
         tail_len: (1 + rng.below(8), 9 + rng.below(56)),
         store_batch: 1 + rng.below(16),
@@ -89,7 +95,7 @@ impl Subject {
             qscratch: OverlapScratch::default(),
         }
     }
-    fn apply(&mut self, op: &Op) -> bool {
+    fn apply(&mut self, op: &Op) -> Option<(u32, u32)> {
         match op {
             Op::Store {
                 holder,
@@ -101,8 +107,8 @@ impl Subject {
                     Core::Chain(t) => t.store(self.ids[*holder], *parent, blocks),
                 };
                 match r {
-                    Ok(_) => true,
-                    Err(StoreError::ParentNotFound) => false,
+                    Ok(o) => Some((o.applied, o.duplicates)),
+                    Err(StoreError::ParentNotFound) => None,
                     Err(e) => panic!("unexpected store error {e:?}"),
                 }
             }
@@ -111,14 +117,14 @@ impl Subject {
                     Core::Flat(t) => t.remove(self.ids[*holder], keys),
                     Core::Chain(t) => t.remove(self.ids[*holder], keys),
                 };
-                true
+                Some((0, 0))
             }
             Op::Clear { holder } => {
                 match &mut self.core {
                     Core::Flat(t) => t.clear(self.ids[*holder]),
                     Core::Chain(t) => t.clear(self.ids[*holder]),
                 }
-                true
+                Some((0, 0))
             }
         }
     }
@@ -140,6 +146,18 @@ impl Subject {
             Core::Chain(t) => t.holder_blocks(self.ids[h]),
         }
     }
+    fn enumerate(&self, h: usize) -> Vec<(u32, u64, u64)> {
+        match &self.core {
+            Core::Flat(t) => t.enumerate(self.ids[h]).collect(),
+            Core::Chain(t) => t.enumerate(self.ids[h]).collect(),
+        }
+    }
+    fn distinct_entries(&self) -> u64 {
+        match &self.core {
+            Core::Flat(t) => t.stats().distinct_entries,
+            Core::Chain(t) => t.stats().distinct_entries,
+        }
+    }
     fn audit(&self) -> Result<(), String> {
         match &self.core {
             Core::Flat(t) => t.audit(),
@@ -148,9 +166,9 @@ impl Subject {
     }
 }
 
-fn run_one_in_contract(seed: u64) {
+fn run_one_in_contract(seed: u64, wide: bool) {
     let mut rng = Rng::new(seed ^ 0xF00D);
-    let cfg = random_config(&mut rng);
+    let cfg = random_config(&mut rng, wide);
     let wl = workload::generate(seed, &cfg);
     let audit_every_op = wl.ops.len() < 4000;
     let mut model = Model::new(wl.holders);
@@ -162,13 +180,28 @@ fn run_one_in_contract(seed: u64) {
     for (i, op) in wl.ops.iter().enumerate() {
         let model_outcome = model.apply(op);
         for (ci, subject) in subjects.iter_mut().enumerate() {
-            let subject_ok = subject.apply(op);
+            let subject_out = subject.apply(op);
             if let Op::Store { .. } = op {
-                let model_ok = !matches!(model_outcome, Some(StoreResult::ParentNotFound));
-                assert_eq!(
-                    model_ok, subject_ok,
-                    "core{ci} acceptance diverged: seed {seed} op {i}"
-                );
+                // StoreOutcome PARITY, not just acceptance: the relay
+                // gate depends on applied counts (audit finding — the
+                // payload was discarded everywhere).
+                match (&model_outcome, &subject_out) {
+                    (Some(StoreResult::ParentNotFound), None) => {}
+                    (
+                        Some(StoreResult::Applied {
+                            applied,
+                            duplicates,
+                        }),
+                        Some((a, d)),
+                    ) => {
+                        assert_eq!(
+                            (*applied, *duplicates),
+                            (*a, *d),
+                            "core{ci} StoreOutcome diverged: seed {seed} op {i}"
+                        );
+                    }
+                    other => panic!("core{ci} acceptance diverged: seed {seed} op {i}: {other:?}"),
+                }
             }
             if audit_every_op {
                 subject
@@ -200,7 +233,20 @@ fn run_one_in_contract(seed: u64) {
                 model.holder_blocks(h),
                 "core{ci} holder_blocks diverged: seed {seed} holder {h}"
             );
+            // Terminal ENUMERATE parity: per-block position/key/
+            // content — off-query-path corruption was invisible to
+            // the whole campaign without this (audit finding).
+            assert_eq!(
+                subject.enumerate(h),
+                model.enumerate(h),
+                "core{ci} enumerate diverged: seed {seed} holder {h}"
+            );
         }
+        assert_eq!(
+            subject.distinct_entries(),
+            model.distinct_entries(),
+            "core{ci} distinct_entries diverged: seed {seed}"
+        );
     }
 }
 
@@ -525,7 +571,7 @@ fn run_one_chaos(seed: u64) {
 #[test]
 fn fuzz_quick() {
     for seed in 1..=32u64 {
-        run_one_in_contract(seed);
+        run_one_in_contract(seed, false);
     }
     for seed in 1..=8u64 {
         run_one_chaos(seed);
@@ -544,7 +590,9 @@ fn fuzz_campaign() {
         .and_then(|v| v.parse().ok())
         .unwrap_or(1000);
     for seed in start..start + seeds {
-        run_one_in_contract(seed);
+        // Every 4th campaign seed runs the wide-sharing (H<=64)
+        // distribution under the full model gate.
+        run_one_in_contract(seed, seed % 4 == 0);
         if seed % 3 == 0 {
             run_one_chaos(seed);
         }

--- a/crates/radix_tree/tests/fuzz_differential.rs
+++ b/crates/radix_tree/tests/fuzz_differential.rs
@@ -28,7 +28,7 @@ use common::{
     workload::{self, Config as WlConfig},
     Op, Rng,
 };
-use radix_tree::{Config, HolderId, OverlapScratch, RadixTree, StoreError};
+use radix_tree::{Config, HolderId, OverlapScratch, RadixTree, RadixTree3, StoreError};
 
 fn random_config(rng: &mut Rng) -> WlConfig {
     let holders = 2 + rng.below(255);
@@ -52,21 +52,38 @@ fn random_config(rng: &mut Rng) -> WlConfig {
     }
 }
 
+enum Core {
+    Flat(RadixTree),
+    Chain(RadixTree3),
+}
+
 struct Subject {
-    tree: RadixTree,
+    core: Core,
     ids: Vec<HolderId>,
     scratch: Vec<radix_tree::Overlap>,
     qscratch: OverlapScratch,
 }
 
 impl Subject {
-    fn new(holders: usize) -> Self {
+    fn new_flat(holders: usize) -> Self {
         let mut tree = RadixTree::new(Config::default());
         let ids = (0..holders)
             .map(|h| tree.create_holder(&format!("holder-{h}")))
             .collect();
         Self {
-            tree,
+            core: Core::Flat(tree),
+            ids,
+            scratch: Vec::new(),
+            qscratch: OverlapScratch::default(),
+        }
+    }
+    fn new_chain(holders: usize) -> Self {
+        let mut tree = RadixTree3::new(Config::default());
+        let ids = (0..holders)
+            .map(|h| tree.create_holder(&format!("holder-{h}")))
+            .collect();
+        Self {
+            core: Core::Chain(tree),
             ids,
             scratch: Vec::new(),
             qscratch: OverlapScratch::default(),
@@ -78,29 +95,56 @@ impl Subject {
                 holder,
                 parent,
                 blocks,
-            } => match self.tree.store(self.ids[*holder], *parent, blocks) {
-                Ok(_) => true,
-                Err(StoreError::ParentNotFound) => false,
-                Err(e) => panic!("unexpected store error {e:?}"),
-            },
+            } => {
+                let r = match &mut self.core {
+                    Core::Flat(t) => t.store(self.ids[*holder], *parent, blocks),
+                    Core::Chain(t) => t.store(self.ids[*holder], *parent, blocks),
+                };
+                match r {
+                    Ok(_) => true,
+                    Err(StoreError::ParentNotFound) => false,
+                    Err(e) => panic!("unexpected store error {e:?}"),
+                }
+            }
             Op::Remove { holder, keys } => {
-                self.tree.remove(self.ids[*holder], keys);
+                match &mut self.core {
+                    Core::Flat(t) => t.remove(self.ids[*holder], keys),
+                    Core::Chain(t) => t.remove(self.ids[*holder], keys),
+                };
                 true
             }
             Op::Clear { holder } => {
-                self.tree.clear(self.ids[*holder]);
+                match &mut self.core {
+                    Core::Flat(t) => t.clear(self.ids[*holder]),
+                    Core::Chain(t) => t.clear(self.ids[*holder]),
+                }
                 true
             }
         }
     }
     fn overlap(&mut self, query: &[u64]) -> BTreeMap<usize, u32> {
         let scratch = &mut self.scratch;
-        self.tree.overlap(query, &mut self.qscratch, scratch);
+        match &mut self.core {
+            Core::Flat(t) => t.overlap(query, &mut self.qscratch, scratch),
+            Core::Chain(t) => t.overlap(query, &mut self.qscratch, scratch),
+        }
         let mut out = BTreeMap::new();
         for o in scratch.iter() {
             out.insert(o.holder.parts().0 as usize, o.depth);
         }
         out
+    }
+    fn holder_blocks(&self, h: usize) -> u64 {
+        match &self.core {
+            Core::Flat(t) => t.holder_blocks(self.ids[h]),
+            Core::Chain(t) => t.holder_blocks(self.ids[h]),
+        }
+    }
+    fn audit(&self) -> Result<(), String> {
+        match &self.core {
+            Core::Flat(t) => t.audit(),
+            Core::Chain(t) => t.audit(),
+        }
     }
 }
 
@@ -110,51 +154,131 @@ fn run_one_in_contract(seed: u64) {
     let wl = workload::generate(seed, &cfg);
     let audit_every_op = wl.ops.len() < 4000;
     let mut model = Model::new(wl.holders);
-    let mut subject = Subject::new(wl.holders);
+    let mut subjects = [
+        Subject::new_flat(wl.holders),
+        Subject::new_chain(wl.holders),
+    ];
     let checkpoint_every = (wl.ops.len() / 6).max(1);
     for (i, op) in wl.ops.iter().enumerate() {
         let model_outcome = model.apply(op);
-        let subject_ok = subject.apply(op);
-        if let Op::Store { .. } = op {
-            let model_ok = !matches!(model_outcome, Some(StoreResult::ParentNotFound));
-            assert_eq!(
-                model_ok, subject_ok,
-                "acceptance diverged: seed {seed} op {i}"
-            );
-        }
-        if audit_every_op {
-            subject
-                .tree
-                .audit()
-                .unwrap_or_else(|e| panic!("audit failed: seed {seed} op {i}: {e}"));
+        for (ci, subject) in subjects.iter_mut().enumerate() {
+            let subject_ok = subject.apply(op);
+            if let Op::Store { .. } = op {
+                let model_ok = !matches!(model_outcome, Some(StoreResult::ParentNotFound));
+                assert_eq!(
+                    model_ok, subject_ok,
+                    "core{ci} acceptance diverged: seed {seed} op {i}"
+                );
+            }
+            if audit_every_op {
+                subject
+                    .audit()
+                    .unwrap_or_else(|e| panic!("core{ci} audit failed: seed {seed} op {i}: {e}"));
+            }
         }
         if i % checkpoint_every == 0 || i + 1 == wl.ops.len() {
-            if !audit_every_op {
-                subject
-                    .tree
-                    .audit()
-                    .unwrap_or_else(|e| panic!("audit failed: seed {seed} op {i}: {e}"));
-            }
-            for query in &wl.queries {
-                assert_eq!(
-                    subject.overlap(query),
-                    model.overlap(query),
-                    "subject != model: seed {seed} op {i}"
-                );
+            for (ci, subject) in subjects.iter_mut().enumerate() {
+                if !audit_every_op {
+                    subject.audit().unwrap_or_else(|e| {
+                        panic!("core{ci} audit failed: seed {seed} op {i}: {e}")
+                    });
+                }
+                for query in &wl.queries {
+                    assert_eq!(
+                        subject.overlap(query),
+                        model.overlap(query),
+                        "core{ci} != model: seed {seed} op {i}"
+                    );
+                }
             }
         }
     }
-    for h in 0..wl.holders {
-        assert_eq!(
-            subject.tree.holder_blocks(subject.ids[h]),
-            model.holder_blocks(h),
-            "holder_blocks diverged: seed {seed} holder {h}"
-        );
+    for (ci, subject) in subjects.iter().enumerate() {
+        for h in 0..wl.holders {
+            assert_eq!(
+                subject.holder_blocks(h),
+                model.holder_blocks(h),
+                "core{ci} holder_blocks diverged: seed {seed} holder {h}"
+            );
+        }
     }
 }
 
+/// Uniform surface over both cores for the generic chaos driver.
+trait CoreApi {
+    fn create_holder(&mut self, name: &str) -> HolderId;
+    fn store(
+        &mut self,
+        id: HolderId,
+        parent: Option<u64>,
+        blocks: &[(u64, u64)],
+    ) -> Result<radix_tree::StoreOutcome, StoreError>;
+    fn remove(&mut self, id: HolderId, keys: &[u64]) -> u32;
+    fn clear(&mut self, id: HolderId);
+    fn truncate_tail(&mut self, id: HolderId, keep: u64) -> u64;
+    fn retire_holder(&mut self, id: HolderId);
+    fn holder_blocks(&self, id: HolderId) -> u64;
+    fn holder_name(&self, id: HolderId) -> Option<&str>;
+    fn overlap(&self, q: &[u64], sc: &mut OverlapScratch, out: &mut Vec<radix_tree::Overlap>);
+    fn audit(&self) -> Result<(), String>;
+    fn distinct_entries(&self) -> u64;
+}
+
+macro_rules! impl_core_api {
+    ($t:ty) => {
+        impl CoreApi for $t {
+            fn create_holder(&mut self, name: &str) -> HolderId {
+                <$t>::create_holder(self, name)
+            }
+            fn store(
+                &mut self,
+                id: HolderId,
+                parent: Option<u64>,
+                blocks: &[(u64, u64)],
+            ) -> Result<radix_tree::StoreOutcome, StoreError> {
+                <$t>::store(self, id, parent, blocks)
+            }
+            fn remove(&mut self, id: HolderId, keys: &[u64]) -> u32 {
+                <$t>::remove(self, id, keys)
+            }
+            fn clear(&mut self, id: HolderId) {
+                <$t>::clear(self, id)
+            }
+            fn truncate_tail(&mut self, id: HolderId, keep: u64) -> u64 {
+                <$t>::truncate_tail(self, id, keep)
+            }
+            fn retire_holder(&mut self, id: HolderId) {
+                <$t>::retire_holder(self, id)
+            }
+            fn holder_blocks(&self, id: HolderId) -> u64 {
+                <$t>::holder_blocks(self, id)
+            }
+            fn holder_name(&self, id: HolderId) -> Option<&str> {
+                <$t>::holder_name(self, id)
+            }
+            fn overlap(
+                &self,
+                q: &[u64],
+                sc: &mut OverlapScratch,
+                out: &mut Vec<radix_tree::Overlap>,
+            ) {
+                <$t>::overlap(self, q, sc, out)
+            }
+            fn audit(&self) -> Result<(), String> {
+                <$t>::audit(self)
+            }
+            fn distinct_entries(&self) -> u64 {
+                <$t>::stats(self).distinct_entries
+            }
+        }
+    };
+}
+impl_core_api!(RadixTree);
+impl_core_api!(RadixTree3);
+
 /// Chaos: arbitrary op soup. Contract: no panic, audit always green,
-/// stale-id ops are loud no-ops, replay is deterministic.
+/// stale-id ops are loud no-ops, replay is deterministic — for BOTH
+/// cores, each against the total model.
 fn run_one_chaos(seed: u64) {
     #[derive(Clone, Debug)]
     enum COp {
@@ -235,8 +359,13 @@ fn run_one_chaos(seed: u64) {
         });
     }
 
-    let run = |script: &[COp]| -> (Vec<BTreeMap<usize, u32>>, u64, u64) {
-        let mut tree = RadixTree::new(Config { max_chain_len: 64 });
+    fn chaos_run<T: CoreApi>(
+        seed: u64,
+        slots: usize,
+        key_pool: &[u64],
+        script: &[COp],
+        mut tree: T,
+    ) -> (Vec<BTreeMap<usize, u32>>, u64) {
         // The model is total (defined on arbitrary inputs), so chaos
         // now runs under the same hard referee gate as the
         // in-contract fuzz — keyed by chaos slot.
@@ -356,18 +485,41 @@ fn run_one_chaos(seed: u64) {
                 }
             }
         }
-        let stats = tree.stats();
+        let distinct = tree.distinct_entries();
         assert_eq!(
-            stats.distinct_entries,
+            distinct,
             model.distinct_entries(),
             "chaos distinct_entries diverged (seed {seed})"
         );
-        (answers, stats.holder_blocks, stats.distinct_entries)
-    };
-    // Determinism: two independent executions of the same soup agree.
-    let a = run(&script);
-    let b = run(&script);
-    assert_eq!(a, b, "chaos replay diverged (seed {seed})");
+        (answers, distinct)
+    }
+    // Determinism per core, and cross-core agreement, all vs model.
+    let flat_a = chaos_run(
+        seed,
+        slots,
+        &key_pool,
+        &script,
+        RadixTree::new(Config { max_chain_len: 64 }),
+    );
+    let flat_b = chaos_run(
+        seed,
+        slots,
+        &key_pool,
+        &script,
+        RadixTree::new(Config { max_chain_len: 64 }),
+    );
+    assert_eq!(flat_a, flat_b, "flat chaos replay diverged (seed {seed})");
+    let chain_a = chaos_run(
+        seed,
+        slots,
+        &key_pool,
+        &script,
+        RadixTree3::new(Config { max_chain_len: 64 }),
+    );
+    assert_eq!(
+        flat_a, chain_a,
+        "flat vs chain chaos diverged (seed {seed})"
+    );
 }
 
 #[test]

--- a/crates/radix_tree/tests/fuzz_differential.rs
+++ b/crates/radix_tree/tests/fuzz_differential.rs
@@ -28,7 +28,7 @@ use common::{
     workload::{self, Config as WlConfig},
     Op, Rng,
 };
-use radix_tree::{Config, HolderId, OverlapScratch, RadixTree, RadixTree3, StoreError};
+use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree3, StoreError};
 
 fn random_config(rng: &mut Rng) -> WlConfig {
     let holders = 2 + rng.below(255);
@@ -53,7 +53,7 @@ fn random_config(rng: &mut Rng) -> WlConfig {
 }
 
 enum Core {
-    Flat(RadixTree),
+    Flat(FlatTree),
     Chain(RadixTree3),
 }
 
@@ -66,7 +66,7 @@ struct Subject {
 
 impl Subject {
     fn new_flat(holders: usize) -> Self {
-        let mut tree = RadixTree::new(Config::default());
+        let mut tree = FlatTree::new(Config::default());
         let ids = (0..holders)
             .map(|h| tree.create_holder(&format!("holder-{h}")))
             .collect();
@@ -273,7 +273,7 @@ macro_rules! impl_core_api {
         }
     };
 }
-impl_core_api!(RadixTree);
+impl_core_api!(FlatTree);
 impl_core_api!(RadixTree3);
 
 /// Chaos: arbitrary op soup. Contract: no panic, audit always green,
@@ -499,14 +499,14 @@ fn run_one_chaos(seed: u64) {
         slots,
         &key_pool,
         &script,
-        RadixTree::new(Config { max_chain_len: 64 }),
+        FlatTree::new(Config { max_chain_len: 64 }),
     );
     let flat_b = chaos_run(
         seed,
         slots,
         &key_pool,
         &script,
-        RadixTree::new(Config { max_chain_len: 64 }),
+        FlatTree::new(Config { max_chain_len: 64 }),
     );
     assert_eq!(flat_a, flat_b, "flat chaos replay diverged (seed {seed})");
     let chain_a = chaos_run(

--- a/crates/radix_tree/tests/fuzz_differential.rs
+++ b/crates/radix_tree/tests/fuzz_differential.rs
@@ -28,7 +28,7 @@ use common::{
     workload::{self, Config as WlConfig},
     Op, Rng,
 };
-use radix_tree::{Config, HolderId, RadixTree, StoreError};
+use radix_tree::{Config, HolderId, OverlapScratch, RadixTree, StoreError};
 
 fn random_config(rng: &mut Rng) -> WlConfig {
     let holders = 2 + rng.below(255);
@@ -56,6 +56,7 @@ struct Subject {
     tree: RadixTree,
     ids: Vec<HolderId>,
     scratch: Vec<radix_tree::Overlap>,
+    qscratch: OverlapScratch,
 }
 
 impl Subject {
@@ -68,6 +69,7 @@ impl Subject {
             tree,
             ids,
             scratch: Vec::new(),
+            qscratch: OverlapScratch::default(),
         }
     }
     fn apply(&mut self, op: &Op) -> bool {
@@ -93,7 +95,7 @@ impl Subject {
     }
     fn overlap(&mut self, query: &[u64]) -> BTreeMap<usize, u32> {
         let scratch = &mut self.scratch;
-        self.tree.overlap(query, scratch);
+        self.tree.overlap(query, &mut self.qscratch, scratch);
         let mut out = BTreeMap::new();
         for o in scratch.iter() {
             out.insert(o.holder.parts().0 as usize, o.depth);
@@ -241,6 +243,7 @@ fn run_one_chaos(seed: u64) {
         let mut stale: Vec<HolderId> = Vec::new();
         let mut answers = Vec::new();
         let mut scratch = Vec::new();
+        let mut qscratch = OverlapScratch::default();
         for (i, op) in script.iter().enumerate() {
             match op {
                 COp::Store {
@@ -298,7 +301,7 @@ fn run_one_chaos(seed: u64) {
                     }
                 }
                 COp::Query { probe } => {
-                    tree.overlap(probe, &mut scratch);
+                    tree.overlap(probe, &mut qscratch, &mut scratch);
                     let mut m = BTreeMap::new();
                     for o in scratch.iter() {
                         m.insert(o.holder.parts().0 as usize, o.depth);

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -18,7 +18,7 @@ mod common;
 use std::time::Instant;
 
 use common::{oracle::Oracle, Op, Rng};
-use radix_tree::{Config, HolderId, OverlapScratch, RadixTree};
+use radix_tree::{Config, HolderId, OverlapScratch, RadixTree, RadixTree3};
 
 // ---- §11 normative constants (default scale) ----
 // RADIX_BENCH_SCALE=large runs 8x blocks / 8x holders (~20 GB peak,
@@ -222,6 +222,12 @@ enum Sider {
         Vec<radix_tree::Overlap>,
         OverlapScratch,
     ),
+    R3(
+        RadixTree3,
+        Vec<HolderId>,
+        Vec<radix_tree::Overlap>,
+        OverlapScratch,
+    ),
 }
 
 impl Sider {
@@ -257,6 +263,19 @@ impl Sider {
                 }
                 Op::Clear { holder } => tree.clear(ids[*holder]),
             },
+            Sider::R3(tree, ids, _, _) => match op {
+                Op::Store {
+                    holder,
+                    parent,
+                    blocks,
+                } => {
+                    let _ = tree.store(ids[*holder], *parent, blocks);
+                }
+                Op::Remove { holder, keys } => {
+                    tree.remove(ids[*holder], keys);
+                }
+                Op::Clear { holder } => tree.clear(ids[*holder]),
+            },
         }
     }
 
@@ -264,6 +283,10 @@ impl Sider {
         match self {
             Sider::Oracle(oracle, _) => oracle.overlap(q).len(),
             Sider::R1(tree, _, out, qscratch) => {
+                tree.overlap(q, qscratch, out);
+                out.len()
+            }
+            Sider::R3(tree, _, out, qscratch) => {
                 tree.overlap(q, qscratch, out);
                 out.len()
             }
@@ -303,6 +326,13 @@ fn pinned_workload() {
                 .map(|h| tree.create_holder(&format!("holder-{h}")))
                 .collect();
             Sider::R1(tree, ids, Vec::new(), OverlapScratch::default())
+        }
+        "r3" => {
+            let mut tree = RadixTree3::new(Config::default());
+            let ids = (0..holders())
+                .map(|h| tree.create_holder(&format!("holder-{h}")))
+                .collect();
+            Sider::R3(tree, ids, Vec::new(), OverlapScratch::default())
         }
         _ => Sider::Oracle(Oracle::new(holders()), vec![Vec::new(); holders()]),
     };

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -36,19 +36,87 @@ fn target_blocks() -> u64 {
 fn holders() -> usize {
     match std::env::var("RADIX_BENCH_SCALE").as_deref() {
         Ok("large") => 2048,
-        _ => 256,
+        _ => profile().holders_default,
     }
 }
-/// (sharing factor H, share of total holder-blocks in percent).
-const SHARING_MIX: [(usize, u64); 3] = [(1, 50), (8, 35), (64, 15)];
-const SHARED_DEPTH: (u32, u32) = (8, 512); // log-uniform
-const TAIL_LEN: (u32, u32) = (4, 64); // uniform
 const BATCH: usize = 8;
-const DUPLICATE_PCT: u64 = 5;
-const GAP_PCT: u64 = 2;
 const MISS_QUERY_PCT: u64 = 20;
 /// The gate cell: depth 78 with 64 candidate holders.
 const GATE_DEPTH: u32 = 78;
+
+/// One workload stream shape. `pinned` is the §11 NORMATIVE config —
+/// gates are quoted on it and its parameters must never drift. The
+/// other profiles answer "does the win hold on different input
+/// distributions?" (audit follow-up: one stream shape proves one
+/// point on the workload space): RADIX_BENCH_PROFILE=agentic|churn|
+/// fleet selects them; they are diagnostics, not gates.
+struct Profile {
+    name: &'static str,
+    holders_default: usize,
+    /// (sharing factor H, share of total holder-blocks in percent).
+    sharing_mix: [(usize, u64); 3],
+    /// Log-uniform shared-prefix length range.
+    shared_depth: (u32, u32),
+    /// Uniform divergent-tail length range.
+    tail_len: (u32, u32),
+    duplicate_pct: u64,
+    gap_pct: u64,
+}
+
+/// The §11 constants, verbatim.
+const PINNED: Profile = Profile {
+    name: "pinned",
+    holders_default: 256,
+    sharing_mix: [(1, 50), (8, 35), (64, 15)],
+    shared_depth: (8, 512),
+    tail_len: (4, 64),
+    duplicate_pct: 5,
+    gap_pct: 2,
+};
+/// Long-context / agentic traffic: deep shared prefixes (system
+/// prompts, long conversations), heavy cross-worker sharing.
+const AGENTIC: Profile = Profile {
+    name: "agentic",
+    holders_default: 256,
+    sharing_mix: [(1, 20), (8, 40), (64, 40)],
+    shared_depth: (64, 2048),
+    tail_len: (16, 256),
+    duplicate_pct: 5,
+    gap_pct: 2,
+};
+/// Short-prompt chat with aggressive eviction churn: shallow chains,
+/// little sharing, lots of duplicate re-publish and mid-chain gaps.
+const CHURN: Profile = Profile {
+    name: "churn",
+    holders_default: 256,
+    sharing_mix: [(1, 70), (8, 25), (64, 5)],
+    shared_depth: (4, 64),
+    tail_len: (2, 16),
+    duplicate_pct: 20,
+    gap_pct: 10,
+};
+/// Wide fleet at the default block budget: 4x the workers, each
+/// holding proportionally less — stresses holder-set interning and
+/// span fan-out rather than chain depth.
+const FLEET: Profile = Profile {
+    name: "fleet",
+    holders_default: 1024,
+    sharing_mix: [(1, 40), (8, 30), (64, 30)],
+    shared_depth: (8, 512),
+    tail_len: (4, 64),
+    duplicate_pct: 5,
+    gap_pct: 2,
+};
+
+fn profile() -> &'static Profile {
+    match std::env::var("RADIX_BENCH_PROFILE").as_deref() {
+        Ok("agentic") => &AGENTIC,
+        Ok("churn") => &CHURN,
+        Ok("fleet") => &FLEET,
+        Ok(other) if other != "pinned" => panic!("unknown RADIX_BENCH_PROFILE {other:?}"),
+        _ => &PINNED,
+    }
+}
 
 fn log_uniform(rng: &mut Rng, lo: u32, hi: u32) -> u32 {
     let (llo, lhi) = ((lo as f64).ln(), (hi as f64).ln());
@@ -65,7 +133,8 @@ fn build_families(rng: &mut Rng) -> Vec<Family> {
     let mut families = Vec::new();
     let next_content = |rng: &mut Rng| rng.next() | 1;
     // One forced gate family: H=64, shared length >= GATE_DEPTH.
-    let mut budgets: Vec<(usize, u64)> = SHARING_MIX
+    let mut budgets: Vec<(usize, u64)> = profile()
+        .sharing_mix
         .iter()
         .map(|&(h, pct)| (h, target_blocks() * pct / 100))
         .collect();
@@ -77,7 +146,7 @@ fn build_families(rng: &mut Rng) -> Vec<Family> {
                 force_gate = false;
                 96
             } else {
-                log_uniform(rng, SHARED_DEPTH.0, SHARED_DEPTH.1)
+                log_uniform(rng, profile().shared_depth.0, profile().shared_depth.1)
             };
             let mut blocks = Vec::with_capacity(shared_len as usize);
             let mut prev_key = 0u64;
@@ -111,9 +180,14 @@ fn build_families(rng: &mut Rng) -> Vec<Family> {
 
 /// Expand families into the mixed write stream (stores + duplicates +
 /// gap removes), per-holder order preserved, §7-scoped interleave.
-fn build_ops(rng: &mut Rng, families: &[Family]) -> (Vec<Op>, u64) {
+fn build_ops(rng: &mut Rng, families: &[Family]) -> (Vec<Op>, u64, u64) {
     let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); holders()];
     let mut holder_blocks = 0u64;
+    // Exact count of blocks the gap removes take back out: the
+    // resident cross-check must not blame the structure for blocks
+    // the WORKLOAD removed (the churn profile's 10% gaps tripped the
+    // pinned-calibrated 97% floor and killed the run).
+    let mut removed_blocks = 0u64;
     for family in families {
         for &holder in &family.holders {
             let mut parent = None;
@@ -127,7 +201,8 @@ fn build_ops(rng: &mut Rng, families: &[Family]) -> (Vec<Op>, u64) {
                 parent = Some(chunk.last().expect("non-empty").0);
             }
             // Divergent tail.
-            let tail_len = TAIL_LEN.0 + (rng.next() % (TAIL_LEN.1 - TAIL_LEN.0 + 1) as u64) as u32;
+            let (tail_lo, tail_hi) = profile().tail_len;
+            let tail_len = tail_lo + (rng.next() % (tail_hi - tail_lo + 1) as u64) as u32;
             let mut prev_key = parent.expect("family non-empty");
             let mut tail = Vec::with_capacity(tail_len as usize);
             for _ in 0..tail_len {
@@ -150,12 +225,12 @@ fn build_ops(rng: &mut Rng, families: &[Family]) -> (Vec<Op>, u64) {
             holder_blocks += (family.blocks.len() + tail.len()) as u64;
             let mut dups = Vec::new();
             for b in &batches {
-                if rng.chance(DUPLICATE_PCT) {
+                if rng.chance(profile().duplicate_pct) {
                     dups.push(b.clone());
                 }
             }
             let mut gaps = Vec::new();
-            if rng.chance(GAP_PCT * 10) && family.blocks.len() > 2 {
+            if rng.chance(profile().gap_pct * 10) && family.blocks.len() > 2 {
                 // ~GAP_PCT of blocks overall: one block per ~10% of
                 // instances at these lengths.
                 let victim = family.blocks[1 + rng.below(family.blocks.len() - 2)].0;
@@ -163,6 +238,9 @@ fn build_ops(rng: &mut Rng, families: &[Family]) -> (Vec<Op>, u64) {
                     holder,
                     keys: vec![victim],
                 });
+                // Dups precede gaps in the script, so the victim is
+                // present exactly once when the remove lands.
+                removed_blocks += 1;
             }
             let script = &mut per_holder[holder];
             script.extend(batches);
@@ -184,7 +262,7 @@ fn build_ops(rng: &mut Rng, families: &[Family]) -> (Vec<Op>, u64) {
             live.swap_remove(li);
         }
     }
-    (ops, holder_blocks)
+    (ops, holder_blocks, removed_blocks)
 }
 
 fn rss_kib() -> u64 {
@@ -301,7 +379,7 @@ impl Sider {
 fn pinned_workload() {
     let mut rng = Rng::new(20260901);
     let families = build_families(&mut rng);
-    let (ops, holder_blocks) = build_ops(&mut rng, &families);
+    let (ops, holder_blocks, removed_blocks) = build_ops(&mut rng, &families);
     let total_blocks: u64 = ops
         .iter()
         .map(|op| match op {
@@ -320,6 +398,7 @@ fn pinned_workload() {
 
     let side_name = side();
     println!("side: {side_name}");
+    println!("profile: {} ({} holders)", profile().name, holders());
     // P4 mixed-phase probes: built BEFORE the fill so latency can be
     // sampled while the write stream runs.
     let mut mixed_probes: Vec<Vec<u64>> = Vec::new();
@@ -388,9 +467,11 @@ fn pinned_workload() {
         Sider::R1(tree, _, _, _) => tree.stats().holder_blocks,
         Sider::R3(tree, _, _, _) => tree.stats().holder_blocks,
     };
+    let expected = holder_blocks - removed_blocks;
     assert!(
-        resident * 100 >= holder_blocks * 97,
-        "structure holds {resident} of {holder_blocks} generated holder-blocks — silent loss"
+        resident * 100 >= expected * 97,
+        "structure holds {resident} of {expected} expected holder-blocks \
+         ({holder_blocks} generated - {removed_blocks} removed) — silent loss"
     );
     let rss_after = rss_kib();
     println!(
@@ -415,7 +496,7 @@ fn pinned_workload() {
             .map(|&(_, c)| c)
             .collect()
     };
-    for &(h, _) in &SHARING_MIX {
+    for &(h, _) in &profile().sharing_mix {
         let mut queries = Vec::new();
         for fam in families.iter().filter(|f| f.holders.len() == h) {
             if queries.len() >= 2000 {
@@ -442,9 +523,11 @@ fn pinned_workload() {
     if !mixed_lat.is_empty() {
         mixed_lat.sort_unstable();
         println!(
-            "cell mixed-phase: n={} p50={}ns p99={}ns (queries during live writes)",
+            "cell mixed-phase: n={} p50={}ns p90={}ns p95={}ns p99={}ns (queries during live writes)",
             mixed_lat.len(),
             percentile(&mixed_lat, 0.50),
+            percentile(&mixed_lat, 0.90),
+            percentile(&mixed_lat, 0.95),
             percentile(&mixed_lat, 0.99),
         );
     }
@@ -466,9 +549,11 @@ fn pinned_workload() {
         }
         lat.sort_unstable();
         println!(
-            "cell {label}: n={} p50={}ns p99={}ns",
+            "cell {label}: n={} p50={}ns p90={}ns p95={}ns p99={}ns",
             lat.len(),
             percentile(&lat, 0.50),
+            percentile(&lat, 0.90),
+            percentile(&lat, 0.95),
             percentile(&lat, 0.99),
         );
     }

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -318,6 +318,25 @@ fn pinned_workload() {
 
     let side_name = side();
     println!("side: {side_name}");
+    // P4 mixed-phase probes: built BEFORE the fill so latency can be
+    // sampled while the write stream runs.
+    let mut mixed_probes: Vec<Vec<u64>> = Vec::new();
+    for fam in families.iter().filter(|f| f.holders.len() == 64) {
+        if fam.blocks.len() >= GATE_DEPTH as usize && mixed_probes.len() < 32 {
+            mixed_probes.push(
+                fam.blocks[..GATE_DEPTH as usize]
+                    .iter()
+                    .map(|&(_, c)| c)
+                    .collect(),
+            );
+        }
+    }
+    for fam in families.iter().filter(|f| f.holders.len() == 1) {
+        if mixed_probes.len() < 64 {
+            let d = fam.blocks.len().min(64);
+            mixed_probes.push(fam.blocks[..d].iter().map(|&(_, c)| c).collect());
+        }
+    }
     let rss_before = rss_kib();
     let mut sider = match side_name.as_str() {
         "r1" => {
@@ -337,8 +356,25 @@ fn pinned_workload() {
         _ => Sider::Oracle(Oracle::new(holders()), vec![Vec::new(); holders()]),
     };
     let fill_start = Instant::now();
+    let mut mixed_lat: Vec<u64> = Vec::new();
+    let mut since_probe = 0u64;
+    let mut probe_idx = 0usize;
     for op in &ops {
         sider.apply(op);
+        if let Op::Store { blocks, .. } = op {
+            since_probe += blocks.len() as u64;
+        }
+        // P4: one probe query every ~250k stream blocks, timed inside
+        // the live write phase.
+        if since_probe >= 250_000 && !mixed_probes.is_empty() {
+            since_probe = 0;
+            let q = &mixed_probes[probe_idx % mixed_probes.len()];
+            probe_idx += 1;
+            let t = Instant::now();
+            let n = sider.query(q);
+            mixed_lat.push(t.elapsed().as_nanos() as u64);
+            std::hint::black_box(n);
+        }
     }
     let fill = fill_start.elapsed();
     let rss_after = rss_kib();
@@ -388,6 +424,15 @@ fn pinned_workload() {
     }
     cells.push(("miss".to_string(), misses));
 
+    if !mixed_lat.is_empty() {
+        mixed_lat.sort_unstable();
+        println!(
+            "cell mixed-phase: n={} p50={}ns p99={}ns (queries during live writes)",
+            mixed_lat.len(),
+            percentile(&mixed_lat, 0.50),
+            percentile(&mixed_lat, 0.99),
+        );
+    }
     for (label, queries) in &cells {
         if queries.is_empty() {
             println!("cell {label}: EMPTY (workload bug)");
@@ -410,6 +455,67 @@ fn pinned_workload() {
             lat.len(),
             percentile(&lat, 0.50),
             percentile(&lat, 0.99),
+        );
+    }
+    // P4 soak (RADIX_BENCH_SOAK_SECS): steady-state churn — cyclic
+    // duplicate re-publish (idempotent placement churn), retire/create
+    // holder cycles, and a query stream. RSS must stay flat: growth
+    // here is a leak by definition (no new state is being added).
+    let soak_secs: u64 = std::env::var("RADIX_BENCH_SOAK_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    if soak_secs > 0 {
+        println!("soak: {soak_secs}s of duplicate/holder churn + queries");
+        let soak_start = Instant::now();
+        let mut last_report = Instant::now();
+        let rss_soak_start = rss_kib();
+        let mut op_i = 0usize;
+        let mut probe_i = 0usize;
+        let mut churn_cycle = 0u64;
+        let mut qps = 0u64;
+        let mut ops_applied = 0u64;
+        while soak_start.elapsed().as_secs() < soak_secs {
+            for _ in 0..2000 {
+                sider.apply(&ops[op_i % ops.len()]);
+                op_i += 1;
+            }
+            ops_applied += 2000;
+            for _ in 0..64 {
+                if !mixed_probes.is_empty() {
+                    let q = &mixed_probes[probe_i % mixed_probes.len()];
+                    probe_i += 1;
+                    std::hint::black_box(sider.query(q));
+                    qps += 1;
+                }
+            }
+            if let Sider::R1(tree, _, _, _) = &mut sider {
+                churn_cycle += 1;
+                let h = tree.create_holder(&format!("soak-churn-{churn_cycle}"));
+                let _ = tree.store(h, None, &[(churn_cycle | 1, churn_cycle | 1)]);
+                tree.retire_holder(h);
+            } else if let Sider::R3(tree, _, _, _) = &mut sider {
+                churn_cycle += 1;
+                let h = tree.create_holder(&format!("soak-churn-{churn_cycle}"));
+                let _ = tree.store(h, None, &[(churn_cycle | 1, churn_cycle | 1)]);
+                tree.retire_holder(h);
+            }
+            if last_report.elapsed().as_secs() >= 60 {
+                last_report = Instant::now();
+                println!(
+                    "soak t={}s rss={} KiB (drift {:+} KiB) ops={} queries={}",
+                    soak_start.elapsed().as_secs(),
+                    rss_kib(),
+                    rss_kib() as i64 - rss_soak_start as i64,
+                    ops_applied,
+                    qps
+                );
+            }
+        }
+        let drift = rss_kib() as i64 - rss_soak_start as i64;
+        println!(
+            "soak done: rss drift {:+} KiB over {soak_secs}s ({} ops, {} queries)",
+            drift, ops_applied, qps
         );
     }
     std::hint::black_box(&sider as *const _);

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -18,7 +18,7 @@ mod common;
 use std::time::Instant;
 
 use common::{oracle::Oracle, Op, Rng};
-use radix_tree::{Config, HolderId, OverlapScratch, RadixTree, RadixTree3};
+use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree3};
 
 // ---- §11 normative constants (default scale) ----
 // RADIX_BENCH_SCALE=large runs 8x blocks / 8x holders (~20 GB peak,
@@ -217,7 +217,7 @@ fn side() -> String {
 enum Sider {
     Oracle(Oracle, Vec<Vec<u64>>),
     R1(
-        RadixTree,
+        FlatTree,
         Vec<HolderId>,
         Vec<radix_tree::Overlap>,
         OverlapScratch,
@@ -340,7 +340,7 @@ fn pinned_workload() {
     let rss_before = rss_kib();
     let mut sider = match side_name.as_str() {
         "r1" => {
-            let mut tree = RadixTree::new(Config::default());
+            let mut tree = FlatTree::new(Config::default());
             let ids = (0..holders())
                 .map(|h| tree.create_holder(&format!("holder-{h}")))
                 .collect();

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -18,6 +18,7 @@ mod common;
 use std::time::Instant;
 
 use common::{oracle::Oracle, Op, Rng};
+use radix_tree::{Config, HolderId, RadixTree};
 
 // ---- §11 normative constants ----
 const TARGET_BLOCKS: u64 = 10_000_000;
@@ -185,9 +186,69 @@ fn percentile(sorted: &[u64], p: f64) -> u64 {
     sorted[idx]
 }
 
+/// Which implementation this process measures. One side per process
+/// so RSS deltas are clean (§11 protocol):
+///   RADIX_BENCH_SIDE=oracle (default) | r1
+fn side() -> String {
+    std::env::var("RADIX_BENCH_SIDE").unwrap_or_else(|_| "oracle".into())
+}
+
+#[allow(clippy::large_enum_variant)] // bench-local, two instances ever
+enum Sider {
+    Oracle(Oracle, Vec<Vec<u64>>),
+    R1(RadixTree, Vec<HolderId>, Vec<radix_tree::Overlap>),
+}
+
+impl Sider {
+    fn apply(&mut self, op: &Op) {
+        match self {
+            Sider::Oracle(oracle, chains) => {
+                oracle.apply(op);
+                if let Op::Store {
+                    holder,
+                    parent,
+                    blocks,
+                } = op
+                {
+                    // Engine glue the §11 oracle side must carry:
+                    // last-chain Vec (reset on parent-None anchors).
+                    let chain = &mut chains[*holder];
+                    if parent.is_none() {
+                        chain.clear();
+                    }
+                    chain.extend(blocks.iter().map(|&(k, _)| k));
+                }
+            }
+            Sider::R1(tree, ids, _) => match op {
+                Op::Store {
+                    holder,
+                    parent,
+                    blocks,
+                } => {
+                    let _ = tree.store(ids[*holder], *parent, blocks);
+                }
+                Op::Remove { holder, keys } => {
+                    tree.remove(ids[*holder], keys);
+                }
+                Op::Clear { holder } => tree.clear(ids[*holder]),
+            },
+        }
+    }
+
+    fn query(&mut self, q: &[u64]) -> usize {
+        match self {
+            Sider::Oracle(oracle, _) => oracle.overlap(q).len(),
+            Sider::R1(tree, _, out) => {
+                tree.overlap(q, out);
+                out.len()
+            }
+        }
+    }
+}
+
 #[test]
 #[ignore = "pinned benchmark; run --release --ignored --nocapture"]
-fn oracle_baseline() {
+fn pinned_workload() {
     let mut rng = Rng::new(20260901);
     let families = build_families(&mut rng);
     let (ops, holder_blocks) = build_ops(&mut rng, &families);
@@ -207,27 +268,22 @@ fn oracle_baseline() {
         holder_blocks
     );
 
+    let side_name = side();
+    println!("side: {side_name}");
     let rss_before = rss_kib();
-    let mut oracle = Oracle::new(HOLDERS);
-    // Engine glue the §11 oracle side must carry: last-chain Vec per
-    // holder (reset on parent-None anchors, as engine extend_chain
-    // does) and the id->holder map (inside Oracle already).
-    let mut chains: Vec<Vec<u64>> = vec![Vec::new(); HOLDERS];
+    let mut sider = match side_name.as_str() {
+        "r1" => {
+            let mut tree = RadixTree::new(Config::default());
+            let ids = (0..HOLDERS)
+                .map(|h| tree.create_holder(&format!("holder-{h}")))
+                .collect();
+            Sider::R1(tree, ids, Vec::new())
+        }
+        _ => Sider::Oracle(Oracle::new(HOLDERS), vec![Vec::new(); HOLDERS]),
+    };
     let fill_start = Instant::now();
     for op in &ops {
-        oracle.apply(op);
-        if let Op::Store {
-            holder,
-            parent,
-            blocks,
-        } = op
-        {
-            let chain = &mut chains[*holder];
-            if parent.is_none() {
-                chain.clear();
-            }
-            chain.extend(blocks.iter().map(|&(k, _)| k));
-        }
+        sider.apply(op);
     }
     let fill = fill_start.elapsed();
     let rss_after = rss_kib();
@@ -288,9 +344,9 @@ fn oracle_baseline() {
         let mut lat: Vec<u64> = Vec::with_capacity(queries.len());
         for q in queries {
             let t = Instant::now();
-            let out = oracle.overlap(q);
+            let n = sider.query(q);
             let ns = t.elapsed().as_nanos() as u64;
-            std::hint::black_box(out);
+            std::hint::black_box(n);
             lat.push(ns);
         }
         lat.sort_unstable();
@@ -301,5 +357,5 @@ fn oracle_baseline() {
             percentile(&lat, 0.99),
         );
     }
-    std::hint::black_box(chains);
+    std::hint::black_box(&sider as *const _);
 }

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -18,7 +18,7 @@ mod common;
 use std::time::Instant;
 
 use common::{oracle::Oracle, Op, Rng};
-use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree3};
+use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree};
 
 // ---- §11 normative constants (default scale) ----
 // RADIX_BENCH_SCALE=large runs 8x blocks / 8x holders (~20 GB peak,
@@ -223,7 +223,7 @@ enum Sider {
         OverlapScratch,
     ),
     R3(
-        RadixTree3,
+        RadixTree,
         Vec<HolderId>,
         Vec<radix_tree::Overlap>,
         OverlapScratch,
@@ -347,7 +347,7 @@ fn pinned_workload() {
             Sider::R1(tree, ids, Vec::new(), OverlapScratch::default())
         }
         "r3" => {
-            let mut tree = RadixTree3::new(Config::default());
+            let mut tree = RadixTree::new(Config::default());
             let ids = (0..holders())
                 .map(|h| tree.create_holder(&format!("holder-{h}")))
                 .collect();

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -18,7 +18,7 @@ mod common;
 use std::time::Instant;
 
 use common::{oracle::Oracle, Op, Rng};
-use radix_tree::{Config, HolderId, RadixTree};
+use radix_tree::{Config, HolderId, OverlapScratch, RadixTree};
 
 // ---- §11 normative constants (default scale) ----
 // RADIX_BENCH_SCALE=large runs 8x blocks / 8x holders (~20 GB peak,
@@ -216,7 +216,12 @@ fn side() -> String {
 #[allow(clippy::large_enum_variant)] // bench-local, two instances ever
 enum Sider {
     Oracle(Oracle, Vec<Vec<u64>>),
-    R1(RadixTree, Vec<HolderId>, Vec<radix_tree::Overlap>),
+    R1(
+        RadixTree,
+        Vec<HolderId>,
+        Vec<radix_tree::Overlap>,
+        OverlapScratch,
+    ),
 }
 
 impl Sider {
@@ -239,7 +244,7 @@ impl Sider {
                     chain.extend(blocks.iter().map(|&(k, _)| k));
                 }
             }
-            Sider::R1(tree, ids, _) => match op {
+            Sider::R1(tree, ids, _, _) => match op {
                 Op::Store {
                     holder,
                     parent,
@@ -258,8 +263,8 @@ impl Sider {
     fn query(&mut self, q: &[u64]) -> usize {
         match self {
             Sider::Oracle(oracle, _) => oracle.overlap(q).len(),
-            Sider::R1(tree, _, out) => {
-                tree.overlap(q, out);
+            Sider::R1(tree, _, out, qscratch) => {
+                tree.overlap(q, qscratch, out);
                 out.len()
             }
         }
@@ -297,7 +302,7 @@ fn pinned_workload() {
             let ids = (0..holders())
                 .map(|h| tree.create_holder(&format!("holder-{h}")))
                 .collect();
-            Sider::R1(tree, ids, Vec::new())
+            Sider::R1(tree, ids, Vec::new(), OverlapScratch::default())
         }
         _ => Sider::Oracle(Oracle::new(holders()), vec![Vec::new(); holders()]),
     };

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -510,6 +510,9 @@ fn pinned_workload() {
                     ops_applied,
                     qps
                 );
+                if let Sider::R3(tree, _, _, _) = &sider {
+                    println!("  footprint: {}", tree.debug_footprint());
+                }
             }
         }
         let drift = rss_kib() as i64 - rss_soak_start as i64;

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -1,0 +1,305 @@
+//! The pinned performance workload (SPEC.md §11), oracle baseline.
+//!
+//! Normative constants live HERE; gates pass on this configuration
+//! only. R0 runs it against the oracle plus the engine's replicated
+//! glue (per-holder reverse map, last-chain Vec, id maps) to record
+//! the baseline; R1 adds the RadixTree side under the same driver.
+//!
+//! Run (numbers are meaningless in debug):
+//!   cargo test -p radix-tree --release --test pinned_bench \
+//!     -- --ignored --nocapture
+//!
+//! Protocol (§11): RSS sampled after fill, before query-phase
+//! allocations; no asserts or allocation inside timed regions;
+//! quote the median of >=3 runs.
+
+mod common;
+
+use std::time::Instant;
+
+use common::{oracle::Oracle, Op, Rng};
+
+// ---- §11 normative constants ----
+const TARGET_BLOCKS: u64 = 10_000_000;
+const HOLDERS: usize = 256;
+/// (sharing factor H, share of total holder-blocks in percent).
+const SHARING_MIX: [(usize, u64); 3] = [(1, 50), (8, 35), (64, 15)];
+const SHARED_DEPTH: (u32, u32) = (8, 512); // log-uniform
+const TAIL_LEN: (u32, u32) = (4, 64); // uniform
+const BATCH: usize = 8;
+const DUPLICATE_PCT: u64 = 5;
+const GAP_PCT: u64 = 2;
+const MISS_QUERY_PCT: u64 = 20;
+/// The gate cell: depth 78 with 64 candidate holders.
+const GATE_DEPTH: u32 = 78;
+
+fn log_uniform(rng: &mut Rng, lo: u32, hi: u32) -> u32 {
+    let (llo, lhi) = ((lo as f64).ln(), (hi as f64).ln());
+    let u = (rng.next() >> 11) as f64 / (1u64 << 53) as f64;
+    (llo + u * (lhi - llo)).exp().round() as u32
+}
+
+struct Family {
+    blocks: Vec<(u64, u64)>,
+    holders: Vec<usize>,
+}
+
+fn build_families(rng: &mut Rng) -> Vec<Family> {
+    let mut families = Vec::new();
+    let next_content = |rng: &mut Rng| rng.next() | 1;
+    // One forced gate family: H=64, shared length >= GATE_DEPTH.
+    let mut budgets: Vec<(usize, u64)> = SHARING_MIX
+        .iter()
+        .map(|&(h, pct)| (h, TARGET_BLOCKS * pct / 100))
+        .collect();
+    let mut force_gate = true;
+    for (h, budget) in budgets.iter_mut() {
+        let mut used = 0u64;
+        while used < *budget {
+            let shared_len = if force_gate && *h == 64 {
+                force_gate = false;
+                96
+            } else {
+                log_uniform(rng, SHARED_DEPTH.0, SHARED_DEPTH.1)
+            };
+            let mut blocks = Vec::with_capacity(shared_len as usize);
+            let mut prev_key = 0u64;
+            for i in 0..shared_len {
+                let content = next_content(rng);
+                let key = if i == 0 {
+                    content
+                } else {
+                    (prev_key ^ content.rotate_left(17)).wrapping_mul(0x2545F4914F6CDD1D) | 1
+                };
+                blocks.push((key, content));
+                prev_key = key;
+            }
+            let mut holders = Vec::with_capacity(*h);
+            let base = rng.below(HOLDERS);
+            for k in 0..*h {
+                holders.push((base + k * 7) % HOLDERS);
+            }
+            holders.sort_unstable();
+            holders.dedup();
+            used += shared_len as u64 * holders.len() as u64;
+            families.push(Family { blocks, holders });
+        }
+    }
+    families
+}
+
+/// Expand families into the mixed write stream (stores + duplicates +
+/// gap removes), per-holder order preserved, §7-scoped interleave.
+fn build_ops(rng: &mut Rng, families: &[Family]) -> (Vec<Op>, u64) {
+    let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); HOLDERS];
+    let mut holder_blocks = 0u64;
+    for family in families {
+        for &holder in &family.holders {
+            let mut parent = None;
+            let mut batches = Vec::new();
+            for chunk in family.blocks.chunks(BATCH) {
+                batches.push(Op::Store {
+                    holder,
+                    parent,
+                    blocks: chunk.to_vec(),
+                });
+                parent = Some(chunk.last().expect("non-empty").0);
+            }
+            // Divergent tail.
+            let tail_len = TAIL_LEN.0 + (rng.next() % (TAIL_LEN.1 - TAIL_LEN.0 + 1) as u64) as u32;
+            let mut prev_key = parent.expect("family non-empty");
+            let mut tail = Vec::with_capacity(tail_len as usize);
+            for _ in 0..tail_len {
+                let content = rng.next() | 1;
+                let key = (prev_key ^ content.rotate_left(29))
+                    .wrapping_mul(0x9E3779B97F4A7C15)
+                    .wrapping_add(holder as u64)
+                    | 1;
+                tail.push((key, content));
+                prev_key = key;
+            }
+            for chunk in tail.chunks(BATCH) {
+                batches.push(Op::Store {
+                    holder,
+                    parent,
+                    blocks: chunk.to_vec(),
+                });
+                parent = Some(chunk.last().expect("non-empty").0);
+            }
+            holder_blocks += (family.blocks.len() + tail.len()) as u64;
+            let mut dups = Vec::new();
+            for b in &batches {
+                if rng.chance(DUPLICATE_PCT) {
+                    dups.push(b.clone());
+                }
+            }
+            let mut gaps = Vec::new();
+            if rng.chance(GAP_PCT * 10) && family.blocks.len() > 2 {
+                // ~GAP_PCT of blocks overall: one block per ~10% of
+                // instances at these lengths.
+                let victim = family.blocks[1 + rng.below(family.blocks.len() - 2)].0;
+                gaps.push(Op::Remove {
+                    holder,
+                    keys: vec![victim],
+                });
+            }
+            let script = &mut per_holder[holder];
+            script.extend(batches);
+            script.extend(dups);
+            script.extend(gaps);
+        }
+    }
+    let mut cursors = vec![0usize; HOLDERS];
+    let mut ops = Vec::new();
+    let mut live: Vec<usize> = (0..HOLDERS)
+        .filter(|&h| !per_holder[h].is_empty())
+        .collect();
+    while !live.is_empty() {
+        let li = rng.below(live.len());
+        let h = live[li];
+        ops.push(per_holder[h][cursors[h]].clone());
+        cursors[h] += 1;
+        if cursors[h] == per_holder[h].len() {
+            live.swap_remove(li);
+        }
+    }
+    (ops, holder_blocks)
+}
+
+fn rss_kib() -> u64 {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &std::process::id().to_string()])
+        .output()
+        .expect("ps");
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0)
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted.len() as f64 - 1.0) * p).round() as usize;
+    sorted[idx]
+}
+
+#[test]
+#[ignore = "pinned benchmark; run --release --ignored --nocapture"]
+fn oracle_baseline() {
+    let mut rng = Rng::new(20260901);
+    let families = build_families(&mut rng);
+    let (ops, holder_blocks) = build_ops(&mut rng, &families);
+    let total_blocks: u64 = ops
+        .iter()
+        .map(|op| match op {
+            Op::Store { blocks, .. } => blocks.len() as u64,
+            Op::Remove { keys, .. } => keys.len() as u64,
+            Op::Clear { .. } => 0,
+        })
+        .sum();
+    println!(
+        "workload: {} families, {} ops, {} stream blocks, {} resident holder-blocks",
+        families.len(),
+        ops.len(),
+        total_blocks,
+        holder_blocks
+    );
+
+    let rss_before = rss_kib();
+    let mut oracle = Oracle::new(HOLDERS);
+    // Engine glue the §11 oracle side must carry: last-chain Vec per
+    // holder (reset on parent-None anchors, as engine extend_chain
+    // does) and the id->holder map (inside Oracle already).
+    let mut chains: Vec<Vec<u64>> = vec![Vec::new(); HOLDERS];
+    let fill_start = Instant::now();
+    for op in &ops {
+        oracle.apply(op);
+        if let Op::Store {
+            holder,
+            parent,
+            blocks,
+        } = op
+        {
+            let chain = &mut chains[*holder];
+            if parent.is_none() {
+                chain.clear();
+            }
+            chain.extend(blocks.iter().map(|&(k, _)| k));
+        }
+    }
+    let fill = fill_start.elapsed();
+    let rss_after = rss_kib();
+    println!(
+        "fill: {:.2}s -> {:.2}M stream blocks/s",
+        fill.as_secs_f64(),
+        total_blocks as f64 / fill.as_secs_f64() / 1e6
+    );
+    println!(
+        "memory: {} KiB delta -> {:.1} B/holder-block ({} holder-blocks)",
+        rss_after - rss_before,
+        (rss_after - rss_before) as f64 * 1024.0 / holder_blocks as f64,
+        holder_blocks
+    );
+
+    // Query phase: prefix probes per sharing cell + misses. Build all
+    // query vectors BEFORE timing (no allocation inside the region).
+    let mut cells: Vec<(String, Vec<Vec<u64>>)> = Vec::new();
+    let mut gate_queries = Vec::new();
+    let warm = |fam: &Family, depth: u32| -> Vec<u64> {
+        fam.blocks[..depth as usize]
+            .iter()
+            .map(|&(_, c)| c)
+            .collect()
+    };
+    for &(h, _) in &SHARING_MIX {
+        let mut queries = Vec::new();
+        for fam in families.iter().filter(|f| f.holders.len() == h) {
+            if queries.len() >= 2000 {
+                break;
+            }
+            let d = 1 + rng.below(fam.blocks.len());
+            queries.push(warm(fam, d as u32));
+        }
+        cells.push((format!("H={h}"), queries));
+    }
+    for fam in families.iter().filter(|f| f.holders.len() == 64) {
+        if fam.blocks.len() >= GATE_DEPTH as usize && gate_queries.len() < 2000 {
+            gate_queries.push(warm(fam, GATE_DEPTH));
+        }
+    }
+    cells.push((format!("gate d={GATE_DEPTH} W=64"), gate_queries));
+    let mut misses = Vec::new();
+    for _ in 0..1000 {
+        let len = 1 + rng.below(96);
+        misses.push((0..len).map(|_| rng.next() | 1).collect::<Vec<u64>>());
+    }
+    cells.push(("miss".to_string(), misses));
+
+    for (label, queries) in &cells {
+        if queries.is_empty() {
+            println!("cell {label}: EMPTY (workload bug)");
+            continue;
+        }
+        // MISS_QUERY_PCT is embodied by the dedicated miss cell; warm
+        // cells stay pure so percentiles are per-shape.
+        let _ = MISS_QUERY_PCT;
+        let mut lat: Vec<u64> = Vec::with_capacity(queries.len());
+        for q in queries {
+            let t = Instant::now();
+            let out = oracle.overlap(q);
+            let ns = t.elapsed().as_nanos() as u64;
+            std::hint::black_box(out);
+            lat.push(ns);
+        }
+        lat.sort_unstable();
+        println!(
+            "cell {label}: n={} p50={}ns p99={}ns",
+            lat.len(),
+            percentile(&lat, 0.50),
+            percentile(&lat, 0.99),
+        );
+    }
+    std::hint::black_box(chains);
+}

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -256,7 +256,8 @@ impl Sider {
                     parent,
                     blocks,
                 } => {
-                    let _ = tree.store(ids[*holder], *parent, blocks);
+                    tree.store(ids[*holder], *parent, blocks)
+                        .expect("bench stores are in-contract");
                 }
                 Op::Remove { holder, keys } => {
                     tree.remove(ids[*holder], keys);
@@ -269,7 +270,8 @@ impl Sider {
                     parent,
                     blocks,
                 } => {
-                    let _ = tree.store(ids[*holder], *parent, blocks);
+                    tree.store(ids[*holder], *parent, blocks)
+                        .expect("bench stores are in-contract");
                 }
                 Op::Remove { holder, keys } => {
                     tree.remove(ids[*holder], keys);
@@ -377,6 +379,19 @@ fn pinned_workload() {
         }
     }
     let fill = fill_start.elapsed();
+    // Cross-check the memory-gate denominator against the structure
+    // itself: a silent drop would otherwise flatter every number at
+    // once (audit finding). Gap removes make resident slightly less
+    // than generated.
+    let resident = match &sider {
+        Sider::Oracle(_, _) => holder_blocks, // oracle side has no cheap recount
+        Sider::R1(tree, _, _, _) => tree.stats().holder_blocks,
+        Sider::R3(tree, _, _, _) => tree.stats().holder_blocks,
+    };
+    assert!(
+        resident * 100 >= holder_blocks * 97,
+        "structure holds {resident} of {holder_blocks} generated holder-blocks — silent loss"
+    );
     let rss_after = rss_kib();
     println!(
         "fill: {:.2}s -> {:.2}M stream blocks/s",

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -20,9 +20,25 @@ use std::time::Instant;
 use common::{oracle::Oracle, Op, Rng};
 use radix_tree::{Config, HolderId, RadixTree};
 
-// ---- §11 normative constants ----
-const TARGET_BLOCKS: u64 = 10_000_000;
-const HOLDERS: usize = 256;
+// ---- §11 normative constants (default scale) ----
+// RADIX_BENCH_SCALE=large runs 8x blocks / 8x holders (~20 GB peak,
+// ~60% of the 1.7e8 production target) to expose growth
+// nonlinearities the normative scale can't: hash-table growth stalls,
+// TLB pressure on a ~17 GB resident structure, query latency vs
+// table size. Gates are quoted at the DEFAULT scale; large-scale
+// runs are diagnostics.
+fn target_blocks() -> u64 {
+    match std::env::var("RADIX_BENCH_SCALE").as_deref() {
+        Ok("large") => 100_000_000,
+        _ => 10_000_000,
+    }
+}
+fn holders() -> usize {
+    match std::env::var("RADIX_BENCH_SCALE").as_deref() {
+        Ok("large") => 2048,
+        _ => 256,
+    }
+}
 /// (sharing factor H, share of total holder-blocks in percent).
 const SHARING_MIX: [(usize, u64); 3] = [(1, 50), (8, 35), (64, 15)];
 const SHARED_DEPTH: (u32, u32) = (8, 512); // log-uniform
@@ -51,7 +67,7 @@ fn build_families(rng: &mut Rng) -> Vec<Family> {
     // One forced gate family: H=64, shared length >= GATE_DEPTH.
     let mut budgets: Vec<(usize, u64)> = SHARING_MIX
         .iter()
-        .map(|&(h, pct)| (h, TARGET_BLOCKS * pct / 100))
+        .map(|&(h, pct)| (h, target_blocks() * pct / 100))
         .collect();
     let mut force_gate = true;
     for (h, budget) in budgets.iter_mut() {
@@ -75,15 +91,19 @@ fn build_families(rng: &mut Rng) -> Vec<Family> {
                 blocks.push((key, content));
                 prev_key = key;
             }
-            let mut holders = Vec::with_capacity(*h);
-            let base = rng.below(HOLDERS);
+            let holder_count = holders();
+            let mut members = Vec::with_capacity(*h);
+            let base = rng.below(holder_count);
             for k in 0..*h {
-                holders.push((base + k * 7) % HOLDERS);
+                members.push((base + k * 7) % holder_count);
             }
-            holders.sort_unstable();
-            holders.dedup();
-            used += shared_len as u64 * holders.len() as u64;
-            families.push(Family { blocks, holders });
+            members.sort_unstable();
+            members.dedup();
+            used += shared_len as u64 * members.len() as u64;
+            families.push(Family {
+                blocks,
+                holders: members,
+            });
         }
     }
     families
@@ -92,7 +112,7 @@ fn build_families(rng: &mut Rng) -> Vec<Family> {
 /// Expand families into the mixed write stream (stores + duplicates +
 /// gap removes), per-holder order preserved, §7-scoped interleave.
 fn build_ops(rng: &mut Rng, families: &[Family]) -> (Vec<Op>, u64) {
-    let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); HOLDERS];
+    let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); holders()];
     let mut holder_blocks = 0u64;
     for family in families {
         for &holder in &family.holders {
@@ -150,9 +170,9 @@ fn build_ops(rng: &mut Rng, families: &[Family]) -> (Vec<Op>, u64) {
             script.extend(gaps);
         }
     }
-    let mut cursors = vec![0usize; HOLDERS];
+    let mut cursors = vec![0usize; holders()];
     let mut ops = Vec::new();
-    let mut live: Vec<usize> = (0..HOLDERS)
+    let mut live: Vec<usize> = (0..holders())
         .filter(|&h| !per_holder[h].is_empty())
         .collect();
     while !live.is_empty() {
@@ -274,12 +294,12 @@ fn pinned_workload() {
     let mut sider = match side_name.as_str() {
         "r1" => {
             let mut tree = RadixTree::new(Config::default());
-            let ids = (0..HOLDERS)
+            let ids = (0..holders())
                 .map(|h| tree.create_holder(&format!("holder-{h}")))
                 .collect();
             Sider::R1(tree, ids, Vec::new())
         }
-        _ => Sider::Oracle(Oracle::new(HOLDERS), vec![Vec::new(); HOLDERS]),
+        _ => Sider::Oracle(Oracle::new(holders()), vec![Vec::new(); holders()]),
     };
     let fill_start = Instant::now();
     for op in &ops {

--- a/crates/radix_tree/tests/tree_compare.rs
+++ b/crates/radix_tree/tests/tree_compare.rs
@@ -134,6 +134,7 @@ fn placement_chain_keys(hashes: &[kv_index::ContentHash]) -> Vec<(u64, u64)> {
     out
 }
 
+#[allow(clippy::large_enum_variant)] // bench-local, one instance per process
 enum Side {
     Token(TokenTree),
     String(StringTree),

--- a/crates/radix_tree/tests/tree_compare.rs
+++ b/crates/radix_tree/tests/tree_compare.rs
@@ -1,0 +1,291 @@
+//! Cross-structure comparison: the gateway's TokenTree (per-token
+//! radix) and StringTree (per-character radix) vs the new block-hash
+//! RadixTree, on one shared token corpus — build rate, resident
+//! bytes, match latency, and MATCHING RESOLUTION (what each promises
+//! vs what an engine paging KV in fixed blocks can physically reuse).
+//!
+//! Block size is a swept axis (64/128/256/512), exercising the same
+//! knob the wire exposes end to end (gateway --kv-indexer-block-size,
+//! bridge --block-size, keyspace-keyed on the service).
+//!
+//! One structure per process for clean RSS deltas:
+//!   RADIX_COMPARE_SIDE=token|string|radix64|radix128|radix256|radix512
+//!
+//! Run: RADIX_COMPARE_SIDE=... cargo test -p radix-tree --release \
+//!   --test tree_compare -- --ignored --nocapture
+
+mod common;
+
+use std::time::Instant;
+
+use common::Rng;
+use kv_index::{compute_request_content_hashes, RadixTree as _, StringTree, TokenTree};
+use radix_tree::{Config, HolderId, RadixTree};
+
+const TENANTS: usize = 64;
+const FAMILIES: usize = 400;
+/// Shared prefix length in tokens, log-uniform.
+const SHARED_TOKENS: (u32, u32) = (512, 8192);
+const TAIL_TOKENS: (u32, u32) = (128, 1024);
+const TENANTS_PER_FAMILY: (usize, usize) = (1, 6);
+const TOKEN_SPACE: u64 = 150_000;
+/// The engine's actual page size: the amount of matching resolution
+/// that is PHYSICALLY reusable, whatever the index promises.
+const ENGINE_PAGE: u32 = 256;
+
+fn log_uniform(rng: &mut Rng, lo: u32, hi: u32) -> u32 {
+    let (llo, lhi) = ((lo as f64).ln(), (hi as f64).ln());
+    let u = (rng.next() >> 11) as f64 / (1u64 << 53) as f64;
+    (llo + u * (lhi - llo)).exp().round() as u32
+}
+
+struct Corpus {
+    /// (tokens of shared prefix, member tenants)
+    families: Vec<(Vec<u32>, Vec<usize>)>,
+    /// (tenant, full sequence = family prefix + private tail, family)
+    inserts: Vec<(usize, Vec<u32>, usize)>,
+    /// (family, query length clamped to family prefix, tenant known
+    /// to hold it) — the TRUE cached-prefix length equals the query
+    /// length by construction.
+    queries: Vec<(usize, u32, usize)>,
+}
+
+fn build_corpus(seed: u64) -> Corpus {
+    let mut rng = Rng::new(seed);
+    let mut families = Vec::with_capacity(FAMILIES);
+    for _ in 0..FAMILIES {
+        let len = log_uniform(&mut rng, SHARED_TOKENS.0, SHARED_TOKENS.1);
+        let tokens: Vec<u32> = (0..len)
+            .map(|_| (rng.next() % TOKEN_SPACE) as u32)
+            .collect();
+        let n = TENANTS_PER_FAMILY.0 + rng.below(TENANTS_PER_FAMILY.1 - TENANTS_PER_FAMILY.0 + 1);
+        let mut members: Vec<usize> = (0..n).map(|_| rng.below(TENANTS)).collect();
+        members.sort_unstable();
+        members.dedup();
+        families.push((tokens, members));
+    }
+    let mut inserts = Vec::new();
+    for (fi, (tokens, members)) in families.iter().enumerate() {
+        for &tenant in members {
+            let tail_len =
+                TAIL_TOKENS.0 + (rng.next() % (TAIL_TOKENS.1 - TAIL_TOKENS.0 + 1) as u64) as u32;
+            let mut seq = tokens.clone();
+            seq.extend((0..tail_len).map(|_| (rng.next() % TOKEN_SPACE) as u32));
+            inserts.push((tenant, seq, fi));
+        }
+    }
+    let mut queries = Vec::new();
+    for (fi, (tokens, members)) in families.iter().enumerate() {
+        if members.is_empty() {
+            continue;
+        }
+        for _ in 0..8 {
+            let d = 1 + rng.below(tokens.len()) as u32;
+            queries.push((fi, d, members[rng.below(members.len())]));
+        }
+    }
+    Corpus {
+        families,
+        inserts,
+        queries,
+    }
+}
+
+fn rss_kib() -> u64 {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &std::process::id().to_string()])
+        .output()
+        .expect("ps");
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0)
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    sorted[((sorted.len() as f64 - 1.0) * p).round() as usize]
+}
+
+/// Tokens -> 4-hex-char words, the string-side rendering of the same
+/// corpus (per-character tree granularity, 4 chars per token).
+fn to_text(tokens: &[u32]) -> String {
+    let mut s = String::with_capacity(tokens.len() * 4);
+    for &t in tokens {
+        s.push_str(&format!("{:04x}", t & 0xFFFF));
+    }
+    s
+}
+
+fn placement_chain_keys(hashes: &[kv_index::ContentHash]) -> Vec<(u64, u64)> {
+    let mut out = Vec::with_capacity(hashes.len());
+    let mut prev = kv_index::SequenceHash(0);
+    for (i, &h) in hashes.iter().enumerate() {
+        let seq = if i == 0 {
+            kv_index::SequenceHash(h.0)
+        } else {
+            kv_index::chain_prefix_hash(prev, h)
+        };
+        out.push((seq.0, h.0));
+        prev = seq;
+    }
+    out
+}
+
+enum Side {
+    Token(TokenTree),
+    String(StringTree),
+    Radix {
+        tree: RadixTree,
+        ids: Vec<HolderId>,
+        block: u32,
+        out: Vec<radix_tree::Overlap>,
+    },
+}
+
+#[test]
+#[ignore = "comparison benchmark; run --release --ignored --nocapture with RADIX_COMPARE_SIDE"]
+fn tree_compare() {
+    let side_name = std::env::var("RADIX_COMPARE_SIDE").unwrap_or_else(|_| "radix256".into());
+    let corpus = build_corpus(20260902);
+    let total_tokens: u64 = corpus.inserts.iter().map(|(_, s, _)| s.len() as u64).sum();
+    println!(
+        "side: {side_name}; corpus: {} families, {} inserts, {:.1}M tokens",
+        corpus.families.len(),
+        corpus.inserts.len(),
+        total_tokens as f64 / 1e6
+    );
+
+    let rss_before = rss_kib();
+    let mut side = match side_name.as_str() {
+        "token" => Side::Token(TokenTree::new()),
+        "string" => Side::String(StringTree::new()),
+        other => {
+            let block: u32 = other
+                .strip_prefix("radix")
+                .and_then(|b| b.parse().ok())
+                .expect("radix<block>");
+            let mut tree = RadixTree::new(Config::default());
+            let ids = (0..TENANTS)
+                .map(|t| tree.create_holder(&format!("tenant-{t}")))
+                .collect();
+            Side::Radix {
+                tree,
+                ids,
+                block,
+                out: Vec::new(),
+            }
+        }
+    };
+
+    // Pre-render side-specific insert inputs OUTSIDE the timed region.
+    enum Prepared {
+        Tokens(usize, Vec<u32>),
+        Text(usize, String),
+        Blocks(usize, Vec<(u64, u64)>),
+    }
+    let prepared: Vec<Prepared> = corpus
+        .inserts
+        .iter()
+        .map(|(tenant, seq, _)| match &side {
+            Side::Token(_) => Prepared::Tokens(*tenant, seq.clone()),
+            Side::String(_) => Prepared::Text(*tenant, to_text(seq)),
+            Side::Radix { block, .. } => Prepared::Blocks(
+                *tenant,
+                placement_chain_keys(&compute_request_content_hashes(seq, *block as usize)),
+            ),
+        })
+        .collect();
+
+    let build_start = Instant::now();
+    for item in &prepared {
+        match (&mut side, item) {
+            (Side::Token(t), Prepared::Tokens(tenant, seq)) => {
+                t.insert_tokens(seq, &format!("tenant-{tenant}"));
+            }
+            (Side::String(t), Prepared::Text(tenant, text)) => {
+                t.insert_text(text, &format!("tenant-{tenant}"));
+            }
+            (Side::Radix { tree, ids, .. }, Prepared::Blocks(tenant, blocks)) => {
+                tree.store(ids[*tenant], None, blocks).expect("store");
+            }
+            _ => unreachable!(),
+        }
+    }
+    let build = build_start.elapsed();
+    let rss_after = rss_kib();
+    println!(
+        "build: {:.2}s -> {:.2}M tokens/s; memory: {:.1} MiB -> {:.2} B/token",
+        build.as_secs_f64(),
+        total_tokens as f64 / build.as_secs_f64() / 1e6,
+        (rss_after - rss_before) as f64 / 1024.0,
+        (rss_after - rss_before) as f64 * 1024.0 / total_tokens as f64
+    );
+
+    // Queries: latency + promised-vs-physical matching resolution.
+    // True cached prefix = query length L (by construction). Physical
+    // ceiling = floor(L / ENGINE_PAGE) * ENGINE_PAGE.
+    let mut prepared_queries = Vec::new();
+    for &(fi, len, tenant) in &corpus.queries {
+        let toks = &corpus.families[fi].0[..len as usize];
+        match &side {
+            Side::Token(_) => prepared_queries.push((Prepared::Tokens(tenant, toks.to_vec()), len)),
+            Side::String(_) => prepared_queries.push((Prepared::Text(tenant, to_text(toks)), len)),
+            Side::Radix { block, .. } => prepared_queries.push((
+                Prepared::Blocks(
+                    tenant,
+                    placement_chain_keys(&compute_request_content_hashes(toks, *block as usize)),
+                ),
+                len,
+            )),
+        }
+    }
+    let mut lat: Vec<u64> = Vec::with_capacity(prepared_queries.len());
+    let mut promised_minus_true = 0i64;
+    let mut promised_minus_physical = 0i64;
+    let mut n = 0i64;
+    for (q, true_len) in &prepared_queries {
+        let physical = (*true_len / ENGINE_PAGE) * ENGINE_PAGE;
+        let t = Instant::now();
+        let matched_tokens: u32 = match (&mut side, q) {
+            (Side::Token(tree), Prepared::Tokens(_, toks)) => {
+                tree.prefix_match_with_counts(toks).matched_token_count as u32
+            }
+            (Side::String(tree), Prepared::Text(_, text)) => {
+                (tree.prefix_match_with_counts(text).matched_char_count as u32) / 4
+            }
+            (
+                Side::Radix {
+                    tree,
+                    ids,
+                    block,
+                    out,
+                },
+                Prepared::Blocks(tenant, blocks),
+            ) => {
+                let chain: Vec<u64> = blocks.iter().map(|&(_, c)| c).collect();
+                tree.overlap(&chain, out);
+                let (idx, _) = ids[*tenant].parts();
+                out.iter()
+                    .find(|o| o.holder.parts().0 == idx)
+                    .map_or(0, |o| o.depth * *block)
+            }
+            _ => unreachable!(),
+        };
+        lat.push(t.elapsed().as_nanos() as u64);
+        promised_minus_true += matched_tokens as i64 - *true_len as i64;
+        promised_minus_physical += matched_tokens as i64 - physical as i64;
+        n += 1;
+    }
+    lat.sort_unstable();
+    println!(
+        "match: n={} p50={}ns p99={}ns; promised-vs-true avg {:+.1} tokens; promised-vs-physical(page {ENGINE_PAGE}) avg {:+.1} tokens",
+        n,
+        percentile(&lat, 0.50),
+        percentile(&lat, 0.99),
+        promised_minus_true as f64 / n as f64,
+        promised_minus_physical as f64 / n as f64,
+    );
+}

--- a/crates/radix_tree/tests/tree_compare.rs
+++ b/crates/radix_tree/tests/tree_compare.rs
@@ -20,7 +20,7 @@ use std::time::Instant;
 
 use common::Rng;
 use kv_index::{compute_request_content_hashes, RadixTree as _, StringTree, TokenTree};
-use radix_tree::{Config, HolderId, RadixTree};
+use radix_tree::{Config, HolderId, OverlapScratch, RadixTree};
 
 const TENANTS: usize = 64;
 const FAMILIES: usize = 400;
@@ -142,6 +142,7 @@ enum Side {
         ids: Vec<HolderId>,
         block: u32,
         out: Vec<radix_tree::Overlap>,
+        qscratch: OverlapScratch,
     },
 }
 
@@ -176,6 +177,7 @@ fn tree_compare() {
                 ids,
                 block,
                 out: Vec::new(),
+                qscratch: OverlapScratch::default(),
             }
         }
     };
@@ -262,11 +264,12 @@ fn tree_compare() {
                     ids,
                     block,
                     out,
+                    qscratch,
                 },
                 Prepared::Blocks(tenant, blocks),
             ) => {
                 let chain: Vec<u64> = blocks.iter().map(|&(_, c)| c).collect();
-                tree.overlap(&chain, out);
+                tree.overlap(&chain, qscratch, out);
                 let (idx, _) = ids[*tenant].parts();
                 out.iter()
                     .find(|o| o.holder.parts().0 == idx)

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -78,6 +78,7 @@ llm-tokenizer.workspace = true
 smg-auth.workspace = true
 smg-mcp.workspace = true
 kv-index.workspace = true
+radix-index = { path = "../crates/radix_index" }
 smg-data-connector.workspace = true
 llm-multimodal = { workspace = true, default-features = false }
 smg-mm-rdma.workspace = true

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -81,6 +81,9 @@ pub struct AppContext {
     pub worker_client_cache: Arc<WorkerHttpClientCache>,
     pub inflight_tracker: Arc<InFlightRequestTracker>,
     pub kv_event_monitor: Option<Arc<KvEventMonitor>>,
+    /// Remote radix index client (`--kv-indexer-url`); `None` leaves
+    /// every routing path on local-index behavior.
+    pub remote_index: Option<Arc<remote_index::RemoteIndexHandle>>,
     pub realtime_registry: Arc<RealtimeRegistry>,
     /// Bind address for WebRTC UDP sockets (`None` = `0.0.0.0`, auto-detect).
     pub webrtc_bind_addr: Option<std::net::IpAddr>,
@@ -117,6 +120,7 @@ pub struct AppContextBuilder {
     mcp_format_registry: Option<FormatRegistry>,
     wasm_manager: Option<Arc<WasmModuleManager>>,
     kv_event_monitor: Option<Arc<KvEventMonitor>>,
+    remote_index: Option<Arc<remote_index::RemoteIndexHandle>>,
     webrtc_bind_addr: Option<std::net::IpAddr>,
     webrtc_stun_server: Option<String>,
 }
@@ -171,6 +175,7 @@ impl AppContextBuilder {
             mcp_format_registry: None,
             wasm_manager: None,
             kv_event_monitor: None,
+            remote_index: None,
             webrtc_bind_addr: None,
             webrtc_stun_server: None,
         }
@@ -406,6 +411,7 @@ impl AppContextBuilder {
             worker_client_cache,
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: self.kv_event_monitor,
+            remote_index: self.remote_index,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: self.webrtc_bind_addr,
             webrtc_stun_server: self.webrtc_stun_server,
@@ -754,11 +760,14 @@ impl AppContextBuilder {
             self.kv_event_monitor = Some(monitor);
         }
 
-        // Remote radix index (experiment flag): one process-global client;
-        // the selection stage and the pipelines consult it directly. Unset
+        // Remote radix index: one client handle per process, threaded to
+        // the selection stage and pipelines through this context. Unset
         // leaves every code path on its exact prior behavior.
         if let Some(url) = &config.kv_indexer_url {
-            remote_index::init(url, config.kv_indexer_block_size.unwrap_or(128) as usize);
+            self.remote_index = Some(remote_index::RemoteIndexHandle::connect(
+                url,
+                config.kv_indexer_block_size.unwrap_or(128) as usize,
+            ));
         }
 
         self

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -22,7 +22,7 @@ use crate::{
     rate_limit::RateLimitManager,
     routers::{
         common::{openai_bridge::FormatRegistry, overload, realtime::RealtimeRegistry},
-        grpc::multimodal::MultimodalConfigRegistry,
+        grpc::{multimodal::MultimodalConfigRegistry, remote_index},
         router_manager::RouterManager,
     },
     wasm::{config::WasmRuntimeConfig, module_manager::WasmModuleManager},
@@ -752,6 +752,13 @@ impl AppContextBuilder {
             }
 
             self.kv_event_monitor = Some(monitor);
+        }
+
+        // Remote radix index (experiment flag): one process-global client;
+        // the selection stage and the pipelines consult it directly. Unset
+        // leaves every code path on its exact prior behavior.
+        if let Some(url) = &config.kv_indexer_url {
+            remote_index::init(url, config.kv_indexer_block_size.unwrap_or(128) as usize);
         }
 
         self

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -288,6 +288,16 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn kv_indexer_url(mut self, url: Option<String>) -> Self {
+        self.config.kv_indexer_url = url;
+        self
+    }
+
+    pub fn kv_indexer_block_size(mut self, block: Option<u32>) -> Self {
+        self.config.kv_indexer_block_size = block;
+        self
+    }
+
     pub fn kv_indexer_max_entries(mut self, max: Option<usize>) -> Self {
         self.config.kv_indexer_max_entries = max;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -127,6 +127,19 @@ pub struct RouterConfig {
     /// `None`/`0` disables the TTL pass (default, preserving unbounded growth).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kv_indexer_ttl_secs: Option<u64>,
+    /// Remote radix index endpoint for cache-aware routing. When set, the
+    /// gateway prefetches per-holder overlap scores from the shared index
+    /// service on the selection path (hard per-query deadline, falling
+    /// back to expected-wait) and publishes placements after successful
+    /// dispatch. Unset (default) leaves routing byte-identical to before
+    /// this option existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kv_indexer_url: Option<String>,
+    /// Keyspace block size for the remote radix index: the ENGINE page
+    /// size the index was fed at (worker events / bridge --block-size),
+    /// which query hashing must match exactly. Default 128.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kv_indexer_block_size: Option<u32>,
     /// Capacity ceiling per model for the positional indexer, enforced by the
     /// same periodic prune: beyond it, oldest-touched entries are evicted down
     /// to 90% of the ceiling. `None`/`0` disables the ceiling (default).
@@ -1063,6 +1076,8 @@ impl Default for RouterConfig {
             worker_overload_waiting_requests: None,
             worker_overload_token_usage: None,
             kv_indexer_ttl_secs: None,
+            kv_indexer_url: None,
+            kv_indexer_block_size: None,
             kv_indexer_max_entries: None,
             engine_metrics: false,
             multimodal_tensor_transport: None,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -539,6 +539,18 @@ struct CliArgs {
     #[arg(long, help_heading = "Routing Policy")]
     kv_indexer_ttl_secs: Option<u64>,
 
+    /// Remote radix index endpoint (e.g. http://127.0.0.1:40000) for
+    /// cache-aware routing: overlap scores are prefetched from the shared
+    /// index on selection (hard deadline, expected-wait fallback) and
+    /// placements published after successful dispatch. Unset = off.
+    #[arg(long, help_heading = "Routing Policy")]
+    kv_indexer_url: Option<String>,
+
+    /// Keyspace block size for --kv-indexer-url queries: the ENGINE page
+    /// size the index was fed at (must match the bridge/worker events).
+    #[arg(long, help_heading = "Routing Policy")]
+    kv_indexer_block_size: Option<u32>,
+
     /// Capacity ceiling per model for the event-driven cache-aware indexer;
     /// beyond it, oldest-touched entries are pruned down to 90% of the
     /// ceiling. Unset or 0 disables the ceiling.
@@ -1787,6 +1799,8 @@ impl CliArgs {
             .worker_overload_waiting_requests(self.worker_overload_waiting_requests)
             .worker_overload_token_usage(self.worker_overload_token_usage)
             .kv_indexer_ttl_secs(self.kv_indexer_ttl_secs)
+            .kv_indexer_url(self.kv_indexer_url.clone())
+            .kv_indexer_block_size(self.kv_indexer_block_size)
             .kv_indexer_max_entries(self.kv_indexer_max_entries)
             .engine_metrics(self.engine_metrics)
             .multimodal_tensor_transport(self.multimodal_tensor_transport)

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -1337,6 +1337,20 @@ impl Metrics {
     }
 
     /// Record worker selection
+    /// One remote radix-index overlap query on the selection path.
+    /// `outcome`: remote_hit | remote_empty | remote_timeout |
+    /// remote_disconnected.
+    pub fn record_remote_index_query(outcome: &'static str, duration: Duration) {
+        counter!("smg_remote_index_query_total", "outcome" => outcome).increment(1);
+        histogram!("smg_remote_index_query_duration_seconds", "outcome" => outcome)
+            .record(duration.as_secs_f64());
+    }
+
+    /// One placement published (fire-and-forget) after successful dispatch.
+    pub fn record_remote_index_publish() {
+        counter!("smg_remote_index_publish_total").increment(1);
+    }
+
     pub fn record_worker_selection(
         worker_type: &'static str,
         connection_mode: &'static str,

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -1421,15 +1421,20 @@ impl CacheAwarePolicy {
                 avg_load,
                 info,
             )?;
+            // "Cache-aware selection" + branch= is the harness's parse
+            // contract (branch_counts in scripts/generate_sim/sim.py);
+            // event-driven decisions must land in the same breakdown as
+            // the tree/hash modes.
             debug!(
-                worker = workers[idx].url(),
+                index = "event",
                 branch = if affinity_candidates.contains(&idx) {
                     "event_hit"
                 } else {
                     "event_spill"
                 },
+                worker = workers[idx].url(),
                 model_id,
-                "Event-driven routing: overlap match"
+                "Cache-aware selection"
             );
             return Some(idx);
         }
@@ -1437,8 +1442,11 @@ impl CacheAwarePolicy {
         // No cache overlap — expected-wait fallback over the healthy fleet.
         let selected = self.select_expected_wait(workers, healthy_indices, info)?;
         debug!(
+            index = "event",
+            branch = "event_miss",
             worker = workers[selected].url(),
-            model_id, "Event-driven routing: no overlap, expected-wait fallback"
+            model_id,
+            "Cache-aware selection"
         );
         Some(selected)
     }

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -72,7 +72,7 @@ use tracing::{debug, warn};
 
 use super::{
     normalize_model_key, utils::PeriodicTask, CacheAwareConfig, LeastLoadPolicy,
-    LoadBalancingPolicy, SelectWorkerInfo,
+    LoadBalancingPolicy, RemoteOverlap, SelectWorkerInfo,
 };
 /// Latest per-worker backend load snapshot stream, keyed by worker URL.
 pub(crate) use crate::worker::load_state::{LoadReceiver, LoadSnapshot};
@@ -1120,6 +1120,92 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
             let text = request_text.unwrap_or("");
             self.select_worker_with_text(workers, text, &healthy_indices, avg_load, model_id, info)
         }
+    }
+
+    /// Remote-index selection: the pipeline prefetched per-holder overlap
+    /// scores from the shared radix index; score and gate them exactly
+    /// like the local event-driven path (overlap decay, temperature,
+    /// per-candidate spill, LeastLoad final pick), so remote-vs-local
+    /// comparisons vary only where the scores came from.
+    fn select_worker_with_remote(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        info: &SelectWorkerInfo,
+        remote: &RemoteOverlap,
+    ) -> Option<usize> {
+        let mut healthy_indices: Vec<usize> = Vec::with_capacity(workers.len());
+        let mut load_sum = 0usize;
+        for (idx, worker) in workers.iter().enumerate() {
+            let state = worker.routing_state();
+            if state.eligible() {
+                healthy_indices.push(idx);
+                load_sum += state.load;
+            }
+        }
+        if healthy_indices.is_empty() {
+            return None;
+        }
+        let avg_load = load_sum as f64 / healthy_indices.len() as f64;
+        let model_id = normalize_model_key(workers[healthy_indices[0]].model_id());
+
+        if self.is_kv_imbalanced(workers, &healthy_indices) {
+            return self.select_worker_fallback(workers, info, &healthy_indices, model_id);
+        }
+
+        let mut candidates: Vec<OverlapCandidate> = healthy_indices
+            .iter()
+            .filter_map(|&idx| {
+                let url = workers[idx].url();
+                remote
+                    .scores
+                    .iter()
+                    .find(|(holder, matched)| *matched > 0 && holder == url)
+                    .map(|(_, matched)| OverlapCandidate {
+                        idx,
+                        effective_score: f64::from(*matched),
+                    })
+            })
+            .collect();
+        let waiting_prefill_tokens = self.waiting_prefill_snapshot();
+        let tuning = OverlapTuning {
+            overlap_decay: self.config.overlap_decay,
+            selection_temperature: self.config.selection_temperature,
+            waiting_prefill_tokens: waiting_prefill_tokens.as_deref(),
+        };
+        Self::apply_overlap_decay(
+            workers,
+            &mut candidates,
+            remote.request_blocks,
+            remote.block_size.max(1),
+            &tuning,
+        );
+
+        let affinity = Self::affinity_score_group(&candidates, tuning.selection_temperature);
+        if let Some(idx) =
+            self.select_final_from_affinity(workers, &affinity, &healthy_indices, avg_load, info)
+        {
+            debug!(
+                index = "remote",
+                branch = if affinity.contains(&idx) {
+                    "remote_hit"
+                } else {
+                    "remote_spill"
+                },
+                worker = workers[idx].url(),
+                model_id,
+                "Cache-aware selection"
+            );
+            return Some(idx);
+        }
+        let selected = self.select_expected_wait(workers, &healthy_indices, info)?;
+        debug!(
+            index = "remote",
+            branch = "remote_miss",
+            worker = workers[selected].url(),
+            model_id,
+            "Cache-aware selection"
+        );
+        Some(selected)
     }
 
     fn on_request_complete(&self, worker_url: &str, success: bool) {
@@ -2320,6 +2406,50 @@ mod tests {
     }
 
     /// Healthy workers (health checks disabled) for the given URLs.
+    #[test]
+    fn remote_overlap_scores_drive_selection_and_fall_back() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        });
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
+        policy.init_workers(&workers);
+        let info = SelectWorkerInfo::default();
+
+        // The highest remote score wins the affinity group.
+        let remote = RemoteOverlap {
+            scores: vec![
+                ("http://w2:8000".to_string(), 40),
+                ("http://w1:8000".to_string(), 5),
+            ],
+            request_blocks: 40,
+            block_size: 128,
+        };
+        assert_eq!(
+            policy.select_worker_with_remote(&workers, &info, &remote),
+            Some(1),
+            "top remote holder must be selected"
+        );
+
+        // Scores for unknown holders match nothing and fall back to
+        // expected-wait over the healthy fleet (any worker is valid).
+        let stranger = RemoteOverlap {
+            scores: vec![("http://elsewhere:8000".to_string(), 40)],
+            request_blocks: 40,
+            block_size: 128,
+        };
+        assert!(policy
+            .select_worker_with_remote(&workers, &info, &stranger)
+            .is_some());
+
+        // The default trait impl (every other policy) ignores the scores.
+        let random = crate::policies::RandomPolicy::new();
+        assert!(
+            LoadBalancingPolicy::select_worker_with_remote(&random, &workers, &info, &remote)
+                .is_some()
+        );
+    }
+
     fn make_workers(urls: &[&str]) -> Vec<Arc<dyn Worker>> {
         urls.iter()
             .map(|u| {

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -58,6 +58,19 @@ pub trait LoadBalancingPolicy: Send + Sync + Debug {
     /// * `info` - Additional information for routing decisions
     fn select_worker(&self, workers: &[Arc<dyn Worker>], info: &SelectWorkerInfo) -> Option<usize>;
 
+    /// Selection with prefetched remote-index overlap scores (the shared
+    /// radix index; `--kv-indexer-url`). The default ignores the scores
+    /// and delegates, so every policy except cache_aware — and every
+    /// caller that never prefetches — behaves exactly as `select_worker`.
+    fn select_worker_with_remote(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        info: &SelectWorkerInfo,
+        _remote: &RemoteOverlap,
+    ) -> Option<usize> {
+        self.select_worker(workers, info)
+    }
+
     /// Update policy state after request completion
     ///
     /// This is called when a request completes (successfully or not) to allow
@@ -276,6 +289,18 @@ impl WorkerLeg {
             WorkerLeg::Decode => "decode:",
         }
     }
+}
+
+/// Prefetched overlap scores from the remote radix index, resolved by the
+/// async pipeline stage before the (synchronous) policy call.
+#[derive(Debug, Clone, Default)]
+pub struct RemoteOverlap {
+    /// Per-holder (worker url, matched prefix blocks), descending.
+    pub scores: Vec<(String, u32)>,
+    /// The request's full prefix depth in blocks (for overlap decay).
+    pub request_blocks: usize,
+    /// Block size the scores were computed at.
+    pub block_size: usize,
 }
 
 /// Information passed to policy for worker selection

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -18,7 +18,7 @@ use super::{
     get_healthy_worker_indices,
     manual::{ExecutionBranch, PinState},
     BucketPolicy, CacheAwarePolicy, DPRankLoadPolicy, LoadBalancingPolicy, ManualConfig,
-    ManualPolicy, PolicyFactory, SelectWorkerInfo, WorkerLeg,
+    ManualPolicy, PolicyFactory, RemoteOverlap, SelectWorkerInfo, WorkerLeg,
 };
 use crate::{
     config::types::{ManualAssignmentMode, PolicyConfig, RoutingKeyOverrideConfig},
@@ -244,6 +244,38 @@ impl PolicyRegistry {
             }
         }
         policy.select_worker(workers, info)
+    }
+
+    /// [`Self::select_worker`] with prefetched remote-index scores: the
+    /// sticky override still wins identically; the scores only reach the
+    /// policy on the delegated path (and only cache_aware consumes them).
+    pub fn select_worker_with_remote(
+        &self,
+        policy: &Arc<dyn LoadBalancingPolicy>,
+        workers: &[Arc<dyn Worker>],
+        info: &SelectWorkerInfo,
+        remote: Option<&RemoteOverlap>,
+    ) -> Option<usize> {
+        if let Some(sticky) = self.routing_key_sticky.as_ref() {
+            if Self::routing_key_override_applies(policy.name()) {
+                if let Some((key, source)) = self.effective_sticky_key(info) {
+                    return Self::select_sticky(sticky, policy, workers, info, key, source);
+                }
+            }
+        }
+        match remote {
+            Some(remote) if !remote.scores.is_empty() => {
+                policy.select_worker_with_remote(workers, info, remote)
+            }
+            _ => policy.select_worker(workers, info),
+        }
+    }
+
+    /// Whether the sticky routing-key override is configured at all (used
+    /// by the selection stage to skip a wasted remote-index prefetch when
+    /// the override will win anyway).
+    pub fn routing_key_override_enabled(&self) -> bool {
+        self.routing_key_sticky.is_some()
     }
 
     /// Keyed selection: honor an existing pin under the in-flight cap;

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -46,6 +46,7 @@ pub(crate) struct WorkerSelectionStage {
     worker_registry: Arc<WorkerRegistry>,
     policy_registry: Arc<PolicyRegistry>,
     mode: WorkerSelectionMode,
+    remote_index: Option<Arc<remote_index::RemoteIndexHandle>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -63,11 +64,13 @@ impl WorkerSelectionStage {
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
         mode: WorkerSelectionMode,
+        remote_index: Option<Arc<remote_index::RemoteIndexHandle>>,
     ) -> Self {
         Self {
             worker_registry,
             policy_registry,
             mode,
+            remote_index,
         }
     }
 }
@@ -115,20 +118,21 @@ impl PipelineStage for WorkerSelectionStage {
         // policy, no tokens, or a sticky override key that will win anyway.
         let mut remote_overlap: Option<crate::policies::RemoteOverlap> = None;
         if matches!(self.mode, WorkerSelectionMode::Regular) {
-            if let (Some(client), Some(tokens)) = (remote_index::get(), tokens) {
+            if let (Some(handle), Some(tokens)) = (self.remote_index.as_ref(), tokens) {
                 let sticky_wins = self.policy_registry.routing_key_override_enabled()
                     && (rid_key.is_some()
                         || self.policy_registry.resolve_routing_key(headers).is_some());
                 let policy = self.policy_registry.get_policy_or_default(model_id);
                 if policy.name() == "cache_aware" && !sticky_wins {
-                    let block = remote_index::block_size();
+                    let block = handle.block_size();
                     let hashes: Vec<u64> = kv_index::compute_request_content_hashes(tokens, block)
                         .iter()
                         .map(|h| h.0)
                         .collect();
                     if !hashes.is_empty() {
                         let started = std::time::Instant::now();
-                        let outcome = client
+                        let outcome = handle
+                            .client()
                             .query(
                                 model_id,
                                 block as u32,
@@ -883,6 +887,7 @@ mod tests {
             Arc::clone(&worker_registry),
             Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
             WorkerSelectionMode::PrefillDecode,
+            None,
         );
         assert!(stage
             .select_pd_pair(model_id, None, None, None, None)
@@ -934,6 +939,7 @@ mod tests {
             Arc::clone(&worker_registry),
             Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
             WorkerSelectionMode::EncodePrefillDecode,
+            None,
         );
 
         // No prefill/decode workers registered: with encode undemanded this is
@@ -958,6 +964,7 @@ mod tests {
             Arc::new(WorkerRegistry::new()),
             Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
             WorkerSelectionMode::PrefillDecode,
+            None,
         );
         assert_eq!(
             stage
@@ -990,6 +997,7 @@ mod tests {
             worker_registry,
             policy_registry,
             WorkerSelectionMode::PrefillDecode,
+            None,
         );
         let (prefill_hits, decode_hits) = count_select_pd_pair_hits(&stage, model_id, 40);
         assert_even_pd_round_robin_coverage(
@@ -1022,6 +1030,7 @@ mod tests {
             worker_registry,
             policy_registry,
             WorkerSelectionMode::PrefillDecode,
+            None,
         );
         let (prefill_hits, decode_hits) = count_select_pd_pair_hits(&stage, model_id, 40);
         assert_even_pd_round_robin_coverage(
@@ -1060,6 +1069,7 @@ mod tests {
             Arc::clone(&worker_registry),
             Arc::clone(&policy_registry),
             WorkerSelectionMode::PrefillDecode,
+            None,
         );
 
         assert!(
@@ -1111,6 +1121,7 @@ mod tests {
             worker_registry,
             policy_registry.clone(),
             WorkerSelectionMode::Regular,
+            None,
         );
 
         let rid_key = policy_registry.derive_rid_key(Some("conv7_t1"));
@@ -1169,6 +1180,7 @@ mod tests {
             Arc::clone(&worker_registry),
             policy_registry,
             WorkerSelectionMode::Regular,
+            None,
         );
 
         assert!(stage

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -21,7 +21,7 @@ use crate::{
         error,
         grpc::{
             context::{EncodeWorkerAssignment, RequestContext, WorkerSelection},
-            multimodal,
+            multimodal, remote_index,
         },
     },
     worker::{
@@ -107,9 +107,68 @@ impl PipelineStage for WorkerSelectionStage {
         let rid_key = rid_key.as_deref();
 
         let model_id = ctx.input.model_id.as_str();
+
+        // Remote-index prefetch (--kv-indexer-url, Regular mode only):
+        // resolve per-holder overlap scores from the shared radix index
+        // BEFORE the synchronous policy call, under a hard deadline.
+        // Skipped whenever it could not matter: flag off, non-cache_aware
+        // policy, no tokens, or a sticky override key that will win anyway.
+        let mut remote_overlap: Option<crate::policies::RemoteOverlap> = None;
+        if matches!(self.mode, WorkerSelectionMode::Regular) {
+            if let (Some(client), Some(tokens)) = (remote_index::get(), tokens) {
+                let sticky_wins = self.policy_registry.routing_key_override_enabled()
+                    && (rid_key.is_some()
+                        || self.policy_registry.resolve_routing_key(headers).is_some());
+                let policy = self.policy_registry.get_policy_or_default(model_id);
+                if policy.name() == "cache_aware" && !sticky_wins {
+                    let block = remote_index::block_size();
+                    let hashes: Vec<u64> = kv_index::compute_request_content_hashes(tokens, block)
+                        .iter()
+                        .map(|h| h.0)
+                        .collect();
+                    if !hashes.is_empty() {
+                        let started = std::time::Instant::now();
+                        let outcome = client
+                            .query(
+                                model_id,
+                                block as u32,
+                                hashes.clone(),
+                                remote_index::QUERY_DEADLINE,
+                            )
+                            .await;
+                        let label = remote_index::outcome_label(&outcome);
+                        Metrics::record_remote_index_query(label, started.elapsed());
+                        let scores = match outcome {
+                            radix_index::client::QueryOutcome::Scores(scores) => scores,
+                            _ => Vec::new(),
+                        };
+                        remote_overlap = Some(crate::policies::RemoteOverlap {
+                            scores: scores.clone(),
+                            request_blocks: hashes.len(),
+                            block_size: block,
+                        });
+                        ctx.state.index_prediction = Some(remote_index::IndexPrediction {
+                            source: label,
+                            scores,
+                            block_size: block,
+                            content_hashes: hashes,
+                            model: model_id.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+
         let workers = match self.mode {
             WorkerSelectionMode::Regular => {
-                match self.select_single_worker(model_id, text, tokens, headers, rid_key) {
+                match self.select_single_worker(
+                    model_id,
+                    text,
+                    tokens,
+                    headers,
+                    rid_key,
+                    remote_overlap.as_ref(),
+                ) {
                     Some(w) => WorkerSelection::Single { worker: w },
                     None => return Err(self.selection_failure(model_id, &[WorkerType::Regular])),
                 }
@@ -272,6 +331,7 @@ impl WorkerSelectionStage {
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
+        remote_overlap: Option<&crate::policies::RemoteOverlap>,
     ) -> Option<Arc<dyn Worker>> {
         // Get workers for the specified model. The gRPC router serves both gRPC
         // and direct-ZMQ workers, so accept either transport (not HTTP).
@@ -302,7 +362,7 @@ impl WorkerSelectionStage {
 
         // Select worker via the registry (applies the routing-key sticky override
         // when enabled; otherwise delegates to the configured policy).
-        let idx = self.policy_registry.select_worker(
+        let idx = self.policy_registry.select_worker_with_remote(
             &policy,
             available,
             &SelectWorkerInfo {
@@ -314,6 +374,7 @@ impl WorkerSelectionStage {
                 hash_ring,
                 leg: WorkerLeg::Single,
             },
+            remote_overlap,
         )?;
         let selected = available[idx].clone();
 
@@ -1058,7 +1119,7 @@ mod tests {
         let mut poison = HeaderMap::new();
         poison.insert("x-smg-routing-key", "req-unique-1".parse().unwrap());
         let first = stage
-            .select_single_worker(model_id, None, None, Some(&poison), rid_key)
+            .select_single_worker(model_id, None, None, Some(&poison), rid_key, None)
             .unwrap();
         for (i, rid) in ["conv7_t2", "conv7_t2_r1", "conv7_t3"].iter().enumerate() {
             let mut rotated = HeaderMap::new();
@@ -1073,6 +1134,7 @@ mod tests {
                     None,
                     Some(&rotated),
                     policy_registry.derive_rid_key(Some(rid)),
+                    None,
                 )
                 .unwrap();
             assert_eq!(again.url(), first.url(), "follow-up must pin by rid key");
@@ -1110,13 +1172,13 @@ mod tests {
         );
 
         assert!(stage
-            .select_single_worker(model_id, None, None, None, None)
+            .select_single_worker(model_id, None, None, None, None, None)
             .is_some());
 
         worker_registry.set_worker_overloaded(&workers[0], true);
         assert!(
             stage
-                .select_single_worker(model_id, None, None, None, None)
+                .select_single_worker(model_id, None, None, None, None, None)
                 .is_some(),
             "one eligible worker left still serves"
         );
@@ -1124,7 +1186,7 @@ mod tests {
         worker_registry.set_worker_overloaded(&workers[1], true);
         assert!(
             stage
-                .select_single_worker(model_id, None, None, None, None)
+                .select_single_worker(model_id, None, None, None, None, None)
                 .is_none(),
             "the veto empties the candidate pool"
         );
@@ -1140,7 +1202,7 @@ mod tests {
         // genuinely absent model.
         worker_registry.set_worker_overloaded(&workers[0], false);
         assert!(stage
-            .select_single_worker(model_id, None, None, None, None)
+            .select_single_worker(model_id, None, None, None, None, None)
             .is_some());
         assert_eq!(
             stage

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -187,6 +187,10 @@ pub(crate) struct ProcessingState {
 
     // Stage 5: Dispatch metadata
     pub dispatch: Option<DispatchMetadata>,
+    /// Remote radix-index prefetch outcome (selection stage), consumed by
+    /// the placement publish and the response echo headers. `None` unless
+    /// `--kv-indexer-url` is set and the request took the prefetch path.
+    pub index_prediction: Option<super::remote_index::IndexPrediction>,
 
     // Load guard for worker load tracking (created at execution stage)
     pub load_guards: Option<LoadGuards>,

--- a/model_gateway/src/routers/grpc/mod.rs
+++ b/model_gateway/src/routers/grpc/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod multimodal;
 pub(crate) mod pipeline;
 pub(crate) mod proto_wrapper;
 pub(crate) mod regular;
+pub(crate) mod remote_index;
 pub(crate) mod router; // Used by routers/factory
 pub mod utils; // Used by routers/http and bindings/golang
 pub mod zmq_client; // ZMQ backend adapter behind the vLLM client surface

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -624,9 +624,29 @@ impl RequestPipeline {
                 );
                 // Remote-index bookkeeping, after the request actually
                 // completed (selection is not dispatch: shed/retry paths
-                // must not create phantom placements): publish the served
-                // prefix and echo the prediction so the harness can
-                // separate index error from policy spill.
+                // must not create phantom placements): publish what the
+                // worker now holds — its KV blocks span the prompt AND
+                // the generated tail, so the placement chain is
+                // prompt ⊕ output, not the routing-time query prefix —
+                // and echo the prediction so the harness can separate
+                // index error from policy spill.
+                let placement_chain: Option<Vec<u64>> =
+                    ctx.state.index_prediction.as_ref().map(|prediction| {
+                        match (&ctx.state.preparation, response.first()) {
+                            (Some(prep), Some(first)) => {
+                                let mut tokens = prep.token_ids().to_vec();
+                                tokens.extend_from_slice(&first.output_ids);
+                                kv_index::compute_request_content_hashes(
+                                    &tokens,
+                                    prediction.block_size,
+                                )
+                                .iter()
+                                .map(|h| h.0)
+                                .collect()
+                            }
+                            _ => prediction.content_hashes.clone(),
+                        }
+                    });
                 let mut http_response = axum::Json(response).into_response();
                 if let Some(prediction) = &ctx.state.index_prediction {
                     if let (Some(client), Some(WorkerSelection::Single { worker })) =
@@ -636,7 +656,9 @@ impl RequestPipeline {
                             &prediction.model,
                             prediction.block_size as u32,
                             worker.url(),
-                            &prediction.content_hashes,
+                            placement_chain
+                                .as_deref()
+                                .unwrap_or(&prediction.content_hashes),
                         );
                         Metrics::record_remote_index_publish();
                         let predicted_tokens = prediction

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -87,11 +87,18 @@ pub(crate) struct PipelineDeps {
     /// `None` when tenant rate limiting is disabled; read only by the
     /// endpoints that insert `RateLimitReserveStage` (chat/messages/completion/harmony).
     rate_limit_manager: Option<Arc<RateLimitManager>>,
+    /// Remote radix index (`--kv-indexer-url`); consulted by the
+    /// selection stage's prefetch and the generate placement publish.
+    remote_index: Option<Arc<remote_index::RemoteIndexHandle>>,
 }
 
 impl PipelineDeps {
     /// Full deps for the chat/messages/harmony endpoints, which consume the
     /// configured parser factories/overrides.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "constructor mirrors the struct's fields one-to-one"
+    )]
     pub(crate) fn new(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
@@ -100,6 +107,7 @@ impl PipelineDeps {
         configured_tool_parser: Option<String>,
         configured_reasoning_parser: Option<String>,
         rate_limit_manager: Option<Arc<RateLimitManager>>,
+        remote_index: Option<Arc<remote_index::RemoteIndexHandle>>,
     ) -> Self {
         Self {
             worker_registry,
@@ -109,6 +117,7 @@ impl PipelineDeps {
             configured_tool_parser,
             configured_reasoning_parser,
             rate_limit_manager,
+            remote_index,
         }
     }
 
@@ -118,6 +127,7 @@ impl PipelineDeps {
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
         rate_limit_manager: Option<Arc<RateLimitManager>>,
+        remote_index: Option<Arc<remote_index::RemoteIndexHandle>>,
     ) -> Self {
         Self {
             worker_registry,
@@ -127,6 +137,7 @@ impl PipelineDeps {
             configured_tool_parser: None,
             configured_reasoning_parser: None,
             rate_limit_manager,
+            remote_index,
         }
     }
 
@@ -191,6 +202,7 @@ impl PipelineDeps {
             configured_tool_parser: None,
             configured_reasoning_parser: None,
             rate_limit_manager: None,
+            remote_index: None,
         }
     }
 }
@@ -204,6 +216,8 @@ pub(crate) struct RequestPipeline {
     stages: Arc<Vec<Box<dyn PipelineStage>>>,
     /// Backend type for metrics labeling
     backend_type: &'static str,
+    /// Remote radix index handle for the generate placement publish.
+    remote_index: Option<Arc<remote_index::RemoteIndexHandle>>,
 }
 
 impl RequestPipeline {
@@ -296,6 +310,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.remote_index.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                 ];
@@ -325,6 +340,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.remote_index.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                 ];
@@ -355,6 +371,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.remote_index.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                 ];
@@ -387,6 +404,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.remote_index.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                     Box::new(harmony::stages::HarmonyRequestBuildingStage::new(
@@ -409,6 +427,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.remote_index.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                     Box::new(EmbeddingRequestBuildingStage::new()),
@@ -428,6 +447,7 @@ impl RequestPipeline {
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
                         worker_selection,
+                        deps.remote_index.clone(),
                     )),
                     Box::new(ClientAcquisitionStage),
                     Box::new(EmbeddingRequestBuildingStage::new()),
@@ -441,6 +461,7 @@ impl RequestPipeline {
         Some(Self {
             stages: Arc::new(stages),
             backend_type: backend,
+            remote_index: deps.remote_index.clone(),
         })
     }
 
@@ -649,10 +670,10 @@ impl RequestPipeline {
                     });
                 let mut http_response = axum::Json(response).into_response();
                 if let Some(prediction) = &ctx.state.index_prediction {
-                    if let (Some(client), Some(WorkerSelection::Single { worker })) =
-                        (remote_index::get(), &ctx.state.workers)
+                    if let (Some(handle), Some(WorkerSelection::Single { worker })) =
+                        (self.remote_index.as_ref(), &ctx.state.workers)
                     {
-                        client.publish_placement(
+                        handle.client().publish_placement(
                             &prediction.model,
                             prediction.block_size as u32,
                             worker.url(),
@@ -1618,7 +1639,7 @@ mod alias_pipeline_tests {
             .unwrap();
 
         let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin));
-        let deps = PipelineDeps::pair(worker_registry.clone(), policy_registry, None);
+        let deps = PipelineDeps::pair(worker_registry.clone(), policy_registry, None, None);
         let pipeline = RequestPipeline::build(Endpoint::Chat, Mode::PrefillDecode, &deps).unwrap();
         let components = Arc::new(SharedComponents {
             tokenizer_registry,

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -46,7 +46,7 @@ use super::{
         },
         streaming,
     },
-    utils,
+    remote_index, utils,
     utils::error_type_from_status,
 };
 use crate::{
@@ -622,7 +622,38 @@ impl RequestPipeline {
                     metrics_labels::ENDPOINT_GENERATE,
                     start.elapsed(),
                 );
-                axum::Json(response).into_response()
+                // Remote-index bookkeeping, after the request actually
+                // completed (selection is not dispatch: shed/retry paths
+                // must not create phantom placements): publish the served
+                // prefix and echo the prediction so the harness can
+                // separate index error from policy spill.
+                let mut http_response = axum::Json(response).into_response();
+                if let Some(prediction) = &ctx.state.index_prediction {
+                    if let (Some(client), Some(WorkerSelection::Single { worker })) =
+                        (remote_index::get(), &ctx.state.workers)
+                    {
+                        client.publish_placement(
+                            &prediction.model,
+                            prediction.block_size as u32,
+                            worker.url(),
+                            &prediction.content_hashes,
+                        );
+                        Metrics::record_remote_index_publish();
+                        let predicted_tokens = prediction
+                            .scores
+                            .iter()
+                            .find(|(url, _)| url == worker.url())
+                            .map_or(0, |(_, blocks)| *blocks as usize * prediction.block_size);
+                        let headers = http_response.headers_mut();
+                        if let Ok(value) = predicted_tokens.to_string().parse() {
+                            headers.insert("x-smg-index-predicted-tokens", value);
+                        }
+                        if let Ok(value) = prediction.source.parse() {
+                            headers.insert("x-smg-index-source", value);
+                        }
+                    }
+                }
+                http_response
             }
             Some(
                 response_type @ (FinalResponse::Chat(_)

--- a/model_gateway/src/routers/grpc/remote_index.rs
+++ b/model_gateway/src/routers/grpc/remote_index.rs
@@ -1,36 +1,49 @@
-//! Remote radix index access (`--kv-indexer-url`), experiment-scoped:
-//! process-global handle set once at startup; M3 plumbs it through
-//! AppContext properly. With the flag unset nothing here runs and every
-//! caller's fast path is a `None` check.
+//! Remote radix index access (`--kv-indexer-url`): a per-process client
+//! handle carried on `AppContext` and threaded into the gRPC pipelines.
+//! With the flag unset the handle is `None` and every caller's fast path
+//! is a `None` check.
 
-use std::{
-    sync::{Arc, OnceLock},
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use radix_index::client::{QueryOutcome, RemoteIndex};
-
-static REMOTE: OnceLock<Arc<RemoteIndex>> = OnceLock::new();
-static BLOCK: OnceLock<usize> = OnceLock::new();
 
 /// Hard deadline for the routing-time overlap query; a miss falls back
 /// to expected-wait for that one decision.
 pub(crate) const QUERY_DEADLINE: Duration = Duration::from_millis(2);
 
-/// Idempotent: the first URL wins (one client per process). `block_size`
-/// is the KEYSPACE block size — the engine-side page size the index was
-/// fed at (worker events / bridge `--block-size`), not the routing block.
-pub(crate) fn init(url: &str, block_size: usize) {
-    let _ = BLOCK.set(block_size.max(1));
-    let _ = REMOTE.set(RemoteIndex::connect(url.to_string()));
+/// The connected remote-index client plus the keyspace block size it was
+/// configured for. One per process, owned by `AppContext`.
+pub struct RemoteIndexHandle {
+    client: Arc<RemoteIndex>,
+    block_size: usize,
 }
 
-pub(crate) fn block_size() -> usize {
-    BLOCK.get().copied().unwrap_or(128)
+impl RemoteIndexHandle {
+    /// `block_size` is the KEYSPACE block size — the engine-side page
+    /// size the index was fed at (worker events / bridge `--block-size`),
+    /// not the routing block.
+    pub fn connect(url: &str, block_size: usize) -> Arc<Self> {
+        Arc::new(Self {
+            client: RemoteIndex::connect(url.to_string()),
+            block_size: block_size.max(1),
+        })
+    }
+
+    pub(crate) fn client(&self) -> &RemoteIndex {
+        &self.client
+    }
+
+    pub(crate) fn block_size(&self) -> usize {
+        self.block_size
+    }
 }
 
-pub(crate) fn get() -> Option<&'static Arc<RemoteIndex>> {
-    REMOTE.get()
+impl std::fmt::Debug for RemoteIndexHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteIndexHandle")
+            .field("block_size", &self.block_size)
+            .finish_non_exhaustive()
+    }
 }
 
 /// What the selection-stage prefetch resolved, kept on the request

--- a/model_gateway/src/routers/grpc/remote_index.rs
+++ b/model_gateway/src/routers/grpc/remote_index.rs
@@ -1,0 +1,58 @@
+//! Remote radix index access (`--kv-indexer-url`), experiment-scoped:
+//! process-global handle set once at startup; M3 plumbs it through
+//! AppContext properly. With the flag unset nothing here runs and every
+//! caller's fast path is a `None` check.
+
+use std::{
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
+
+use radix_index::client::{QueryOutcome, RemoteIndex};
+
+static REMOTE: OnceLock<Arc<RemoteIndex>> = OnceLock::new();
+static BLOCK: OnceLock<usize> = OnceLock::new();
+
+/// Hard deadline for the routing-time overlap query; a miss falls back
+/// to expected-wait for that one decision.
+pub(crate) const QUERY_DEADLINE: Duration = Duration::from_millis(2);
+
+/// Idempotent: the first URL wins (one client per process). `block_size`
+/// is the KEYSPACE block size — the engine-side page size the index was
+/// fed at (worker events / bridge `--block-size`), not the routing block.
+pub(crate) fn init(url: &str, block_size: usize) {
+    let _ = BLOCK.set(block_size.max(1));
+    let _ = REMOTE.set(RemoteIndex::connect(url.to_string()));
+}
+
+pub(crate) fn block_size() -> usize {
+    BLOCK.get().copied().unwrap_or(128)
+}
+
+pub(crate) fn get() -> Option<&'static Arc<RemoteIndex>> {
+    REMOTE.get()
+}
+
+/// What the selection-stage prefetch resolved, kept on the request
+/// context for the placement publish and the response echo headers.
+#[derive(Debug, Clone)]
+pub(crate) struct IndexPrediction {
+    /// remote_hit | remote_empty | remote_timeout | remote_disconnected
+    pub source: &'static str,
+    /// Per-holder (url, matched blocks) as answered (empty on non-hit).
+    pub scores: Vec<(String, u32)>,
+    pub block_size: usize,
+    /// The request prefix's content hashes (block-aligned from 0),
+    /// republished as the placement chain after successful dispatch.
+    pub content_hashes: Vec<u64>,
+    pub model: String,
+}
+
+pub(crate) fn outcome_label(outcome: &QueryOutcome) -> &'static str {
+    match outcome {
+        QueryOutcome::Scores(_) => "remote_hit",
+        QueryOutcome::Empty => "remote_empty",
+        QueryOutcome::Timeout => "remote_timeout",
+        QueryOutcome::Disconnected => "remote_disconnected",
+    }
+}

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -372,6 +372,7 @@ impl GrpcRouter {
             ctx.configured_tool_parser.clone(),
             ctx.configured_reasoning_parser.clone(),
             ctx.rate_limit_manager.clone(),
+            ctx.remote_index.clone(),
         );
         // Deps for the parser-free endpoints (completion/embeddings/classify).
         // Only completion's stage list actually reads `rate_limit_manager`;
@@ -380,6 +381,7 @@ impl GrpcRouter {
             worker_registry.clone(),
             policy_registry.clone(),
             ctx.rate_limit_manager.clone(),
+            ctx.remote_index.clone(),
         );
 
         // Present in every mode: chat/generate, messages, completion.

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1178,6 +1178,7 @@ mod tests {
             )),
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: None,
+            remote_index: None,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,

--- a/model_gateway/src/workflow/steps/local/drain_workers.rs
+++ b/model_gateway/src/workflow/steps/local/drain_workers.rs
@@ -178,6 +178,7 @@ mod tests {
             worker_service: Arc::new(WorkerService::new(registry, job_queue, router_config)),
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: None,
+            remote_index: None,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,

--- a/model_gateway/src/workflow/steps/local/update_worker_properties.rs
+++ b/model_gateway/src/workflow/steps/local/update_worker_properties.rs
@@ -262,6 +262,7 @@ mod tests {
             worker_service: Arc::new(WorkerService::new(registry, job_queue, router_config)),
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: None,
+            remote_index: None,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,

--- a/model_gateway/src/workflow/steps/shared/update_policies.rs
+++ b/model_gateway/src/workflow/steps/shared/update_policies.rs
@@ -153,8 +153,12 @@ impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for UpdatePolicie
                     .init_cache_aware_policy(&model_id, &all_workers);
             }
 
-            // Start KV event subscription for gRPC workers with cache_aware policy
-            if cache_aware {
+            // Start KV event subscription for gRPC workers with cache_aware
+            // policy — unless a remote radix index is configured, which
+            // REPLACES per-gateway indexing (that duplication is the memory
+            // cost the remote index exists to remove, and a warm local
+            // index would silently absorb remote misses).
+            if cache_aware && crate::routers::grpc::remote_index::get().is_none() {
                 if let Some(ref monitor) = app_context.kv_event_monitor {
                     if *worker.connection_mode() == ConnectionMode::Grpc {
                         monitor.on_worker_added(worker).await;

--- a/model_gateway/src/workflow/steps/shared/update_policies.rs
+++ b/model_gateway/src/workflow/steps/shared/update_policies.rs
@@ -9,7 +9,6 @@ use wfaas::{
 };
 
 use crate::{
-    routers::grpc::remote_index,
     worker::{ConnectionMode, Worker},
     workflow::data::WorkerRegistrationData,
 };
@@ -159,7 +158,7 @@ impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for UpdatePolicie
             // REPLACES per-gateway indexing (that duplication is the memory
             // cost the remote index exists to remove, and a warm local
             // index would silently absorb remote misses).
-            if cache_aware && remote_index::get().is_none() {
+            if cache_aware && app_context.remote_index.is_none() {
                 if let Some(ref monitor) = app_context.kv_event_monitor {
                     if *worker.connection_mode() == ConnectionMode::Grpc {
                         monitor.on_worker_added(worker).await;

--- a/model_gateway/src/workflow/steps/shared/update_policies.rs
+++ b/model_gateway/src/workflow/steps/shared/update_policies.rs
@@ -9,6 +9,7 @@ use wfaas::{
 };
 
 use crate::{
+    routers::grpc::remote_index,
     worker::{ConnectionMode, Worker},
     workflow::data::WorkerRegistrationData,
 };
@@ -158,7 +159,7 @@ impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for UpdatePolicie
             // REPLACES per-gateway indexing (that duplication is the memory
             // cost the remote index exists to remove, and a warm local
             // index would silently absorb remote misses).
-            if cache_aware && crate::routers::grpc::remote_index::get().is_none() {
+            if cache_aware && remote_index::get().is_none() {
                 if let Some(ref monitor) = app_context.kv_event_monitor {
                     if *worker.connection_mode() == ConnectionMode::Grpc {
                         monitor.on_worker_added(worker).await;


### PR DESCRIPTION
> [!NOTE]
> **WIP / experiment branch — not ready for review.** Every commit is pushed here as it lands. Stacked on `perf/generate-scale-sim` (this PR's base), which must merge first. Product code only — the benchmark harness lives in #2373 (stacked on this branch); no benchmark reports are checked in anywhere.

## What this is

A shared radix membership index for cache-aware routing: gateways ask "which worker already holds the longest prefix of this request?" against one stateful service instead of each gateway building and syncing its own tree.

- **`crates/radix_tree`** — the index data structure, built ground-up to replace the service's original import of the gateway's `kv_index` indexer. Chains stored as contiguous data shared by every holder, membership as maximal runs over hash-consed holder sets, one entry probe per query, exact (collision-immune) matching, generational holder lifecycle. Two cores behind one contract: the chain-native primary (`RadixTree`) and the first-generation flat layout (`FlatTree`), both continuously asserted equal to a reference model. Spec, design note, and verification record live in the crate (`SPEC.md`, `R3-DESIGN.md`, `VERIFICATION.md`, `README.md`).
- **`crates/radix_index`** — the service: keyspace engine on `RadixTree` (epochs, event vs placement feeds, feed authority, holder-granular TTL, runaway-capacity protection), gRPC Publish/Subscribe/Pull, state-change-gated peer relay, bootstrap, admin plane (`/metrics`, `/healthz`, `/readyz`), graceful shutdown, service-owned wire-hash module pinned by golden vectors, versioned hash scheme on the wire. `kv_index` remains only as a dev-dependency test oracle; the production gateway crate is untouched.
- **Gateway seam** behind `--kv-indexer-url`: routing-time overlap prefetch (2 ms deadline, fast-fail while disconnected) feeding cache_aware, placement publish of the prompt⊕output chain on completion. Flag off = byte-identical behavior.

## Verification (all evidence in `crates/radix_tree/VERIFICATION.md`)

Harness-first: a representationally complete reference model, differential + chaos fuzz (10,000 seeds green; model equality, full-state audits, deterministic replay), adversarial review passes, and fault drills on the sim rig — partition (severed TCP proxies), wedged replica, kill/relaunch, flap, scale-up under load, forced relay overflow — all zero request errors with measured divergence bounds. Ten real bugs were found by these instruments and fixed with regression locks, including one production-service protocol bug (symmetric-peer relay echo) and a capacity/eviction race caught by the end-to-end leg.

## Measured

| pinned workload, 12.8M blocks / 256 workers | old `kv_index` indexer (+glue) | `RadixTree` |
|---|---|---|
| memory per tracked block | 166.7 B | **26.9 B** |
| worst cell (depth 78 × 64 workers) cold p99 | 6.0 µs (count-skip heuristic) | **7.6 µs exact** |
| single-worker query p50 | 917 ns | **292 ns** |
| writes (mixed stream) | 5.5M blocks/s | 4.6M blocks/s |
| at 128M blocks: worst-cell p99 | 29 µs | **8.0 µs** |

End-to-end on the sim rig (placement feed, no KV events): follow-up cached **0.9433** vs 0.9398 for the old stack — statistically tied with event-fed ground truth (0.9423) — prediction error p95 **0 tokens**, zero request errors. 15-minute churn soak: RSS flat.

## Reading order

1. `crates/radix_tree`: `README.md` → `SPEC.md` → `src/chain.rs` (primary core) → `tests/` (the referee)
2. `crates/radix_index`: `README.md` → `engine.rs` → `server.rs` / `client.rs` / `bridge.rs` → `wire_hash.rs`
3. Gateway seam: `model_gateway/src/routers/grpc/remote_index.rs` → `worker_selection.rs` prefetch → `pipeline.rs` placement publish

Known limits (documented in `VERIFICATION.md`): single-machine validation only — real-fabric partitions, hundreds-of-gateways fan-in, and days-scale churn need a staging soak; no auth/TLS story yet on the gRPC surface; dynamic replica membership beyond pre-configured peers is a design backlog item.
