### PR TITLE
fix(grpc): relay M-RoPE grid tensors to the PD decode leg

### DIFF
--- a/e2e_test/router/test_pd_multimodal.py
+++ b/e2e_test/router/test_pd_multimodal.py
@@ -44,36 +44,45 @@ _DOG_IMAGE = _fixture_image_data_url("dog.jpg")  # black lab, no blanket -> "no"
 _PUG_IMAGE = _fixture_image_data_url("pug.jpg")  # pug in a blanket -> "yes"
 
 
+def _blanket_messages(image_url: str) -> list[dict]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": _PROMPT},
+                {"type": "image_url", "image_url": {"url": image_url}},
+            ],
+        }
+    ]
+
+
+def _first_word(answer: str | None) -> str:
+    words = (answer or "").lower().split()
+    return words[0].strip(".,!?\"'") if words else ""
+
+
 def _ask_blanket(client, model: str, image_url: str) -> str:
     response = client.chat.completions.create(
         model=model,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": _PROMPT},
-                    {"type": "image_url", "image_url": {"url": image_url}},
-                ],
-            }
-        ],
+        messages=_blanket_messages(image_url),
         temperature=0,
         max_tokens=16,
     )
-    return (response.choices[0].message.content or "").lower()
+    return _first_word(response.choices[0].message.content)
 
 
 def _assert_no_cross_image_aliasing(client, model: str) -> None:
     # Seed the decode worker's prefix cache with the blanket-less dog's KV.
     first = _ask_blanket(client, model, _DOG_IMAGE)
     logger.info("PD multimodal seed answer (dog, no blanket): %s", first)
-    assert "no" in first, f"Expected 'no' for the seed image, got: {first}"
+    assert first == "no", f"Expected 'no' for the seed image, got: {first}"
 
     # Same text prefix, same-resolution image, different pixels. Without
     # per-image decode-side block hashes this aliases onto the seed
     # request's cached KV and answers 'no'.
     second = _ask_blanket(client, model, _PUG_IMAGE)
     logger.info("PD multimodal probe answer (pug in blanket): %s", second)
