### PR TITLE
feat(protocols): provider extension modules for Kimi and MiniMax fields

### DIFF
--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -29,6 +29,8 @@ use crate::{
 pub enum ChatMessage {
     #[serde(rename = "system")]
     System {
+        /// Defaults to empty text: K3 tools-only system messages omit content entirely
+        #[serde(default)]
         content: MessageContent,
         name: Option<String>,
         #[serde(flatten)]
@@ -67,6 +69,12 @@ pub enum ChatMessage {
 pub enum MessageContent {
     Text(String),
     Parts(Vec<ContentPart>),
+}
+
+impl Default for MessageContent {
+    fn default() -> Self {
+        MessageContent::Text(String::new())
+    }
 }
 
 impl MessageContent {

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -470,14 +470,21 @@ fn validate_chat_cross_parameters(
         }
     }
 
-    // 7. Validate tool_choice requires tools (except for "none")
+    // 7. Validate tool_choice requires tools — except "none" and "auto", which are valid without tools
     if let Some(ref tool_choice) = req.tool_choice {
-        let has_tools = req.tools.as_ref().is_some_and(|t| !t.is_empty());
+        // Dynamic tools on system messages count as tools (Kimi K3)
+        let has_tools = req.tools.as_ref().is_some_and(|t| !t.is_empty())
+            || req.messages.iter().any(|m| {
+                matches!(m, ChatMessage::System { kimi, .. }
+                    if kimi.tools.as_ref().is_some_and(|t| !t.is_empty()))
+            });
 
-        // Check if tool_choice is anything other than "none"
-        let is_some_choice = !matches!(tool_choice, ToolChoice::Value(ToolChoiceValue::None));
+        let requires_tools = !matches!(
+            tool_choice,
+            ToolChoice::Value(ToolChoiceValue::None) | ToolChoice::Value(ToolChoiceValue::Auto)
+        );
 
-        if is_some_choice && !has_tools {
+        if requires_tools && !has_tools {
             let mut e = validator::ValidationError::new("tool_choice_requires_tools");
             e.message = Some("Invalid value for 'tool_choice': 'tool_choice' is only allowed when 'tools' are specified.".into());
             return Err(e);

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -15,6 +15,7 @@ use super::{
 };
 use crate::{
     builders::{ChatCompletionResponseBuilder, ChatCompletionStreamResponseBuilder},
+    ext::kimi::KimiSystemExt,
     validated::Normalizable,
 };
 
@@ -30,6 +31,8 @@ pub enum ChatMessage {
     System {
         content: MessageContent,
         name: Option<String>,
+        #[serde(flatten)]
+        kimi: KimiSystemExt,
     },
     #[serde(rename = "user")]
     User {

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -34,7 +34,7 @@ pub enum ChatMessage {
         content: MessageContent,
         name: Option<String>,
         #[serde(flatten)]
-        kimi: KimiSystemExt,
+        ext: KimiSystemExt,
     },
     #[serde(rename = "user")]
     User {
@@ -483,8 +483,8 @@ fn validate_chat_cross_parameters(
         // Dynamic tools on system messages count as tools (Kimi K3)
         let has_tools = req.tools.as_ref().is_some_and(|t| !t.is_empty())
             || req.messages.iter().any(|m| {
-                matches!(m, ChatMessage::System { kimi, .. }
-                    if kimi.tools.as_ref().is_some_and(|t| !t.is_empty()))
+                matches!(m, ChatMessage::System { ext, .. }
+                    if ext.tools.as_ref().is_some_and(|t| !t.is_empty()))
             });
 
         let requires_tools = !matches!(

--- a/crates/protocols/src/ext/kimi.rs
+++ b/crates/protocols/src/ext/kimi.rs
@@ -1,0 +1,14 @@
+//! Kimi/Moonshot protocol extensions (K3 serving requirements; Kimi-Vendor-Verifier).
+
+use serde::{Deserialize, Serialize};
+
+use crate::common::Tool;
+
+/// Dynamic-tool declaration on system messages (K3): tools may be declared on
+/// a system message with empty content, at any position in the conversation,
+/// with the same status as request-level tools.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct KimiSystemExt {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Tool>>,
+}

--- a/crates/protocols/src/ext/mod.rs
+++ b/crates/protocols/src/ext/mod.rs
@@ -1,0 +1,9 @@
+//! Provider-owned protocol extensions.
+//!
+//! Each provider contributes one module of all-`Option` extension structs that
+//! are `#[serde(flatten)]`-ed into the core request types. Fields are promoted
+//! here only when a provider's vendor-acceptance contract enforces behavior on
+//! them; cosmetic extras stay out. Absent fields serialize to nothing, so
+//! OpenAI-only traffic is wire-identical.
+
+pub mod kimi;

--- a/crates/protocols/src/lib.rs
+++ b/crates/protocols/src/lib.rs
@@ -14,6 +14,7 @@ pub mod common;
 pub mod completion;
 pub mod embedding;
 pub mod event_types;
+pub mod ext;
 pub mod generate;
 pub mod interactions;
 pub mod messages;

--- a/crates/protocols/tests/provider_ext.rs
+++ b/crates/protocols/tests/provider_ext.rs
@@ -1,11 +1,13 @@
 //! Provider extension fields must survive the HTTP router's
-//! deserialize→serialize round trip.
+//! deserialize→serialize round trip, and tool_choice validation must
+//! accept "auto"/"none" without tools.
 
 use openai_protocol::{
     chat::{ChatCompletionRequest, ChatMessage},
-    common::{ImageUrl, VideoUrl},
+    common::{ImageUrl, ToolChoice, ToolChoiceValue, VideoUrl},
 };
 use serde_json::{json, Value};
+use validator::Validate;
 
 #[expect(clippy::expect_used, reason = "test helper")]
 fn roundtrip(value: Value) -> Value {
@@ -111,4 +113,60 @@ fn parsed_system_message_exposes_dynamic_tools() {
         }
         other => panic!("expected system message, got {other:?}"),
     }
+}
+
+#[expect(clippy::expect_used, reason = "test helper")]
+fn request_with_tool_choice(tool_choice: ToolChoice) -> ChatCompletionRequest {
+    let mut req: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "kimi-k3",
+        "messages": [{"role": "user", "content": "hi"}]
+    }))
+    .expect("request deserializes");
+    req.tool_choice = Some(tool_choice);
+    req
+}
+
+#[test]
+fn tool_choice_auto_and_none_valid_without_tools() {
+    for value in [ToolChoiceValue::Auto, ToolChoiceValue::None] {
+        let req = request_with_tool_choice(ToolChoice::Value(value));
+        assert!(
+            req.validate().is_ok(),
+            "{:?} must not require tools",
+            req.tool_choice
+        );
+    }
+}
+
+#[test]
+fn tool_choice_required_and_function_still_require_tools() {
+    let required = request_with_tool_choice(ToolChoice::Value(ToolChoiceValue::Required));
+    assert!(required.validate().is_err());
+
+    let named: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "kimi-k3",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tool_choice": {"type": "function", "function": {"name": "get_weather"}}
+    }))
+    .expect("request deserializes");
+    assert!(named.validate().is_err());
+}
+
+#[test]
+fn tool_choice_required_valid_with_only_dynamic_tools() {
+    let req: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "kimi-k3",
+        "messages": [
+            {"role": "system", "content": "", "tools": [
+                {"type": "function", "function": {"name": "get_weather"}}
+            ]},
+            {"role": "user", "content": "weather in beijing?"}
+        ],
+        "tool_choice": "required"
+    }))
+    .expect("request deserializes");
+    assert!(
+        req.validate().is_ok(),
+        "dynamic tools must satisfy tool_choice=required"
+    );
 }

--- a/crates/protocols/tests/provider_ext.rs
+++ b/crates/protocols/tests/provider_ext.rs
@@ -170,3 +170,19 @@ fn tool_choice_required_valid_with_only_dynamic_tools() {
         "dynamic tools must satisfy tool_choice=required"
     );
 }
