### PR TITLE
fix(vllm): carry multimodal identity into PD decode-side block hashes

### DIFF
--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -162,6 +162,14 @@ MODEL_SPECS: dict[str, dict] = {
         "tp": 1,
         "features": ["chat", "streaming", "multimodal"],
     },
+    # Standard-RoPE vision model for the PD multimodal KV-isolation test:
+    # M-RoPE models (Qwen-VL) cannot decode on the tensor-stripped PD leg.
+    "microsoft/Phi-3.5-vision-instruct": {
+        "model": _resolve_model_path("microsoft/Phi-3.5-vision-instruct"),
+        "tp": 1,
+        "features": ["chat", "streaming", "multimodal"],
+        "vllm_args": ["--trust-remote-code"],
+    },
     # TokenSpeed EPD multimodal model. Qwen3.5-9B is a vision-language model
     # (hybrid Gated DeltaNet + sparse MoE); BF16 ~18GB fits one 80GB H100 at
     # tp=1, so every EPD topology (1e1p1d/1e2p1d/2e1p1d/1e1p2d) runs on the

--- a/e2e_test/router/test_pd_multimodal.py
+++ b/e2e_test/router/test_pd_multimodal.py
@@ -1,0 +1,109 @@
+"""Cross-image KV isolation test for vLLM PD disaggregation (gRPC mode).
+
+Regression test for decode-side prefix-cache image contamination. The PD
+router strips multimodal tensors from the decode leg, and an image region in
+the expanded prompt is a run of one repeated placeholder token id — so two
+different same-resolution images behind an identical text prefix produce
+byte-identical decode-side token sequences. Unless the router carries the
+per-image identity into the decode worker's block hashes (the mm cache_salt),
+the second request takes a local prefix-cache hit onto the first request's KV
+and is answered from the wrong image.
+
+The probe images share one resolution on purpose: identical vision grids
+expand to identical placeholder-token runs, which is the collision
+precondition this test probes. Unlike the KV-transfer tests, output
+correctness is a sufficient signal here — before the cache_salt fix the
+second answer names the first image's color.
+
+The model must be a standard-RoPE VLM: on an M-RoPE model (Qwen-VL family)
+the tensor-stripped decode leg computes text-only positions that disagree
+with the prefill's grid-aware positions, so PD decoding is degenerate with
+or without the salt — a separate bug this test cannot see past.
+
+Requirements: same as test_pd_mmlu (2 GPUs, 1 prefill + 1 decode). Runs
+under both NIXL and Mooncake KV backends.
+
+Usage:
+    E2E_RUNTIME=vllm pytest e2e_test/router/test_pd_multimodal.py -v
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+
+import pytest
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+# Large enough that the color survives any processor resize; identical for
+# every probe image so the placeholder-token runs are identical.
+_PROBE_SIZE = (448, 448)
+
+_PROMPT = "What is the dominant color of this image? Answer with one English word."
+
+
+def _solid_image_data_url(color: tuple[int, int, int]) -> str:
+    buf = io.BytesIO()
+    Image.new("RGB", _PROBE_SIZE, color).save(buf, format="PNG")
+    data = base64.b64encode(buf.getvalue()).decode("utf-8")
+    return f"data:image/png;base64,{data}"
+
+
+_RED_IMAGE = _solid_image_data_url((220, 20, 20))
+_BLUE_IMAGE = _solid_image_data_url((20, 20, 220))
+
+
+def _ask_color(client, model: str, image_url: str) -> str:
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": _PROMPT},
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                ],
+            }
+        ],
+        temperature=0,
+        max_tokens=16,
+    )
+    return (response.choices[0].message.content or "").lower()
+
+
+@pytest.mark.engine("vllm")
+@pytest.mark.gpu(2)
+@pytest.mark.model("microsoft/Phi-3.5-vision-instruct")
+@pytest.mark.e2e
+@pytest.mark.parametrize("setup_backend", ["pd_grpc"], indirect=True)
+class TestPDMultimodalKvIsolation:
+    """Decode-side prefix-cache isolation between different images."""
+
+    def test_different_images_same_prefix_do_not_alias(self, setup_backend):
+        backend, model, client, *_ = setup_backend
+
+        # Seed the decode worker's prefix cache with the red image's KV.
+        first = _ask_color(client, model, _RED_IMAGE)
+        logger.info("PD multimodal seed answer (red image): %s", first)
+        assert "red" in first, f"Expected 'red' for the seed image, got: {first}"
+
+        # Same text prefix, same-resolution image, different pixels. Without
+        # per-image decode-side block hashes this aliases onto the red
+        # request's cached KV and answers 'red'.
+        second = _ask_color(client, model, _BLUE_IMAGE)
+        logger.info("PD multimodal probe answer (blue image): %s", second)
+        assert "blue" in second, (
+            f"Expected 'blue', got: {second} — a 'red' answer means the decode "
+            "worker served this request from the other image's KV "
+            "(prefix-cache contamination across images)"
+        )
+
+        # Same-image reuse must still answer correctly: the salt is
+        # deterministic per image content, so this leg may hit the decode
+        # prefix cache but must land on the right KV.
+        third = _ask_color(client, model, _RED_IMAGE)
+        logger.info("PD multimodal reuse answer (red image): %s", third)
+        assert "red" in third, f"Expected 'red' on same-image reuse, got: {third}"

--- a/grpc_servicer/smg_grpc_servicer/vllm/mm_salt.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/mm_salt.py
@@ -1,0 +1,19 @@
+"""Multimodal identity cache salt for tensor-stripped (PD decode) legs."""
+
+from collections.abc import Sequence
+
+
+def mm_identity_cache_salt(mm_hashes: Sequence[str]) -> str | None:
+    """Fold per-image content hashes into a deterministic cache salt.
+
+    The PD router strips multimodal tensors from the decode leg (the KV
+    arrives via the P/D transfer), keeping only the per-image content hashes.
+    Without tensors no ``mm_features`` can be built, so the engine's
+    prefix-cache block hashes would carry no image identity — the identity
+    rides ``cache_salt`` instead. Deterministic per image content: same-image
+    reuse still hits the decode prefix cache, while different images behind
+    the same text prefix no longer alias onto each other's KV.
+    """
+    if not mm_hashes:
+        return None
+    return "mm:" + ",".join(mm_hashes)

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -45,6 +45,7 @@ from smg_grpc_servicer.vllm.kv_events import (
     stream_kv_events,
 )
 from smg_grpc_servicer.vllm.kv_transfer import params_from_request, params_to_response_fields
+from smg_grpc_servicer.vllm.mm_salt import mm_identity_cache_salt
 
 logger = init_logger(__name__)
 SAMPLING_DEFAULT_KEYS = (
@@ -201,6 +202,12 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
                 prompt: TokensPrompt = {"prompt_token_ids": list(request.tokenized.input_ids)}
                 if request.tokenized.original_text:
                     prompt["prompt"] = request.tokenized.original_text
+                # PD decode leg: tensors stripped, mm hashes kept — salt the
+                # block hashes per-image so different images cannot alias.
+                if request.HasField("mm_inputs") and not request.mm_inputs.HasField("pixel_values"):
+                    cache_salt = mm_identity_cache_salt(request.mm_inputs.mm_hashes)
+                    if cache_salt is not None:
+                        prompt["cache_salt"] = cache_salt
                 prompt = self.engine.renderer.process_for_engine(prompt, arrival_time=arrival_time)
             else:
                 prompt = request.text

--- a/grpc_servicer/tests/test_vllm_mm_salt.py
+++ b/grpc_servicer/tests/test_vllm_mm_salt.py
@@ -1,0 +1,34 @@
+"""Unit tests for the multimodal identity cache salt (engine-free, no vLLM required).
+
+Run with: pytest grpc_servicer/tests/test_vllm_mm_salt.py
+"""
+
+import importlib.util
+from pathlib import Path
+
+# Import the module directly to avoid pulling vllm via the package __init__
+_MODULE_PATH = Path(__file__).parents[1] / "smg_grpc_servicer" / "vllm" / "mm_salt.py"
+_spec = importlib.util.spec_from_file_location("mm_salt", _MODULE_PATH)
+mm_salt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mm_salt)
+
+
+def test_empty_hashes_produce_no_salt():
+    assert mm_salt.mm_identity_cache_salt([]) is None
+
+
+def test_salt_is_deterministic_per_content():
+    salt = mm_salt.mm_identity_cache_salt(["h1", "h2"])
+    assert salt == "mm:h1,h2"
+    assert salt == mm_salt.mm_identity_cache_salt(["h1", "h2"])
+
+
+def test_different_images_get_different_salts():
+    assert mm_salt.mm_identity_cache_salt(["dog"]) != mm_salt.mm_identity_cache_salt(["passport"])
+
+
+def test_salt_is_order_sensitive():
+    # Same images in a different order occupy different placeholder positions.
+    assert mm_salt.mm_identity_cache_salt(["h1", "h2"]) != mm_salt.mm_identity_cache_salt(
+        ["h2", "h1"]
+    )

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -559,7 +559,8 @@ impl RequestExecutionStage {
         // reused ShmHandle would be unreadable. Same request_id on both legs
         // is load-bearing for NIXL P/D correlation on vLLM < 0.13. The
         // pixel-free leg is the clone, so pixel tensors are never duplicated
-        // and die with the prefill send.
+        // and die with the prefill send. Per-image mm hashes stay in the
+        // clone and become the decode leg's cache_salt.
         let mut decode_request = proto_request.clone_without_mm_pixels();
         // Sanitize prefill sampling (max_tokens=1, n=1), stream=false.
         let mut prefill_request = proto_request;
@@ -830,9 +831,60 @@ mod tests {
         assert!(original.mm_inputs.is_some(), "prefill leg keeps pixels");
         assert!(
             decode.mm_inputs.is_none(),
-            "decode leg never carries pixels"
+            "hash-less mm payload is dropped whole on the decode leg"
         );
         assert_eq!(decode.request_id, "pd-1");
+    }
+
+    #[test]
+    fn clone_without_mm_pixels_keeps_vllm_identity() {
+        // The decode leg drops the tensors but keeps the per-image identity —
+        // downstream it becomes the engine cache_salt.
+        let mut request = ProtoGenerateRequest::Vllm(Box::new(vllm::GenerateRequest {
+            request_id: "pd-2".to_string(),
+            mm_inputs: Some(vllm::MultimodalInputs {
+                pixel_values: Some(vllm::TensorData::default()),
+                model_specific_tensors: std::collections::HashMap::from([(
+                    "image_grid_thw".to_string(),
+                    vllm::TensorData::default(),
+                )]),
+                im_token_id: Some(151_655),
+                mm_placeholders: vec![vllm::PlaceholderRange {
+                    offset: 3,
+                    length: 4,
+                }],
+                mm_hashes: vec!["h1".to_string()],
+                batched_keys: vec!["pixel_values".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+        let clone = request.clone_without_mm_pixels();
+        let ProtoGenerateRequest::Vllm(original) = request else {
+            panic!("expected vLLM request");
+        };
+        let ProtoGenerateRequest::Vllm(decode) = clone else {
+            panic!("expected vLLM clone");
+        };
+        let original_mm = original.mm_inputs.expect("prefill leg keeps mm_inputs");
+        assert!(
+            original_mm.pixel_values.is_some(),
+            "prefill leg keeps pixels"
+        );
+        assert_eq!(original_mm.model_specific_tensors.len(), 1);
+        assert_eq!(original_mm.batched_keys, vec!["pixel_values".to_string()]);
+        let decode_mm = decode.mm_inputs.expect("decode leg keeps identity");
+        assert!(
+            decode_mm.pixel_values.is_none(),
+            "decode leg never carries pixels"
+        );
+        assert!(decode_mm.model_specific_tensors.is_empty());
+        assert!(decode_mm.batched_keys.is_empty());
+        assert!(decode_mm.flat_keys.is_empty());
+        assert!(decode_mm.keep_on_cpu_keys.is_empty());
+        assert_eq!(decode_mm.mm_hashes, vec!["h1".to_string()]);
+        assert_eq!(decode_mm.mm_placeholders.len(), 1);
+        assert_eq!(decode_mm.im_token_id, Some(151_655));
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -1298,7 +1298,10 @@ impl ProtoGenerateRequest {
 
     /// Clone for a PD leg that carries no multimodal pixels (see
     /// `clear_mm_pixel_values`), without ever duplicating them: detach,
-    /// clone, reattach to `self`.
+    /// clone, reattach to `self`. vLLM keeps `mm_hashes`/placeholders in the
+    /// clone: the servicer folds them into the engine `cache_salt`, so
+    /// decode-side block hashes stay per-image and different images behind
+    /// the same text prefix cannot alias in the decode prefix cache.
     pub fn clone_without_mm_pixels(&mut self) -> Self {
         match self {
             Self::Sglang(req) => {
@@ -1309,7 +1312,20 @@ impl ProtoGenerateRequest {
             }
             Self::Vllm(req) => {
                 let mm = req.mm_inputs.take();
-                let clone = Self::Vllm(req.clone());
+                let mut clone = Self::Vllm(req.clone());
+                // Rebuild the identity (no tensors or layout keys) on the
+                // clone; a hash-less payload carries no identity worth keeping.
+                if let (Self::Vllm(clone_req), Some(mm_ref)) = (&mut clone, mm.as_ref()) {
+                    if !mm_ref.mm_hashes.is_empty() {
+                        clone_req.mm_inputs = Some(vllm::MultimodalInputs {
+                            im_token_id: mm_ref.im_token_id,
+                            mm_placeholders: mm_ref.mm_placeholders.clone(),
+                            mm_hashes: mm_ref.mm_hashes.clone(),
+                            modality: mm_ref.modality,
+                            ..Default::default()
+                        });
+                    }
+                }
                 req.mm_inputs = mm;
                 clone
             }


### PR DESCRIPTION
## Description

### Problem

Cross-request image contamination on the vLLM PD disaggregated gRPC path: a request can be answered from a **different request's image**, returning HTTP 200, `finish_reason: stop`, and a correct-looking token count.

The PD router strips `mm_inputs` wholesale from the decode leg (`clone_without_mm_pixels()` — the vLLM arm detaches the whole message, so the clone carries no hashes or placeholders either). The decode worker therefore falls to the plain tokenized path (`TokensPrompt {prompt_token_ids}`) and computes prefix-cache block hashes from token ids alone. An image region in the expanded prompt is a run of one repeated placeholder token id, so **two different same-resolution images behind the same text prefix produce byte-identical decode block hashes**. The later request takes a local prefix-cache hit on the decode worker onto the earlier request's KV and skips fetching its own prefill's blocks.

Reproduced end-to-end on current main (e4df69b4) with the e2e harness (`pd_grpc`, NIXL, 1P+1D on 2×H100), microsoft/Phi-3.5-vision-instruct, three sequential requests "What is the dominant color of this image?" with solid 448×448 images:

| request | expected | before fix | after fix |
|---|---|---|---|
| red image | Red | Red | Red |
| **blue image** | **Blue** | **Red** (full-prompt prefix-cache hit onto the red request's KV) | **Blue** |
| red image again | Red | Red | Red (still a cache hit — caching stays on) |

Billing looks right (`prompt_tokens` comes from the request's own expansion), so this is invisible to monitoring.

### Solution

Keep the per-image identity on the decode leg and fold it into the engine `cache_salt`, only on the path where the engine cannot salt blocks itself (tensors stripped ⇒ no `mm_features` can exist):

- `clone_without_mm_pixels()` keeps `mm_hashes`, `mm_placeholders`, `im_token_id`, and `modality` on the vLLM decode clone (tensors and layout keys still dropped, and never duplicated). A hash-less payload is still dropped whole.
- The servicer maps an identity-only `mm_inputs` (present, but no `pixel_values`) to `cache_salt = "mm:" + ",".join(mm_hashes)` on the `TokensPrompt`. `cache_salt` enters vLLM's chained block hash at block 0, so every block becomes per-image **without disabling prefix caching** — same-image reuse still hits.

The aggregated path is untouched (it forwards `mm_hashes` into `mm_features`, so the engine salts blocks itself — confirmed correct in the same environment). The vLLM PD HTTP lane is unaffected (each engine preprocesses raw images itself).

**No ZMQ changes**: PD is unreachable over the direct-ZMQ transport — ZMQ workers are rejected from PD prefill/decode pools at registration (`create_worker.rs::validate_zmq_worker_type`) and filtered at selection (#2176) — so `translate_request` needs no salt.

### Also observed, not fixed here

M-RoPE VLMs (Qwen-VL family) cannot decode at all on the tensor-stripped PD leg: with no grid metadata (`image_grid_thw` rides `model_specific_tensors`, which is dropped) the decode worker computes text-only positions that disagree with the prefill's grid-aware M-RoPE positions, and every PD multimodal response comes back empty — Qwen3-VL-8B deterministically samples `'\n'` sixteen times at ≈0 logprob until `finish_reason: length` — before *and* after this fix, while the same requests on the aggregated path and text-only requests on the same PD deployment are perfect. That is a separate wrong-computation bug (the decode leg would need `image_grid_thw` or a relayed position delta); the new e2e test deliberately uses a standard-RoPE VLM (Phi-3.5-vision) so it can see past it.

## Changes

- `model_gateway/src/routers/grpc/proto_wrapper.rs` — `clone_without_mm_pixels()` vLLM arm rebuilds the identity (`mm_hashes`/`mm_placeholders`/`im_token_id`/`modality`) on the decode clone instead of leaving `mm_inputs` empty.
- `grpc_servicer/smg_grpc_servicer/vllm/servicer.py` — tokenized requests carrying identity-only `mm_inputs` get `cache_salt` on the `TokensPrompt` (survives `renderer.process_for_engine`, verified against vllm 0.27.1).
- `grpc_servicer/smg_grpc_servicer/vllm/mm_salt.py` — new dependency-free salt helper (+ `grpc_servicer/tests/test_vllm_mm_salt.py`).
- `model_gateway/src/routers/grpc/common/stages/request_execution.rs` — comment at the decode-leg call site; new `clone_without_mm_pixels_keeps_vllm_identity` unit test.
- `e2e_test/router/test_pd_multimodal.py` — new e2e regression test for the contamination (red/blue/red sequence above) on `pd_grpc`. Slots into the existing `e2e-2gpu-pd` vLLM lanes (NIXL + Mooncake) with no workflow changes.
- `e2e_test/infra/model_specs.py` — adds microsoft/Phi-3.5-vision-instruct (tp=1, standard-RoPE VLM; see M-RoPE note above for why the test cannot use Qwen3-VL).

## Test Plan

Everything below was run on a 2×H100 pod against main (e4df69b4), with the CI scripts (`ci_setup_python_venv.sh`, `ci_install_vllm.sh` with `vllm==0.27.1` + NIXL, maturin-built router wheel), UCX over TCP (no IB devices in the pod):

- **e2e before/after**: `E2E_RUNTIME=vllm E2E_GPU_TIER=2 E2E_VLLM_KV_BACKEND=nixl pytest e2e_test/router/test_pd_multimodal.py` — fails on main with the blue request answered "Red" (table above), passes with this change. Text-only PD (`Paris` control) and the aggregated multimodal path pass identically before and after.
- `pytest grpc_servicer/tests/test_vllm_mm_salt.py` — 4 passed.
- `cargo test -p smg --lib clone_without_mm_pixels` / `proto_wrapper` / `request_execution` module suites — all pass.
- Mooncake leg not exercised on the dev pod (NIXL only); it runs in CI's `e2e-2gpu-pd` matrix and the change is transport-agnostic (the salt is derived router/servicer-side).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes on the gateway package (`--all-features` needs system OpenCV for the `llm-multimodal` crate, unavailable in this dev environment and unrelated to this change)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
