### PR TITLE
fix(tool_parser): treat a blank MiniMax-M3 leaf as an empty container

### DIFF
--- a/crates/tool_parser/src/parsers/minimax_m3.rs
+++ b/crates/tool_parser/src/parsers/minimax_m3.rs
@@ -78,6 +78,18 @@ impl MinimaxM3Parser {
     /// Parse a leaf value from text, coercing by declared schema type when known,
     /// otherwise inferring the JSON type (number/bool/null) and defaulting to string.
     fn coerce_leaf(text: &str, declared_type: Option<&str>) -> Value {
+        // An empty container renders as an element with no children and no
+        // text, which reaches the leaf path indistinguishable from an empty
+        // string. `coerce_by_schema_type` cannot parse "" as JSON, so without
+        // this the value would be inferred as `""` and fail the tool's schema.
+        if text.trim().is_empty() {
+            match declared_type {
+                Some("array") => return Value::Array(Vec::new()),
+                Some("object") => return Value::Object(Map::new()),
+                _ => {}
+            }
+        }
+
         if let Some(value) = helpers::coerce_by_schema_type(text, declared_type) {
             return value;
         }

--- a/crates/tool_parser/tests/tool_parser_minimax_m3.rs
+++ b/crates/tool_parser/tests/tool_parser_minimax_m3.rs
@@ -809,3 +809,122 @@ async fn test_m3_streaming_incomplete_tool_call_emits_nothing() {
         "tool-call markup must not leak into normal text"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Empty containers
+//
+// The template renders an empty sequence or mapping as an element with no
+// children and no text, which is indistinguishable at the leaf from an empty
+// string. Without the declared type it infers as `""` and fails the tool's
+// schema — observed against MiniMax's Provider-Verifier as
+// "'' is not of type 'array'" on a declared `array` parameter.
+// ---------------------------------------------------------------------------
+
+fn container_tools() -> Vec<Tool> {
+    vec![Tool {
+        tool_type: "function".to_string(),
+        function: Function {
+            name: "plan_route".to_string(),
+            description: None,
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "avoid_aisles": {"type": "array", "items": {"type": "string"}},
+                    "options":      {"type": "object"},
+                    "note":         {"type": "string"}
+                }
+            }),
+            strict: None,
+        },
+    }]
+}
+
+#[tokio::test]
+async fn test_empty_leaf_under_array_schema_is_empty_array() {
+    let parser = MinimaxM3Parser::new();
+    let tools = container_tools();
+    let text = tool_block(&[("plan_route", element("avoid_aisles", ""))]);
+
+    let (_, calls) = parser
+        .parse_complete_with_tools(&text, &tools)
+        .await
+        .unwrap();
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+
+    assert_eq!(args["avoid_aisles"], json!([]));
+}
+
+#[tokio::test]
+async fn test_empty_leaf_under_object_schema_is_empty_object() {
+    let parser = MinimaxM3Parser::new();
+    let tools = container_tools();
+    let text = tool_block(&[("plan_route", element("options", ""))]);
+
+    let (_, calls) = parser
+        .parse_complete_with_tools(&text, &tools)
+        .await
+        .unwrap();
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+
+    assert_eq!(args["options"], json!({}));
+}
+
+#[tokio::test]
+async fn test_whitespace_only_leaf_under_array_schema_is_empty_array() {
+    let parser = MinimaxM3Parser::new();
+    let tools = container_tools();
+    let text = tool_block(&[("plan_route", element("avoid_aisles", "\n  "))]);
+
+    let (_, calls) = parser
+        .parse_complete_with_tools(&text, &tools)
+        .await
+        .unwrap();
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+
+    assert_eq!(args["avoid_aisles"], json!([]));
+}
+
+#[tokio::test]
+async fn test_empty_leaf_under_string_schema_stays_empty_string() {
+    let parser = MinimaxM3Parser::new();
+    let tools = container_tools();
+    let text = tool_block(&[("plan_route", element("note", ""))]);
+
+    let (_, calls) = parser
+        .parse_complete_with_tools(&text, &tools)
+        .await
+        .unwrap();
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+
+    // Only container types collapse; a declared string keeps the empty string.
+    assert_eq!(args["note"], json!(""));
+}
+
+#[tokio::test]
+async fn test_empty_leaf_without_schema_is_unchanged() {
+    let parser = MinimaxM3Parser::new();
+    let text = tool_block(&[("plan_route", element("avoid_aisles", ""))]);
+
+    // With no tool schema there is nothing to say the value is a container,
+    // so the previous inference behaviour is preserved.
+    let (_, calls) = parser.parse_complete(&text).await.unwrap();
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+
+    assert_eq!(args["avoid_aisles"], json!(""));
+}
+
+#[tokio::test]
+async fn test_populated_array_still_parses_after_empty_container_fix() {
+    let parser = MinimaxM3Parser::new();
+    let tools = container_tools();
+    let items = format!("{}{}", element("item", "dairy"), element("item", "frozen"));
+    let text = tool_block(&[("plan_route", element("avoid_aisles", &items))]);
+
+    let (_, calls) = parser
+        .parse_complete_with_tools(&text, &tools)
+        .await
+        .unwrap();
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+
+    assert_eq!(args["avoid_aisles"], json!(["dairy", "frozen"]));
+}


### PR DESCRIPTION
## Description

### Problem

An empty sequence or mapping is rendered by the MiniMax-M3 chat template as an element with no children and no text:

```
]<]minimax[>[<avoid_aisles>]<]minimax[>[</avoid_aisles>
```

At the leaf that is indistinguishable from an empty string. `helpers::coerce_by_schema_type` handles `array`/`object` by doing `serde_json::from_str(text)`, which cannot parse `""`, so it returns `None` and the value falls through to `infer_value` and becomes `""` — failing the tool's own schema.

Found running [MiniMax-Provider-Verifier](https://github.com/MiniMax-AI/MiniMax-Provider-Verifier) against the parser added in #1815, which reported:

```
plan_grocery_route   avoid_aisles   '' is not of type 'array'
```

This was the only remaining SMG-attributable schema violation in that run, reproduced across two independent runs.

### Solution

Check the declared type before falling through to inference: a blank leaf under `array` becomes `[]`, under `object` becomes `{}`. Every other declared type, and leaves with no schema at all, keep their existing behaviour.

## Changes

- `crates/tool_parser/src/parsers/minimax_m3.rs` — empty-container branch in `coerce_leaf`, placed ahead of `coerce_by_schema_type` (which cannot parse `""` for container types).
- `crates/tool_parser/tests/tool_parser_minimax_m3.rs` — 6 regression cases, deliberately including the boundaries so the fix cannot over-reach:

| Case | Expected |
|---|---|
| empty leaf + `array` schema | `[]` (the reported failure) |
| empty leaf + `object` schema | `{}` |
| whitespace-only leaf + `array` schema | `[]` |
| empty leaf + `string` schema | stays `""` — only containers collapse |
| empty leaf + **no** schema | stays `""` — prior inference preserved |
| populated array | `["dairy","frozen"]` still parses |

## Test Plan

- `cargo +nightly fmt --all --check` — clean
- `cargo clippy -p tool-parser -p reasoning-parser --all-targets -- -D warnings` — clean
- `cargo test -p tool-parser -p reasoning-parser` — all pass; the `tool_parser_minimax_m3` suite is 40 cases (34 existing + 6 new)

Verified end-to-end against MiniMax-M3 served by SMG over gRPC (vLLM 0.27.1, TP=8), not only in unit tests.