### PR TITLE
feat(sim): radix-index benchmark legs and harness support (WIP)

### DIFF
--- a/crates/sim_loadgen/src/report.rs
+++ b/crates/sim_loadgen/src/report.rs
@@ -31,6 +31,14 @@ pub struct RequestRecord {
     pub status: u16,
     /// Request start, milliseconds since the Unix epoch.
     pub start_ms: u64,
+    /// Gateway's remote-index echo (`x-smg-index-source`): what the
+    /// prefetch resolved for this decision. `None` when the gateway runs
+    /// without a remote index.
+    pub index_source: Option<String>,
+    /// Gateway's predicted cached tokens for the served worker
+    /// (`x-smg-index-predicted-tokens`); comparing against the worker's
+    /// actual `cached_tokens` separates index error from policy spill.
+    pub index_predicted_tokens: Option<u64>,
 }
 
 impl RequestRecord {
@@ -66,6 +74,8 @@ impl RequestRecord {
             "e2e_ms": self.e2e_ms,
             "status": self.status,
             "start_ms": self.start_ms,
+            "index_source": self.index_source,
+            "index_predicted_tokens": self.index_predicted_tokens,
         })
     }
 }
@@ -420,6 +430,8 @@ mod tests {
             e2e_ms: 100.0,
             status: 200,
             start_ms: 1000,
+            index_source: None,
+            index_predicted_tokens: None,
         }
     }
 

