### PR TITLE
fix(discovery): propagate PD KV metadata from Kubernetes

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -507,8 +507,7 @@ struct Router {
     worker_startup_delay: u64,
     worker_ports_annotation: String,
     /// DP engines per startup ZMQ worker (grouped worker; None/1 = ungrouped).
-    /// Appended last: positional constructor compatibility (see the field
-    /// ordering rule on this struct's signature).
+    /// Positional slot preserved; new constructor arguments belong at the signature tail.
     zmq_engine_count: Option<usize>,
     overlap_decay: f32,
     selection_temperature: f32,
@@ -526,6 +525,8 @@ struct Router {
     worker_overload_protection: bool,
     disable_load_monitoring: bool,
     max_buffered_request_bytes: u64,
+    kv_connector_annotation: String,
+    kv_engine_id_annotation: String,
 }
 
 impl Router {
@@ -728,6 +729,8 @@ impl Router {
                 decode_selector: self.decode_selector.clone(),
                 bootstrap_port_annotation: self.bootstrap_port_annotation.clone(),
                 worker_ports_annotation: self.worker_ports_annotation.clone(),
+                kv_connector_annotation: self.kv_connector_annotation.clone(),
+                kv_engine_id_annotation: self.kv_engine_id_annotation.clone(),
                 router_selector: self.router_selector.clone(),
                 router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
                 model_id_source: self.model_id_from.clone(),
@@ -1088,6 +1091,8 @@ impl Router {
         worker_overload_protection = false,
         disable_load_monitoring = false,
         max_buffered_request_bytes = 1_048_576,
+        kv_connector_annotation = String::from("smg.ai/kv-connector"),
+        kv_engine_id_annotation = String::from("smg.ai/kv-engine-id"),
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1238,6 +1243,8 @@ impl Router {
         worker_overload_protection: bool,
         disable_load_monitoring: bool,
         max_buffered_request_bytes: u64,
+        kv_connector_annotation: String,
+        kv_engine_id_annotation: String,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1402,6 +1409,8 @@ impl Router {
             worker_overload_protection,
             disable_load_monitoring,
             max_buffered_request_bytes,
+            kv_connector_annotation,
+            kv_engine_id_annotation,
         })
     }
 
@@ -1441,6 +1450,8 @@ impl Router {
                 decode_selector: self.decode_selector.clone(),
                 bootstrap_port_annotation: self.bootstrap_port_annotation.clone(),
                 worker_ports_annotation: self.worker_ports_annotation.clone(),
+                kv_connector_annotation: self.kv_connector_annotation.clone(),
+                kv_engine_id_annotation: self.kv_engine_id_annotation.clone(),
                 router_selector: self.router_selector.clone(),
                 router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
                 model_id_source,

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -263,6 +263,11 @@ class Router:
             ports (comma-separated) for pods running multiple engine servers.
             Absent = one worker at service_discovery_port. Default:
             'smg.ai/worker-ports'
+        kv_connector_annotation: Kubernetes annotation containing the vLLM KV
+            connector name. Changes apply after the Pod is replaced. Default:
+            'smg.ai/kv-connector'
+        kv_engine_id_annotation: Kubernetes annotation containing KV engine IDs,
+            aligned with worker_ports_annotation. Default: 'smg.ai/kv-engine-id'
         request_timeout_secs: Request timeout in seconds. Default: 600
         max_concurrent_requests: Maximum number of concurrent requests allowed for
             rate limiting. Default: 256

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -247,6 +247,8 @@ class RouterArgs:
     # Most bytes the router may buffer for a request it holds only to keep
     # it retryable; larger eligible requests stream and forfeit router retries
     max_buffered_request_bytes: int = 1048576
+    kv_connector_annotation: str = "smg.ai/kv-connector"
+    kv_engine_id_annotation: str = "smg.ai/kv-engine-id"
 
     @staticmethod
     def add_cli_args(
@@ -1676,6 +1678,8 @@ class RouterArgs:
         # Mooncake-specific annotation
         args_dict["bootstrap_port_annotation"] = "sglang.ai/bootstrap-port"
         args_dict["worker_ports_annotation"] = "smg.ai/worker-ports"
+        args_dict["kv_connector_annotation"] = "smg.ai/kv-connector"
+        args_dict["kv_engine_id_annotation"] = "smg.ai/kv-engine-id"
 
         # Parse control plane API keys
         args_dict["control_plane_api_keys"] = cls._parse_control_plane_api_keys(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1413,6 +1413,8 @@ class TestRouterArgsFieldOrder:
         "worker_overload_protection",
         "disable_load_monitoring",
         "max_buffered_request_bytes",
+        "kv_connector_annotation",
+        "kv_engine_id_annotation",
     ]
 
     def test_complete_field_sequence_is_frozen(self):
@@ -1445,6 +1447,8 @@ class TestRouterArgsFieldOrder:
             "worker_overload_protection",
             "disable_load_monitoring",
             "max_buffered_request_bytes",
+            "kv_connector_annotation",
+            "kv_engine_id_annotation",
         ):
             assert names.index(appended) > marker, (
                 f"{appended} must be appended after worker_startup_delay to "

--- a/bindings/python/tests/test_router_config.py
+++ b/bindings/python/tests/test_router_config.py
@@ -237,6 +237,8 @@ class TestRouterConfigValidation:
         assert args.decode_selector == {"app": "decode"}
         assert args.bootstrap_port_annotation == "sglang.ai/bootstrap-port"
         assert args.worker_ports_annotation == "smg.ai/worker-ports"
+        assert args.kv_connector_annotation == "smg.ai/kv-connector"
+        assert args.kv_engine_id_annotation == "smg.ai/kv-engine-id"
 
     def test_prometheus_config_validation(self):
         """Test Prometheus configuration validation."""

--- a/e2e_test/kind_discovery/test_kind_discovery.py
+++ b/e2e_test/kind_discovery/test_kind_discovery.py
@@ -389,6 +389,8 @@ class TestKindPDDisaggregation:
                 {
                     "smg.ai/worker-ports": "29600,29601",
                     "sglang.ai/bootstrap-port": "29700,29701",
+                    "smg.ai/kv-connector": "MooncakeConnector",
+                    "smg.ai/kv-engine-id": "prefill-0,prefill-1",
                 },
                 probe_port=29600,
                 extra_labels={"role": "prefill"},
@@ -407,7 +409,11 @@ class TestKindPDDisaggregation:
                     "--model",
                     "kind-e2e-model",
                 ],
-                {"smg.ai/worker-ports": "29610,29611"},
+                {
+                    "smg.ai/worker-ports": "29610,29611",
+                    "smg.ai/kv-connector": "NixlConnector",
+                    "smg.ai/kv-engine-id": "decode-0,decode-1",
+                },
                 probe_port=29610,
                 extra_labels={"role": "decode"},
             )
@@ -438,6 +444,12 @@ class TestKindPDDisaggregation:
         assert by_port["29600"].get("bootstrap_port") == 29700
         assert by_port["29601"].get("bootstrap_port") == 29701
         assert "bootstrap_port" not in by_port["29610"]
+        assert by_port["29600"]["kv_connector"] == "MooncakeConnector"
+        assert by_port["29600"]["kv_engine_id"] == "prefill-0"
+        assert by_port["29601"]["kv_engine_id"] == "prefill-1"
+        assert by_port["29610"]["kv_connector"] == "NixlConnector"
+        assert by_port["29610"]["kv_engine_id"] == "decode-0"
+        assert by_port["29611"]["kv_engine_id"] == "decode-1"
 
         kubectl("delete", "pod", "prefill-0", "decode-0", "--grace-period=0", "--force")
         gateway.wait_for_count(0, "PD fleet unwound")

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -862,6 +862,10 @@ pub struct DiscoveryConfig {
     /// Absent on a pod = single worker at `port`.
     #[serde(default = "default_worker_ports_annotation")]
     pub worker_ports_annotation: String,
+    #[serde(default = "default_kv_connector_annotation")]
+    pub kv_connector_annotation: String,
+    #[serde(default = "default_kv_engine_id_annotation")]
+    pub kv_engine_id_annotation: String,
     /// Router node discovery for HA (Kubernetes label selector)
     #[serde(default)]
     pub router_selector: HashMap<String, String>,
@@ -881,6 +885,14 @@ fn default_worker_ports_annotation() -> String {
     "smg.ai/worker-ports".to_string()
 }
 
+fn default_kv_connector_annotation() -> String {
+    "smg.ai/kv-connector".to_string()
+}
+
+fn default_kv_engine_id_annotation() -> String {
+    "smg.ai/kv-engine-id".to_string()
+}
+
 impl Default for DiscoveryConfig {
     fn default() -> Self {
         Self {
@@ -894,6 +906,8 @@ impl Default for DiscoveryConfig {
             decode_selector: HashMap::new(),
             bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
             worker_ports_annotation: default_worker_ports_annotation(),
+            kv_connector_annotation: default_kv_connector_annotation(),
+            kv_engine_id_annotation: default_kv_engine_id_annotation(),
             router_selector: HashMap::new(),
             router_mesh_port_annotation: default_router_mesh_port_annotation(),
             model_id_source: None,
@@ -1843,6 +1857,8 @@ mod tests {
         assert!(config.prefill_selector.is_empty());
         assert!(config.decode_selector.is_empty());
         assert_eq!(config.bootstrap_port_annotation, "sglang.ai/bootstrap-port");
+        assert_eq!(config.kv_connector_annotation, "smg.ai/kv-connector");
+        assert_eq!(config.kv_engine_id_annotation, "smg.ai/kv-engine-id");
     }
 
     #[test]
@@ -1862,6 +1878,8 @@ mod tests {
             decode_selector: selector.clone(),
             bootstrap_port_annotation: "custom.io/port".to_string(),
             worker_ports_annotation: "smg.ai/worker-ports".to_string(),
+            kv_connector_annotation: "custom.io/kv-connector".to_string(),
+            kv_engine_id_annotation: "custom.io/kv-engine-id".to_string(),
             router_selector: HashMap::new(),
             router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
             model_id_source: None,
@@ -2143,6 +2161,8 @@ mod tests {
                 decode_selector: selectors,
                 bootstrap_port_annotation: "mycompany.io/bootstrap".to_string(),
                 worker_ports_annotation: "smg.ai/worker-ports".to_string(),
+                kv_connector_annotation: "smg.ai/kv-connector".to_string(),
+                kv_engine_id_annotation: "smg.ai/kv-engine-id".to_string(),
                 router_selector: HashMap::new(),
                 router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
                 model_id_source: None,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1651,6 +1651,8 @@ impl CliArgs {
                 decode_selector: Self::parse_selector(&self.decode_selector),
                 bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
                 worker_ports_annotation: "smg.ai/worker-ports".to_string(),
+                kv_connector_annotation: "smg.ai/kv-connector".to_string(),
+                kv_engine_id_annotation: "smg.ai/kv-engine-id".to_string(),
                 router_selector: Self::parse_selector(&self.router_selector),
                 router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
                 model_id_source: self.model_id_from.clone(),
@@ -1895,16 +1897,30 @@ impl CliArgs {
     fn to_server_config(&self, router_config: RouterConfig) -> ConfigResult<ServerConfig> {
         let service_discovery_config = if self.service_discovery {
             // Get router discovery config from router_config.discovery if available
-            let (router_selector, router_mesh_port_annotation) = router_config
+            let (
+                router_selector,
+                router_mesh_port_annotation,
+                kv_connector_annotation,
+                kv_engine_id_annotation,
+            ) = router_config
                 .discovery
                 .as_ref()
                 .map(|d| {
                     (
                         d.router_selector.clone(),
                         d.router_mesh_port_annotation.clone(),
+                        d.kv_connector_annotation.clone(),
+                        d.kv_engine_id_annotation.clone(),
                     )
                 })
-                .unwrap_or_else(|| (HashMap::new(), "sglang.ai/mesh-port".to_string()));
+                .unwrap_or_else(|| {
+                    (
+                        HashMap::new(),
+                        "sglang.ai/mesh-port".to_string(),
+                        "smg.ai/kv-connector".to_string(),
+                        "smg.ai/kv-engine-id".to_string(),
+                    )
+                });
 
             let model_id_source = self
                 .model_id_from
@@ -1936,6 +1952,8 @@ impl CliArgs {
                 decode_selector: Self::parse_selector(&self.decode_selector),
                 bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
                 worker_ports_annotation: "smg.ai/worker-ports".to_string(),
+                kv_connector_annotation,
+                kv_engine_id_annotation,
                 router_selector,
                 router_mesh_port_annotation,
                 model_id_source,

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -27,7 +27,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     app_context::AppContext,
     observability::metrics::{metrics_labels, Metrics},
-    worker::WorkerOrigin,
+    worker::{WorkerOrigin, MOONCAKE_CONNECTOR, NIXL_CONNECTOR},
     workflow::{Job, WorkerRegistrationMode},
 };
 
@@ -101,6 +101,9 @@ pub struct ServiceDiscoveryConfig {
     /// Annotation listing the pod's worker data ports (comma-separated).
     /// Absent = single worker at `port`.
     pub worker_ports_annotation: String,
+    /// KV metadata is captured at worker registration; replace a Pod after changing it.
+    pub kv_connector_annotation: String,
+    pub kv_engine_id_annotation: String,
     // Router node discovery for mesh
     pub router_selector: HashMap<String, String>,
     pub router_mesh_port_annotation: String,
@@ -195,6 +198,8 @@ impl Default for ServiceDiscoveryConfig {
             decode_selector: HashMap::new(),
             bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
             worker_ports_annotation: "smg.ai/worker-ports".to_string(),
+            kv_connector_annotation: "smg.ai/kv-connector".to_string(),
+            kv_engine_id_annotation: "smg.ai/kv-engine-id".to_string(),
             router_selector: HashMap::new(),
             router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
             model_id_source: None,
@@ -228,6 +233,8 @@ pub struct PodInfo {
     pub ports: Vec<u16>,
     /// Per-port bootstrap ports (Encode/Prefill only), aligned with `ports`.
     pub bootstrap_ports: Vec<Option<u16>>,
+    pub kv_connector: Option<String>,
+    pub kv_engine_ids: Vec<Option<String>>,
     pub is_router: bool,
     pub mesh_port: Option<u16>,
     pub model_id_override: Option<String>,
@@ -318,6 +325,20 @@ impl PodInfo {
         } else {
             vec![None; ports.len()]
         };
+        let kv_connector = config.and_then(|config| {
+            let connector = annotation_value(pod, &config.kv_connector_annotation)?;
+            if connector != MOONCAKE_CONNECTOR && connector != NIXL_CONNECTOR {
+                warn!(
+                    "Pod {}: {} annotation '{}' is not a connector with explicit PD handling; \
+                     using passthrough behavior",
+                    name, config.kv_connector_annotation, connector
+                );
+            }
+            Some(connector.to_string())
+        });
+        let kv_engine_ids = config
+            .map(|config| resolve_kv_engine_ids(&name, pod, config, ports.len()))
+            .unwrap_or_else(|| vec![None; ports.len()]);
 
         // Check if this is a router pod
         let is_router = if let Some(config) = config {
@@ -356,6 +377,8 @@ impl PodInfo {
             pod_type,
             ports,
             bootstrap_ports,
+            kv_connector,
+            kv_engine_ids,
             is_router,
             mesh_port,
             model_id_override,
@@ -405,6 +428,42 @@ fn resolve_worker_ports(pod_name: &str, pod: &Pod, config: &ServiceDiscoveryConf
             vec![config.port]
         }
     }
+}
+
+fn annotation_value<'a>(pod: &'a Pod, key: &str) -> Option<&'a str> {
+    pod.metadata
+        .annotations
+        .as_ref()?
+        .get(key)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+}
+
+/// Resolve one unique KV engine ID per worker port; unlike bootstrap ports,
+/// one ID cannot be broadcast because each engine core owns a distinct ID.
+fn resolve_kv_engine_ids(
+    pod_name: &str,
+    pod: &Pod,
+    config: &ServiceDiscoveryConfig,
+    num_ports: usize,
+) -> Vec<Option<String>> {
+    let Some(raw) = annotation_value(pod, &config.kv_engine_id_annotation) else {
+        return vec![None; num_ports];
+    };
+    let ids: Vec<&str> = raw.split(',').map(str::trim).collect();
+    let mut seen = HashSet::new();
+    if ids.len() != num_ports
+        || ids.iter().any(|id| id.is_empty())
+        || !ids.iter().all(|id| seen.insert(*id))
+    {
+        warn!(
+            "Pod {}: {} annotation '{}' must contain one distinct non-empty ID for each of {} \
+             worker port(s), ignoring",
+            pod_name, config.kv_engine_id_annotation, raw, num_ports
+        );
+        return vec![None; num_ports];
+    }
+    ids.into_iter().map(|id| Some(id.to_string())).collect()
 }
 
 /// Bootstrap ports aligned with the pod's worker ports: a single value applies
@@ -662,6 +721,8 @@ struct DesiredWorker {
     pod_name: String,
     pod_uid: String,
     model_id_override: Option<String>,
+    kv_connector: Option<String>,
+    kv_engine_id: Option<String>,
 }
 
 /// Desired view of the cluster derived from the store snapshot.
@@ -723,6 +784,8 @@ fn compute_desired_state(pods: &[Arc<Pod>], config: &ServiceDiscoveryConfig) -> 
                     pod_name: info.name.clone(),
                     pod_uid: info.uid.clone(),
                     model_id_override: info.model_id_override.clone(),
+                    kv_connector: info.kv_connector.clone(),
+                    kv_engine_id: info.kv_engine_ids.get(index).cloned().flatten(),
                 });
             }
         }
@@ -820,6 +883,8 @@ fn build_worker_spec(desired: &DesiredWorker, app_context: &AppContext) -> Worke
         spec.labels
             .insert("served_model_name".to_string(), model_id.clone());
     }
+    spec.kv_connector.clone_from(&desired.kv_connector);
+    spec.kv_engine_id.clone_from(&desired.kv_engine_id);
     spec.api_key.clone_from(&app_context.router_config.api_key);
     spec.max_connection_attempts = app_context
         .router_config
@@ -1205,6 +1270,8 @@ mod tests {
             decode_selector,
             bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
             worker_ports_annotation: "smg.ai/worker-ports".to_string(),
+            kv_connector_annotation: "smg.ai/kv-connector".to_string(),
+            kv_engine_id_annotation: "smg.ai/kv-engine-id".to_string(),
             router_selector: HashMap::new(),
             router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
             model_id_source: None,
@@ -1273,6 +1340,8 @@ mod tests {
         assert!(config.decode_selector.is_empty());
         assert_eq!(config.bootstrap_port_annotation, "sglang.ai/bootstrap-port");
         assert_eq!(config.worker_ports_annotation, "smg.ai/worker-ports");
+        assert_eq!(config.kv_connector_annotation, "smg.ai/kv-connector");
+        assert_eq!(config.kv_engine_id_annotation, "smg.ai/kv-engine-id");
     }
 
     #[test]
@@ -1457,6 +1526,8 @@ mod tests {
             pod_type: None,
             ports: vec![],
             bootstrap_ports: vec![],
+            kv_connector: None,
+            kv_engine_ids: vec![],
             is_router: false,
             mesh_port: None,
             model_id_override: None,
@@ -1472,6 +1543,8 @@ mod tests {
             pod_type: None,
             ports: vec![],
             bootstrap_ports: vec![],
+            kv_connector: None,
+            kv_engine_ids: vec![],
             is_router: false,
             mesh_port: None,
             model_id_override: None,
@@ -1487,6 +1560,8 @@ mod tests {
             pod_type: None,
             ports: vec![],
             bootstrap_ports: vec![],
+            kv_connector: None,
+            kv_engine_ids: vec![],
             is_router: false,
             mesh_port: None,
             model_id_override: None,
@@ -1536,6 +1611,39 @@ mod tests {
         let info = PodInfo::from_pod(&pod, Some(&config)).unwrap();
         assert_eq!(info.ports, vec![8080, 8081, 8082, 8083]);
         assert_eq!(info.bootstrap_ports, vec![None; 4]);
+    }
+
+    #[test]
+    fn test_from_pod_kv_metadata_aligns_with_worker_ports() {
+        let config = make_regular_config();
+        let pod = pod_with_annotations(
+            "w",
+            &[
+                ("smg.ai/worker-ports", "8080,8081"),
+                ("smg.ai/kv-connector", "MooncakeConnector"),
+                ("smg.ai/kv-engine-id", "engine-0,engine-1"),
+            ],
+        );
+        let info = PodInfo::from_pod(&pod, Some(&config)).unwrap();
+        assert_eq!(info.kv_connector.as_deref(), Some("MooncakeConnector"));
+        assert_eq!(
+            info.kv_engine_ids,
+            vec![Some("engine-0".to_string()), Some("engine-1".to_string())]
+        );
+
+        for invalid_ids in ["shared", "shared,shared"] {
+            let invalid = pod_with_annotations(
+                "w",
+                &[
+                    ("smg.ai/worker-ports", "8080,8081"),
+                    ("smg.ai/kv-connector", "NixlConnector"),
+                    ("smg.ai/kv-engine-id", invalid_ids),
+                ],
+            );
+            let info = PodInfo::from_pod(&invalid, Some(&config)).unwrap();
+            assert_eq!(info.kv_connector.as_deref(), Some("NixlConnector"));
+            assert_eq!(info.kv_engine_ids, vec![None, None]);
+        }
     }
 
     #[test]
@@ -1753,6 +1861,8 @@ mod tests {
             pod_name: "w".to_string(),
             pod_uid: uid.to_string(),
             model_id_override: None,
+            kv_connector: None,
+            kv_engine_id: None,
         }
     }
 
@@ -1787,8 +1897,10 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_actions_noop_when_converged() {
-        let desired = desired_state_of(&[desired_worker("10.0.0.1:8080", "u1")]);
+    fn test_compute_actions_same_uid_metadata_change_is_noop() {
+        let mut worker = desired_worker("10.0.0.1:8080", "u1");
+        worker.kv_connector = Some("NixlConnector".to_string());
+        let desired = desired_state_of(&[worker]);
         let registered = [owned("10.0.0.1:8080", "u1")];
         let actions = compute_actions(&desired, &registered);
         assert!(actions.add.is_empty());
@@ -1924,11 +2036,15 @@ mod tests {
             pod_name: "prefill-0".to_string(),
             pod_uid: "uid-1".to_string(),
             model_id_override: Some("llama".to_string()),
+            kv_connector: Some("MooncakeConnector".to_string()),
+            kv_engine_id: Some("engine-1".to_string()),
         };
         let spec = build_worker_spec(&desired, &app_context);
         assert_eq!(spec.url, "10.0.0.1:8081");
         assert_eq!(spec.worker_type, WorkerType::Prefill);
         assert_eq!(spec.bootstrap_port, Some(9080));
+        assert_eq!(spec.kv_connector.as_deref(), Some("MooncakeConnector"));
+        assert_eq!(spec.kv_engine_id.as_deref(), Some("engine-1"));
         assert_eq!(
             spec.labels.get(POD_NAME_LABEL),
             Some(&"prefill-0".to_string())

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -64,10 +64,7 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
             labels.insert(key.clone(), value.clone());
         }
 
-        // Extract KV transfer config (dedicated metadata fields, not labels)
-        let kv_connector = labels.remove("kv_connector");
-        let kv_role = labels.remove("kv_role");
-        let kv_engine_id = labels.remove("kv_engine_id").filter(|s| !s.is_empty());
+        let (kv_connector, kv_role, kv_engine_id) = take_kv_transfer_metadata(config, &mut labels);
 
         let model_id = resolve_model_id(config, &labels);
         // ZMQ EngineCore does not report a served model name over the wire, so a
@@ -303,6 +300,29 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         false
     }
+}
+
+fn take_kv_transfer_metadata(
+    config: &WorkerSpec,
+    labels: &mut HashMap<String, String>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let connector_label = labels.remove("kv_connector");
+    let role = labels.remove("kv_role");
+    let engine_id_label = labels.remove("kv_engine_id");
+    (
+        config
+            .kv_connector
+            .clone()
+            .filter(|s| !s.is_empty())
+            .or(connector_label),
+        role,
+        config
+            .kv_engine_id
+            .clone()
+            .filter(|s| !s.is_empty())
+            .or(engine_id_label)
+            .filter(|s| !s.is_empty()),
+    )
 }
 
 /// Resolve the canonical model ID before aliases are applied.
@@ -741,6 +761,39 @@ fn validate_zmq_dp(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dedicated_kv_metadata_wins_and_legacy_labels_are_removed() {
+        let mut spec = WorkerSpec::new("http://worker:8080");
+        spec.kv_connector = Some("NixlConnector".to_string());
+        spec.kv_engine_id = Some("engine-direct".to_string());
+        let mut labels = HashMap::from([
+            ("kv_connector".to_string(), "legacy".to_string()),
+            ("kv_role".to_string(), "kv_consumer".to_string()),
+            ("kv_engine_id".to_string(), "engine-legacy".to_string()),
+        ]);
+
+        let metadata = take_kv_transfer_metadata(&spec, &mut labels);
+        assert_eq!(
+            metadata,
+            (
+                Some("NixlConnector".to_string()),
+                Some("kv_consumer".to_string()),
+                Some("engine-direct".to_string()),
+            )
+        );
+        assert!(labels.is_empty());
+
+        spec.kv_connector = Some(String::new());
+        spec.kv_engine_id = Some(String::new());
+        labels.insert("kv_connector".to_string(), "legacy".to_string());
+        labels.insert("kv_engine_id".to_string(), "engine-legacy".to_string());
+        let metadata = take_kv_transfer_metadata(&spec, &mut labels);
+        assert_eq!(
+            (metadata.0.as_deref(), metadata.2.as_deref()),
+            (Some("legacy"), Some("engine-legacy"))
+        );
+    }
 
     #[test]
     fn dp_expansion_pins_only_multi_rank_widths() {

--- a/model_gateway/tests/k8s_discovery_test.rs
+++ b/model_gateway/tests/k8s_discovery_test.rs
@@ -781,7 +781,15 @@ async fn same_url_pod_replacement_reregisters_with_new_uid() {
     let app_context = test_context().await;
     let (_engine, port) = start_mock_engine().await;
 
-    fake.apply_pod(worker_pod("stable-0", "uid-gen1", &port.to_string(), true));
+    let mut first = worker_pod("stable-0", "uid-gen1", &port.to_string(), true);
+    first.metadata.annotations.as_mut().unwrap().extend([
+        (
+            "smg.ai/kv-connector".to_string(),
+            "NixlConnector".to_string(),
+        ),
+        ("smg.ai/kv-engine-id".to_string(), "engine-gen1".to_string()),
+    ]);
+    fake.apply_pod(first);
     let handle = start_service_discovery_with_client(
         fake.client(),
         discovery_config(),
@@ -796,12 +804,38 @@ async fn same_url_pod_replacement_reregisters_with_new_uid() {
         "first generation registered",
     )
     .await;
+    let first = app_context.worker_registry.get_all().pop().unwrap();
+    assert_eq!(
+        first.metadata().spec.kv_connector.as_deref(),
+        Some("NixlConnector")
+    );
+    assert_eq!(
+        first.metadata().spec.kv_engine_id.as_deref(),
+        Some("engine-gen1")
+    );
 
     // Stable-IP restart: same name and URL, new uid.
     fake.delete_pod("stable-0");
-    fake.apply_pod(worker_pod("stable-0", "uid-gen2", &port.to_string(), true));
+    let mut replacement = worker_pod("stable-0", "uid-gen2", &port.to_string(), true);
+    replacement.metadata.annotations.as_mut().unwrap().extend([
+        (
+            "smg.ai/kv-connector".to_string(),
+            "MooncakeConnector".to_string(),
+        ),
+        ("smg.ai/kv-engine-id".to_string(), "engine-gen2".to_string()),
+    ]);
+    fake.apply_pod(replacement);
 
     wait_for_pod_uid(&app_context, port, "uid-gen2", "replacement re-registered").await;
+    let replacement = app_context.worker_registry.get_all().pop().unwrap();
+    assert_eq!(
+        replacement.metadata().spec.kv_connector.as_deref(),
+        Some("MooncakeConnector")
+    );
+    assert_eq!(
+        replacement.metadata().spec.kv_engine_id.as_deref(),
+        Some("engine-gen2")
+    );
 
     handle.abort();
 }


### PR DESCRIPTION
## Description

### Problem

The vLLM PD paths added by #2255 select NIXL or Mooncake from `WorkerSpec.kv_connector` and, for Mooncake, use `WorkerSpec.kv_engine_id`. Kubernetes service discovery currently creates worker specs without either field, so discovered vLLM PD workers silently use passthrough/local recompute even when the serving Pods are configured for KV transfer. Multi-engine Pods also need one engine ID to remain aligned with each discovered worker port.

### Solution

Read two namespaced Pod annotations during Kubernetes discovery and propagate them through the existing registration workflow as dedicated `WorkerSpec` fields:

- `smg.ai/kv-connector`: one connector name shared by every worker in the Pod
- `smg.ai/kv-engine-id`: one value for a single-port Pod, or an ordered comma-separated list whose length exactly matches `smg.ai/worker-ports`

An absent engine-ID annotation leaves every worker's engine ID unset. A misaligned, empty, or duplicate list does the same and emits a warning; it never shifts requests onto the wrong engine. Dedicated spec fields take precedence over the legacy unnamespaced worker labels, while those labels remain backward compatible. The annotations are Pod-start metadata: replace the Pod after changing them so discovery re-registers the worker under a new UID.

Mooncake prefill Pods must also set the existing `bootstrap_port_annotation` (default `sglang.ai/bootstrap-port`) to the port their bootstrap server actually exposes; this PR does not change SMG's existing default-port fallback.

The annotation keys follow the existing `smg.ai/worker-ports` convention and are configurable through `DiscoveryConfig` and the Python `RouterArgs` surface. I am open to maintainer input on the names before this becomes a public convention.

Refs: #2255

## Changes

- propagate connector and per-port engine IDs from Pod annotations through `PodInfo`, desired state, `WorkerSpec`, and local worker creation
- preserve Python positional compatibility by appending the two new `RouterArgs`/PyO3 arguments
- treat empty dedicated metadata as unset so it cannot mask valid legacy labels
- warn on connector names without explicit PD handling while preserving passthrough compatibility
- cover aligned, misaligned, and duplicate multi-port metadata, dedicated-field precedence, Pod-UID replacement, fake-Kubernetes registration, and the existing Kind PD topology

## Test Plan

- `cargo +nightly fmt --all -- --check` — passed on macOS and Linux
- `cargo +1.95.0 test -p smg --lib` — passed on the final Linux tree: 1,891 passed, 5 ignored, 0 failed; the new alignment test also passed on macOS
- `cargo +1.95.0 test -p smg --test k8s_discovery_test` — 21 passed, 0 failed; includes annotation-to-registry propagation and new-UID replacement
- `make python-dev JOBS=18` — passed on Linux
- focused Python tests for argument ordering/defaults — 86 passed, 2 skipped
- `ruff check` on the changed Python files — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed on Linux with OpenCV/NIXL enabled
- Kind discovery E2E — not run locally; the existing `TestKindPDDisaggregation` now asserts all four per-port connector/engine-ID mappings and will run in hosted CI

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
