### PR TITLE
feat(router): add explicit --connection-mode flag for discovery-only fleets

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -530,19 +530,6 @@ struct Router {
 }
 
 impl Router {
-    fn determine_connection_mode(worker_urls: &[String]) -> worker::ConnectionMode {
-        use worker::ConnectionMode;
-        // First worker URL that declares ipc:// or grpc:// wins; http:// and bare
-        // host:port fall through to the HTTP default. See ConnectionMode::from_url.
-        worker_urls
-            .iter()
-            .find_map(|url| match ConnectionMode::from_url(url) {
-                mode @ (Some(ConnectionMode::Zmq) | Some(ConnectionMode::Grpc)) => mode,
-                _ => None,
-            })
-            .unwrap_or(ConnectionMode::Http)
-    }
-
     fn parse_mesh_socket_addr(
         host: &str,
         port: u16,
@@ -1093,12 +1080,9 @@ impl Router {
         max_buffered_request_bytes = 1_048_576,
         kv_connector_annotation = String::from("smg.ai/kv-connector"),
         kv_engine_id_annotation = String::from("smg.ai/kv-engine-id"),
+        connection_mode = None,
     ))]
     #[expect(clippy::too_many_arguments)]
-    #[expect(
-        clippy::unnecessary_wraps,
-        reason = "PyO3 #[new] method signature requires PyResult"
-    )]
     fn new(
         worker_urls: Vec<String>,
         policy: PolicyType,
@@ -1245,6 +1229,7 @@ impl Router {
         max_buffered_request_bytes: u64,
         kv_connector_annotation: String,
         kv_engine_id_annotation: String,
+        connection_mode: Option<String>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1264,7 +1249,21 @@ impl Router {
             all_urls.extend(decode_urls.clone());
         }
 
-        let connection_mode = Self::determine_connection_mode(&all_urls);
+        // Explicit --connection-mode wins over URL-scheme inference. "zmq" is
+        // accepted because `smg serve` forwards its own worker transport here.
+        let explicit_mode = match connection_mode.as_deref() {
+            None => None,
+            Some("http") => Some(worker::ConnectionMode::Http),
+            Some("grpc") => Some(worker::ConnectionMode::Grpc),
+            Some("zmq") => Some(worker::ConnectionMode::Zmq),
+            Some(other) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Invalid value for connection_mode='{other}': expected 'http', 'grpc', or 'zmq'"
+                )))
+            }
+        };
+        let connection_mode = config::resolve_connection_mode(explicit_mode, &all_urls)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
         Ok(Router {
             host,

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -154,6 +154,9 @@ class Router:
         host: Host address to bind the router server. Supports IPv4, IPv6 (e.g., ::,
             ::1), or 0.0.0.0 for all interfaces. Default: '0.0.0.0'
         port: Port number to bind the router server. Default: 3001
+        connection_mode: Worker connection mode ('http' or 'grpc'). None infers
+            the mode from worker URL schemes (grpc:// => grpc); set it explicitly
+            when only service discovery supplies workers. Default: None
         worker_startup_timeout_secs: Timeout in seconds for worker startup and
             registration. Large models can take significant time to load into GPU
             memory. Default: 1800 (30 minutes)

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -249,6 +249,8 @@ class RouterArgs:
     max_buffered_request_bytes: int = 1048576
     kv_connector_annotation: str = "smg.ai/kv-connector"
     kv_engine_id_annotation: str = "smg.ai/kv-engine-id"
+    # Worker transport; None = infer from worker URL schemes (grpc:// => grpc)
+    connection_mode: str | None = None
 
     @staticmethod
     def add_cli_args(
@@ -367,6 +369,18 @@ class RouterArgs:
             help=(
                 "List of worker URLs. Supports IPv4 and IPv6 addresses"
                 " (use brackets for IPv6, e.g., http://[::1]:8000 http://192.168.1.1:8000)"
+            ),
+        )
+        worker_group.add_argument(
+            f"--{prefix}connection-mode",
+            type=str,
+            choices=["http", "grpc"],
+            default=RouterArgs.connection_mode,
+            help=(
+                "Worker connection mode. By default it is inferred from worker URL"
+                " schemes (grpc:// => grpc); with Kubernetes service discovery and"
+                " no static URLs there is nothing to infer from, so declare a gRPC"
+                " fleet explicitly here."
             ),
         )
         worker_group.add_argument(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -539,6 +539,21 @@ class TestParseRouterArgs:
         assert router_args.worker_urls == ["http://worker1:8000", "http://worker2:8000"]
         assert router_args.policy == "round_robin"
 
+    def test_parse_connection_mode(self):
+        """Explicit worker transport; unset keeps infer-from-URLs (None)."""
+        router_args = parse_router_args(["--connection-mode", "grpc"])
+        assert router_args.connection_mode == "grpc"
+
+        router_args = parse_router_args(["--connection-mode", "http"])
+        assert router_args.connection_mode == "http"
+
+        defaults = parse_router_args([])
+        assert defaults.connection_mode is None
+
+        # argparse rejects values outside the http/grpc choices
+        with pytest.raises(SystemExit):
+            parse_router_args(["--connection-mode", "zmq"])
+
     def test_parse_routing_key_headers(self):
         """Ordered list flag; unset keeps the x-smg-routing-key default."""
         router_args = parse_router_args(
@@ -1431,6 +1446,7 @@ class TestRouterArgsFieldOrder:
         "max_buffered_request_bytes",
         "kv_connector_annotation",
         "kv_engine_id_annotation",
+        "connection_mode",
     ]
 
     def test_complete_field_sequence_is_frozen(self):

--- a/bindings/python/tests/test_startup_sequence.py
+++ b/bindings/python/tests/test_startup_sequence.py
@@ -254,6 +254,32 @@ class TestRouterInitialization:
             assert captured_args["enable_igw"] is False
             mock_router_instance.start.assert_called_once()
 
+    def test_connection_mode_survives_startup(self):
+        """Discovery-only PD deployments can declare gRPC workers explicitly."""
+        args = RouterArgs(
+            service_discovery=True,
+            pd_disaggregation=True,
+            prefill_selector={"component": "engine"},
+            decode_selector={"component": "decoder"},
+            connection_mode="grpc",
+        )
+
+        with patch("smg.launch_router.Router") as router_mod:
+            captured_args = {}
+            mock_router_instance = MagicMock()
+
+            def fake_from_args(router_args):
+                captured_args["connection_mode"] = router_args.connection_mode
+                return mock_router_instance
+
+            router_mod.from_args = MagicMock(side_effect=fake_from_args)
+
+            launch_router(args)
+
+            router_mod.from_args.assert_called_once()
+            assert captured_args["connection_mode"] == "grpc"
+            mock_router_instance.start.assert_called_once()
+
     def test_router_initialization_with_retry_config(self):
         """Test router initialization with retry configuration."""
         args = RouterArgs(

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -8,7 +8,7 @@ pub use smg_data_connector::{
     HistoryBackend, OracleConfig, PostgresConfig, RedisConfig, SchemaConfig,
 };
 
-use super::{validation::ConfigValidator, ConfigResult};
+use super::{validation::ConfigValidator, ConfigError, ConfigResult};
 use crate::{
     tenant::DEFAULT_TENANT_HEADER_NAME,
     worker::{ConnectionMode, RuntimeType},
@@ -979,6 +979,41 @@ fn default_drain_settle_secs() -> u64 {
 /// opt-in.
 pub fn resolve_worker_auto_recovery(explicit: Option<bool>, service_discovery: bool) -> bool {
     explicit.unwrap_or(service_discovery)
+}
+
+/// Resolve `--connection-mode`: an explicit setting always wins; otherwise
+/// infer from the worker URLs (first `ipc://` or `grpc://` scheme wins,
+/// defaulting to HTTP).
+///
+/// The explicit setting exists because inference has nothing to look at in a
+/// service-discovery-only deployment: with no static URLs the router defaults
+/// to HTTP, discovered gRPC workers never join the HTTP selection pool, and
+/// every request fails with "no workers available". An explicit setting that
+/// contradicts a static URL's scheme is rejected rather than silently ignored.
+pub fn resolve_connection_mode(
+    explicit: Option<ConnectionMode>,
+    worker_urls: &[String],
+) -> ConfigResult<ConnectionMode> {
+    let Some(mode) = explicit else {
+        return Ok(worker_urls
+            .iter()
+            .find_map(|url| match ConnectionMode::from_url(url) {
+                m @ (Some(ConnectionMode::Zmq) | Some(ConnectionMode::Grpc)) => m,
+                _ => None,
+            })
+            .unwrap_or(ConnectionMode::Http));
+    };
+    if let Some(url) = worker_urls
+        .iter()
+        .find(|url| ConnectionMode::from_url(url).is_some_and(|m| m != mode))
+    {
+        return Err(ConfigError::InvalidValue {
+            field: "connection_mode".to_string(),
+            value: mode.to_string(),
+            reason: format!("conflicts with worker URL '{url}'"),
+        });
+    }
+    Ok(mode)
 }
 
 impl Default for HealthCheckConfig {
@@ -2349,5 +2384,66 @@ mod tests {
             PolicyConfig::RoundRobin => {}
             _ => panic!("Expected RoundRobin for regular mode"),
         }
+    }
+
+    #[test]
+    fn test_resolve_connection_mode_infers_from_urls() {
+        let urls = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+
+        // No explicit setting: first ipc:// or grpc:// scheme wins, HTTP default.
+        assert_eq!(
+            resolve_connection_mode(None, &[]).unwrap(),
+            ConnectionMode::Http
+        );
+        assert_eq!(
+            resolve_connection_mode(None, &urls(&["http://w1:8000"])).unwrap(),
+            ConnectionMode::Http
+        );
+        assert_eq!(
+            resolve_connection_mode(None, &urls(&["http://w1:8000", "grpc://w2:50051"])).unwrap(),
+            ConnectionMode::Grpc
+        );
+        assert_eq!(
+            resolve_connection_mode(None, &urls(&["ipc:///tmp/engine-0"])).unwrap(),
+            ConnectionMode::Zmq
+        );
+    }
+
+    #[test]
+    fn test_resolve_connection_mode_explicit_override() {
+        // Discovery-only deployment: no URLs to infer from, explicit wins.
+        assert_eq!(
+            resolve_connection_mode(Some(ConnectionMode::Grpc), &[]).unwrap(),
+            ConnectionMode::Grpc
+        );
+        // Schemeless URLs carry no mode; the explicit setting declares it.
+        assert_eq!(
+            resolve_connection_mode(Some(ConnectionMode::Grpc), &["w1:50051".to_string()]).unwrap(),
+            ConnectionMode::Grpc
+        );
+        // Matching schemes are fine.
+        assert_eq!(
+            resolve_connection_mode(
+                Some(ConnectionMode::Http),
+                &["http://w1:8000".to_string(), "https://w2:8000".to_string()]
+            )
+            .unwrap(),
+            ConnectionMode::Http
+        );
+    }
+
+    #[test]
+    fn test_resolve_connection_mode_rejects_url_mismatch() {
+        let err =
+            resolve_connection_mode(Some(ConnectionMode::Http), &["grpc://w1:50051".to_string()])
+                .unwrap_err();
+        assert!(err.to_string().contains("grpc://w1:50051"), "{err}");
+
+        let err = resolve_connection_mode(
+            Some(ConnectionMode::Grpc),
+            &["grpc://w1:50051".to_string(), "http://w2:8000".to_string()],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("http://w2:8000"), "{err}");
     }
 }

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -12,11 +12,12 @@ use openai_protocol::worker::TransportMode;
 use rand::{distr::Alphanumeric, RngExt};
 use smg::{
     config::{
-        resolve_worker_auto_recovery, validate_mesh_server_name, CacheIndexKind,
-        CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
-        HistoryBackend, ManualAssignmentMode, MetricsConfig, OracleConfig, PolicyConfig,
-        PostgresConfig, RedisConfig, RetryConfig, RouterConfig, RoutingKeyOverrideConfig,
-        RoutingMode, SchemaConfig, TenantApiKeyEntry, TokenizerCacheConfig, TraceConfig,
+        resolve_connection_mode, resolve_worker_auto_recovery, validate_mesh_server_name,
+        CacheIndexKind, CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig,
+        HealthCheckConfig, HistoryBackend, ManualAssignmentMode, MetricsConfig, OracleConfig,
+        PolicyConfig, PostgresConfig, RedisConfig, RetryConfig, RouterConfig,
+        RoutingKeyOverrideConfig, RoutingMode, SchemaConfig, TenantApiKeyEntry,
+        TokenizerCacheConfig, TraceConfig,
     },
     observability::{
         metrics::{register_jemalloc_as_global_allocator, PrometheusConfig},
@@ -227,6 +228,12 @@ struct CliArgs {
     /// List of worker URLs (supports IPv4 and IPv6)
     #[arg(long, num_args = 0.., help_heading = "Worker Configuration")]
     worker_urls: Vec<String>,
+
+    /// Worker connection mode. Defaults to inference from worker URL schemes
+    /// (grpc:// => grpc); a service-discovery-only deployment has no URLs to
+    /// infer from, so declare a discovered gRPC fleet explicitly here.
+    #[arg(long, value_parser = ["http", "grpc"], help_heading = "Worker Configuration")]
+    connection_mode: Option<String>,
 
     // ==================== Routing Policy ====================
     /// Load balancing policy to use
@@ -1290,18 +1297,6 @@ impl CliArgs {
         }
     }
 
-    fn determine_connection_mode(worker_urls: &[String]) -> ConnectionMode {
-        // First worker URL that declares ipc:// or grpc:// wins; http:// and bare
-        // host:port fall through to the HTTP default. See ConnectionMode::from_url.
-        worker_urls
-            .iter()
-            .find_map(|url| match ConnectionMode::from_url(url) {
-                mode @ (Some(ConnectionMode::Zmq) | Some(ConnectionMode::Grpc)) => mode,
-                _ => None,
-            })
-            .unwrap_or(ConnectionMode::Http)
-    }
-
     fn parse_selector(selector_list: &[String]) -> HashMap<String, String> {
         let mut map = HashMap::new();
         for item in selector_list {
@@ -1723,7 +1718,13 @@ impl CliArgs {
                 all_urls.extend(worker_urls.clone());
             }
         }
-        let connection_mode = Self::determine_connection_mode(&all_urls);
+        // Explicit --connection-mode wins over URL-scheme inference.
+        let explicit_mode = match self.connection_mode.as_deref() {
+            Some("http") => Some(ConnectionMode::Http),
+            Some("grpc") => Some(ConnectionMode::Grpc),
+            _ => None,
+        };
+        let connection_mode = resolve_connection_mode(explicit_mode, &all_urls)?;
 
         // `--backend` normally only steers the routing mode. Over ZMQ it
         // additionally pins the startup workers' runtime: the shared EngineCore


### PR DESCRIPTION
## Description

### Problem

In PD mode with `--service-discovery` and no static worker URLs, the router infers its connection mode from worker URL schemes (`determine_connection_mode(&all_urls)` in `model_gateway/src/main.rs` and its twin in the pyo3 layer). Over an empty URL list the inference falls through to HTTP, so `RouterManager::determine_router_id` selects `http-pd`. Discovered gRPC workers then register as healthy typed workers but never enter the selection pool, and every request fails with 503 "No prefill workers available".

Hit live deploying OME OMENative PD (Qwen3-VL, moirai-dev). The current workaround is seeding static `grpc://` service URLs alongside discovery just so inference has something to look at. #2372 fixed the IGW half of this same discovery-only gap; the connection mode still had no explicit knob.

### Solution

Add an explicit `--connection-mode {http,grpc}` CLI flag (Rust binary and Python launcher) so deployments using only Kubernetes service discovery can declare their worker transport. Resolution lives in one shared helper, `config::resolve_connection_mode`: an explicit setting always wins and is validated against static worker URL schemes (a contradiction is a config error instead of being silently ignored); unset keeps today's infer-from-URLs behavior exactly.

## Changes

- `model_gateway/src/config/types.rs`: new `resolve_connection_mode(explicit, worker_urls)` helper — explicit wins, URL-scheme mismatch rejected, unset infers (first `ipc://`/`grpc://` wins, HTTP default) — plus unit tests
- `model_gateway/src/main.rs`: `--connection-mode` clap flag; `to_router_config` resolves through the shared helper (drops the duplicated local inference fn)
- `bindings/python/src/lib.rs`: `_Router` accepts `connection_mode` (appended at the signature tail) and resolves through the same helper; `"zmq"` is also accepted at this boundary because `smg serve` forwards its own worker transport
- `bindings/python/src/smg/router_args.py`: `connection_mode` dataclass field (appended at the tail per the frozen field-order contract) + `--connection-mode {http,grpc}` argparse flag (default `None` = infer from URLs)
- `bindings/python/src/smg/router.py`: document the new arg
- Tests: `test_arg_parser.py` parse coverage (and the frozen field sequence), `test_startup_sequence.py` assertion that the value reaches `Router.from_args`

## Test Plan

- `cargo test -p smg --lib config::` — 142 passed, including the new `resolve_connection_mode` inference/override/mismatch tests
- `maturin develop` + `pytest bindings/python/tests/` against the rebuilt extension — 300 passed, 4 skipped
- End-to-end against the real `_Router` (no server start):
  - discovery-only PD `RouterArgs(service_discovery=True, pd_disaggregation=True, connection_mode="grpc")` constructs (previously inferred HTTP)
  - `connection_mode="http"` + `grpc://` static worker URL raises `ValueError: Invalid value for field 'connection_mode': http - conflicts with worker URL 'grpc://w1:50051'`
  - flag unset + `grpc://` URLs keeps today's inference; `connection_mode="zmq"` + `ipc://` URL still constructs (the `smg serve` forwarding path)
- `cargo +nightly fmt`, `ruff check`/`ruff format --check` on touched Python files
- `cargo clippy -p smg --lib --bins -- -D warnings` and `cargo clippy -p smg-python --lib -- -D warnings` pass; the full `--all-targets --all-features` sweep needs opencv/pkg-config system deps not present on this machine, so that one is left to CI
- Not exercised against a live discovery-only cluster in this PR; with the flag unset the resolved mode is unchanged by construction (same inference, now in one shared helper)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
