### PR TITLE
fix(python): keep PD mode when service discovery auto-enables IGW

### DIFF
--- a/bindings/python/src/smg/launch_router.py
+++ b/bindings/python/src/smg/launch_router.py
@@ -40,7 +40,12 @@ def launch_router(args: argparse.Namespace | RouterArgs) -> None:
         if Router is None:
             raise RuntimeError("Rust Router is not installed")
 
-        if router_args.service_discovery and not router_args.enable_igw:
+        if (
+            router_args.service_discovery
+            and not router_args.enable_igw
+            and not router_args.pd_disaggregation
+            and not router_args.epd_disaggregation
+        ):
             logger.info("IGW mode automatically enabled because service discovery is turned on")
             router_args.enable_igw = True
 

--- a/bindings/python/tests/test_startup_sequence.py
+++ b/bindings/python/tests/test_startup_sequence.py
@@ -221,6 +221,39 @@ class TestRouterInitialization:
 
             # Function returns None; ensure start was invoked
 
+    def test_pd_service_discovery_does_not_force_igw(self):
+        """PD mode with service discovery keeps PD routing (no IGW auto-enable)."""
+        args = RouterArgs(
+            service_discovery=True,
+            pd_disaggregation=True,
+            prefill_selector={"component": "engine"},
+            decode_selector={"component": "decoder"},
+            service_discovery_port=8080,
+            service_discovery_namespace="default",
+        )
+
+        with patch("smg.launch_router.Router") as router_mod:
+            captured_args = {}
+            mock_router_instance = MagicMock()
+
+            def fake_from_args(router_args):
+                captured_args.update(
+                    dict(
+                        pd_disaggregation=router_args.pd_disaggregation,
+                        enable_igw=router_args.enable_igw,
+                    )
+                )
+                return mock_router_instance
+
+            router_mod.from_args = MagicMock(side_effect=fake_from_args)
+
+            launch_router(args)
+
+            router_mod.from_args.assert_called_once()
+            assert captured_args["pd_disaggregation"] is True
+            assert captured_args["enable_igw"] is False
+            mock_router_instance.start.assert_called_once()
+
     def test_router_initialization_with_retry_config(self):
         """Test router initialization with retry configuration."""
         args = RouterArgs(


### PR DESCRIPTION
## Description

### Problem

#2362 force-enables IGW whenever `--service-discovery` is set, including when `--pd-disaggregation` / `--epd-disaggregation` is also set. IGW takes precedence in routing-mode resolution, so a PD router with Kubernetes service discovery resolves to `RoutingMode::Regular`, and startup fails validation:

```
Error starting router: Configuration error: Validation failed: Regular mode with service discovery requires a non-empty selector
```

Every OME-style PD deployment (`--pd-disaggregation --service-discovery --prefill-selector … --decode-selector …`) crashloops on any router built after 2026-08-30. Hit in a live OMENative PD deployment of Qwen3-VL on the moirai-dev cluster; the pod command was verified correct, and the banner shows `mode IGW` despite `--pd-disaggregation`.

### Solution

Only auto-enable IGW for service discovery when neither PD nor EPD disaggregation is requested — disaggregated modes have their own per-pool selectors and must keep their routing mode.

## Changes

- `bindings/python/src/smg/launch_router.py`: gate the #2362 auto-enable on `pd_disaggregation`/`epd_disaggregation`.
- `bindings/python/tests/test_startup_sequence.py`: regression test — PD + service discovery keeps `pd_disaggregation=True`, `enable_igw=False`.

## Test Plan

Before: router with `--pd-disaggregation --service-discovery --prefill-selector 'component=engine …' --decode-selector 'component=decoder …'` exits with the validation error above (reproduced on ghcr tag nightly-20260901-9d63971). After: same flags start in PD Disaggregated mode; new unit test covers the regression; redeploying the OME ISVC with an image from this branch brings the routers Ready.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>