--- a/crates/sim_loadgen/src/session.rs
+++ b/crates/sim_loadgen/src/session.rs
@@ -251,8 +251,22 @@ async fn send_turn(ctx: &Ctx, req: &TurnRequest<'_>) -> Option<Vec<u32>> {
     let mut status: u16 = 0;
     let mut ttft_ms: Option<f64> = None;
     let mut response: Option<Value> = None;
+    let mut index_source: Option<String> = None;
+    let mut index_predicted_tokens: Option<u64> = None;
     if let Ok(resp) = request.body(body).send().await {
         status = resp.status().as_u16();
+        // Remote-index echo headers (absent unless the gateway runs with
+        // --kv-indexer-url); captured before the body consumes `resp`.
+        index_source = resp
+            .headers()
+            .get("x-smg-index-source")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        index_predicted_tokens = resp
+            .headers()
+            .get("x-smg-index-predicted-tokens")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse().ok());
         if resp.status().is_success() {
             if args.stream {
                 match consume_sse(resp, started).await {
@@ -333,6 +347,8 @@ async fn send_turn(ctx: &Ctx, req: &TurnRequest<'_>) -> Option<Vec<u32>> {
         e2e_ms,
         status,
         start_ms,
+        index_source,
+        index_predicted_tokens,
     };
     // A send error means the collector is gone (shutdown); nothing to do.
     let _ = ctx.records.send(record);

--- a/scripts/generate_sim/failover_bins.py
+++ b/scripts/generate_sim/failover_bins.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Time-sliced failover analysis: bin follow-up cache ratios around the
+index-replica kill instant recorded in meta.json.
+
+Usage: failover_bins.py <scenario-run-dir> [bin_secs]
+"""
+import glob
+import json
+import sys
+
+
+def main():
+    base = sys.argv[1]
+    width = int(sys.argv[2]) if len(sys.argv) > 2 else 10
+    bins = {}
+    seeds = sorted(glob.glob(f"{base}/*/seed-*/"))
+    observed = 0
+    errors = requests = 0
+    for sd in seeds:
+        meta = json.load(open(sd + "meta.json"))
+        killed = meta.get("index_killed_at_ms")
+        if not killed:
+            print(f"WARN: kill not observed in {sd}")
+            continue
+        observed += 1
+        for line in open(sd + "requests.jsonl"):
+            rec = json.loads(line)
+            requests += 1
+            if not (200 <= rec.get("status", 0) < 300):
+                errors += 1
+            if rec.get("turn", 1) < 2:
+                continue
+            prompt = rec.get("prompt_tokens") or 0
+            cached = rec.get("cached_tokens") or 0
+            if not prompt:
+                continue
+            offset = (rec["start_ms"] - killed) / 1000.0
+            b = int(offset // width) * width
+            slot = bins.setdefault(b, {"p": 0, "c": 0, "src": {}})
+            slot["p"] += prompt
+            slot["c"] += cached
+            src = rec.get("index_source") or "none"
+            slot["src"][src] = slot["src"].get(src, 0) + 1
+    print(f"kill observed in {observed}/{len(seeds)} seeds; errors {errors}/{requests}")
+    for b in sorted(bins):
+        slot = bins[b]
+        total = sum(slot["src"].values())
+        top = ", ".join(
+            f"{k} {v / total:.0%}"
+            for k, v in sorted(slot["src"].items(), key=lambda kv: -kv[1])[:3]
+        )
+        print(f"{b:+6d}s  followup cached {slot['c'] / slot['p']:.4f}  {top}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_sim/scenarios.py
+++ b/scripts/generate_sim/scenarios.py
@@ -552,6 +552,21 @@ def cmd_compare(args):
             json.dump(seed_rows, f, indent=2)
         leg_results.append((label, aggregate_seed_rows(seed_rows)))
 
+    # Leg-to-leg binary identity: when no leg deliberately uses a prebuilt
+    # slot (revision A/B does), every leg must have run the SAME gateway
+    # binary — otherwise the comparison silently includes a build delta.
+    if all(slot is None for _, _, slot in legs):
+        smg_shas = set()
+        for label, _, _ in legs:
+            for meta_path in sorted((scenario_dir / label).glob("seed-*/meta.json")):
+                with open(meta_path) as f:
+                    smg_shas.add(json.load(f)["binary_sha256"]["smg"])
+        if len(smg_shas) > 1:
+            raise SystemExit(
+                "scenario %s legs ran different gateway binaries: %s"
+                % (args.scenario, sorted(smg_shas))
+            )
+
     write_compare_md(args.scenario, leg_results, scenario_dir / "compare.md")
     sim.log("compare: %s" % (scenario_dir / "compare.md"))
 

--- a/scripts/generate_sim/scenarios.py
+++ b/scripts/generate_sim/scenarios.py
@@ -97,6 +97,38 @@ def patch_smg_flags(flags, patches):
     return out
 
 
+REMOTE_INDEX_FLAGS = {
+    "--enable-igw": None,
+    "--kv-indexer-url": "http://127.0.0.1:40000",
+    "--kv-indexer-block-size": "256",
+}
+
+
+def remote_leg(index_overrides, extra=None):
+    """A sprayed remote-index leg; sweep legs vary ONLY index_overrides."""
+    leg = {
+        **KV_EVENT_OVERRIDES,
+        "loadgen.ingress": "random",
+        "loadgen.turn2_ingress": "random",
+        "index_service": {
+            "replicas": 2,
+            "bridge": True,
+            "inferred_ttl_secs": 18,
+            "sweep_interval_secs": 1,
+            "default_capacity_blocks": 4688,
+            **index_overrides,
+        },
+        "smg_flag_overrides": {
+            **RADIX_TREE_FLAGS,
+            **COMPRESSED_CLOCK_FLAGS,
+            **REMOTE_INDEX_FLAGS,
+        },
+    }
+    if extra:
+        leg.update(extra)
+    return leg
+
+
 # Leg: (label, {dotted override: value}, smg_bin slot: None | "a" | "b").
 # The special override key "smg_flag_overrides" patches individual gateway
 # flags via patch_smg_flags. smg1-vs-smg8 keeps the same session_rps:
@@ -383,6 +415,50 @@ SCENARIOS = {
                     **COMPRESSED_CLOCK_FLAGS,
                 },
             },
+            None,
+        ),
+    ],
+    # Staleness sweep (event feed; the placement feed has no Removed to
+    # delay): constant injected apply lag, reported against the 3 s
+    # compressed think time (= 30 s production). Stored and Removed are
+    # delayed in SEPARATE legs — they fail in opposite directions.
+    "index-staleness": [
+        ("stored-30ms", remote_leg({"apply_delay_stored_ms": 30}), None),
+        ("stored-300ms", remote_leg({"apply_delay_stored_ms": 300}), None),
+        ("stored-3000ms", remote_leg({"apply_delay_stored_ms": 3000}), None),
+        ("removed-3000ms", remote_leg({"apply_delay_removed_ms": 3000}), None),
+    ],
+    # Capacity-model sensitivity for the inferred feed (placement-only):
+    # 0.5x / 2x of the 1x=4688 blocks used by the core matrix leg.
+    "index-capacity": [
+        (
+            "capacity-half",
+            remote_leg({"bridge": False, "default_capacity_blocks": 2344}),
+            None,
+        ),
+        (
+            "capacity-double",
+            remote_leg({"bridge": False, "default_capacity_blocks": 9375}),
+            None,
+        ),
+    ],
+    # Failover drill: kill replica 0 (the endpoint every gateway and
+    # publisher dials) mid-window, relaunch 30 s later bootstrapping from
+    # the survivor. Placement-fed (the harder case: no replayable feed).
+    # Run with --seeds 6: timing nondeterminism needs the wider n.
+    "index-failover": [
+        (
+            "kill-replica0",
+            remote_leg(
+                {"bridge": False},
+                {
+                    "kill_index_replica": {
+                        "at_secs": 60,
+                        "replica": 0,
+                        "relaunch_after_secs": 30,
+                    }
+                },
+            ),
             None,
         ),
     ],

--- a/scripts/generate_sim/scenarios.py
+++ b/scripts/generate_sim/scenarios.py
@@ -300,6 +300,92 @@ SCENARIOS = {
             None,
         ),
     ],
+    # M2 core matrix (02-experiment-plan.md): sprayed ingress everywhere
+    # (the regime that breaks per-replica state), one variable per
+    # comparison. local-event = per-gateway event indexers (round-3
+    # architecture); remote-event = same feed, ONE shared index (parity =
+    # location only); remote-placement = shared index fed ONLY by gateway
+    # placements (bridge off — the eventless-engine thesis, the number
+    # that does not exist yet); mesh-tree = the in-repo TreeSync
+    # alternative (approximate trees synced gateway-to-gateway).
+    # Compressed gateway clocks on every leg (held constant).
+    "remote-index": [
+        (
+            "local-event-sprayed",
+            {
+                **KV_EVENT_OVERRIDES,
+                "loadgen.ingress": "random",
+                "loadgen.turn2_ingress": "random",
+                "smg_flag_overrides": {
+                    **RADIX_TREE_FLAGS,
+                    "--enable-igw": None,
+                    **COMPRESSED_CLOCK_FLAGS,
+                },
+            },
+            None,
+        ),
+        (
+            "remote-event-sprayed",
+            {
+                **KV_EVENT_OVERRIDES,
+                "loadgen.ingress": "random",
+                "loadgen.turn2_ingress": "random",
+                "index_service": {
+                    "replicas": 2,
+                    "bridge": True,
+                    "inferred_ttl_secs": 18,
+                    "sweep_interval_secs": 1,
+                    "default_capacity_blocks": 4688,
+                },
+                "smg_flag_overrides": {
+                    **RADIX_TREE_FLAGS,
+                    "--enable-igw": None,
+                    **COMPRESSED_CLOCK_FLAGS,
+                    "--kv-indexer-url": "http://127.0.0.1:40000",
+                    "--kv-indexer-block-size": "256",
+                },
+            },
+            None,
+        ),
+        (
+            "remote-placement-sprayed",
+            {
+                **KV_EVENT_OVERRIDES,
+                "loadgen.ingress": "random",
+                "loadgen.turn2_ingress": "random",
+                "index_service": {
+                    "replicas": 2,
+                    "bridge": False,
+                    "inferred_ttl_secs": 18,
+                    "sweep_interval_secs": 1,
+                    "default_capacity_blocks": 4688,
+                },
+                "smg_flag_overrides": {
+                    **RADIX_TREE_FLAGS,
+                    "--enable-igw": None,
+                    **COMPRESSED_CLOCK_FLAGS,
+                    "--kv-indexer-url": "http://127.0.0.1:40000",
+                    "--kv-indexer-block-size": "256",
+                },
+            },
+            None,
+        ),
+        (
+            "mesh-tree-sprayed",
+            {
+                **KV_EVENT_OVERRIDES,
+                "loadgen.ingress": "random",
+                "loadgen.turn2_ingress": "random",
+                "mesh_smgs": True,
+                "smg_flag_overrides": {
+                    **RADIX_TREE_FLAGS,
+                    "--enable-igw": None,
+                    **COMPRESSED_CLOCK_FLAGS,
+                },
+            },
+            None,
+        ),
+    ],
     # Kill and relaunch every SMG mid-window: sticky pins and placements are
     # process state, so affinity must rebuild; errors during the blackout
     # are part of the result.
@@ -463,6 +549,23 @@ def extract_rows(report):
             paths[name] = paths.get(name, 0) + count
     path_total = sum(paths.values())
     streamed = sum(v for k, v in paths.items() if k.startswith("streamed"))
+    # Remote-index rows (--kv-indexer-url legs): per-request echo shares
+    # and the direct accuracy signal (predicted-vs-actual cached tokens).
+    sources = req.get("index_sources") or {}
+    total_sourced = sum(sources.values())
+    if total_sourced:
+        rows["index remote_hit share"] = round(
+            sources.get("remote_hit", 0) / total_sourced, 4
+        )
+        misses = total_sourced - sources.get("remote_hit", 0) - sources.get("remote_empty", 0)
+        rows["index degraded share (timeout+disconnect)"] = round(
+            misses / total_sourced, 4
+        )
+    pred = req.get("index_prediction_error_tokens")
+    if pred:
+        rows["index prediction error mean (tokens)"] = pred.get("mean")
+        rows["index prediction error p95 abs (tokens)"] = pred.get("p95_abs")
+
     rows["body path streamed share"] = (
         round(streamed / path_total, 4) if path_total else None
     )

--- a/scripts/generate_sim/scenarios.py
+++ b/scripts/generate_sim/scenarios.py
@@ -466,6 +466,50 @@ SCENARIOS = {
             None,
         ),
     ],
+    # Fault injection on the shared index: a full inter-replica network
+    # partition (severable TCP proxies) healed mid-run, and a wedged
+    # replica (SIGSTOP: TCP up, nothing drains) resumed mid-run. Both
+    # on the placement feed with 2 replicas; the per-replica metrics
+    # timeline in meta records divergence and reconvergence.
+    "index-partition": [
+        (
+            "partition-45s",
+            remote_leg(
+                {"bridge": False, "partitionable": True},
+                extra={"partition_drill": {"at_secs": 60, "heal_after_secs": 45}},
+            ),
+            None,
+        ),
+        (
+            "hang-45s",
+            remote_leg(
+                {"bridge": False},
+                extra={"hang_index_replica": {"at_secs": 60, "replica": 1, "resume_after_secs": 45}},
+            ),
+            None,
+        ),
+    ],
+    # F5: scale-up — replica 2 is in everyone's peer list from the
+    # start but only launches at t=60s, bootstrapping from replica 0
+    # under live load. F7: replica 1 flaps (kill+relaunch x3).
+    "index-scaleup-flap": [
+        (
+            "scaleup-r3",
+            remote_leg(
+                {"bridge": False, "replicas": 3, "deferred_replicas": [2]},
+                extra={"start_deferred_replica": {"replica": 2, "at_secs": 60}},
+            ),
+            None,
+        ),
+        (
+            "flap-r1",
+            remote_leg(
+                {"bridge": False},
+                extra={"flap_index_replica": {"replica": 1, "at_secs": 45, "cycles": 3, "period_secs": 20}},
+            ),
+            None,
+        ),
+    ],
     # Staleness sweep (event feed; the placement feed has no Removed to
     # delay): constant injected apply lag, reported against the 3 s
     # compressed think time (= 30 s production). Stored and Removed are

--- a/scripts/generate_sim/scenarios.py
+++ b/scripts/generate_sim/scenarios.py
@@ -437,6 +437,35 @@ SCENARIOS = {
             None,
         ),
     ],
+    # Placement-fed leg alone: rerunnable after the prompt-plus-output
+    # placement-chain fix to measure how much of the 1.6-point gap to the
+    # event feed it closes (the routing-time chain covered only the
+    # prompt; the worker's blocks span the generated tail too).
+    "remote-index-placement": [
+        (
+            "remote-placement-sprayed",
+            {
+                **KV_EVENT_OVERRIDES,
+                "loadgen.ingress": "random",
+                "loadgen.turn2_ingress": "random",
+                "index_service": {
+                    "replicas": 2,
+                    "bridge": False,
+                    "inferred_ttl_secs": 18,
+                    "sweep_interval_secs": 1,
+                    "default_capacity_blocks": 4688,
+                },
+                "smg_flag_overrides": {
+                    **RADIX_TREE_FLAGS,
+                    "--enable-igw": None,
+                    **COMPRESSED_CLOCK_FLAGS,
+                    "--kv-indexer-url": "http://127.0.0.1:40000",
+                    "--kv-indexer-block-size": "256",
+                },
+            },
+            None,
+        ),
+    ],
     # Staleness sweep (event feed; the placement feed has no Removed to
     # delay): constant injected apply lag, reported against the 3 s
     # compressed think time (= 30 s production). Stored and Removed are

--- a/scripts/generate_sim/scenarios.py
+++ b/scripts/generate_sim/scenarios.py
@@ -418,6 +418,25 @@ SCENARIOS = {
             None,
         ),
     ],
+    # Mesh TreeSync leg alone (the core matrix's first three legs already
+    # completed; peer-url format fix made this rerunnable separately).
+    "remote-index-mesh": [
+        (
+            "mesh-tree-sprayed",
+            {
+                **KV_EVENT_OVERRIDES,
+                "loadgen.ingress": "random",
+                "loadgen.turn2_ingress": "random",
+                "mesh_smgs": True,
+                "smg_flag_overrides": {
+                    **RADIX_TREE_FLAGS,
+                    "--enable-igw": None,
+                    **COMPRESSED_CLOCK_FLAGS,
+                },
+            },
+            None,
+        ),
+    ],
     # Staleness sweep (event feed; the placement feed has no Removed to
     # delay): constant injected apply lag, reported against the 3 s
     # compressed think time (= 30 s production). Stored and Removed are

--- a/scripts/generate_sim/scenarios.py
+++ b/scripts/generate_sim/scenarios.py
@@ -36,6 +36,17 @@ MULTITURN = {
 }
 
 
+# 10x-compressed gateway clocks for timing-sensitive legs. The profiles
+# compress request time 10x (itl/think/prefill), but the gateway's
+# wall-clock timers keep production defaults (load monitor 10 s,
+# eviction 120 s, cache TTL 180 s) — uncompressed they distort any leg
+# whose behavior depends on load freshness, tree eviction, or TTL.
+COMPRESSED_CLOCK_FLAGS = {
+    "--load-monitor-interval": "1",
+    "--eviction-interval": "12",
+    "--cache-ttl-secs": "18",
+}
+
 # Shared gateway-flag patch for the radix-replica legs: route on the
 # approximate radix tree with no sticky short-circuit. False removes a flag.
 RADIX_TREE_FLAGS = {

--- a/scripts/generate_sim/sim.py
+++ b/scripts/generate_sim/sim.py
@@ -43,6 +43,7 @@ MOCK_BASE_PORT = 9000
 SMG_BASE_PORT = 30000
 PROM_BASE_PORT = 39000
 INDEX_BASE_PORT = 40000
+MESH_BASE_PORT = 41000
 
 # Cache-aware decision branches are DEBUG logs only (no branch metric), scoped
 # so the rest of the gateway stays at warn.
@@ -58,6 +59,11 @@ METRIC_PREFIXES = (
     # cache-aware debug lines then cover only delegated (turn-1) decisions.
     "smg_manual_policy_branch_total",
     "smg_routing_key_source_total",
+    # Remote radix-index query outcomes + placement publishes
+    # (--kv-indexer-url legs); deadline-miss and fallback rates come
+    # straight from these.
+    "smg_remote_index_query_total",
+    "smg_remote_index_publish_total",
     # Buffered vs streamed body routing, per path/reason — the direct
     # verification of which request-body regime a leg actually ran in.
     "smg_router_request_body_path_total",
@@ -409,6 +415,27 @@ def launch_smgs(profile, logs_dir, smg_bin):
             "--prometheus-port",
             str(PROM_BASE_PORT + i),
         ] + list(profile["smg_flags"])
+        if profile.get("mesh_smgs"):
+            # Gateway-to-gateway mesh (TreeSync of approximate-tree inserts):
+            # per-instance port, full peer list minus self.
+            peers = [
+                "http://127.0.0.1:%d" % (MESH_BASE_PORT + j)
+                for j in range(count)
+                if j != i
+            ]
+            cmd += [
+                "--enable-mesh",
+                "--mesh-host",
+                "127.0.0.1",
+                "--mesh-advertise-host",
+                "127.0.0.1",
+                "--mesh-port",
+                str(MESH_BASE_PORT + i),
+                "--mesh-server-name",
+                "smg-%d" % i,
+            ]
+            if peers:
+                cmd += ["--mesh-peer-urls"] + peers
         children.append(spawn("smg-%d" % i, cmd, logs_dir / ("smg-%d.log" % i), env=env))
     log("gateways: %d on ports %d.. (prometheus %d..)"
         % (count, SMG_BASE_PORT, PROM_BASE_PORT))
@@ -649,6 +676,8 @@ def analyze_requests(path, workers_total, window=None):
     per_turn_worker = {}
     turn_stats = {}
     session_turn_worker = {}
+    index_sources = Counter()
+    prediction_errors = []
     if not path.exists():
         return {"error": "requests.jsonl missing"}
     records = []
@@ -687,6 +716,13 @@ def analyze_requests(path, workers_total, window=None):
         # Request-level "hit" per the design doc: cached/prompt >= 0.3.
         if prompt and cached / prompt >= 0.3:
             ts["hits"] += 1
+        source = rec.get("index_source")
+        if source:
+            index_sources[source] += 1
+            predicted = rec.get("index_predicted_tokens")
+            cached = rec.get("cached_tokens")
+            if predicted is not None and cached is not None:
+                prediction_errors.append(predicted - cached)
         port = rec.get("worker_port")
         if port is not None:
             per_worker[port] += 1
@@ -714,6 +750,22 @@ def analyze_requests(path, workers_total, window=None):
         "t2_same_worker_rate": round(same / len(both), 4) if both else None,
         "windowed": lo_ms is not None,
         "window_dropped_requests": dropped,
+        # Remote-index echo (only on --kv-indexer-url legs): what each
+        # decision resolved to, and predicted-vs-actual cached tokens —
+        # the direct index-accuracy signal, separable from policy spill.
+        "index_sources": dict(index_sources),
+        "index_prediction_error_tokens": (
+            {
+                "n": len(prediction_errors),
+                "mean": round(statistics.mean(prediction_errors), 1),
+                "median": statistics.median(prediction_errors),
+                "p95_abs": sorted(abs(e) for e in prediction_errors)[
+                    int(len(prediction_errors) * 0.95)
+                ],
+            }
+            if prediction_errors
+            else None
+        ),
     }
 
 

--- a/scripts/generate_sim/sim.py
+++ b/scripts/generate_sim/sim.py
@@ -361,7 +361,13 @@ def launch_index_service(profile, logs_dir, index_bin, bridge_bin):
         peers = ",".join(u for j, u in enumerate(urls) if j != i)
         if peers:
             cmd += ["--peers", peers]
-        for key in ("inferred_ttl_secs", "default_capacity_blocks", "sweep_interval_secs"):
+        for key in (
+            "inferred_ttl_secs",
+            "default_capacity_blocks",
+            "sweep_interval_secs",
+            "apply_delay_stored_ms",
+            "apply_delay_removed_ms",
+        ):
             if key in cfg:
                 cmd += ["--" + key.replace("_", "-"), str(cfg[key])]
         children.append(
@@ -1184,6 +1190,58 @@ def run_profile(profile, run_dir, smg_bin=None, skip_build=False):
         log("loadgen: %ds run" % duration)
         loadgen = spawn("loadgen", cmd, logs_dir / "loadgen.log")
         children.append(loadgen)
+
+        # Optional index-replica failover drill: kill replica N at t, and
+        # (optionally) relaunch it after a gap; timestamps recorded into
+        # meta so analysis can bin around the kill instant. The leg FAILS
+        # if the kill was never observed.
+        drill = profile.get("kill_index_replica")
+        if drill:
+
+            def _kill_index_replica():
+                at = float(drill.get("at_secs", 60))
+                replica = int(drill.get("replica", 1))
+                time.sleep(at)
+                name = "index-%d" % replica
+                victims = [c for c in children if c["name"] == name and c["proc"].poll() is None]
+                if not victims:
+                    meta["index_kill_failed"] = name
+                    return
+                for child in victims:
+                    child["proc"].kill()
+                meta["index_killed_at_ms"] = int(time.time() * 1000)
+                meta["index_killed_replica"] = replica
+                relaunch_after = drill.get("relaunch_after_secs")
+                if relaunch_after is not None:
+                    time.sleep(float(relaunch_after))
+                    cfg = profile.get("index_service", {})
+                    urls = [
+                        "http://127.0.0.1:%d" % (INDEX_BASE_PORT + i)
+                        for i in range(int(cfg.get("replicas", 2)))
+                    ]
+                    cmd = [
+                        str(index_bin),
+                        "--port",
+                        str(INDEX_BASE_PORT + replica),
+                        "--bootstrap-from",
+                        urls[0 if replica != 0 else 1],
+                    ]
+                    peers = ",".join(u for j, u in enumerate(urls) if j != replica)
+                    if peers:
+                        cmd += ["--peers", peers]
+                    env = dict(os.environ)
+                    env["RUST_LOG"] = "info"
+                    children.append(
+                        spawn(
+                            "index-%d" % replica,
+                            cmd,
+                            logs_dir / ("index-%d-relaunch.log" % replica),
+                            env=env,
+                        )
+                    )
+                    meta["index_relaunched_at_ms"] = int(time.time() * 1000)
+
+            threading.Thread(target=_kill_index_replica, daemon=True).start()
 
         # Optional mid-window gateway restart: sticky pins and hash
         # placements are process state, so affinity must rebuild from

--- a/scripts/generate_sim/sim.py
+++ b/scripts/generate_sim/sim.py
@@ -43,6 +43,80 @@ MOCK_BASE_PORT = 9000
 SMG_BASE_PORT = 30000
 PROM_BASE_PORT = 39000
 INDEX_BASE_PORT = 40000
+INDEX_METRICS_BASE = 40100
+INDEX_PROXY_BASE = 40300
+
+# Severable TCP proxies for inter-replica links: replica i reaches
+# replica j through proxy port INDEX_PROXY_BASE + i*8 + j, so a drill
+# can partition the pair (close live conns, refuse new ones) and heal
+# it later without touching the processes. Protocol-agnostic byte
+# pumps, so gRPC/HTTP2 rides through untouched.
+INDEX_SEVERED_LINKS = set()  # {(i, j)}
+INDEX_LINK_CONNS = {}  # (i, j) -> [socket, ...]
+
+
+def _proxy_pump(src, dst):
+    try:
+        while True:
+            data = src.recv(65536)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    finally:
+        for sock in (src, dst):
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+
+
+def start_peer_proxy(i, j, real_port):
+    lport = INDEX_PROXY_BASE + i * 8 + j
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", lport))
+    srv.listen(16)
+    INDEX_LINK_CONNS.setdefault((i, j), [])
+
+    def _accept():
+        while True:
+            try:
+                client, _ = srv.accept()
+            except OSError:
+                return
+            if (i, j) in INDEX_SEVERED_LINKS:
+                client.close()
+                continue
+            try:
+                upstream = socket.create_connection(("127.0.0.1", real_port), timeout=5)
+            except OSError:
+                client.close()
+                continue
+            INDEX_LINK_CONNS[(i, j)].append(client)
+            INDEX_LINK_CONNS[(i, j)].append(upstream)
+            threading.Thread(target=_proxy_pump, args=(client, upstream), daemon=True).start()
+            threading.Thread(target=_proxy_pump, args=(upstream, client), daemon=True).start()
+
+    threading.Thread(target=_accept, daemon=True).start()
+    return lport
+
+
+def sever_index_links(pairs):
+    for pair in pairs:
+        INDEX_SEVERED_LINKS.add(tuple(pair))
+        for sock in INDEX_LINK_CONNS.get(tuple(pair), []):
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+        INDEX_LINK_CONNS[tuple(pair)] = []
+
+
+def heal_index_links(pairs):
+    for pair in pairs:
+        INDEX_SEVERED_LINKS.discard(tuple(pair))
 MESH_BASE_PORT = 41000
 
 # Cache-aware decision branches are DEBUG logs only (no branch metric), scoped
@@ -354,11 +428,24 @@ def launch_index_service(profile, logs_dir, index_bin, bridge_bin):
     env = dict(os.environ)
     env["RUST_LOG"] = "info"
     replicas = int(cfg.get("replicas", 2))
+    deferred = set(cfg.get("deferred_replicas", []))
     urls = ["http://127.0.0.1:%d" % (INDEX_BASE_PORT + i) for i in range(replicas)]
+    partitionable = bool(cfg.get("partitionable"))
     children = []
     for i in range(replicas):
+        if i in deferred:
+            continue
         cmd = [str(index_bin), "--port", str(INDEX_BASE_PORT + i)]
-        peers = ",".join(u for j, u in enumerate(urls) if j != i)
+        cmd += ["--metrics-port", str(INDEX_METRICS_BASE + i)]
+        if partitionable:
+            peer_urls = [
+                "http://127.0.0.1:%d" % start_peer_proxy(i, j, INDEX_BASE_PORT + j)
+                for j in range(replicas)
+                if j != i
+            ]
+            peers = ",".join(peer_urls)
+        else:
+            peers = ",".join(u for j, u in enumerate(urls) if j != i)
         if peers:
             cmd += ["--peers", peers]
         for key in (
@@ -374,6 +461,8 @@ def launch_index_service(profile, logs_dir, index_bin, bridge_bin):
             spawn("index-%d" % i, cmd, logs_dir / ("index-%d.log" % i), env=env)
         )
     for i in range(replicas):
+        if i in deferred:
+            continue
         wait_tcp(INDEX_BASE_PORT + i, 30, "index-%d" % i)
     bridged = 0
     if cfg.get("bridge", True):
@@ -1240,6 +1329,189 @@ def run_profile(profile, run_dir, smg_bin=None, skip_build=False):
                     meta["index_relaunched_at_ms"] = int(time.time() * 1000)
 
             threading.Thread(target=_kill_index_replica, daemon=True).start()
+
+        # Partition drill: sever every inter-replica link both ways at
+        # `at_secs`, heal after `heal_after_secs`. Requires
+        # index_service.partitionable so peers ride the proxies.
+        pdrill = profile.get("partition_drill")
+        if pdrill:
+
+            def _partition():
+                cfg = profile.get("index_service", {})
+                replicas = int(cfg.get("replicas", 2))
+                pairs = [
+                    (i, j)
+                    for i in range(replicas)
+                    for j in range(replicas)
+                    if i != j
+                ]
+                time.sleep(float(pdrill.get("at_secs", 60)))
+                sever_index_links(pairs)
+                meta["index_partitioned_at_ms"] = int(time.time() * 1000)
+                heal_after = pdrill.get("heal_after_secs")
+                if heal_after is not None:
+                    time.sleep(float(heal_after))
+                    heal_index_links(pairs)
+                    meta["index_healed_at_ms"] = int(time.time() * 1000)
+
+            threading.Thread(target=_partition, daemon=True).start()
+
+        # Hang drill: SIGSTOP a replica (wedged-but-connected peer —
+        # TCP stays up, nothing drains) and SIGCONT it later.
+        hdrill = profile.get("hang_index_replica")
+        if hdrill:
+
+            def _hang():
+                import signal as _signal
+
+                replica = int(hdrill.get("replica", 1))
+                name = "index-%d" % replica
+                time.sleep(float(hdrill.get("at_secs", 60)))
+                victims = [
+                    c for c in children if c["name"] == name and c["proc"].poll() is None
+                ]
+                if not victims:
+                    meta["index_hang_failed"] = name
+                    return
+                for child in victims:
+                    child["proc"].send_signal(_signal.SIGSTOP)
+                meta["index_hung_at_ms"] = int(time.time() * 1000)
+                resume = hdrill.get("resume_after_secs")
+                if resume is not None:
+                    time.sleep(float(resume))
+                    for child in victims:
+                        child["proc"].send_signal(_signal.SIGCONT)
+                    meta["index_resumed_at_ms"] = int(time.time() * 1000)
+
+            threading.Thread(target=_hang, daemon=True).start()
+
+        # F5: start a DEFERRED replica mid-run (the k8s scale-up
+        # shape: peers were configured for it from the start, so the
+        # running replicas' relay reconnect loops pick it up the
+        # moment it binds; it bootstraps from replica 0 first).
+        sdrill = profile.get("start_deferred_replica")
+        if sdrill:
+
+            def _start_deferred():
+                cfg = profile.get("index_service", {})
+                replicas = int(cfg.get("replicas", 2))
+                replica = int(sdrill.get("replica", replicas - 1))
+                time.sleep(float(sdrill.get("at_secs", 60)))
+                urls = [
+                    "http://127.0.0.1:%d" % (INDEX_BASE_PORT + i)
+                    for i in range(replicas)
+                ]
+                cmd = [
+                    str(index_bin),
+                    "--port",
+                    str(INDEX_BASE_PORT + replica),
+                    "--metrics-port",
+                    str(INDEX_METRICS_BASE + replica),
+                    "--bootstrap-from",
+                    urls[0 if replica != 0 else 1],
+                ]
+                peers = ",".join(u for j, u in enumerate(urls) if j != replica)
+                if peers:
+                    cmd += ["--peers", peers]
+                for key in ("inferred_ttl_secs", "default_capacity_blocks", "sweep_interval_secs"):
+                    if key in cfg:
+                        cmd += ["--" + key.replace("_", "-"), str(cfg[key])]
+                env2 = dict(os.environ)
+                env2["RUST_LOG"] = "info"
+                children.append(
+                    spawn(
+                        "index-%d" % replica,
+                        cmd,
+                        logs_dir / ("index-%d-deferred.log" % replica),
+                        env=env2,
+                    )
+                )
+                meta["index_deferred_started_at_ms"] = int(time.time() * 1000)
+
+            threading.Thread(target=_start_deferred, daemon=True).start()
+
+        # F7: flap a replica — kill -> relaunch(bootstrap) repeatedly.
+        fdrill = profile.get("flap_index_replica")
+        if fdrill:
+
+            def _flap():
+                cfg = profile.get("index_service", {})
+                replicas = int(cfg.get("replicas", 2))
+                replica = int(fdrill.get("replica", 0))
+                cycles = int(fdrill.get("cycles", 3))
+                period = float(fdrill.get("period_secs", 20))
+                time.sleep(float(fdrill.get("at_secs", 45)))
+                urls = [
+                    "http://127.0.0.1:%d" % (INDEX_BASE_PORT + i)
+                    for i in range(replicas)
+                ]
+                flaps = []
+                for cycle in range(cycles):
+                    name = "index-%d" % replica
+                    for child in children:
+                        if child["name"] == name and child["proc"].poll() is None:
+                            child["proc"].kill()
+                    flaps.append({"killed_ms": int(time.time() * 1000)})
+                    time.sleep(period / 2)
+                    cmd = [
+                        str(index_bin),
+                        "--port",
+                        str(INDEX_BASE_PORT + replica),
+                        "--metrics-port",
+                        str(INDEX_METRICS_BASE + replica),
+                        "--bootstrap-from",
+                        urls[0 if replica != 0 else 1],
+                    ]
+                    peers = ",".join(u for j, u in enumerate(urls) if j != replica)
+                    if peers:
+                        cmd += ["--peers", peers]
+                    env2 = dict(os.environ)
+                    env2["RUST_LOG"] = "info"
+                    children.append(
+                        spawn(
+                            name,
+                            cmd,
+                            logs_dir / ("index-%d-flap%d.log" % (replica, cycle)),
+                            env=env2,
+                        )
+                    )
+                    flaps[-1]["relaunched_ms"] = int(time.time() * 1000)
+                    time.sleep(period / 2)
+                meta["index_flaps"] = flaps
+
+            threading.Thread(target=_flap, daemon=True).start()
+
+        # Per-replica admin-metrics timeline: applies/blocks/relay
+        # drops every 2 s, so divergence during a fault and
+        # reconvergence after it are measured, not asserted.
+        if profile.get("index_service"):
+
+            def _index_timeline():
+                cfg = profile.get("index_service", {})
+                replicas = int(cfg.get("replicas", 2))
+                timeline = meta.setdefault("index_timeline", [])
+                while loadgen["proc"].poll() is None:
+                    now_ms = int(time.time() * 1000)
+                    for i in range(replicas):
+                        try:
+                            body = http_get(
+                                "http://127.0.0.1:%d/metrics" % (INDEX_METRICS_BASE + i),
+                                timeout=2,
+                            )
+                        except Exception:
+                            continue
+                        row = {"t_ms": now_ms, "replica": i}
+                        for line in body.splitlines():
+                            if line.startswith("radix_index_applies_total "):
+                                row["applies"] = float(line.split()[1])
+                            elif line.startswith("radix_index_blocks "):
+                                row["blocks"] = float(line.split()[1])
+                            elif line.startswith("radix_index_relay_dropped_total "):
+                                row["relay_dropped"] = float(line.split()[1])
+                        timeline.append(row)
+                    time.sleep(2)
+
+            threading.Thread(target=_index_timeline, daemon=True).start()
 
         # Optional mid-window gateway restart: sticky pins and hash
         # placements are process state, so affinity must rebuild from

--- a/scripts/generate_sim/sim.py
+++ b/scripts/generate_sim/sim.py
@@ -425,9 +425,7 @@ def launch_smgs(profile, logs_dir, smg_bin):
             # Gateway-to-gateway mesh (TreeSync of approximate-tree inserts):
             # per-instance port, full peer list minus self.
             peers = [
-                "http://127.0.0.1:%d" % (MESH_BASE_PORT + j)
-                for j in range(count)
-                if j != i
+                "127.0.0.1:%d" % (MESH_BASE_PORT + j) for j in range(count) if j != i
             ]
             cmd += [
                 "--enable-mesh",

--- a/scripts/generate_sim/sim.py
+++ b/scripts/generate_sim/sim.py
@@ -42,6 +42,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 MOCK_BASE_PORT = 9000
 SMG_BASE_PORT = 30000
 PROM_BASE_PORT = 39000
+INDEX_BASE_PORT = 40000
 
 # Cache-aware decision branches are DEBUG logs only (no branch metric), scoped
 # so the rest of the gateway stays at warn.
@@ -242,7 +243,9 @@ def ensure_local_tokenizer():
 
 
 def build_binaries(target_dir, build_gateway):
-    packages = ["mock-worker", "sim-loadgen"] + (["smg"] if build_gateway else [])
+    packages = ["mock-worker", "sim-loadgen", "radix-index"] + (
+        ["smg"] if build_gateway else []
+    )
     cmd = ["cargo", "build", "--release"]
     for pkg in packages:
         cmd += ["-p", pkg]
@@ -253,42 +256,139 @@ def build_binaries(target_dir, build_gateway):
     subprocess.run(cmd, cwd=str(REPO_ROOT), env=env, check=True)
 
 
+def worker_segments(profile):
+    """Normalize `worker_mode` to [(mode, start_port, count)]. Accepts a
+    plain "http" / "grpc" (whole fleet) or a list of
+    {"mode": ..., "count": ...} segments summing to workers_total, so one
+    fleet can mix gRPC-event and HTTP workers (per-worker feed selection
+    is only measurable on a mixed fleet)."""
+    total = int(profile["workers_total"])
+    mode = profile.get("worker_mode", "http")
+    if isinstance(mode, str):
+        return [(mode, MOCK_BASE_PORT, total)]
+    segments = []
+    start = MOCK_BASE_PORT
+    for seg in mode:
+        count = int(seg["count"])
+        segments.append((seg["mode"], start, count))
+        start += count
+    if sum(c for _, _, c in segments) != total:
+        raise SystemExit("worker_mode segments must sum to workers_total")
+    return segments
+
+
 def launch_mocks(profile, logs_dir, mock_bin):
     total = int(profile["workers_total"])
     procs = int(profile["mock_processes"])
-    grpc = profile.get("worker_mode", "http") == "grpc"
-    port_flags = ("--grpc-base-port", "--grpc-count") if grpc else (
-        "--http-base-port", "--http-count")
-    per_proc = (total + procs - 1) // procs
+    segments = worker_segments(profile)
     children = []
-    started = 0
-    for j in range(procs):
-        count = min(per_proc, total - started)
-        base = MOCK_BASE_PORT + started
-        cmd = [
-            str(mock_bin),
-            "--host",
-            "127.0.0.1",
-            port_flags[0],
-            str(base),
-            port_flags[1],
-            str(count),
-            "--model",
-            profile.get("model_id", "mock-model"),
-        ] + flags_from(profile.get("mock", {}))
-        children.append(spawn("mock-%d" % j, cmd, logs_dir / ("mock-%d.log" % j)))
-        started += count
-    log("mock fleet: %d %s workers over %d processes (ports %d-%d)"
-        % (total, "grpc" if grpc else "http", procs,
-           MOCK_BASE_PORT, MOCK_BASE_PORT + total - 1))
+    proc_idx = 0
+    for mode, seg_start, seg_count in segments:
+        # Processes split across segments proportionally, at least one.
+        seg_procs = max(1, round(procs * seg_count / max(1, total)))
+        per_proc = (seg_count + seg_procs - 1) // seg_procs
+        port_flags = (
+            ("--grpc-base-port", "--grpc-count")
+            if mode == "grpc"
+            else ("--http-base-port", "--http-count")
+        )
+        started = 0
+        while started < seg_count:
+            count = min(per_proc, seg_count - started)
+            base = seg_start + started
+            cmd = [
+                str(mock_bin),
+                "--host",
+                "127.0.0.1",
+                port_flags[0],
+                str(base),
+                port_flags[1],
+                str(count),
+                "--model",
+                profile.get("model_id", "mock-model"),
+            ] + flags_from(profile.get("mock", {}))
+            children.append(
+                spawn("mock-%d" % proc_idx, cmd, logs_dir / ("mock-%d.log" % proc_idx))
+            )
+            proc_idx += 1
+            started += count
+    log(
+        "mock fleet: %d workers (%s) over %d processes (ports %d-%d)"
+        % (
+            total,
+            ", ".join("%d %s" % (c, m) for m, _, c in segments),
+            proc_idx,
+            MOCK_BASE_PORT,
+            MOCK_BASE_PORT + total - 1,
+        )
+    )
     time.sleep(2)
     for child in children:
         if child["proc"].poll() is not None:
             raise RuntimeError("%s exited early; see its log" % child["name"])
-    if grpc:
-        wait_tcp(MOCK_BASE_PORT, 30, "mock fleet")
-    else:
-        wait_health("http://127.0.0.1:%d/health" % MOCK_BASE_PORT, 30, "mock fleet")
+    for mode, seg_start, _ in segments:
+        if mode == "grpc":
+            wait_tcp(seg_start, 30, "mock fleet (grpc segment)")
+        else:
+            wait_health("http://127.0.0.1:%d/health" % seg_start, 30, "mock fleet")
+    return children
+
+
+def launch_index_service(profile, logs_dir, index_bin, bridge_bin):
+    """Optional radix index service + event bridge, from the profile's
+    `index_service` block:
+      {"replicas": 2, "inferred_ttl_secs": 18, "default_capacity_blocks": N,
+       "sweep_interval_secs": 1, "bridge": true}
+    Replicas relay to each other (single-endpoint topology); the bridge
+    subscribes to every gRPC worker segment and publishes to replica 0
+    (the relay carries updates to the rest)."""
+    cfg = profile.get("index_service")
+    if not cfg:
+        return []
+    env = dict(os.environ)
+    env["RUST_LOG"] = "info"
+    replicas = int(cfg.get("replicas", 2))
+    urls = ["http://127.0.0.1:%d" % (INDEX_BASE_PORT + i) for i in range(replicas)]
+    children = []
+    for i in range(replicas):
+        cmd = [str(index_bin), "--port", str(INDEX_BASE_PORT + i)]
+        peers = ",".join(u for j, u in enumerate(urls) if j != i)
+        if peers:
+            cmd += ["--peers", peers]
+        for key in ("inferred_ttl_secs", "default_capacity_blocks", "sweep_interval_secs"):
+            if key in cfg:
+                cmd += ["--" + key.replace("_", "-"), str(cfg[key])]
+        children.append(
+            spawn("index-%d" % i, cmd, logs_dir / ("index-%d.log" % i), env=env)
+        )
+    for i in range(replicas):
+        wait_tcp(INDEX_BASE_PORT + i, 30, "index-%d" % i)
+    bridged = 0
+    if cfg.get("bridge", True):
+        grpc_workers = [
+            "grpc://127.0.0.1:%d" % port
+            for mode, seg_start, seg_count in worker_segments(profile)
+            if mode == "grpc"
+            for port in range(seg_start, seg_start + seg_count)
+        ]
+        if grpc_workers:
+            cmd = [
+                str(bridge_bin),
+                "--workers",
+                ",".join(grpc_workers),
+                "--index",
+                urls[0],
+                "--model",
+                profile.get("model_id", "mock-model"),
+                "--block-size",
+                str(profile.get("mock", {}).get("block_size", 128)),
+            ]
+            children.append(spawn("bridge", cmd, logs_dir / "bridge.log", env=env))
+            bridged = len(grpc_workers)
+    log(
+        "index service: %d replicas on ports %d.. (bridging %d grpc workers)"
+        % (replicas, INDEX_BASE_PORT, bridged)
+    )
     return children
 
 
@@ -326,12 +426,17 @@ def register_workers(profile):
     """
     total = int(profile["workers_total"])
     model_id = profile.get("model_id", "mock-model")
-    grpc = profile.get("worker_mode", "http") == "grpc"
+    segments = worker_segments(profile)
+    mode_by_port = {}
+    for mode, seg_start, seg_count in segments:
+        for port in range(seg_start, seg_start + seg_count):
+            mode_by_port[port] = mode
+    any_grpc = any(mode == "grpc" for mode, _, _ in segments)
     smg_ports = [SMG_BASE_PORT + i for i in range(int(profile["smg_count"]))]
-    tokenizer_path = str(ensure_local_tokenizer()) if grpc else None
+    tokenizer_path = str(ensure_local_tokenizer()) if any_grpc else None
 
     def register_one(smg_port, worker_port):
-        if grpc:
+        if mode_by_port.get(worker_port) == "grpc":
             # The URL scheme selects the connection mode; runtime picks the
             # proto dialect the mock implements. weight_version is relayed
             # verbatim in every response's meta_info — it is how the
@@ -534,13 +639,20 @@ def imbalance(counter, workers_total):
     }
 
 
-def analyze_requests(path, workers_total):
+def analyze_requests(path, workers_total, window=None):
+    """Aggregate requests.jsonl. With `window` = (warmup_secs,
+    duration_secs), only requests STARTED inside the steady-state window
+    count — mirroring the loadgen summary's finish-time filter, so the
+    turn/CoV rows here no longer mix warmup and the drain tail into
+    otherwise-windowed compare tables."""
     per_worker = Counter()
     per_turn_worker = {}
     turn_stats = {}
     session_turn_worker = {}
     if not path.exists():
         return {"error": "requests.jsonl missing"}
+    records = []
+    t0 = None
     with open(path, errors="replace") as f:
         for line in f:
             line = line.strip()
@@ -550,25 +662,38 @@ def analyze_requests(path, workers_total):
                 rec = json.loads(line)
             except ValueError:
                 continue
-            turn = int(rec.get("turn", 1))
-            ts = turn_stats.setdefault(
-                turn, {"n": 0, "prompt": 0, "cached": 0, "hits": 0}
-            )
-            ts["n"] += 1
-            prompt = rec.get("prompt_tokens") or 0
-            cached = rec.get("cached_tokens") or 0
-            ts["prompt"] += prompt
-            ts["cached"] += cached
-            # Request-level "hit" per the design doc: cached/prompt >= 0.3.
-            if prompt and cached / prompt >= 0.3:
-                ts["hits"] += 1
-            port = rec.get("worker_port")
-            if port is not None:
-                per_worker[port] += 1
-                per_turn_worker.setdefault(turn, Counter())[port] += 1
-                session = rec.get("session")
-                if session is not None:
-                    session_turn_worker.setdefault(session, {})[turn] = port
+            start_ms = rec.get("start_ms")
+            if start_ms is not None:
+                t0 = start_ms if t0 is None else min(t0, start_ms)
+            records.append(rec)
+    lo_ms, hi_ms = None, None
+    if window and t0 is not None:
+        lo_ms = t0 + float(window[0]) * 1000.0
+        hi_ms = t0 + float(window[1]) * 1000.0
+    dropped = 0
+    for rec in records:
+        if lo_ms is not None:
+            start_ms = rec.get("start_ms")
+            if start_ms is None or not (lo_ms <= start_ms < hi_ms):
+                dropped += 1
+                continue
+        turn = int(rec.get("turn", 1))
+        ts = turn_stats.setdefault(turn, {"n": 0, "prompt": 0, "cached": 0, "hits": 0})
+        ts["n"] += 1
+        prompt = rec.get("prompt_tokens") or 0
+        cached = rec.get("cached_tokens") or 0
+        ts["prompt"] += prompt
+        ts["cached"] += cached
+        # Request-level "hit" per the design doc: cached/prompt >= 0.3.
+        if prompt and cached / prompt >= 0.3:
+            ts["hits"] += 1
+        port = rec.get("worker_port")
+        if port is not None:
+            per_worker[port] += 1
+            per_turn_worker.setdefault(turn, Counter())[port] += 1
+            session = rec.get("session")
+            if session is not None:
+                session_turn_worker.setdefault(session, {})[turn] = port
     both = [s for s in session_turn_worker.values() if 1 in s and 2 in s]
     same = sum(1 for s in both if s[1] == s[2])
     turns = {}
@@ -587,6 +712,8 @@ def analyze_requests(path, workers_total):
         "turns": turns,
         "t2_sessions": len(both),
         "t2_same_worker_rate": round(same / len(both), 4) if both else None,
+        "windowed": lo_ms is not None,
+        "window_dropped_requests": dropped,
     }
 
 
@@ -701,7 +828,14 @@ def build_report(run_dir):
         "profile": profile,
         "run_dir": str(run_dir),
         "loadgen_summary": loadgen_summary,
-        "requests": analyze_requests(run_dir / "requests.jsonl", workers_total),
+        "requests": analyze_requests(
+            run_dir / "requests.jsonl",
+            workers_total,
+            window=(
+                int(profile.get("warmup_secs", 0)),
+                int(profile["duration_secs"]),
+            ),
+        ),
         "samples": summarize_samples(
         run_dir / "samples.jsonl",
         smg_count,
@@ -913,7 +1047,12 @@ def run_profile(profile, run_dir, smg_bin=None, skip_build=False):
     smg_bin = Path(smg_bin) if smg_bin else target_dir / "release" / "smg"
     mock_bin = target_dir / "release" / "mock-worker"
     loadgen_bin = target_dir / "release" / "sim-loadgen"
-    for path in (smg_bin, mock_bin, loadgen_bin):
+    index_bin = target_dir / "release" / "radix-index-service"
+    bridge_bin = target_dir / "release" / "radix-index-bridge"
+    required = [smg_bin, mock_bin, loadgen_bin]
+    if profile.get("index_service"):
+        required += [index_bin, bridge_bin]
+    for path in required:
         if not os.access(str(path), os.X_OK):
             raise SystemExit("binary missing: %s (drop --skip-build?)" % path)
 
@@ -924,7 +1063,7 @@ def run_profile(profile, run_dir, smg_bin=None, skip_build=False):
         json.dump(profile, f, indent=2)
 
     raise_nofile_limit()
-    all_bins = [smg_bin, mock_bin, loadgen_bin]
+    all_bins = [smg_bin, mock_bin, loadgen_bin, index_bin, bridge_bin]
     teardown([], all_bins)  # clear leftovers from prior runs so ports are free
     time.sleep(1)
 
@@ -940,6 +1079,8 @@ def run_profile(profile, run_dir, smg_bin=None, skip_build=False):
             "smg": _sha256(smg_bin),
             "mock-worker": _sha256(mock_bin),
             "sim-loadgen": _sha256(loadgen_bin),
+            "radix-index-service": _sha256(index_bin) if index_bin.exists() else None,
+            "radix-index-bridge": _sha256(bridge_bin) if bridge_bin.exists() else None,
         },
         "profile_sha256": hashlib.sha256(
             json.dumps(profile, sort_keys=True).encode()
@@ -951,6 +1092,7 @@ def run_profile(profile, run_dir, smg_bin=None, skip_build=False):
     sampler = None
     try:
         children += launch_mocks(profile, logs_dir, mock_bin)
+        children += launch_index_service(profile, logs_dir, index_bin, bridge_bin)
         children += launch_smgs(profile, logs_dir, smg_bin)
         meta["registered"] = register_workers(profile)
         meta["ready"] = wait_ready(profile)

--- a/scripts/generate_sim/test_generate_sim.py
+++ b/scripts/generate_sim/test_generate_sim.py
@@ -133,6 +133,66 @@ class ScenarioConstruction(unittest.TestCase):
         )
         self.assertIn("--routing-key-override", flags, "input must not be mutated")
 
+    def test_worker_segments_normalize_and_validate(self):
+        whole = sim.worker_segments({"workers_total": 10, "worker_mode": "grpc"})
+        self.assertEqual(whole, [("grpc", sim.MOCK_BASE_PORT, 10)])
+        default = sim.worker_segments({"workers_total": 4})
+        self.assertEqual(default, [("http", sim.MOCK_BASE_PORT, 4)])
+        mixed = sim.worker_segments(
+            {
+                "workers_total": 6,
+                "worker_mode": [
+                    {"mode": "grpc", "count": 4},
+                    {"mode": "http", "count": 2},
+                ],
+            }
+        )
+        self.assertEqual(
+            mixed,
+            [
+                ("grpc", sim.MOCK_BASE_PORT, 4),
+                ("http", sim.MOCK_BASE_PORT + 4, 2),
+            ],
+        )
+        with self.assertRaises(SystemExit):
+            sim.worker_segments(
+                {"workers_total": 5, "worker_mode": [{"mode": "grpc", "count": 4}]}
+            )
+
+    def test_analyze_requests_applies_steady_state_window(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "requests.jsonl"
+            t0 = 1_000_000
+            rows = [
+                # warmup (dropped), in-window, drain tail (dropped)
+                {"turn": 1, "session": 1, "worker_port": 9000,
+                 "prompt_tokens": 100, "cached_tokens": 0, "start_ms": t0},
+                {"turn": 1, "session": 2, "worker_port": 9001,
+                 "prompt_tokens": 100, "cached_tokens": 50,
+                 "start_ms": t0 + 15_000},
+                {"turn": 1, "session": 3, "worker_port": 9002,
+                 "prompt_tokens": 100, "cached_tokens": 0,
+                 "start_ms": t0 + 65_000},
+            ]
+            with open(path, "w") as f:
+                for row in rows:
+                    f.write(json.dumps(row) + "\n")
+            out = sim.analyze_requests(path, 3, window=(10, 60))
+            self.assertTrue(out["windowed"])
+            self.assertEqual(out["window_dropped_requests"], 2)
+            self.assertEqual(out["turns"]["turn1"]["requests"], 1)
+            # Unwindowed keeps everything (back-compat for old run dirs).
+            out = sim.analyze_requests(path, 3)
+            self.assertEqual(out["turns"]["turn1"]["requests"], 3)
+
+    def test_compressed_clock_flags_patch_cleanly(self):
+        flags = scenarios.patch_smg_flags(
+            ["--policy", "cache_aware"], scenarios.COMPRESSED_CLOCK_FLAGS
+        )
+        self.assertIn("--load-monitor-interval", flags)
+        self.assertIn("--eviction-interval", flags)
+        self.assertIn("--cache-ttl-secs", flags)
+
     def test_kv_event_legs_run_grpc_nonstreaming_with_igw(self):
         for label, overrides, _ in scenarios.SCENARIOS["kv-events"]:
             self.assertEqual(overrides["worker_mode"], "grpc", label)


### PR DESCRIPTION
> [!NOTE]
> **WIP — stacked on #2357** (this PR's base is `feat/radix-index-experiment`). The diff is only the benchmark and fault-injection harness for the radix-index experiments. No reports/results are checked in — numbers are summarized in #2357 and reproducible with these scripts.

## What this adds

**Scenario legs** (`scenarios.py`): the `remote-index` core matrix (local-event / remote-event / remote-placement / mesh), `index-staleness` (constant-lag apply-delay injection), `index-capacity`, `index-failover`, `remote-index-placement` (single rerunnable leg), `index-partition` (partition + wedged-replica drills), `index-scaleup-flap` (scale-up under load + kill/relaunch flap); compressed-clock gateway flags; binary-identity assertion in compare.

**Fault injection** (`sim.py`): severable TCP proxies on every inter-replica link (real network partitions, healable mid-run), SIGSTOP/SIGCONT wedged-replica drill, kill→relaunch-with-bootstrap flap cycles, deferred-replica scale-up (peers pre-configured, started mid-run), and a per-replica admin-metrics timeline (applies / blocks / relay drops every 2s into run metadata) so divergence and reconvergence are measured, not asserted. The relay-overflow drill uses the service's `RADIX_RELAY_QUEUE` override. This timeline is what exposed the symmetric-peer relay echo bug fixed in #2357.

**Analysis**: windowed request analysis, `x-smg-index-*` prediction-header capture in `sim_loadgen`, `failover_bins.py` (10s bins around a replica kill).

Run shape: `python3 scenarios.py compare --scenario remote-index --profile profiles/local-small.json --seeds 3`.