+
+#[test]
+fn system_message_without_content_defaults_to_empty() {
+    let msg: ChatMessage = serde_json::from_value(json!({
+        "role": "system",
+        "tools": [{"type": "function", "function": {"name": "get_weather"}}]
+    }))
+    .expect("tools-only system message deserializes");
+    match msg {
+        ChatMessage::System { content, kimi, .. } => {
+            assert_eq!(content.to_simple_string(), "");
+            assert!(kimi.tools.is_some());
+        }
+        other => panic!("expected system message, got {other:?}"),
+    }
+}

--- a/crates/protocols/tests/provider_ext.rs
+++ b/crates/protocols/tests/provider_ext.rs
@@ -106,8 +106,8 @@ fn parsed_system_message_exposes_dynamic_tools() {
     }))
     .unwrap();
     match msg {
-        ChatMessage::System { kimi, .. } => {
-            let tools = kimi.tools.expect("tools parsed");
+        ChatMessage::System { ext, .. } => {
+            let tools = ext.tools.expect("tools parsed");
             assert_eq!(tools.len(), 1);
             assert_eq!(tools[0].function.name, "get_time");
         }
@@ -179,9 +179,9 @@ fn system_message_without_content_defaults_to_empty() {
     }))
     .expect("tools-only system message deserializes");
     match msg {
-        ChatMessage::System { content, kimi, .. } => {
+        ChatMessage::System { content, ext, .. } => {
             assert_eq!(content.to_simple_string(), "");
-            assert!(kimi.tools.is_some());
+            assert!(ext.tools.is_some());
         }
         other => panic!("expected system message, got {other:?}"),
     }

--- a/crates/protocols/tests/provider_ext.rs
+++ b/crates/protocols/tests/provider_ext.rs
@@ -1,0 +1,114 @@
+//! Provider extension fields must survive the HTTP router's
+//! deserialize→serialize round trip.
+
+use openai_protocol::{
+    chat::{ChatCompletionRequest, ChatMessage},
+    common::{ImageUrl, VideoUrl},
+};
+use serde_json::{json, Value};
+
+#[expect(clippy::expect_used, reason = "test helper")]
+fn roundtrip(value: Value) -> Value {
+    let req: ChatCompletionRequest = serde_json::from_value(value).expect("request deserializes");
+    serde_json::to_value(&req).expect("request serializes")
+}
+
+#[test]
+fn image_url_preserves_max_long_side_pixel() {
+    let image: ImageUrl = serde_json::from_value(json!({
+        "url": "data:image/png;base64,AAAA",
+        "detail": "high",
+        "max_long_side_pixel": 448
+    }))
+    .unwrap();
+    assert_eq!(image.max_long_side_pixel, Some(448));
+
+    let out = serde_json::to_value(&image).unwrap();
+    assert_eq!(out["max_long_side_pixel"], json!(448));
+    assert_eq!(out["detail"], json!("high"));
+}
+
+#[test]
+fn video_url_preserves_sizing_and_fps() {
+    let video: VideoUrl = serde_json::from_value(json!({
+        "url": "https://example.com/clip.mp4",
+        "max_long_side_pixel": 896,
+        "fps": 2.5
+    }))
+    .unwrap();
+    assert_eq!(video.max_long_side_pixel, Some(896));
+    assert_eq!(video.fps, Some(2.5));
+
+    let out = serde_json::to_value(&video).unwrap();
+    assert_eq!(out["max_long_side_pixel"], json!(896));
+    assert_eq!(out["fps"], json!(2.5));
+}
+
+#[test]
+fn media_parts_without_ext_stay_wire_identical() {
+    let image: ImageUrl = serde_json::from_value(json!({"url": "u"})).unwrap();
+    let out = serde_json::to_value(&image).unwrap();
+    assert_eq!(out, json!({"url": "u"}));
+
+    let video: VideoUrl = serde_json::from_value(json!({"url": "v"})).unwrap();
+    let out = serde_json::to_value(&video).unwrap();
+    assert_eq!(out, json!({"url": "v"}));
+}
+
+#[test]
+fn system_message_preserves_dynamic_tools() {
+    let request = json!({
+        "model": "kimi-k3",
+        "messages": [
+            {"role": "system", "content": "", "tools": [
+                {"type": "function", "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}
+                }}
+            ]},
+            {"role": "user", "content": "what is the weather in beijing?"}
+        ],
+        "tool_choice": "required"
+    });
+    let out = roundtrip(request);
+
+    let system = &out["messages"][0];
+    assert_eq!(system["role"], json!("system"));
+    assert_eq!(
+        system["tools"][0]["function"]["name"],
+        json!("get_weather"),
+        "dynamic tools must survive the round trip: {system}"
+    );
+}
+
+#[test]
+fn system_message_without_tools_has_no_tools_key() {
+    let out = roundtrip(json!({
+        "model": "kimi-k3",
+        "messages": [
+            {"role": "system", "content": "be terse"},
+            {"role": "user", "content": "hi"}
+        ]
+    }));
+    let system = out["messages"][0].as_object().unwrap();
+    assert!(!system.contains_key("tools"));
+}
+
+#[test]
+fn parsed_system_message_exposes_dynamic_tools() {
+    let msg: ChatMessage = serde_json::from_value(json!({
+        "role": "system",
+        "content": "",
+        "tools": [{"type": "function", "function": {"name": "get_time"}}]
+    }))
+    .unwrap();
+    match msg {
+        ChatMessage::System { kimi, .. } => {
+            let tools = kimi.tools.expect("tools parsed");
+            assert_eq!(tools.len(), 1);
+            assert_eq!(tools[0].function.name, "get_time");
+        }
+        other => panic!("expected system message, got {other:?}"),
+    }
+}