-    assert "yes" in second, (
+    assert second == "yes", (
         f"Expected 'yes', got: {second} — a 'no' answer means the decode "
         "worker served this request from the other image's KV "
         "(prefix-cache contamination across images)"
@@ -84,7 +93,7 @@ def _assert_no_cross_image_aliasing(client, model: str) -> None:
     # land on the right KV.
     third = _ask_blanket(client, model, _DOG_IMAGE)
     logger.info("PD multimodal reuse answer (dog, no blanket): %s", third)
-    assert "no" in third, f"Expected 'no' on same-image reuse, got: {third}"
+    assert third == "no", f"Expected 'no' on same-image reuse, got: {third}"
 
 
 @pytest.mark.engine("vllm")
@@ -116,3 +125,22 @@ class TestPDMultimodalMrope:
     def test_mrope_decode_answers_and_does_not_alias(self, setup_backend):
         backend, model, client, *_ = setup_backend
         _assert_no_cross_image_aliasing(client, model)
+
+    def test_parallel_sampling_keeps_vision_on_decode(self, setup_backend):
+        # n>1 skips the KV handoff, so the decode leg recomputes the prompt
+        # locally and must carry the full multimodal payload to run the
+        # vision encoder (a pixel-less leg would answer image-blind).
+        backend, model, client, *_ = setup_backend
+        response = client.chat.completions.create(
+            model=model,
+            messages=_blanket_messages(_PUG_IMAGE),
+            # Near-greedy: vLLM rejects n>1 with temperature=0.
+            temperature=0.1,
+            max_tokens=16,
+            n=2,
+        )
+        assert len(response.choices) == 2
+        for choice in response.choices:
+            answer = _first_word(choice.message.content)
+            logger.info("PD multimodal n=2 answer (pug in blanket): %s", answer)
+            assert answer == "yes", f"Expected 'yes' from each sample, got: {answer}"

--- a/e2e_test/router/test_pd_multimodal.py
+++ b/e2e_test/router/test_pd_multimodal.py
@@ -1,24 +1,9 @@
-"""Cross-image KV isolation test for vLLM PD disaggregation (gRPC mode).
+"""Cross-image KV isolation tests for vLLM PD disaggregation (gRPC mode).
 
-Regression test for decode-side prefix-cache image contamination. The PD
-router strips multimodal tensors from the decode leg, and an image region in
-the expanded prompt is a run of one repeated placeholder token id — so two
-different same-resolution images behind an identical text prefix produce
-byte-identical decode-side token sequences. Unless the router carries the
-per-image identity into the decode worker's block hashes (the mm cache_salt),
-the second request takes a local prefix-cache hit onto the first request's KV
-and is answered from the wrong image.
-
-The probe images share one resolution on purpose: identical vision grids
-expand to identical placeholder-token runs, which is the collision
-precondition this test probes. Unlike the KV-transfer tests, output
-correctness is a sufficient signal here — before the cache_salt fix the
-second answer names the first image's color.
-
-The model must be a standard-RoPE VLM: on an M-RoPE model (Qwen-VL family)
-the tensor-stripped decode leg computes text-only positions that disagree
-with the prefill's grid-aware positions, so PD decoding is degenerate with
-or without the salt — a separate bug this test cannot see past.
+Two same-resolution images behind an identical text prefix expand to
+identical placeholder-token runs; the decode worker must still keep their
+KV apart (per-image mm identity) and, for M-RoPE models, decode with
+grid-aware positions from the relayed grid tensors.
 
 Requirements: same as test_pd_mmlu (2 GPUs, 1 prefill + 1 decode). Runs
 under both NIXL and Mooncake KV backends.
@@ -32,31 +17,34 @@ from __future__ import annotations
 import base64
 import io
 import logging
+from pathlib import Path
 
 import pytest
 from PIL import Image
 
 logger = logging.getLogger(__name__)
 
-# Large enough that the color survives any processor resize; identical for
-# every probe image so the placeholder-token runs are identical.
+_FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "images"
+
+# One shared resolution so both images expand to identical placeholder-token
+# runs — the collision precondition these tests probe.
 _PROBE_SIZE = (448, 448)
 
-_PROMPT = "What is the dominant color of this image? Answer with one English word."
+_PROMPT = "Is the dog wrapped in a blanket? Answer with one word: yes or no."
 
 
-def _solid_image_data_url(color: tuple[int, int, int]) -> str:
+def _fixture_image_data_url(name: str) -> str:
     buf = io.BytesIO()
-    Image.new("RGB", _PROBE_SIZE, color).save(buf, format="PNG")
+    Image.open(_FIXTURES_DIR / name).convert("RGB").resize(_PROBE_SIZE).save(buf, format="JPEG")
     data = base64.b64encode(buf.getvalue()).decode("utf-8")
-    return f"data:image/png;base64,{data}"
+    return f"data:image/jpeg;base64,{data}"
 
 
-_RED_IMAGE = _solid_image_data_url((220, 20, 20))
-_BLUE_IMAGE = _solid_image_data_url((20, 20, 220))
+_DOG_IMAGE = _fixture_image_data_url("dog.jpg")  # black lab, no blanket -> "no"
+_PUG_IMAGE = _fixture_image_data_url("pug.jpg")  # pug in a blanket -> "yes"
 
 
-def _ask_color(client, model: str, image_url: str) -> str:
+def _ask_blanket(client, model: str, image_url: str) -> str:
     response = client.chat.completions.create(
         model=model,
         messages=[
@@ -74,36 +62,57 @@ def _ask_color(client, model: str, image_url: str) -> str:
     return (response.choices[0].message.content or "").lower()
 
 
+def _assert_no_cross_image_aliasing(client, model: str) -> None:
+    # Seed the decode worker's prefix cache with the blanket-less dog's KV.
+    first = _ask_blanket(client, model, _DOG_IMAGE)
+    logger.info("PD multimodal seed answer (dog, no blanket): %s", first)
+    assert "no" in first, f"Expected 'no' for the seed image, got: {first}"
+
+    # Same text prefix, same-resolution image, different pixels. Without
+    # per-image decode-side block hashes this aliases onto the seed
+    # request's cached KV and answers 'no'.
+    second = _ask_blanket(client, model, _PUG_IMAGE)
+    logger.info("PD multimodal probe answer (pug in blanket): %s", second)
+    assert "yes" in second, (
+        f"Expected 'yes', got: {second} — a 'no' answer means the decode "
+        "worker served this request from the other image's KV "
+        "(prefix-cache contamination across images)"
+    )
+
+    # Same-image reuse must still answer correctly: per-image hashing is
+    # deterministic, so this leg may hit the decode prefix cache but must
+    # land on the right KV.
+    third = _ask_blanket(client, model, _DOG_IMAGE)
+    logger.info("PD multimodal reuse answer (dog, no blanket): %s", third)
+    assert "no" in third, f"Expected 'no' on same-image reuse, got: {third}"
+
+
 @pytest.mark.engine("vllm")
 @pytest.mark.gpu(2)
 @pytest.mark.model("microsoft/Phi-3.5-vision-instruct")
 @pytest.mark.e2e
 @pytest.mark.parametrize("setup_backend", ["pd_grpc"], indirect=True)
 class TestPDMultimodalKvIsolation:
-    """Decode-side prefix-cache isolation between different images."""
+    """Grid-less (standard-RoPE) decode leg: isolation via mm cache_salt."""
 
     def test_different_images_same_prefix_do_not_alias(self, setup_backend):
         backend, model, client, *_ = setup_backend
+        _assert_no_cross_image_aliasing(client, model)
 
-        # Seed the decode worker's prefix cache with the red image's KV.
-        first = _ask_color(client, model, _RED_IMAGE)
-        logger.info("PD multimodal seed answer (red image): %s", first)
-        assert "red" in first, f"Expected 'red' for the seed image, got: {first}"
 
-        # Same text prefix, same-resolution image, different pixels. Without
-        # per-image decode-side block hashes this aliases onto the red
-        # request's cached KV and answers 'red'.
-        second = _ask_color(client, model, _BLUE_IMAGE)
-        logger.info("PD multimodal probe answer (blue image): %s", second)
-        assert "blue" in second, (
-            f"Expected 'blue', got: {second} — a 'red' answer means the decode "
-            "worker served this request from the other image's KV "
-            "(prefix-cache contamination across images)"
-        )
+@pytest.mark.engine("vllm")
+@pytest.mark.gpu(2)
+@pytest.mark.model("Qwen/Qwen3-VL-8B-Instruct")
+@pytest.mark.e2e
+@pytest.mark.parametrize("setup_backend", ["pd_grpc"], indirect=True)
+class TestPDMultimodalMrope:
+    """M-RoPE decode leg: relayed grid tensors give correct positions.
 
-        # Same-image reuse must still answer correctly: the salt is
-        # deterministic per image content, so this leg may hit the decode
-        # prefix cache but must land on the right KV.
-        third = _ask_color(client, model, _RED_IMAGE)
-        logger.info("PD multimodal reuse answer (red image): %s", third)
-        assert "red" in third, f"Expected 'red' on same-image reuse, got: {third}"
+    Without the grids the decode worker mis-rotates every generated token
+    and answers with degenerate output, so any correct answer implies the
+    position relay works; the three-probe sequence also covers isolation.
+    """
+
+    def test_mrope_decode_answers_and_does_not_alias(self, setup_backend):
+        backend, model, client, *_ = setup_backend
+        _assert_no_cross_image_aliasing(client, model)

--- a/grpc_servicer/smg_grpc_servicer/vllm/mm_salt.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/mm_salt.py
@@ -1,6 +1,16 @@
-"""Multimodal identity cache salt for tensor-stripped (PD decode) legs."""
+"""Engine-free multimodal helpers for tensor-stripped (PD decode) legs."""
 
 from collections.abc import Sequence
+
+
+def has_preprocessed_mm_payload(mm_inputs) -> bool:
+    """True when the payload carries tensors the preprocessed path can use.
+
+    A grid-only payload (model-specific tensors, no pixels) is the PD decode
+    leg's form; a bare identity payload (hashes only) is not preprocessable
+    and falls back to the cache-salt path.
+    """
+    return mm_inputs.HasField("pixel_values") or bool(mm_inputs.model_specific_tensors)
 
 
 def mm_identity_cache_salt(mm_hashes: Sequence[str]) -> str | None:

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -199,6 +199,11 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
                 # remote KV: a local recompute would schedule the vision
                 # encoder with no pixels and crash the engine.
                 if not request.mm_inputs.HasField("pixel_values") and kv_transfer_params is None:
+                    logger.warning(
+                        "Request %s: pixel-less multimodal payload with no kv_transfer_params; "
+                        "rejecting (prefill worker did not hand off KV?)",
+                        request_id,
+                    )
                     raise ValueError(
                         "multimodal payload carries grid tensors but no pixel_values and "
                         "no kv_transfer_params; a pixel-less leg requires remote KV"

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -174,8 +174,11 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         """
         request_id = request.request_id
         input_type = request.WhichOneof("input")
-        has_preprocessed_mm = request.HasField("mm_inputs") and request.mm_inputs.HasField(
-            "pixel_values"
+        # A tensor-less mm payload with grid tensors is the PD decode leg's
+        # form: enough to rebuild mm features (positions + block hashing).
+        has_preprocessed_mm = request.HasField("mm_inputs") and (
+            request.mm_inputs.HasField("pixel_values")
+            or bool(request.mm_inputs.model_specific_tensors)
         )
         logger.info(
             "Generate request %s: input_type=%s, stream=%s, preprocessed_mm=%s, dp_rank=%s",
@@ -202,8 +205,9 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
                 prompt: TokensPrompt = {"prompt_token_ids": list(request.tokenized.input_ids)}
                 if request.tokenized.original_text:
                     prompt["prompt"] = request.tokenized.original_text
-                # PD decode leg: tensors stripped, mm hashes kept — salt the
-                # block hashes per-image so different images cannot alias.
+                # Grid-less PD decode leg: fold the kept mm hashes into
+                # cache_salt so different images cannot alias. (Grid-carrying
+                # legs take the preprocessed path above instead.)
                 if request.HasField("mm_inputs") and not request.mm_inputs.HasField("pixel_values"):
                     cache_salt = mm_identity_cache_salt(request.mm_inputs.mm_hashes)
                     if cache_salt is not None:
@@ -635,10 +639,11 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
                 return "pixel_values_videos"
             return key
 
-        # Deserialize all tensors from proto
-        hf_dict: dict[str, torch.Tensor] = {
-            mm_key("pixel_values"): _tensor_from_proto(mm_proto.pixel_values),
-        }
+        # Deserialize all tensors from proto. The PD decode leg carries no
+        # pixel_values (KV arrives via the P/D transfer), only grid tensors.
+        hf_dict: dict[str, torch.Tensor] = {}
+        if mm_proto.HasField("pixel_values"):
+            hf_dict[mm_key("pixel_values")] = _tensor_from_proto(mm_proto.pixel_values)
         for key, td in mm_proto.model_specific_tensors.items():
             hf_dict[mm_key(key)] = _tensor_from_proto(td)
 

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -195,6 +195,14 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             kv_transfer_params = params_from_request(request)
 
             if has_preprocessed_mm and input_type == "tokenized":
+                # A pixel-less payload (PD decode leg) is only decodable with
+                # remote KV: a local recompute would schedule the vision
+                # encoder with no pixels and crash the engine.
+                if not request.mm_inputs.HasField("pixel_values") and kv_transfer_params is None:
+                    raise ValueError(
+                        "multimodal payload carries grid tensors but no pixel_values and "
+                        "no kv_transfer_params; a pixel-less leg requires remote KV"
+                    )
                 # Preprocessed multimodal from Rust router.
                 # Token IDs already have expanded placeholders; tensors are
                 # ready for the model. Bypass the renderer entirely.

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -45,7 +45,7 @@ from smg_grpc_servicer.vllm.kv_events import (
     stream_kv_events,
 )
 from smg_grpc_servicer.vllm.kv_transfer import params_from_request, params_to_response_fields
-from smg_grpc_servicer.vllm.mm_salt import mm_identity_cache_salt
+from smg_grpc_servicer.vllm.mm_salt import has_preprocessed_mm_payload, mm_identity_cache_salt
 
 logger = init_logger(__name__)
 SAMPLING_DEFAULT_KEYS = (
@@ -174,11 +174,10 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         """
         request_id = request.request_id
         input_type = request.WhichOneof("input")
-        # A tensor-less mm payload with grid tensors is the PD decode leg's
+        # A pixel-less mm payload with grid tensors is the PD decode leg's
         # form: enough to rebuild mm features (positions + block hashing).
-        has_preprocessed_mm = request.HasField("mm_inputs") and (
-            request.mm_inputs.HasField("pixel_values")
-            or bool(request.mm_inputs.model_specific_tensors)
+        has_preprocessed_mm = request.HasField("mm_inputs") and has_preprocessed_mm_payload(
+            request.mm_inputs
         )
         logger.info(
             "Generate request %s: input_type=%s, stream=%s, preprocessed_mm=%s, dp_rank=%s",
@@ -205,13 +204,20 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
                 prompt: TokensPrompt = {"prompt_token_ids": list(request.tokenized.input_ids)}
                 if request.tokenized.original_text:
                     prompt["prompt"] = request.tokenized.original_text
-                # Grid-less PD decode leg: fold the kept mm hashes into
-                # cache_salt so different images cannot alias. (Grid-carrying
-                # legs take the preprocessed path above instead.)
-                if request.HasField("mm_inputs") and not request.mm_inputs.HasField("pixel_values"):
+                # Tensor-less mm payload (grid-less PD decode leg): fold the
+                # kept mm hashes into cache_salt so different images cannot
+                # alias. Grid-carrying legs took the preprocessed path above.
+                if request.HasField("mm_inputs"):
                     cache_salt = mm_identity_cache_salt(request.mm_inputs.mm_hashes)
                     if cache_salt is not None:
                         prompt["cache_salt"] = cache_salt
+                    model_config = getattr(self.engine, "model_config", None)
+                    if model_config is not None and getattr(model_config, "uses_mrope", False):
+                        logger.warning(
+                            "Request %s carries mm identity but no grid tensors on an "
+                            "M-RoPE model; decode-side positions will be text-only",
+                            request_id,
+                        )
                 prompt = self.engine.renderer.process_for_engine(prompt, arrival_time=arrival_time)
             else:
                 prompt = request.text
@@ -619,10 +625,11 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
     ) -> VllmMultiModalInput:
         """Build vLLM MultiModalInput from preprocessed proto data.
 
-        Bypasses HF processor entirely — pixel values and model-specific
-        tensors were already computed by the Rust router.  Field layouts
-        (batched / flat / shared) are also determined by the router via
-        ``batched_keys`` and ``flat_keys`` proto fields.
+        Bypasses HF processor entirely — the tensors were already computed by
+        the Rust router. Pixel values are optional: the PD decode leg carries
+        only the grid tensors (positions + block hashing need no pixels).
+        Field layouts (batched / flat / shared) are also determined by the
+        router via ``batched_keys`` and ``flat_keys`` proto fields.
         """
         prompt_token_ids = list(tokenized.input_ids)
         num_items = len(mm_proto.mm_placeholders)

--- a/grpc_servicer/tests/test_vllm_mm_salt.py
+++ b/grpc_servicer/tests/test_vllm_mm_salt.py
@@ -6,11 +6,33 @@ Run with: pytest grpc_servicer/tests/test_vllm_mm_salt.py
 import importlib.util
 from pathlib import Path
 
+from smg_grpc_proto import vllm_engine_pb2
+
 # Import the module directly to avoid pulling vllm via the package __init__
 _MODULE_PATH = Path(__file__).parents[1] / "smg_grpc_servicer" / "vllm" / "mm_salt.py"
 _spec = importlib.util.spec_from_file_location("mm_salt", _MODULE_PATH)
 mm_salt = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(mm_salt)
+
+
+def test_gate_accepts_pixel_payloads():
+    mm = vllm_engine_pb2.MultimodalInputs(pixel_values=vllm_engine_pb2.TensorData(dtype="float32"))
+    assert mm_salt.has_preprocessed_mm_payload(mm)
+
+
+def test_gate_accepts_grid_only_payloads():
+    # The PD decode leg's form: grid tensors without pixels.
+    mm = vllm_engine_pb2.MultimodalInputs(mm_hashes=["h1"])
+    mm.model_specific_tensors["image_grid_thw"].CopyFrom(
+        vllm_engine_pb2.TensorData(dtype="int64", shape=[1, 3])
+    )
+    assert mm_salt.has_preprocessed_mm_payload(mm)
+
+
+def test_gate_rejects_identity_only_payloads():
+    # Hashes alone cannot rebuild mm features; this leg takes the salt path.
+    mm = vllm_engine_pb2.MultimodalInputs(mm_hashes=["h1"])
+    assert not mm_salt.has_preprocessed_mm_payload(mm)
 
 
 def test_empty_hashes_produce_no_salt():

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -554,14 +554,22 @@ impl RequestExecutionStage {
             _ => None,
         };
 
-        // Decode reuses the request minus pixels: it receives KV via the P/D
-        // transfer, and prefill reads and unlinks any /dev/shm segments, so a
-        // reused ShmHandle would be unreadable. Same request_id on both legs
-        // is load-bearing for NIXL P/D correlation on vLLM < 0.13. The
-        // pixel-free leg is the clone, so pixel tensors are never duplicated
-        // and die with the prefill send. Per-image mm hashes stay in the
-        // clone and become the decode leg's cache_salt.
-        let mut decode_request = proto_request.clone_without_mm_pixels();
+        // Decode normally reuses the request minus pixels: it receives KV via
+        // the P/D transfer, and prefill reads and unlinks any /dev/shm
+        // segments, so a reused ShmHandle would be unreadable. Same request_id
+        // on both legs is load-bearing for NIXL P/D correlation on vLLM <
+        // 0.13. The pixel-free leg is the clone, so pixel tensors are never
+        // duplicated and die with the prefill send; the per-image mm identity
+        // and grid tensors survive for decode-side hashing and positions.
+        // Without a KV handoff (n>1) decode recomputes the prompt locally and
+        // must run the vision encoder, so that leg keeps the full multimodal
+        // payload (SHM-backed tensors cannot serve both legs and fail loudly
+        // on the decode read).
+        let mut decode_request = if relay_kv_params {
+            proto_request.clone_without_mm_pixels()
+        } else {
+            proto_request.clone()
+        };
         // Sanitize prefill sampling (max_tokens=1, n=1), stream=false.
         let mut prefill_request = proto_request;
         prefill_request.sanitize_sampling_for_prefill(1);

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -861,8 +861,15 @@ mod tests {
                     ("image_grid_thw".to_string(), grid.clone()),
                     // Payload-less grids and non-grid tensors are dropped.
                     ("video_grid_thw".to_string(), vllm::TensorData::default()),
-                    ("aspect_ratios".to_string(), grid),
+                    ("aspect_ratios".to_string(), grid.clone()),
+                    // Flat-classified grid keys keep their sizes tensor.
+                    ("second_per_grid_ts".to_string(), grid.clone()),
+                    ("ts_sizes".to_string(), grid),
                 ]),
+                flat_keys: std::collections::HashMap::from([(
+                    "second_per_grid_ts".to_string(),
+                    "ts_sizes".to_string(),
+                )]),
                 im_token_id: Some(151_655),
                 mm_placeholders: vec![vllm::PlaceholderRange {
                     offset: 3,
@@ -891,23 +898,31 @@ mod tests {
             original_mm.pixel_values.is_some(),
             "prefill leg keeps pixels"
         );
-        assert_eq!(original_mm.model_specific_tensors.len(), 3);
+        assert_eq!(original_mm.model_specific_tensors.len(), 5);
         assert_eq!(original_mm.batched_keys.len(), 3);
         let decode_mm = decode.mm_inputs.expect("decode leg keeps identity");
         assert!(
             decode_mm.pixel_values.is_none(),
             "decode leg never carries pixels"
         );
+        let mut decode_keys: Vec<_> = decode_mm.model_specific_tensors.keys().collect();
+        decode_keys.sort();
         assert_eq!(
-            decode_mm.model_specific_tensors.keys().collect::<Vec<_>>(),
-            vec!["image_grid_thw"]
+            decode_keys,
+            vec!["image_grid_thw", "second_per_grid_ts", "ts_sizes"]
         );
         assert_eq!(decode_mm.batched_keys, vec!["image_grid_thw".to_string()]);
         assert_eq!(
             decode_mm.keep_on_cpu_keys,
             vec!["image_grid_thw".to_string()]
         );
-        assert!(decode_mm.flat_keys.is_empty());
+        assert_eq!(
+            decode_mm.flat_keys,
+            std::collections::HashMap::from([(
+                "second_per_grid_ts".to_string(),
+                "ts_sizes".to_string()
+            )])
+        );
         assert_eq!(decode_mm.mm_hashes, vec!["h1".to_string()]);
         assert_eq!(decode_mm.mm_placeholders.len(), 1);
         assert_eq!(decode_mm.im_token_id, Some(151_655));

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -837,24 +837,36 @@ mod tests {
     }
 
     #[test]
-    fn clone_without_mm_pixels_keeps_vllm_identity() {
-        // The decode leg drops the tensors but keeps the per-image identity —
-        // downstream it becomes the engine cache_salt.
+    fn clone_without_mm_pixels_keeps_vllm_identity_and_grid_tensors() {
+        // The decode leg drops the pixel tensors but keeps the per-image
+        // identity and the inline M-RoPE grid tensors.
+        let grid = vllm::TensorData {
+            shape: vec![1, 3],
+            dtype: "int64".to_string(),
+            payload: Some(vllm::tensor_data::Payload::Inline(vec![0; 24])),
+        };
         let mut request = ProtoGenerateRequest::Vllm(Box::new(vllm::GenerateRequest {
             request_id: "pd-2".to_string(),
             mm_inputs: Some(vllm::MultimodalInputs {
                 pixel_values: Some(vllm::TensorData::default()),
-                model_specific_tensors: std::collections::HashMap::from([(
-                    "image_grid_thw".to_string(),
-                    vllm::TensorData::default(),
-                )]),
+                model_specific_tensors: std::collections::HashMap::from([
+                    ("image_grid_thw".to_string(), grid.clone()),
+                    // Payload-less grids and non-grid tensors are dropped.
+                    ("video_grid_thw".to_string(), vllm::TensorData::default()),
+                    ("aspect_ratios".to_string(), grid),
+                ]),
                 im_token_id: Some(151_655),
                 mm_placeholders: vec![vllm::PlaceholderRange {
                     offset: 3,
                     length: 4,
                 }],
                 mm_hashes: vec!["h1".to_string()],
-                batched_keys: vec!["pixel_values".to_string()],
+                batched_keys: vec![
+                    "pixel_values".to_string(),
+                    "image_grid_thw".to_string(),
+                    "aspect_ratios".to_string(),
+                ],
+                keep_on_cpu_keys: vec!["image_grid_thw".to_string()],
                 ..Default::default()
             }),
             ..Default::default()
@@ -871,17 +883,23 @@ mod tests {
             original_mm.pixel_values.is_some(),
             "prefill leg keeps pixels"
         );
-        assert_eq!(original_mm.model_specific_tensors.len(), 1);
-        assert_eq!(original_mm.batched_keys, vec!["pixel_values".to_string()]);
+        assert_eq!(original_mm.model_specific_tensors.len(), 3);
+        assert_eq!(original_mm.batched_keys.len(), 3);
         let decode_mm = decode.mm_inputs.expect("decode leg keeps identity");
         assert!(
             decode_mm.pixel_values.is_none(),
             "decode leg never carries pixels"
         );
-        assert!(decode_mm.model_specific_tensors.is_empty());
-        assert!(decode_mm.batched_keys.is_empty());
+        assert_eq!(
+            decode_mm.model_specific_tensors.keys().collect::<Vec<_>>(),
+            vec!["image_grid_thw"]
+        );
+        assert_eq!(decode_mm.batched_keys, vec!["image_grid_thw".to_string()]);
+        assert_eq!(
+            decode_mm.keep_on_cpu_keys,
+            vec!["image_grid_thw".to_string()]
+        );
         assert!(decode_mm.flat_keys.is_empty());
-        assert!(decode_mm.keep_on_cpu_keys.is_empty());
         assert_eq!(decode_mm.mm_hashes, vec!["h1".to_string()]);
         assert_eq!(decode_mm.mm_placeholders.len(), 1);
         assert_eq!(decode_mm.im_token_id, Some(151_655));

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -294,17 +294,19 @@ impl VllmMultimodalData {
             .model_specific_tensors
             .into_iter()
             .map(|(k, v)| {
+                // Grid tensors are a few ints and must survive the PD decode
+                // clone's inline-only retention: never route them via SHM.
+                let payload = if VLLM_MROPE_GRID_KEYS.contains(&k.as_str()) {
+                    vllm::tensor_data::Payload::Inline(v.data)
+                } else {
+                    vllm_tensor_payload(v.data, shm_enabled, shm_min_bytes, None)
+                };
                 (
                     k,
                     vllm::TensorData {
                         shape: v.shape,
                         dtype: v.dtype,
-                        payload: Some(vllm_tensor_payload(
-                            v.data,
-                            shm_enabled,
-                            shm_min_bytes,
-                            None,
-                        )),
+                        payload: Some(payload),
                     },
                 )
             })

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -296,11 +296,8 @@ impl VllmMultimodalData {
             .map(|(k, v)| {
                 // Grid tensors are a few ints and must survive the PD decode
                 // clone's inline-only retention: never route them via SHM.
-                let payload = if VLLM_MROPE_GRID_KEYS.contains(&k.as_str()) {
-                    vllm::tensor_data::Payload::Inline(v.data)
-                } else {
-                    vllm_tensor_payload(v.data, shm_enabled, shm_min_bytes, None)
-                };
+                let via_shm = shm_enabled && !VLLM_MROPE_GRID_KEYS.contains(&k.as_str());
+                let payload = vllm_tensor_payload(v.data, via_shm, shm_min_bytes, None);
                 (
                     k,
                     vllm::TensorData {
@@ -1329,18 +1326,42 @@ impl ProtoGenerateRequest {
                         // compute decode-side positions; they are a few ints
                         // per item, so keep them (inline payloads only — an
                         // SHM segment is unreadable after the prefill send).
-                        let grid_tensors: HashMap<_, _> = mm_ref
-                            .model_specific_tensors
-                            .iter()
-                            .filter(|(key, tensor)| {
-                                VLLM_MROPE_GRID_KEYS.contains(&key.as_str())
-                                    && matches!(
+                        let inline_tensor = |key: &str| {
+                            mm_ref
+                                .model_specific_tensors
+                                .get(key)
+                                .filter(|tensor| {
+                                    matches!(
                                         tensor.payload,
                                         Some(vllm::tensor_data::Payload::Inline(_))
                                     )
-                            })
-                            .map(|(key, tensor)| (key.clone(), tensor.clone()))
-                            .collect();
+                                })
+                                .cloned()
+                        };
+                        let mut grid_tensors: HashMap<String, vllm::TensorData> =
+                            VLLM_MROPE_GRID_KEYS
+                                .iter()
+                                .filter_map(|key| {
+                                    inline_tensor(key).map(|tensor| (key.to_string(), tensor))
+                                })
+                                .collect();
+                        // A flat-classified grid key needs its sizes tensor to
+                        // keep per-item slicing on the decode leg.
+                        let mut flat_keys = HashMap::new();
+                        for (key, sizes_key) in &mm_ref.flat_keys {
+                            if !grid_tensors.contains_key(key) {
+                                continue;
+                            }
+                            match inline_tensor(sizes_key) {
+                                Some(sizes) => {
+                                    grid_tensors.insert(sizes_key.clone(), sizes);
+                                    flat_keys.insert(key.clone(), sizes_key.clone());
+                                }
+                                None => {
+                                    grid_tensors.remove(key);
+                                }
+                            }
+                        }
                         let retained = |keys: &[String]| {
                             keys.iter()
                                 .filter(|key| grid_tensors.contains_key(*key))
@@ -1354,6 +1375,7 @@ impl ProtoGenerateRequest {
                             modality: mm_ref.modality,
                             batched_keys: retained(&mm_ref.batched_keys),
                             keep_on_cpu_keys: retained(&mm_ref.keep_on_cpu_keys),
+                            flat_keys,
                             model_specific_tensors: grid_tensors,
                             ..Default::default()
                         });

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -1115,6 +1115,10 @@ pub enum ProtoGenerateRequest {
     TokenSpeed(Box<tokenspeed::GenerateRequest>),
 }
 
+/// Per-item grid metadata the engine reads to compute M-RoPE positions
+/// (`_get_mrope_input_positions` in vLLM); a few ints per item.
+const VLLM_MROPE_GRID_KEYS: [&str; 3] = ["image_grid_thw", "video_grid_thw", "second_per_grid_ts"];
+
 impl ProtoGenerateRequest {
     /// Append stop token ids to the request's sampling params (TRT-LLM keeps
     /// them on the request itself). Requests without sampling params are left
@@ -1298,10 +1302,12 @@ impl ProtoGenerateRequest {
 
     /// Clone for a PD leg that carries no multimodal pixels (see
     /// `clear_mm_pixel_values`), without ever duplicating them: detach,
-    /// clone, reattach to `self`. vLLM keeps `mm_hashes`/placeholders in the
-    /// clone: the servicer folds them into the engine `cache_salt`, so
-    /// decode-side block hashes stay per-image and different images behind
-    /// the same text prefix cannot alias in the decode prefix cache.
+    /// clone, reattach to `self`. vLLM keeps `mm_hashes`/placeholders and the
+    /// M-RoPE grid tensors in the clone: the servicer rebuilds pixel-less
+    /// mm features from them, so the decode worker computes grid-aware
+    /// positions and per-image block hashes instead of treating the prompt
+    /// as text (which mis-rotates every generated token on Qwen-VL models
+    /// and lets different images alias in the decode prefix cache).
     pub fn clone_without_mm_pixels(&mut self) -> Self {
         match self {
             Self::Sglang(req) => {
@@ -1313,15 +1319,40 @@ impl ProtoGenerateRequest {
             Self::Vllm(req) => {
                 let mm = req.mm_inputs.take();
                 let mut clone = Self::Vllm(req.clone());
-                // Rebuild the identity (no tensors or layout keys) on the
-                // clone; a hash-less payload carries no identity worth keeping.
+                // Rebuild the identity (no pixel tensors) on the clone; a
+                // hash-less payload carries no identity worth keeping.
                 if let (Self::Vllm(clone_req), Some(mm_ref)) = (&mut clone, mm.as_ref()) {
                     if !mm_ref.mm_hashes.is_empty() {
+                        // M-RoPE models (Qwen-VL) need the grid tensors to
+                        // compute decode-side positions; they are a few ints
+                        // per item, so keep them (inline payloads only — an
+                        // SHM segment is unreadable after the prefill send).
+                        let grid_tensors: HashMap<_, _> = mm_ref
+                            .model_specific_tensors
+                            .iter()
+                            .filter(|(key, tensor)| {
+                                VLLM_MROPE_GRID_KEYS.contains(&key.as_str())
+                                    && matches!(
+                                        tensor.payload,
+                                        Some(vllm::tensor_data::Payload::Inline(_))
+                                    )
+                            })
+                            .map(|(key, tensor)| (key.clone(), tensor.clone()))
+                            .collect();
+                        let retained = |keys: &[String]| {
+                            keys.iter()
+                                .filter(|key| grid_tensors.contains_key(*key))
+                                .cloned()
+                                .collect()
+                        };
                         clone_req.mm_inputs = Some(vllm::MultimodalInputs {
                             im_token_id: mm_ref.im_token_id,
                             mm_placeholders: mm_ref.mm_placeholders.clone(),
                             mm_hashes: mm_ref.mm_hashes.clone(),
                             modality: mm_ref.modality,
+                            batched_keys: retained(&mm_ref.batched_keys),
+                            keep_on_cpu_keys: retained(&mm_ref.keep_on_cpu_keys),
+                            model_specific_tensors: grid_tensors,
                             ..Default::default()
                         });
                     }

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -1358,6 +1358,12 @@ impl ProtoGenerateRequest {
                                     flat_keys.insert(key.clone(), sizes_key.clone());
                                 }
                                 None => {
+                                    tracing::warn!(
+                                        grid_key = %key,
+                                        sizes_key = %sizes_key,
+                                        "dropping grid tensor from the PD decode leg: its \
+                                         sizes tensor is not inline"
+                                    );
                                     grid_tensors.remove(key);
                                 }
                             }


### PR DESCRIPTION
## Description

### Problem

vLLM PD multimodal is broken end-to-end for M-RoPE models (the Qwen-VL family): every response on the gRPC PD path comes back with no visible text — Qwen3-VL-8B deterministically samples `'\n'` sixteen times at ≈0 logprob until `finish_reason: length` — while the same requests on the aggregated path, and text-only requests on the same PD deployment, are answered perfectly. #2365 fixed cross-image cache aliasing on this leg but could not fix this: the failure exists before any cache is warm.

Root cause, verified by instrumenting the deployed engine: the decode leg drops all of `model_specific_tensors`, so the decode worker receives no `image_grid_thw` and vLLM silently computes **text-only M-RoPE positions** (`mrope_position_delta = 0`; `Request.__init__` does `mm_features or []`, no warning). The prefill worker computed the transferred KV at **grid-aware** positions — for a 448×448 image, ~196 placeholder tokens collapse into a 14-step position span, so its delta is **−182**. Measured on a live PD pair (same request, `vllm==0.27.1`, NIXL):

| leg | mm items seen | mrope_position_delta |
|---|---|---|
| prefill | 1 | **−182** |
| decode (before) | 0 | **0** |
| decode (after this fix) | 1 | **−182** |

With delta 0, the decode worker rotates every generated token's query (and the K of the one locally recomputed last prompt token) 182 positions away from where the transferred keys actually sit — degenerate generation. Counterfactual confirmed both ways: leaving `mm_inputs` intact on the decode leg produces `'Red'` + EOS; relaying only the grid does too.

### Solution

Relay the M-RoPE layout — and nothing else — to the decode leg:

- `clone_without_mm_pixels()` keeps the whitelisted per-item grid tensors (`image_grid_thw`, `video_grid_thw`, `second_per_grid_ts`; inline payloads only, since an SHM segment is unreadable after prefill consumed it) alongside the identity it already keeps, with `batched_keys`/`keep_on_cpu_keys` filtered to match. That is **24 bytes per image**; `pixel_values` and the other tensors still never ride the decode leg.
- The servicer treats a tensor-bearing `mm_inputs` without `pixel_values` as preprocessed input: `_build_preprocessed_mm_inputs` seeds `pixel_values` conditionally and otherwise builds the same pixel-less `mm_features`. vLLM computes M-RoPE positions from `mm_features[i].data["image_grid_thw"]` alone, and with the prompt KV fully remote the scheduler never schedules the vision encoder (verified in `_try_schedule_encoder_inputs`: only the final prompt token is recomputed locally, and chat templates always place text after the last image), so the missing pixels are never dereferenced.

Per-image decode-side block hashing comes with the same change: on this path the identity rides the `mm_features` identifiers (`mm_hashes`), vLLM's native mechanism. The `cache_salt` path from #2365 remains and now covers grid-less VLMs (Phi/LLaVA-style), whose standard-RoPE positions never needed the grid.

## Changes

- `model_gateway/src/routers/grpc/proto_wrapper.rs` — `clone_without_mm_pixels()` vLLM arm retains inline M-RoPE grid tensors and filters the layout key lists to the retained keys.
- `grpc_servicer/smg_grpc_servicer/vllm/servicer.py` — preprocessed-mm gate widened to `pixel_values OR model_specific_tensors`; `_build_preprocessed_mm_inputs` no longer assumes `pixel_values` exists; `cache_salt` comment scoped to the grid-less leg.
- `model_gateway/src/routers/grpc/common/stages/request_execution.rs` — clone test updated: grids retained (inline only), non-grid tensors and payload-less grids dropped, pixels stay on the prefill leg.
- `e2e_test/router/test_pd_multimodal.py` — new `TestPDMultimodalMrope` class runs the same three-probe isolation sequence on Qwen3-VL (degenerate output before this fix, so a correct answer covers the position relay and isolation together); probes now use the repo's `e2e_test/fixtures/images/dog.jpg`/`pug.jpg` resized to one resolution ("is the dog wrapped in a blanket?" — no/yes/no), matching the other multimodal e2e tests.

## Test Plan

Debugged and validated on a 2×H100 pod against main (CI scripts, `vllm==0.27.1`, NIXL over TCP):

- Isolation of the bug: text-only PD correct (`'Paris'`); Phi-3.5-vision (standard RoPE) PD correct; Qwen3-VL PD degenerate on the *first* request (`'\n'`×16, logprob ≈ −0.000) — cache-independent, mm-specific, model-family-specific.
- Instrumented `RopeState.init_prefill_positions` in the deployed engine: delta table above; the stripped leg logs `n_mm=0 delta=0`, both legs log `n_mm=1 delta=-182` with this fix.
- `E2E_RUNTIME=vllm E2E_GPU_TIER=2 E2E_VLLM_KV_BACKEND=nixl pytest e2e_test/router/test_pd_multimodal.py` — both classes pass (Qwen3-VL: correct answers + no cross-image aliasing + full-prompt decode cache hits; Phi-3.5-vision unchanged). Mooncake leg runs in CI's `e2e-2gpu-pd` matrix; the relay is transport-agnostic.
- `cargo test -p smg --lib` filtered module suites (proto_wrapper, request_execution) pass; ruff clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes on the gateway package (`--all-features` needs system OpenCV for the `llm-multimodal` crate, unavailable in this dev environment and unrelated to this change)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
