### PR TITLE
fix(discovery): honor custom KV annotation flags

### DIFF
--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -932,6 +932,16 @@ class RouterArgs:
             ),
         )
         k8s_group.add_argument(
+            f"--{prefix}kv-connector-annotation",
+            type=str,
+            help="vLLM KV connector Pod annotation (default: smg.ai/kv-connector)",
+        )
+        k8s_group.add_argument(
+            f"--{prefix}kv-engine-id-annotation",
+            type=str,
+            help="Per-worker KV engine ID Pod annotation (default: smg.ai/kv-engine-id)",
+        )
+        k8s_group.add_argument(
             f"--{prefix}encode-selector",
             type=str,
             nargs="+",
@@ -1678,8 +1688,6 @@ class RouterArgs:
         # Mooncake-specific annotation
         args_dict["bootstrap_port_annotation"] = "sglang.ai/bootstrap-port"
         args_dict["worker_ports_annotation"] = "smg.ai/worker-ports"
-        args_dict["kv_connector_annotation"] = "smg.ai/kv-connector"
-        args_dict["kv_engine_id_annotation"] = "smg.ai/kv-engine-id"
 
         # Parse control plane API keys
         args_dict["control_plane_api_keys"] = cls._parse_control_plane_api_keys(

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -934,11 +934,13 @@ class RouterArgs:
         k8s_group.add_argument(
             f"--{prefix}kv-connector-annotation",
             type=str,
+            default=RouterArgs.kv_connector_annotation,
             help="vLLM KV connector Pod annotation (default: smg.ai/kv-connector)",
         )
         k8s_group.add_argument(
             f"--{prefix}kv-engine-id-annotation",
             type=str,
+            default=RouterArgs.kv_engine_id_annotation,
             help="Per-worker KV engine ID Pod annotation (default: smg.ai/kv-engine-id)",
         )
         k8s_group.add_argument(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -777,6 +777,10 @@ class TestParseRouterArgs:
             "8080",
             "--service-discovery-namespace",
             "default",
+            "--kv-connector-annotation",
+            "example.com/connector",
+            "--kv-engine-id-annotation",
+            "example.com/engine-id",
         ]
         args_b = [
             "--service-discovery",
@@ -787,6 +791,10 @@ class TestParseRouterArgs:
             "8080",
             "--service-discovery-namespace",
             "default",
+            "--kv-connector-annotation",
+            "example.com/connector",
+            "--kv-engine-id-annotation",
+            "example.com/engine-id",
         ]
 
         for args in [args_a, args_b]:
@@ -796,6 +804,8 @@ class TestParseRouterArgs:
             assert router_args.selector == {"app": "worker", "env": "prod"}
             assert router_args.service_discovery_port == 8080
             assert router_args.service_discovery_namespace == "default"
+            assert router_args.kv_connector_annotation == "example.com/connector"
+            assert router_args.kv_engine_id_annotation == "example.com/engine-id"
 
     def test_repeated_list_flags_accumulate(self):
         """Repeated occurrences of list flags append, matching the Rust CLI."""

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -807,6 +807,12 @@ class TestParseRouterArgs:
             assert router_args.kv_connector_annotation == "example.com/connector"
             assert router_args.kv_engine_id_annotation == "example.com/engine-id"
 
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser)
+        defaults = parser.parse_args([])
+        assert defaults.kv_connector_annotation == RouterArgs.kv_connector_annotation
+        assert defaults.kv_engine_id_annotation == RouterArgs.kv_engine_id_annotation
+
     def test_repeated_list_flags_accumulate(self):
         """Repeated occurrences of list flags append, matching the Rust CLI."""
         router_args = parse_router_args(

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -859,11 +859,13 @@ impl ConfigValidator {
                 &discovery.kv_engine_id_annotation,
             ),
         ] {
-            if value.trim().is_empty() {
+            let trimmed = value.trim();
+            if trimmed.is_empty() || trimmed != value {
                 return Err(ConfigError::InvalidValue {
                     field: field.to_string(),
                     value: value.clone(),
-                    reason: "Annotation name must not be empty".to_string(),
+                    reason: "Annotation name must not be empty or padded with whitespace"
+                        .to_string(),
                 });
             }
         }
@@ -1533,20 +1535,33 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_empty_kv_annotation_name() {
-        let mut config = regular_mode_config();
-        config.discovery = Some(DiscoveryConfig {
-            enabled: true,
-            selector: [("app".to_string(), "worker".to_string())].into(),
-            kv_connector_annotation: " ".to_string(),
-            ..Default::default()
-        });
+    fn test_validate_invalid_kv_annotation_names() {
+        for (field, kv_connector_annotation, kv_engine_id_annotation) in [
+            (
+                "discovery.kv_connector_annotation",
+                " ",
+                "smg.ai/kv-engine-id",
+            ),
+            (
+                "discovery.kv_engine_id_annotation",
+                "smg.ai/kv-connector",
+                " smg.ai/kv-engine-id",
+            ),
+        ] {
+            let mut config = regular_mode_config();
+            config.discovery = Some(DiscoveryConfig {
+                enabled: true,
+                selector: [("app".to_string(), "worker".to_string())].into(),
+                kv_connector_annotation: kv_connector_annotation.to_string(),
+                kv_engine_id_annotation: kv_engine_id_annotation.to_string(),
+                ..Default::default()
+            });
 
-        assert!(matches!(
-            ConfigValidator::validate(&config),
-            Err(ConfigError::InvalidValue { ref field, .. })
-                if field == "discovery.kv_connector_annotation"
-        ));
+            assert!(matches!(
+                ConfigValidator::validate(&config),
+                Err(ConfigError::InvalidValue { field: ref actual, .. }) if actual == field
+            ));
+        }
     }
 
     #[test]

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -849,6 +849,25 @@ impl ConfigValidator {
             });
         }
 
+        for (field, value) in [
+            (
+                "discovery.kv_connector_annotation",
+                &discovery.kv_connector_annotation,
+            ),
+            (
+                "discovery.kv_engine_id_annotation",
+                &discovery.kv_engine_id_annotation,
+            ),
+        ] {
+            if value.trim().is_empty() {
+                return Err(ConfigError::InvalidValue {
+                    field: field.to_string(),
+                    value: value.clone(),
+                    reason: "Annotation name must not be empty".to_string(),
+                });
+            }
+        }
+
         match mode {
             RoutingMode::Regular { .. } => {
                 if discovery.selector.is_empty() {
@@ -1511,6 +1530,23 @@ mod tests {
 
         // Should pass validation since service discovery is enabled
         assert!(ConfigValidator::validate(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_empty_kv_annotation_name() {
+        let mut config = regular_mode_config();
+        config.discovery = Some(DiscoveryConfig {
+            enabled: true,
+            selector: [("app".to_string(), "worker".to_string())].into(),
+            kv_connector_annotation: " ".to_string(),
+            ..Default::default()
+        });
+
+        assert!(matches!(
+            ConfigValidator::validate(&config),
+            Err(ConfigError::InvalidValue { ref field, .. })
+                if field == "discovery.kv_connector_annotation"
+        ));
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -583,6 +583,22 @@ struct CliArgs {
     #[arg(long, help_heading = "Service Discovery (Kubernetes)")]
     service_discovery_namespace: Option<String>,
 
+    /// Pod annotation containing the vLLM KV connector name
+    #[arg(
+        long,
+        default_value = "smg.ai/kv-connector",
+        help_heading = "Service Discovery (Kubernetes)"
+    )]
+    kv_connector_annotation: String,
+
+    /// Pod annotation containing per-worker KV engine IDs
+    #[arg(
+        long,
+        default_value = "smg.ai/kv-engine-id",
+        help_heading = "Service Discovery (Kubernetes)"
+    )]
+    kv_engine_id_annotation: String,
+
     /// Label selector for encode server pods in EPD mode
     #[arg(long, num_args = 0.., help_heading = "Service Discovery (Kubernetes)")]
     encode_selector: Vec<String>,
@@ -1651,8 +1667,8 @@ impl CliArgs {
                 decode_selector: Self::parse_selector(&self.decode_selector),
                 bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
                 worker_ports_annotation: "smg.ai/worker-ports".to_string(),
-                kv_connector_annotation: "smg.ai/kv-connector".to_string(),
-                kv_engine_id_annotation: "smg.ai/kv-engine-id".to_string(),
+                kv_connector_annotation: self.kv_connector_annotation.clone(),
+                kv_engine_id_annotation: self.kv_engine_id_annotation.clone(),
                 router_selector: Self::parse_selector(&self.router_selector),
                 router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
                 model_id_source: self.model_id_from.clone(),
@@ -1917,8 +1933,8 @@ impl CliArgs {
                     (
                         HashMap::new(),
                         "sglang.ai/mesh-port".to_string(),
-                        "smg.ai/kv-connector".to_string(),
-                        "smg.ai/kv-engine-id".to_string(),
+                        self.kv_connector_annotation.clone(),
+                        self.kv_engine_id_annotation.clone(),
                     )
                 });
 
@@ -2360,6 +2376,35 @@ mod tests {
         .to_router_config(vec![], vec![])
         .unwrap();
         assert_eq!(format!("{canonical:?}"), format!("{aliased:?}"));
+    }
+
+    #[test]
+    fn kv_annotation_flags_flow_into_both_configs() {
+        let cli = cli_args_from(&[
+            "--service-discovery",
+            "--selector",
+            "app=worker",
+            "--kv-connector-annotation",
+            "example.com/connector",
+            "--kv-engine-id-annotation",
+            "example.com/engine-id",
+        ]);
+        let router = cli.to_router_config(vec![], vec![]).unwrap();
+        let discovery = router.discovery.as_ref().unwrap();
+        assert_eq!(discovery.kv_connector_annotation, "example.com/connector");
+        assert_eq!(discovery.kv_engine_id_annotation, "example.com/engine-id");
+
+        let server = cli.to_server_config(router).unwrap();
+        let discovery = server.service_discovery_config.as_ref().unwrap();
+        assert_eq!(discovery.kv_connector_annotation, "example.com/connector");
+        assert_eq!(discovery.kv_engine_id_annotation, "example.com/engine-id");
+
+        let defaults = cli_args_from(&["--service-discovery", "--selector", "app=worker"])
+            .to_router_config(vec![], vec![])
+            .unwrap();
+        let defaults = defaults.discovery.as_ref().unwrap();
+        assert_eq!(defaults.kv_connector_annotation, "smg.ai/kv-connector");
+        assert_eq!(defaults.kv_engine_id_annotation, "smg.ai/kv-engine-id");
     }
 
     /// `--worker-auto-recovery` defaults to the `--service-discovery`


### PR DESCRIPTION
## Description

### Problem

smg-project/smg#2358 made the Kubernetes KV annotation names configurable through `DiscoveryConfig` and the Python `RouterArgs` surface, but the Rust and Python CLI conversion paths still replaced custom values with the default `smg.ai/*` keys. An operator selecting custom annotation names would therefore get no discovered KV metadata and no explicit configuration error.

### Solution

Expose `--kv-connector-annotation` and `--kv-engine-id-annotation` in both CLIs, preserve their existing defaults, and forward the configured values through both Rust configuration conversions. Reject blank or whitespace-padded annotation names through the shared discovery validator instead of silently disabling metadata lookup.

The default behavior is unchanged. Newly rejected inputs are empty, whitespace-only, or leading/trailing-whitespace annotation names; none can match the intended Pod metadata key and all previously disabled KV discovery silently.

Refs: smg-project/smg#2358 and https://github.com/smg-project/smg/pull/2358#discussion_r3888814525

## Changes

- add matching Rust and Python CLI flags for both KV annotation names
- preserve custom values through `RouterConfig` and `ServiceDiscoveryConfig`
- validate that configured KV annotation names are non-empty and have no surrounding whitespace
- cover explicit custom values, defaults, both Rust conversion paths, and invalid names for both annotation fields

## Test Plan

- `cargo +nightly fmt --all -- --check` — passed on macOS
- `cargo +1.95.0 test -p smg --bin smg tests::kv_annotation_flags_flow_into_both_configs -- --exact` — passed on macOS and Linux (1/1)
- `cargo +1.95.0 test -p smg test_validate_invalid_kv_annotation_names` — passed on macOS and Linux (1/1)
- `uv run --project bindings/python --extra dev pytest bindings/python/tests/test_arg_parser.py -q` — 57 passed, 1 skipped on macOS
- `make python-dev JOBS=18` — passed on Linux
- `pytest -q bindings/python/tests/test_arg_parser.py` — 57 passed, 1 skipped on Linux
- `cargo +1.95.0 test -p smg --lib` — 1,892 passed, 5 ignored, 0 failed on Linux
- `cargo +1.95.0 test` — passed for the full workspace on Linux; 0 failed across unit, integration, and doc tests
- `cargo +1.95.0 clippy --all-targets --all-features -- -D warnings` — passed on Linux

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated — N/A; CLI help carries the public defaults and the behavior is covered in the PR description
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
