### PR TITLE
chore(pypi): link the smg package to its source repository

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -34,6 +34,10 @@ dependencies = [
     "PyYAML",
 ]
 
+[project.urls]
+Homepage = "https://github.com/smg-project/smg"
+Repository = "https://github.com/smg-project/smg"
+
 [project.optional-dependencies]
 dev = [
     "mypy",


### PR DESCRIPTION
## Description

### Problem

The `smg` package on PyPI publishes no `project_urls`, so PyPI shows no link back to this repository and GitHub cannot associate the package (or its dependents) with the repo. All crates.io packages already carry the `repository` field; the flagship PyPI package is the only published artifact missing the link.

### Solution

Add `[project.urls]` (Homepage, Repository) to `bindings/python/pyproject.toml`, matching what `smg-grpc-servicer` and `smg-grpc-proto` already declare. Takes effect with the next PyPI release.

## Changes

- `bindings/python/pyproject.toml`: add `[project.urls]` with Homepage and Repository

## Test Plan

- `python3 -c "import tomllib; tomllib.load(...)"` parses; `project.urls` present with both entries.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated

</details>
