### PR TITLE
fix(router): preserve disaggregated semantics under IGW

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -662,11 +662,9 @@ impl Router {
             })
         };
 
-        let mode = if self.enable_igw {
-            RoutingMode::Regular {
-                worker_urls: vec![],
-            }
-        } else if matches!(self.backend, BackendType::Openai) {
+        // IGW does not override backend or disaggregated modes; IGW-only keeps
+        // the Python binding's existing empty startup-worker behavior.
+        let mode = if matches!(self.backend, BackendType::Openai) {
             RoutingMode::OpenAI {
                 worker_urls: self.worker_urls.clone(),
             }
@@ -712,7 +710,11 @@ impl Router {
             }
         } else {
             RoutingMode::Regular {
-                worker_urls: self.worker_urls.clone(),
+                worker_urls: if self.enable_igw {
+                    vec![]
+                } else {
+                    self.worker_urls.clone()
+                },
             }
         };
 

--- a/bindings/python/src/smg/launch_router.py
+++ b/bindings/python/src/smg/launch_router.py
@@ -40,12 +40,7 @@ def launch_router(args: argparse.Namespace | RouterArgs) -> None:
         if Router is None:
             raise RuntimeError("Rust Router is not installed")
 
-        if (
-            router_args.service_discovery
-            and not router_args.enable_igw
-            and not router_args.pd_disaggregation
-            and not router_args.epd_disaggregation
-        ):
+        if router_args.service_discovery and not router_args.enable_igw:
             logger.info("IGW mode automatically enabled because service discovery is turned on")
             router_args.enable_igw = True
 

--- a/bindings/python/tests/test_startup_sequence.py
+++ b/bindings/python/tests/test_startup_sequence.py
@@ -221,13 +221,7 @@ class TestRouterInitialization:
 
             # Function returns None; ensure start was invoked
 
-    @pytest.mark.parametrize(
-        ("pd_disaggregation", "epd_disaggregation"),
-        [
-            (True, False),
-            (False, True),
-        ],
-    )
+    @pytest.mark.parametrize("pd_disaggregation,epd_disaggregation", [(True, False), (False, True)])
     def test_disaggregated_service_discovery_enables_igw_without_replacing_mode(
         self, pd_disaggregation, epd_disaggregation
     ):

--- a/bindings/python/tests/test_startup_sequence.py
+++ b/bindings/python/tests/test_startup_sequence.py
@@ -221,12 +221,23 @@ class TestRouterInitialization:
 
             # Function returns None; ensure start was invoked
 
-    def test_pd_service_discovery_does_not_force_igw(self):
-        """PD mode with service discovery keeps PD routing (no IGW auto-enable)."""
+    @pytest.mark.parametrize(
+        ("pd_disaggregation", "epd_disaggregation"),
+        [
+            (True, False),
+            (False, True),
+        ],
+    )
+    def test_disaggregated_service_discovery_enables_igw_without_replacing_mode(
+        self, pd_disaggregation, epd_disaggregation
+    ):
+        """Service discovery enables IGW while preserving PD/EPD flags."""
         args = RouterArgs(
             service_discovery=True,
-            pd_disaggregation=True,
-            prefill_selector={"component": "engine"},
+            pd_disaggregation=pd_disaggregation,
+            epd_disaggregation=epd_disaggregation,
+            encode_selector={"component": "encoder"},
+            prefill_selector={"component": "prefill"},
             decode_selector={"component": "decoder"},
             service_discovery_port=8080,
             service_discovery_namespace="default",
@@ -240,6 +251,7 @@ class TestRouterInitialization:
                 captured_args.update(
                     dict(
                         pd_disaggregation=router_args.pd_disaggregation,
+                        epd_disaggregation=router_args.epd_disaggregation,
                         enable_igw=router_args.enable_igw,
                     )
                 )
@@ -250,8 +262,9 @@ class TestRouterInitialization:
             launch_router(args)
 
             router_mod.from_args.assert_called_once()
-            assert captured_args["pd_disaggregation"] is True
-            assert captured_args["enable_igw"] is False
+            assert captured_args["pd_disaggregation"] is pd_disaggregation
+            assert captured_args["epd_disaggregation"] is epd_disaggregation
+            assert captured_args["enable_igw"] is True
             mock_router_instance.start.assert_called_once()
 
     def test_router_initialization_with_retry_config(self):

--- a/bindings/python/tests/test_validation.py
+++ b/bindings/python/tests/test_validation.py
@@ -319,6 +319,7 @@ class TestConfigurationValidation:
     @pytest.mark.parametrize(
         ("epd_disaggregation", "pd_disaggregation", "expected_mode"),
         [
+            (False, False, "Regular mode"),
             (False, True, "PD mode"),
             (True, False, "EPD mode"),
         ],

--- a/bindings/python/tests/test_validation.py
+++ b/bindings/python/tests/test_validation.py
@@ -335,7 +335,10 @@ class TestConfigurationValidation:
 
         # Empty selectors fail native validation before server startup; the
         # mode-specific error proves IGW did not replace PD or EPD with Regular.
-        with pytest.raises(ValueError, match=f"{expected_mode} with service discovery"):
+        with pytest.raises(
+            ValueError,
+            match=rf"^Configuration error: Validation failed: {expected_mode} with service discovery",
+        ):
             Router.from_args(args).start()
 
     def test_policy_validation(self):

--- a/bindings/python/tests/test_validation.py
+++ b/bindings/python/tests/test_validation.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from smg.launch_router import RouterArgs, launch_router
+from smg.router import Router
 
 
 class TestURLValidation:
@@ -314,6 +315,28 @@ class TestConfigurationValidation:
         assert args.service_discovery is True
         assert args.prefill_selector == {"app": "prefill"}
         assert args.decode_selector == {"app": "decode"}
+
+    @pytest.mark.parametrize(
+        ("epd_disaggregation", "pd_disaggregation", "expected_mode"),
+        [
+            (False, True, "PD mode"),
+            (True, False, "EPD mode"),
+        ],
+    )
+    def test_igw_preserves_disaggregated_mode_during_native_validation(
+        self, epd_disaggregation, pd_disaggregation, expected_mode
+    ):
+        args = RouterArgs(
+            service_discovery=True,
+            enable_igw=True,
+            epd_disaggregation=epd_disaggregation,
+            pd_disaggregation=pd_disaggregation,
+        )
+
+        # Empty selectors fail native validation before server startup; the
+        # mode-specific error proves IGW did not replace PD or EPD with Regular.
+        with pytest.raises(ValueError, match=f"{expected_mode} with service discovery"):
+            Router.from_args(args).start()
 
     def test_policy_validation(self):
         """Test policy configuration validation."""

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -1096,9 +1096,11 @@ impl ConfigValidator {
     }
 
     fn validate_compatibility(config: &RouterConfig) -> ConfigResult<()> {
+        let has_service_discovery = config.discovery.as_ref().is_some_and(|d| d.enabled);
         let invalid_decode_policy = match &config.mode {
             RoutingMode::PrefillDecode { decode_policy, .. } => {
-                matches!(decode_policy, Some(PolicyConfig::Bucket { .. }))
+                (config.enable_igw || !has_service_discovery)
+                    && matches!(decode_policy, Some(PolicyConfig::Bucket { .. }))
             }
             RoutingMode::EncodePrefillDecode { decode_policy, .. } => matches!(
                 decode_policy.as_ref().unwrap_or(&config.policy),
@@ -1119,8 +1121,6 @@ impl ConfigValidator {
         }
 
         Self::validate_mtls(config)?;
-
-        let has_service_discovery = config.discovery.as_ref().is_some_and(|d| d.enabled);
 
         if !has_service_discovery {
             if let PolicyConfig::PowerOfTwo { .. } = &config.policy {

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -1096,6 +1096,24 @@ impl ConfigValidator {
     }
 
     fn validate_compatibility(config: &RouterConfig) -> ConfigResult<()> {
+        let invalid_decode_policy = match &config.mode {
+            RoutingMode::PrefillDecode { decode_policy, .. } => {
+                matches!(decode_policy, Some(PolicyConfig::Bucket { .. }))
+            }
+            RoutingMode::EncodePrefillDecode { decode_policy, .. } => matches!(
+                decode_policy.as_ref().unwrap_or(&config.policy),
+                PolicyConfig::Bucket { .. }
+            ),
+            _ => false,
+        };
+        if invalid_decode_policy {
+            return Err(ConfigError::IncompatibleConfig {
+                reason: "Decode policy should not be allowed to be bucket".to_string(),
+            });
+        }
+
+        // IGW may receive workers dynamically, so worker-count validation cannot
+        // reason about its eventual topology. Mode-level compatibility still applies.
         if config.enable_igw {
             return Ok(());
         }
@@ -1103,15 +1121,6 @@ impl ConfigValidator {
         Self::validate_mtls(config)?;
 
         let has_service_discovery = config.discovery.as_ref().is_some_and(|d| d.enabled);
-
-        if let RoutingMode::EncodePrefillDecode { decode_policy, .. } = &config.mode {
-            let effective_decode_policy = decode_policy.as_ref().unwrap_or(&config.policy);
-            if matches!(effective_decode_policy, PolicyConfig::Bucket { .. }) {
-                return Err(ConfigError::IncompatibleConfig {
-                    reason: "Decode policy should not be allowed to be bucket".to_string(),
-                });
-            }
-        }
 
         if !has_service_discovery {
             if let PolicyConfig::PowerOfTwo { .. } = &config.policy {
@@ -1146,13 +1155,6 @@ impl ConfigValidator {
                                     .to_string(),
                         });
                     }
-                }
-
-                // Check bucket for decode
-                if let Some(PolicyConfig::Bucket { .. }) = decode_policy {
-                    return Err(ConfigError::IncompatibleConfig {
-                        reason: "Decode policy should not be allowed to be bucket".to_string(),
-                    });
                 }
             }
 
@@ -1203,6 +1205,44 @@ impl ConfigValidator {
 mod tests {
     use super::*;
     use crate::worker::ConnectionMode;
+
+    #[test]
+    fn igw_disaggregated_modes_reject_bucket_decode_policy() {
+        let bucket = || PolicyConfig::Bucket {
+            balance_abs_threshold: 32,
+            balance_rel_threshold: 1.1,
+            bucket_adjust_interval_secs: 5,
+        };
+        let modes = [
+            RoutingMode::PrefillDecode {
+                prefill_urls: vec![],
+                decode_urls: vec![],
+                prefill_policy: None,
+                decode_policy: Some(bucket()),
+            },
+            RoutingMode::EncodePrefillDecode {
+                encode_urls: vec![],
+                prefill_urls: vec![],
+                decode_urls: vec![],
+                encode_policy: None,
+                prefill_policy: None,
+                decode_policy: Some(bucket()),
+            },
+        ];
+
+        for mode in modes {
+            let config = RouterConfig {
+                enable_igw: true,
+                mode,
+                ..RouterConfig::default()
+            };
+            assert!(matches!(
+                ConfigValidator::validate(&config),
+                Err(ConfigError::IncompatibleConfig { ref reason })
+                    if reason == "Decode policy should not be allowed to be bucket"
+            ));
+        }
+    }
 
     #[test]
     fn prefix_hash_policy_cache_boundaries_are_validated() {

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -1098,14 +1098,15 @@ impl ConfigValidator {
     fn validate_compatibility(config: &RouterConfig) -> ConfigResult<()> {
         let has_service_discovery = config.discovery.as_ref().is_some_and(|d| d.enabled);
         let invalid_decode_policy = match &config.mode {
-            RoutingMode::PrefillDecode { decode_policy, .. } => {
-                (config.enable_igw || !has_service_discovery)
-                    && matches!(decode_policy, Some(PolicyConfig::Bucket { .. }))
+            RoutingMode::PrefillDecode { decode_policy, .. } if !config.enable_igw => {
+                !has_service_discovery && matches!(decode_policy, Some(PolicyConfig::Bucket { .. }))
             }
-            RoutingMode::EncodePrefillDecode { decode_policy, .. } => matches!(
-                decode_policy.as_ref().unwrap_or(&config.policy),
-                PolicyConfig::Bucket { .. }
-            ),
+            RoutingMode::PrefillDecode { .. } | RoutingMode::EncodePrefillDecode { .. } => {
+                matches!(
+                    config.mode.get_decode_policy(&config.policy),
+                    PolicyConfig::Bucket { .. }
+                )
+            }
             _ => false,
         };
         if invalid_decode_policy {
@@ -1213,35 +1214,40 @@ mod tests {
             balance_rel_threshold: 1.1,
             bucket_adjust_interval_secs: 5,
         };
-        let modes = [
-            RoutingMode::PrefillDecode {
+        let mut config = RouterConfig {
+            discovery: Some(DiscoveryConfig {
+                enabled: true,
+                ..Default::default()
+            }),
+            mode: RoutingMode::PrefillDecode {
                 prefill_urls: vec![],
                 decode_urls: vec![],
                 prefill_policy: None,
                 decode_policy: Some(bucket()),
             },
-            RoutingMode::EncodePrefillDecode {
-                encode_urls: vec![],
-                prefill_urls: vec![],
-                decode_urls: vec![],
-                encode_policy: None,
-                prefill_policy: None,
-                decode_policy: Some(bucket()),
-            },
-        ];
+            ..Default::default()
+        };
 
-        for mode in modes {
-            let config = RouterConfig {
-                enable_igw: true,
-                mode,
-                ..RouterConfig::default()
-            };
-            assert!(matches!(
-                ConfigValidator::validate(&config),
-                Err(ConfigError::IncompatibleConfig { ref reason })
-                    if reason == "Decode policy should not be allowed to be bucket"
-            ));
+        assert!(ConfigValidator::validate_compatibility(&config).is_ok());
+        config.enable_igw = true;
+        assert!(ConfigValidator::validate_compatibility(&config).is_err());
+
+        if let RoutingMode::PrefillDecode { decode_policy, .. } = &mut config.mode {
+            *decode_policy = None;
         }
+        config.policy = bucket();
+        assert!(ConfigValidator::validate_compatibility(&config).is_err());
+
+        config.policy = PolicyConfig::Random;
+        config.mode = RoutingMode::EncodePrefillDecode {
+            encode_urls: vec![],
+            prefill_urls: vec![],
+            decode_urls: vec![],
+            encode_policy: None,
+            prefill_policy: None,
+            decode_policy: Some(bucket()),
+        };
+        assert!(ConfigValidator::validate_compatibility(&config).is_err());
     }
 
     #[test]

--- a/model_gateway/src/health.rs
+++ b/model_gateway/src/health.rs
@@ -82,9 +82,8 @@ const CHECKPOINT_INTERVAL: Duration = Duration::from_secs(1);
 /// values the `/readiness` handler used to compute inline per probe.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ReadinessSnapshot {
-    /// Per-mode worker presence: any healthy worker (IGW or single-pool
-    /// modes), or at least one healthy prefill AND one healthy decode
-    /// worker in PrefillDecode mode.
+    /// Per-mode worker presence: any healthy worker in a single-pool mode,
+    /// or at least one healthy worker for every required disaggregated role.
     pub workers_ready: bool,
     /// Tokenizer-autoload gate: every healthy gRPC/ZMQ worker's tokenizer is
     /// registered (`true` when autoload is disabled — the gateway does not
@@ -157,7 +156,11 @@ impl ProbeState {
         let workers = worker_registry.get_all();
         let healthy_workers: Vec<_> = workers.iter().filter(|w| w.is_healthy()).collect();
 
-        let workers_ready = if router_config.enable_igw {
+        let workers_ready = if router_config.enable_igw
+            && !matches!(
+                &router_config.mode,
+                RoutingMode::PrefillDecode { .. } | RoutingMode::EncodePrefillDecode { .. }
+            ) {
             !healthy_workers.is_empty()
         } else {
             match &router_config.mode {
@@ -585,15 +588,18 @@ mod tests {
     }
 
     #[test]
-    fn pd_mode_requires_healthy_prefill_and_decode() {
+    fn pd_mode_requires_healthy_prefill_and_decode_with_igw() {
         let state = probe_state();
         let registry = WorkerRegistry::new();
-        let router_config = config(RoutingMode::PrefillDecode {
-            prefill_urls: vec![],
-            decode_urls: vec![],
-            prefill_policy: None,
-            decode_policy: None,
-        });
+        let router_config = RouterConfig {
+            enable_igw: true,
+            ..config(RoutingMode::PrefillDecode {
+                prefill_urls: vec![],
+                decode_urls: vec![],
+                prefill_policy: None,
+                decode_policy: None,
+            })
+        };
 
         let prefill_id = registry
             .register(worker(
@@ -622,36 +628,32 @@ mod tests {
         recompute(&state, &registry, &router_config);
         assert!(state.readiness().workers_ready);
 
-        // Losing the prefill side flips readiness back off.
         registry.transition_status(&prefill_id, WorkerStatus::NotReady);
         recompute(&state, &registry, &router_config);
         assert!(!state.readiness().workers_ready);
     }
 
     #[test]
-    fn igw_mode_needs_any_healthy_worker_regardless_of_mode() {
+    fn igw_epd_does_not_accept_an_untyped_healthy_worker() {
         let state = probe_state();
         let registry = WorkerRegistry::new();
-        // PD mode would demand prefill+decode, but enable_igw short-circuits
-        // to "any healthy worker".
         let router_config = RouterConfig {
             enable_igw: true,
-            ..config(RoutingMode::PrefillDecode {
+            ..config(RoutingMode::EncodePrefillDecode {
+                encode_urls: vec![],
                 prefill_urls: vec![],
                 decode_urls: vec![],
+                encode_policy: None,
                 prefill_policy: None,
                 decode_policy: None,
             })
         };
 
-        recompute(&state, &registry, &router_config);
-        assert!(!state.readiness().workers_ready);
-
         registry
             .register(http_worker("http://w1:8080", WorkerStatus::Ready))
             .unwrap();
         recompute(&state, &registry, &router_config);
-        assert!(state.readiness().workers_ready);
+        assert!(!state.readiness().workers_ready);
     }
 
     #[test]

--- a/model_gateway/src/routers/factory.rs
+++ b/model_gateway/src/routers/factory.rs
@@ -443,7 +443,9 @@ mod grpc_router_type_tests {
                 encode_urls: vec![],
                 prefill_urls: vec![],
                 decode_urls: vec![],
-                encode_policy: Some(PolicyConfig::RoundRobin),
+                encode_policy: Some(PolicyConfig::PowerOfTwo {
+                    load_check_interval_secs: 5,
+                }),
                 prefill_policy: Some(PolicyConfig::RoundRobin),
                 decode_policy: Some(PolicyConfig::Passthrough),
             },

--- a/model_gateway/src/routers/factory.rs
+++ b/model_gateway/src/routers/factory.rs
@@ -433,36 +433,30 @@ mod grpc_router_type_tests {
     #[tokio::test]
     async fn igw_routers_preserve_disaggregated_role_policies() {
         let modes = [
-            (
-                RoutingMode::PrefillDecode {
-                    prefill_urls: vec![],
-                    decode_urls: vec![],
-                    prefill_policy: Some(PolicyConfig::ConsistentHashing),
-                    decode_policy: Some(PolicyConfig::ConsistentHashing),
-                },
-                "consistent_hashing",
-            ),
-            (
-                RoutingMode::EncodePrefillDecode {
-                    encode_urls: vec![],
-                    prefill_urls: vec![],
-                    decode_urls: vec![],
-                    encode_policy: Some(PolicyConfig::RoundRobin),
-                    prefill_policy: Some(PolicyConfig::ConsistentHashing),
-                    decode_policy: Some(PolicyConfig::ConsistentHashing),
-                },
-                "round_robin",
-            ),
+            RoutingMode::PrefillDecode {
+                prefill_urls: vec![],
+                decode_urls: vec![],
+                prefill_policy: Some(PolicyConfig::RoundRobin),
+                decode_policy: Some(PolicyConfig::Passthrough),
+            },
+            RoutingMode::EncodePrefillDecode {
+                encode_urls: vec![],
+                prefill_urls: vec![],
+                decode_urls: vec![],
+                encode_policy: Some(PolicyConfig::ConsistentHashing),
+                prefill_policy: Some(PolicyConfig::RoundRobin),
+                decode_policy: Some(PolicyConfig::Passthrough),
+            },
         ];
 
-        for (mode, expected_encode_policy) in modes {
+        for mode in modes {
             let ctx = grpc_ctx(mode).await;
             RouterFactory::create_igw_routers(&ctx.router_config.policy, &ctx).await;
 
             let policies = &ctx.policy_registry;
-            assert_eq!(policies.get_encode_policy().name(), expected_encode_policy);
-            assert_eq!(policies.get_prefill_policy().name(), "consistent_hashing");
-            assert_eq!(policies.get_decode_policy().name(), "consistent_hashing");
+            assert_eq!(policies.get_encode_policy().name(), "consistent_hashing");
+            assert_eq!(policies.get_prefill_policy().name(), "round_robin");
+            assert_eq!(policies.get_decode_policy().name(), "passthrough");
         }
     }
 }

--- a/model_gateway/src/routers/factory.rs
+++ b/model_gateway/src/routers/factory.rs
@@ -433,35 +433,36 @@ mod grpc_router_type_tests {
     #[tokio::test]
     async fn igw_routers_preserve_disaggregated_role_policies() {
         let modes = [
-            RoutingMode::PrefillDecode {
-                prefill_urls: vec![],
-                decode_urls: vec![],
-                prefill_policy: Some(PolicyConfig::RoundRobin),
-                decode_policy: Some(PolicyConfig::Random),
-            },
-            RoutingMode::EncodePrefillDecode {
-                encode_urls: vec![],
-                prefill_urls: vec![],
-                decode_urls: vec![],
-                encode_policy: Some(PolicyConfig::ConsistentHashing),
-                prefill_policy: Some(PolicyConfig::RoundRobin),
-                decode_policy: Some(PolicyConfig::Random),
-            },
+            (
+                RoutingMode::PrefillDecode {
+                    prefill_urls: vec![],
+                    decode_urls: vec![],
+                    prefill_policy: Some(PolicyConfig::ConsistentHashing),
+                    decode_policy: Some(PolicyConfig::ConsistentHashing),
+                },
+                "consistent_hashing",
+            ),
+            (
+                RoutingMode::EncodePrefillDecode {
+                    encode_urls: vec![],
+                    prefill_urls: vec![],
+                    decode_urls: vec![],
+                    encode_policy: Some(PolicyConfig::RoundRobin),
+                    prefill_policy: Some(PolicyConfig::ConsistentHashing),
+                    decode_policy: Some(PolicyConfig::ConsistentHashing),
+                },
+                "round_robin",
+            ),
         ];
 
-        for mode in modes {
+        for (mode, expected_encode_policy) in modes {
             let ctx = grpc_ctx(mode).await;
             RouterFactory::create_igw_routers(&ctx.router_config.policy, &ctx).await;
 
-            assert_eq!(
-                ctx.policy_registry.get_encode_policy().name(),
-                "consistent_hashing"
-            );
-            assert_eq!(
-                ctx.policy_registry.get_prefill_policy().name(),
-                "round_robin"
-            );
-            assert_eq!(ctx.policy_registry.get_decode_policy().name(), "random");
+            let policies = &ctx.policy_registry;
+            assert_eq!(policies.get_encode_policy().name(), expected_encode_policy);
+            assert_eq!(policies.get_prefill_policy().name(), "consistent_hashing");
+            assert_eq!(policies.get_decode_policy().name(), "consistent_hashing");
         }
     }
 }

--- a/model_gateway/src/routers/factory.rs
+++ b/model_gateway/src/routers/factory.rs
@@ -264,6 +264,25 @@ impl RouterFactory {
         policy: &PolicyConfig,
         ctx: &Arc<AppContext>,
     ) -> Vec<(RouterId, &'static str, Result<Box<dyn RouterTrait>, String>)> {
+        let (encode_policy, prefill_policy, decode_policy) = match &ctx.router_config.mode {
+            RoutingMode::PrefillDecode {
+                prefill_policy,
+                decode_policy,
+                ..
+            } => (None, prefill_policy.as_ref(), decode_policy.as_ref()),
+            RoutingMode::EncodePrefillDecode {
+                encode_policy,
+                prefill_policy,
+                decode_policy,
+                ..
+            } => (
+                encode_policy.as_ref(),
+                prefill_policy.as_ref(),
+                decode_policy.as_ref(),
+            ),
+            _ => (None, None, None),
+        };
+
         vec![
             (
                 router_ids::HTTP_REGULAR,
@@ -278,14 +297,14 @@ impl RouterFactory {
             (
                 router_ids::HTTP_PD,
                 "HTTP PD",
-                Self::create_pd_router(None, None, policy, ctx).await,
+                Self::create_pd_router(prefill_policy, decode_policy, policy, ctx).await,
             ),
             (router_ids::GRPC_PD, "gRPC PD", {
-                Self::set_pd_policies(None, None, policy, ctx);
+                Self::set_pd_policies(prefill_policy, decode_policy, policy, ctx);
                 Self::create_grpc_router(ctx, Mode::PrefillDecode)
             }),
             (router_ids::GRPC_EPD, "gRPC EPD", {
-                Self::set_epd_policies(None, None, None, policy, ctx);
+                Self::set_epd_policies(encode_policy, prefill_policy, decode_policy, policy, ctx);
                 Self::create_grpc_router(ctx, Mode::EncodePrefillDecode)
             }),
             (
@@ -408,6 +427,41 @@ mod grpc_router_type_tests {
                 .await
                 .expect("router creation");
             assert_eq!(router.router_type(), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn igw_routers_preserve_disaggregated_role_policies() {
+        let modes = [
+            RoutingMode::PrefillDecode {
+                prefill_urls: vec![],
+                decode_urls: vec![],
+                prefill_policy: Some(PolicyConfig::RoundRobin),
+                decode_policy: Some(PolicyConfig::Random),
+            },
+            RoutingMode::EncodePrefillDecode {
+                encode_urls: vec![],
+                prefill_urls: vec![],
+                decode_urls: vec![],
+                encode_policy: Some(PolicyConfig::ConsistentHashing),
+                prefill_policy: Some(PolicyConfig::RoundRobin),
+                decode_policy: Some(PolicyConfig::Random),
+            },
+        ];
+
+        for mode in modes {
+            let ctx = grpc_ctx(mode).await;
+            RouterFactory::create_igw_routers(&ctx.router_config.policy, &ctx).await;
+
+            assert_eq!(
+                ctx.policy_registry.get_encode_policy().name(),
+                "consistent_hashing"
+            );
+            assert_eq!(
+                ctx.policy_registry.get_prefill_policy().name(),
+                "round_robin"
+            );
+            assert_eq!(ctx.policy_registry.get_decode_policy().name(), "random");
         }
     }
 }

--- a/model_gateway/src/routers/factory.rs
+++ b/model_gateway/src/routers/factory.rs
@@ -432,7 +432,7 @@ mod grpc_router_type_tests {
 
     #[tokio::test]
     async fn igw_routers_preserve_disaggregated_role_policies() {
-        let modes = [
+        for mode in [
             RoutingMode::PrefillDecode {
                 prefill_urls: vec![],
                 decode_urls: vec![],
@@ -443,18 +443,19 @@ mod grpc_router_type_tests {
                 encode_urls: vec![],
                 prefill_urls: vec![],
                 decode_urls: vec![],
-                encode_policy: Some(PolicyConfig::ConsistentHashing),
+                encode_policy: Some(PolicyConfig::RoundRobin),
                 prefill_policy: Some(PolicyConfig::RoundRobin),
                 decode_policy: Some(PolicyConfig::Passthrough),
             },
-        ];
-
-        for mode in modes {
+        ] {
+            let expected_encode_policy = mode
+                .get_encode_policy(&PolicyConfig::ConsistentHashing)
+                .name();
             let ctx = grpc_ctx(mode).await;
             RouterFactory::create_igw_routers(&ctx.router_config.policy, &ctx).await;
 
             let policies = &ctx.policy_registry;
-            assert_eq!(policies.get_encode_policy().name(), "consistent_hashing");
+            assert_eq!(policies.get_encode_policy().name(), expected_encode_policy);
             assert_eq!(policies.get_prefill_policy().name(), "round_robin");
             assert_eq!(policies.get_decode_policy().name(), "passthrough");
         }


### PR DESCRIPTION
## Description

### Problem

The Python service-discovery entry point and native router configuration did not preserve the same topology when IGW was combined with PD or EPD. The launcher avoided IGW for disaggregated modes, while the native binding allowed IGW to replace the configured mode with Regular routing. When disaggregated configurations reached the IGW multi-router path, role-specific policies, readiness, and decode-policy validation did not consistently retain the declared PD/EPD semantics.

### Solution

Treat IGW as gateway plumbing while keeping `RoutingMode` authoritative. Python service discovery enables IGW consistently, the native binding preserves backend/EPD/PD/Regular precedence, and IGW router construction retains the configured role policies and role-specific readiness requirements.

## Changes

- Auto-enable IGW for Python service-discovery configurations without clearing PD or EPD selection.
- Preserve backend, EPD, and PD modes when IGW is enabled; retain the existing empty startup-worker behavior for Regular IGW.
- Carry configured encode, prefill, and decode policies into routers created by the IGW factory.
- Require healthy workers for every role required by PD or EPD before readiness succeeds.
- Reject the effective `Bucket` decode policy for IGW PD/EPD, including a global-policy fallback, while preserving the existing non-IGW PD service-discovery behavior.
- Add focused Python and Rust regressions for mode precedence, role-policy propagation, readiness, and validation.

Compatibility boundaries:

- Regular IGW continues to start without statically configured workers.
- Provider backends combined with service discovery fail through their existing mode-specific validation instead of silently degrading to Regular routing.
- Non-IGW PD service discovery retains its existing explicit decode-policy behavior.
- Connection-mode inference and mTLS validation are unchanged.

Scope: 7 files and 249 total changed lines against the current base.

Refs: #2362, #2372

## Test Plan

Current head in the isolated fra-dev CPU builder:

- `cargo +nightly fmt --all -- --check`
- `cargo test -p smg --lib`: 1912 passed, 5 ignored
- `cargo clippy -p smg --lib --tests -- -D warnings`
- Focused Rust review regressions: 2 passed
- Rebuilt the Python native binding with `maturin develop`
- Full Python binding suite: 303 passed, 4 skipped
- Python Ruff check and format: passed

The local `--all-features` gate requires system OpenCV, which is not installed in the isolated builder. Current-head hosted CI is the authoritative all-features and integration gate and is pending.

<details>
<summary>Checklist</summary>

- [x] Rust formatting, full lib tests, targeted tests, and relevant Clippy pass
- [x] Python native binding rebuild, full tests, and Ruff pass
- [ ] Current-head hosted checks pass
- [x] Blocking review conversations resolved
- [x] Documentation not required; this adds no public configuration surface

</details>