--- a/crates/tokenizer/tests/chat_template_format_detection.rs
+++ b/crates/tokenizer/tests/chat_template_format_detection.rs
@@ -176,7 +176,7 @@ assistant:
         ChatMessage::System {
             content: MessageContent::Text("You are helpful".to_string()),
             name: None,
-            kimi: Default::default(),
+            ext: Default::default(),
         },
         ChatMessage::User {
             content: MessageContent::Text("Hello".to_string()),

--- a/crates/tokenizer/tests/chat_template_format_detection.rs
+++ b/crates/tokenizer/tests/chat_template_format_detection.rs
@@ -176,6 +176,7 @@ assistant:
         ChatMessage::System {
             content: MessageContent::Text("You are helpful".to_string()),
             name: None,
+            kimi: Default::default(),
         },
         ChatMessage::User {
             content: MessageContent::Text("Hello".to_string()),

--- a/crates/tokenizer/tests/chat_template_integration.rs
+++ b/crates/tokenizer/tests/chat_template_integration.rs
@@ -118,6 +118,7 @@ fn test_llama_style_template() {
         ChatMessage::System {
             content: MessageContent::Text("You are a helpful assistant".to_string()),
             name: None,
+            kimi: Default::default(),
         },
         ChatMessage::User {
             content: MessageContent::Text("What is 2+2?".to_string()),

--- a/crates/tokenizer/tests/chat_template_integration.rs
+++ b/crates/tokenizer/tests/chat_template_integration.rs
@@ -118,7 +118,7 @@ fn test_llama_style_template() {
         ChatMessage::System {
             content: MessageContent::Text("You are a helpful assistant".to_string()),
             name: None,
-            kimi: Default::default(),
+            ext: Default::default(),
         },
         ChatMessage::User {
             content: MessageContent::Text("What is 2+2?".to_string()),

--- a/model_gateway/benches/request_processing.rs
+++ b/model_gateway/benches/request_processing.rs
@@ -156,6 +156,7 @@ fn create_sample_chat_completion_request() -> ChatCompletionRequest {
         model: "gpt-3.5-turbo".to_string(),
         messages: vec![
             ChatMessage::System {
+                kimi: Default::default(),
                 content: MessageContent::Text("You are a helpful assistant".to_string()),
                 name: None,
             },
@@ -196,6 +197,7 @@ fn create_sample_completion_request() -> CompletionRequest {
 #[allow(deprecated)]
 fn create_large_chat_completion_request() -> ChatCompletionRequest {
     let mut messages = vec![ChatMessage::System {
+        kimi: Default::default(),
         content: MessageContent::Text(
             "You are a helpful assistant with extensive knowledge.".to_string(),
         ),

--- a/model_gateway/benches/request_processing.rs
+++ b/model_gateway/benches/request_processing.rs
@@ -156,7 +156,7 @@ fn create_sample_chat_completion_request() -> ChatCompletionRequest {
         model: "gpt-3.5-turbo".to_string(),
         messages: vec![
             ChatMessage::System {
-                kimi: Default::default(),
+                ext: Default::default(),
                 content: MessageContent::Text("You are a helpful assistant".to_string()),
                 name: None,
             },
@@ -197,7 +197,7 @@ fn create_sample_completion_request() -> CompletionRequest {
 #[allow(deprecated)]
 fn create_large_chat_completion_request() -> ChatCompletionRequest {
     let mut messages = vec![ChatMessage::System {
-        kimi: Default::default(),
+        ext: Default::default(),
         content: MessageContent::Text(
             "You are a helpful assistant with extensive knowledge.".to_string(),
         ),

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -992,7 +992,7 @@ impl HarmonyBuilder {
 
         for msg in messages {
             match msg {
-                ChatMessage::System { content, name } => {
+                ChatMessage::System { content, name, .. } => {
                     // System messages stay as-is
                     let harmony_msg = HarmonyMessage {
                         author: Author {

--- a/model_gateway/src/routers/grpc/multimodal/detect.rs
+++ b/model_gateway/src/routers/grpc/multimodal/detect.rs
@@ -158,7 +158,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "https://example.com/cat.jpg".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -176,7 +175,6 @@ mod tests {
         let messages = vec![ChatMessage::User {
             content: MessageContent::Parts(vec![ContentPart::VideoUrl {
                 video_url: VideoUrl {
-                    minimax: Default::default(),
                     url: "https://example.com/clip.mp4".to_string(),
                     fps: None,
                     max_long_side_pixel: None,
@@ -228,7 +226,7 @@ mod tests {
     fn extracts_image_media_part() {
         let messages = vec![
             ChatMessage::System {
-                kimi: Default::default(),
+                ext: Default::default(),
                 content: MessageContent::Text("You are helpful".to_string()),
                 name: None,
             },
@@ -239,7 +237,6 @@ mod tests {
                     },
                     ContentPart::ImageUrl {
                         image_url: ImageUrl {
-                            minimax: Default::default(),
                             url: "https://example.com/image.jpg".to_string(),
                             detail: Some("high".to_string()),
                             max_long_side_pixel: None,
@@ -267,7 +264,6 @@ mod tests {
         let messages = vec![ChatMessage::User {
             content: MessageContent::Parts(vec![ContentPart::VideoUrl {
                 video_url: VideoUrl {
-                    minimax: Default::default(),
                     url: "https://example.com/video.mp4".to_string(),
                     fps: None,
                     max_long_side_pixel: None,

--- a/model_gateway/src/routers/grpc/multimodal/detect.rs
+++ b/model_gateway/src/routers/grpc/multimodal/detect.rs
@@ -158,6 +158,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "https://example.com/cat.jpg".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -175,6 +176,7 @@ mod tests {
         let messages = vec![ChatMessage::User {
             content: MessageContent::Parts(vec![ContentPart::VideoUrl {
                 video_url: VideoUrl {
+                    minimax: Default::default(),
                     url: "https://example.com/clip.mp4".to_string(),
                     fps: None,
                     max_long_side_pixel: None,
@@ -226,6 +228,7 @@ mod tests {
     fn extracts_image_media_part() {
         let messages = vec![
             ChatMessage::System {
+                kimi: Default::default(),
                 content: MessageContent::Text("You are helpful".to_string()),
                 name: None,
             },
@@ -236,6 +239,7 @@ mod tests {
                     },
                     ContentPart::ImageUrl {
                         image_url: ImageUrl {
+                            minimax: Default::default(),
                             url: "https://example.com/image.jpg".to_string(),
                             detail: Some("high".to_string()),
                             max_long_side_pixel: None,
@@ -263,6 +267,7 @@ mod tests {
         let messages = vec![ChatMessage::User {
             content: MessageContent::Parts(vec![ContentPart::VideoUrl {
                 video_url: VideoUrl {
+                    minimax: Default::default(),
                     url: "https://example.com/video.mp4".to_string(),
                     fps: None,
                     max_long_side_pixel: None,

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -40,6 +40,7 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
         messages.push(ChatMessage::System {
             content: MessageContent::Text(instructions.clone()),
             name: None,
+            kimi: Default::default(),
         });
     }
 
@@ -296,6 +297,7 @@ fn role_to_chat_message(role: &str, text: String) -> ChatMessage {
         "system" => ChatMessage::System {
             content: MessageContent::Text(text),
             name: None,
+            kimi: Default::default(),
         },
         _ => {
             // Unknown role, treat as user message

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -40,7 +40,7 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
         messages.push(ChatMessage::System {
             content: MessageContent::Text(instructions.clone()),
             name: None,
-            kimi: Default::default(),
+            ext: Default::default(),
         });
     }
 
@@ -297,7 +297,7 @@ fn role_to_chat_message(role: &str, text: String) -> ChatMessage {
         "system" => ChatMessage::System {
             content: MessageContent::Text(text),
             name: None,
-            kimi: Default::default(),
+            ext: Default::default(),
         },
         _ => {
             // Unknown role, treat as user message

--- a/model_gateway/src/routers/grpc/regular/stages/transcription/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/transcription/preparation.rs
@@ -114,6 +114,7 @@ fn build_chat_request(
             messages.push(ChatMessage::System {
                 content: MessageContent::Text(prompt.to_string()),
                 name: None,
+                kimi: Default::default(),
             });
         }
     }

--- a/model_gateway/src/routers/grpc/regular/stages/transcription/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/transcription/preparation.rs
@@ -114,7 +114,7 @@ fn build_chat_request(
             messages.push(ChatMessage::System {
                 content: MessageContent::Text(prompt.to_string()),
                 name: None,
-                kimi: Default::default(),
+                ext: Default::default(),
             });
         }
     }

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -949,7 +949,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "https://example.com/image.jpg".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -987,7 +986,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "https://example.com/image.png".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1012,7 +1010,6 @@ mod tests {
                 },
                 ContentPart::VideoUrl {
                     video_url: VideoUrl {
-                        minimax: Default::default(),
                         url: "https://example.com/video.mp4".to_string(),
                         fps: None,
                         max_long_side_pixel: None,
@@ -1043,7 +1040,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "image".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1144,7 +1140,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "https://example.com/image.jpg".to_string(),
                         detail: Some("high".to_string()),
                         max_long_side_pixel: None,
@@ -1200,7 +1195,7 @@ mod tests {
     fn test_transform_messages_multiple_messages() {
         let messages = vec![
             ChatMessage::System {
-                kimi: Default::default(),
+                ext: Default::default(),
                 content: MessageContent::Text("System prompt".to_string()),
                 name: None,
             },
@@ -1211,7 +1206,6 @@ mod tests {
                     },
                     ContentPart::ImageUrl {
                         image_url: ImageUrl {
-                            minimax: Default::default(),
                             url: "https://example.com/image.jpg".to_string(),
                             detail: None,
                             max_long_side_pixel: None,
@@ -1246,7 +1240,6 @@ mod tests {
         let messages = vec![ChatMessage::User {
             content: MessageContent::Parts(vec![ContentPart::ImageUrl {
                 image_url: ImageUrl {
-                    minimax: Default::default(),
                     url: "https://example.com/image.jpg".to_string(),
                     detail: None,
                     max_long_side_pixel: None,
@@ -1280,7 +1273,6 @@ mod tests {
                     },
                     ContentPart::ImageUrl {
                         image_url: ImageUrl {
-                            minimax: Default::default(),
                             url: "https://example.com/image.jpg".to_string(),
                             detail: Some("low".to_string()),
                             max_long_side_pixel: None,
@@ -1326,7 +1318,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "data:image/jpeg;base64,XXX".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1353,7 +1344,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "data:image/jpeg;base64,XXX".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1383,7 +1373,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "i1".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1394,7 +1383,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "i2".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1422,7 +1410,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "image".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1474,7 +1461,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "image".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1588,7 +1574,6 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
-                        minimax: Default::default(),
                         url: "data:image/jpeg;base64,XXX".to_string(),
                         detail: None,
                         max_long_side_pixel: None,

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -949,6 +949,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "https://example.com/image.jpg".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -986,6 +987,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "https://example.com/image.png".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1010,6 +1012,7 @@ mod tests {
                 },
                 ContentPart::VideoUrl {
                     video_url: VideoUrl {
+                        minimax: Default::default(),
                         url: "https://example.com/video.mp4".to_string(),
                         fps: None,
                         max_long_side_pixel: None,
@@ -1040,6 +1043,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "image".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1140,6 +1144,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "https://example.com/image.jpg".to_string(),
                         detail: Some("high".to_string()),
                         max_long_side_pixel: None,
@@ -1195,6 +1200,7 @@ mod tests {
     fn test_transform_messages_multiple_messages() {
         let messages = vec![
             ChatMessage::System {
+                kimi: Default::default(),
                 content: MessageContent::Text("System prompt".to_string()),
                 name: None,
             },
@@ -1205,6 +1211,7 @@ mod tests {
                     },
                     ContentPart::ImageUrl {
                         image_url: ImageUrl {
+                            minimax: Default::default(),
                             url: "https://example.com/image.jpg".to_string(),
                             detail: None,
                             max_long_side_pixel: None,
@@ -1239,6 +1246,7 @@ mod tests {
         let messages = vec![ChatMessage::User {
             content: MessageContent::Parts(vec![ContentPart::ImageUrl {
                 image_url: ImageUrl {
+                    minimax: Default::default(),
                     url: "https://example.com/image.jpg".to_string(),
                     detail: None,
                     max_long_side_pixel: None,
@@ -1272,6 +1280,7 @@ mod tests {
                     },
                     ContentPart::ImageUrl {
                         image_url: ImageUrl {
+                            minimax: Default::default(),
                             url: "https://example.com/image.jpg".to_string(),
                             detail: Some("low".to_string()),
                             max_long_side_pixel: None,
@@ -1317,6 +1326,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "data:image/jpeg;base64,XXX".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1343,6 +1353,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "data:image/jpeg;base64,XXX".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1372,6 +1383,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "i1".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1382,6 +1394,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "i2".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1409,6 +1422,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "image".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1460,6 +1474,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "image".to_string(),
                         detail: None,
                         max_long_side_pixel: None,
@@ -1573,6 +1588,7 @@ mod tests {
                 },
                 ContentPart::ImageUrl {
                     image_url: ImageUrl {
+                        minimax: Default::default(),
                         url: "data:image/jpeg;base64,XXX".to_string(),
                         detail: None,
                         max_long_side_pixel: None,


### PR DESCRIPTION
## Description

### Problem

The HTTP router round-trips requests through the typed `ChatCompletionRequest` structs before dispatch, so any provider field the structs don't model is silently dropped. Running the providers' own vendor-acceptance suites (MoonshotAI/Kimi-Vendor-Verifier, MiniMax-AI/MiniMax-Provider-Verifier) against smg fronting the official APIs isolated three defects:

- Kimi K3 dynamic tools (`messages[].tools` on system messages) vanish in transit: 24 KVV `k3_features` tests and 3 KVV `prompt_tokens` ground-truth cases fail. The drop is silent — the must-400 malformed cases return wrong 200s.
- MiniMax media params (`max_long_side_pixel`, `fps` on `image_url`/`video_url` parts) vanish: 3 MPV tests fail, including an fps-out-of-range must-400 that becomes a 200.
- Validation rejects `tool_choice: "auto"` without `tools`, which both the OpenAI spec and KVV require accepted (`auto` is the documented default).

Verification also exposed a fourth gap: K3 tools-only system messages omit the `content` key entirely, and smg 400s them at deserialization.

### Solution

Adopt a per-provider extension-module layout: each provider contributes one all-`Option` struct in `crates/protocols/src/ext/{kimi,minimax}.rs`, `#[serde(flatten)]`-ed into the core types. Absent fields serialize to nothing, so OpenAI-only traffic stays wire-identical. Fields are promoted only when a provider's vendor-acceptance contract enforces behavior on them.

Rejection-side contract rules (e.g. K3's 400 for `tools` on user/assistant roles) are deliberately not enforced here — the core protocol cannot reject what OpenAI itself tolerates; that belongs to per-provider profile validation in a follow-up.

## Changes

- New `crates/protocols/src/ext/` module: `KimiSystemExt { tools }` flattened into `ChatMessage::System`; `MinimaxImageExt { max_long_side_pixel }` and `MinimaxVideoExt { max_long_side_pixel, fps }` flattened into `ImageUrl`/`VideoUrl`.
- `tool_choice` validation: `auto`/`none` are valid without tools; `required` and named-function still require tools, and dynamic tools on system messages now count as tools.
- `ChatMessage::System.content` defaults to empty text when the key is absent.
- Mechanical initializer updates across gRPC utils/tests/benches; 10 new round-trip and validation regression tests in `crates/protocols/tests/provider_ext.rs`.

## Test Plan

`cargo test -p openai-protocol` (250 tests, incl. 10 new) and `cargo check --workspace --all-targets` pass.

End-to-end, re-running the vendor verifiers through smg (HTTP router fronting the official APIs, worker registered via `POST /workers` with `runtime_type: external`):

| Verifier subset through smg | before | after |
|---|---|---|
| KVV `test_dynamic_tools` + `test_tool_choice` | 46/72 | 68/72 |
| KVV `prompt_tokens` dynamic cases | 0/3 | 3/3 (token counts exact) |
| MPV image/video media-param tests | 0/3 | 3/3 |

The 4 remaining KVV failures are the `tools`-on-user/assistant must-400 tests, deferred to profile-level validation. Direct-API runs are unchanged (the fields now pass through byte-equivalent to a direct call).


### Performance

Criterion A/B vs the parent commit (f35b586a, `benches/request_processing.rs`): deserialization and routing benches unchanged (±1%, noise); serialization shows a small real cost from serde's flatten map-path — +2.5% (+4 ns) small chat request, +3.9% (+290 ns) large chat request, +2.0% on the large round trip. Absolute per-request overhead is sub-microsecond against network/inference latencies. If this ever matters at fleet scale, hand-written `Serialize` impls for the three flatten-bearing structs recover it, at the cost of the manual-sync hazard this PR removes — deliberately not done here.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (run without `--all-features` locally — the opencv feature needs system pkg-config unavailable on this machine; CI runs the full gate)
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

