### PR TITLE
fix(python): enable IGW for service discovery

### DIFF
--- a/bindings/python/src/smg/launch_router.py
+++ b/bindings/python/src/smg/launch_router.py
@@ -39,13 +39,18 @@ def launch_router(args: argparse.Namespace | RouterArgs) -> None:
 
         if Router is None:
             raise RuntimeError("Rust Router is not installed")
+
+        if router_args.service_discovery and not router_args.enable_igw:
+            logger.info("IGW mode automatically enabled because service discovery is turned on")
+            router_args.enable_igw = True
+
         router_args._validate_router_args()
 
         # Determine mode for banner
-        if getattr(router_args, "pd_disaggregation", False):
-            mode = "PD Disaggregated"
-        elif getattr(router_args, "enable_igw", False):
+        if getattr(router_args, "enable_igw", False):
             mode = "IGW"
+        elif getattr(router_args, "pd_disaggregation", False):
+            mode = "PD Disaggregated"
         else:
             mode = "Regular"
         print_banner(router_args.host, router_args.port, mode)

--- a/bindings/python/tests/test_startup_sequence.py
+++ b/bindings/python/tests/test_startup_sequence.py
@@ -199,6 +199,7 @@ class TestRouterInitialization:
                         selector=router_args.selector,
                         service_discovery_port=router_args.service_discovery_port,
                         service_discovery_namespace=router_args.service_discovery_namespace,
+                        enable_igw=router_args.enable_igw,
                     )
                 )
                 return mock_router_instance
@@ -213,6 +214,7 @@ class TestRouterInitialization:
             assert captured_args["selector"] == {"app": "worker", "env": "prod"}
             assert captured_args["service_discovery_port"] == 8080
             assert captured_args["service_discovery_namespace"] == "default"
+            assert captured_args["enable_igw"] is True
 
             # Verify router.start() was called
             mock_router_instance.start.assert_called_once()


### PR DESCRIPTION
## Description

### Problem

The Docker router image starts SMG through the Python launcher. Unlike the Rust CLI, that launcher did not enable IGW when Kubernetes service discovery was enabled. As a result, dynamically discovered gRPC workers could register successfully while the initially constructed single-protocol router remained unable to select them.

### Solution

Apply the Rust CLI's existing startup normalization in the Python launcher before argument validation and router construction: service discovery implicitly enables IGW. The startup banner now uses the same IGW-first precedence as the Rust CLI. Consequently, a configuration that combines PD disaggregation with service discovery is intentionally constructed and reported as IGW.

## Changes

- Enable `enable_igw` when `service_discovery` is set in the Python launcher.
- Extend the existing service-discovery startup test to verify the effective value reaches `Router.from_args`.

## Test Plan

- Regression proof: with the baseline launcher restored, `test_service_discovery_config_passed_to_router` fails because `enable_igw` remains false; with this change, the same test passes.
- Python bindings: `297 passed, 4 skipped`.
- `cargo +nightly fmt --all -- --check`: passed.
- `cargo +1.95.0 test`: passed with zero failures across the workspace and doctests.
- `cargo +1.95.0 clippy --all-targets --all-features -- -D warnings`: passed with zero lint warnings or errors.
- `make python-dev`: built and installed the editable Linux x86_64 binding successfully.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated — not needed; this aligns the Python entrypoint with existing CLI behavior and adds no public option.
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
