### PR TITLE
fix(grpc): reject unknown models with 404 before the pipeline

### DIFF
--- a/e2e_test/chat_completions/test_validation.py
+++ b/e2e_test/chat_completions/test_validation.py
@@ -386,3 +386,47 @@ class TestEosTokenStripping:
         assert has_eos, (
             f"EOS token should be visible with no_stop_trim=true + skip_special_tokens=false: {content}"
         )
+
+
+# =============================================================================
+# Unknown model rejection (gRPC pipeline)
+# =============================================================================
+
+
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
+@pytest.mark.gpu(1)
+@pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
+@pytest.mark.gateway(extra_args=["--history-backend", "memory"])
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+@pytest.mark.parametrize("api_client", ["openai", "smg"], indirect=True)
+class TestUnknownModelRejected:
+    """An unknown model must be rejected with 404 before the pipeline runs.
+
+    The gRPC pipeline tokenizes locally, so its preparation stage runs ahead
+    of worker selection. Without an up-front check, an unknown model reaches
+    tokenizer resolution and surfaces as a 500 ``tokenizer_not_found`` — a
+    client error reported as a server fault. The responses endpoint already
+    fails fast with 404 ``model_not_found``; every gRPC entry point should.
+    """
+
+    UNKNOWN = "nonexistent-model-xyz"
+
+    def test_chat_unknown_model_is_404(self, api_client):
+        with pytest.raises((openai.NotFoundError, smg_client.NotFoundError)) as exc_info:
+            api_client.chat.completions.create(
+                model=self.UNKNOWN,
+                messages=[{"role": "user", "content": "Hello"}],
+                max_tokens=8,
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.code == "model_not_found"
+
+    def test_completions_unknown_model_is_404(self, api_client):
+        with pytest.raises((openai.NotFoundError, smg_client.NotFoundError)) as exc_info:
+            api_client.completions.create(
+                model=self.UNKNOWN,
+                prompt="Hello",
+                max_tokens=8,
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.code == "model_not_found"

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -15,15 +15,12 @@ use smg_data_connector::{
 use smg_mcp::{McpOrchestrator, McpServerBinding};
 use tracing::{debug, error, warn};
 
-use crate::{
-    routers::{
-        common::{
-            mcp_utils::ensure_request_mcp_client, openai_bridge,
-            persistence_utils::persist_conversation_items,
-        },
-        error,
+use crate::routers::{
+    common::{
+        mcp_utils::ensure_request_mcp_client, openai_bridge,
+        persistence_utils::persist_conversation_items,
     },
-    worker::WorkerRegistry,
+    error,
 };
 
 /// Ensure MCP connection succeeds if MCP tools or builtin tools are declared.
@@ -98,23 +95,6 @@ pub(crate) async fn ensure_mcp_connection(
     Ok((false, Vec::new()))
 }
 
-/// Validate that workers are available for the requested model.
-///
-/// Runs on the client-supplied name, before the pipeline canonicalizes it, so
-/// it has to accept aliases as well as canonical model IDs. `contains_model`
-/// covers both; listing `get_models()` and testing membership would reject
-/// every alias here.
-pub(crate) fn validate_worker_availability(
-    worker_registry: &Arc<WorkerRegistry>,
-    model: &str,
-) -> Option<Response> {
-    if !worker_registry.contains_model(model) {
-        return Some(error::model_not_found(model));
-    }
-
-    None
-}
-
 /// Extract function tools from ResponseTools
 ///
 /// This utility consolidates the logic for extracting tools with schemas from ResponseTools.
@@ -176,49 +156,5 @@ pub(crate) async fn persist_response_if_needed(
         } else {
             debug!("Persisted response: {}", response.id);
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use openai_protocol::{model_card::ModelCard, worker::HealthCheckConfig};
-
-    use super::*;
-    use crate::worker::{BasicWorkerBuilder, UNKNOWN_MODEL_ID};
-
-    fn registry_with_aliased_worker() -> Arc<WorkerRegistry> {
-        let registry = Arc::new(WorkerRegistry::new());
-        let worker = BasicWorkerBuilder::new("http://worker:8080")
-            .model(ModelCard::new("canonical-model").with_alias("model-alias"))
-            .health_config(HealthCheckConfig {
-                disable_health_check: true,
-                ..Default::default()
-            })
-            .build();
-        registry.register_or_replace(Arc::new(worker));
-        registry
-    }
-
-    #[test]
-    fn worker_availability_accepts_alias_and_preserves_unknown_rejection() {
-        let registry = registry_with_aliased_worker();
-
-        assert!(validate_worker_availability(&registry, "canonical-model").is_none());
-        assert!(validate_worker_availability(&registry, "model-alias").is_none());
-
-        let response = validate_worker_availability(&registry, UNKNOWN_MODEL_ID)
-            .expect("unknown model should remain rejected for Responses");
-        assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
-    }
-
-    #[test]
-    fn worker_availability_rejects_alias_once_its_worker_is_gone() {
-        let registry = registry_with_aliased_worker();
-        let worker_id = registry.get_id_by_url("http://worker:8080").unwrap();
-        assert!(registry.remove(&worker_id).is_some());
-
-        let response = validate_worker_availability(&registry, "model-alias")
-            .expect("alias must stop resolving with no workers behind it");
-        assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
     }
 }

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -507,6 +507,17 @@ impl GrpcRouter {
             return *response;
         }
 
+        // Fail fast on an unknown model, before canonicalization and before the
+        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
+        // stage runs ahead of worker selection; without this check an unknown
+        // model reaches `resolve_tokenizer` and surfaces as a 500
+        // `tokenizer_not_found` instead of the 404 the client should see.
+        // Mirrors `route_responses_impl`.
+        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
+        {
+            return error_response;
+        }
+
         // EPD has no Harmony pipeline, so its chat requests all use the single
         // chat/generate pipeline.
         let is_harmony = self.harmony_pipeline.is_some()
@@ -562,6 +573,17 @@ impl GrpcRouter {
         model_id: &str,
     ) -> Response {
         debug!("Processing generate request for model: {}", model_id);
+
+        // Fail fast on an unknown model, before canonicalization and before the
+        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
+        // stage runs ahead of worker selection; without this check an unknown
+        // model reaches `resolve_tokenizer` and surfaces as a 500
+        // `tokenizer_not_found` instead of the 404 the client should see.
+        // Mirrors `route_responses_impl`.
+        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
+        {
+            return error_response;
+        }
 
         // Canonicalize once, up front -- see `resolve_canonical_model_id`'s
         // doc comment. Rewrite the body's `model` field to match; see
@@ -675,6 +697,17 @@ impl GrpcRouter {
         };
         debug!("Processing embedding request for model: {}", model_id);
 
+        // Fail fast on an unknown model, before canonicalization and before the
+        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
+        // stage runs ahead of worker selection; without this check an unknown
+        // model reaches `resolve_tokenizer` and surfaces as a 500
+        // `tokenizer_not_found` instead of the 404 the client should see.
+        // Mirrors `route_responses_impl`.
+        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
+        {
+            return error_response;
+        }
+
         embedding_pipeline
             .execute_embeddings(
                 Arc::new(body),
@@ -695,6 +728,17 @@ impl GrpcRouter {
         model_id: &str,
     ) -> Response {
         debug!("Processing messages request for model: {}", model_id);
+
+        // Fail fast on an unknown model, before canonicalization and before the
+        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
+        // stage runs ahead of worker selection; without this check an unknown
+        // model reaches `resolve_tokenizer` and surfaces as a 500
+        // `tokenizer_not_found` instead of the 404 the client should see.
+        // Mirrors `route_responses_impl`.
+        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
+        {
+            return error_response;
+        }
 
         // Canonicalize once, up front -- see `resolve_canonical_model_id`'s
         // doc comment. Rewrite the body's `model` field to match; see
@@ -731,6 +775,17 @@ impl GrpcRouter {
         model_id: &str,
     ) -> Response {
         debug!("Processing completion request for model: {}", model_id);
+
+        // Fail fast on an unknown model, before canonicalization and before the
+        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
+        // stage runs ahead of worker selection; without this check an unknown
+        // model reaches `resolve_tokenizer` and surfaces as a 500
+        // `tokenizer_not_found` instead of the 404 the client should see.
+        // Mirrors `route_responses_impl`.
+        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
+        {
+            return error_response;
+        }
 
         // Canonicalize once, up front -- see `resolve_canonical_model_id`'s
         // doc comment. Rewrite the body's `model` field to match; see
@@ -770,6 +825,17 @@ impl GrpcRouter {
             return not_implemented("Classify not implemented");
         };
         debug!("Processing classify request for model: {}", model_id);
+
+        // Fail fast on an unknown model, before canonicalization and before the
+        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
+        // stage runs ahead of worker selection; without this check an unknown
+        // model reaches `resolve_tokenizer` and surfaces as a 500
+        // `tokenizer_not_found` instead of the 404 the client should see.
+        // Mirrors `route_responses_impl`.
+        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
+        {
+            return error_response;
+        }
 
         classify_pipeline
             .execute_classify(

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -22,9 +22,7 @@ use tracing::debug;
 
 use super::{
     common::{
-        responses::{
-            handlers::cancel_response_impl, utils::validate_worker_availability, ResponsesContext,
-        },
+        responses::{handlers::cancel_response_impl, ResponsesContext},
         stages::{RateLimitCell, RateLimitOutcome},
     },
     context::SharedComponents,
@@ -33,14 +31,14 @@ use super::{
     multimodal::MultimodalComponents,
     pipeline::{Endpoint, PipelineDeps, RequestPipeline},
     regular::responses,
-    utils::ParserResolver,
+    utils::{validate_worker_availability, ParserResolver},
 };
 use crate::{
     app_context::AppContext,
     config::types::RetryConfig,
     middleware::TenantRequestMeta,
     routers::{error, RouterTrait},
-    worker::{WorkerRegistry, WorkerType},
+    worker::{WorkerRegistry, WorkerType, UNKNOWN_MODEL_ID},
 };
 
 const QWEN3_ASR_LANGUAGES: &[(&str, &str)] = &[
@@ -465,6 +463,17 @@ impl GrpcRouter {
             .unwrap_or_else(|| self.retry_config.clone())
     }
 
+    /// Fail fast on an unknown model, before canonicalization and before the
+    /// pipeline. The gRPC pipeline tokenizes locally, so its preparation stage
+    /// runs ahead of worker selection; without this check an unknown model
+    /// reaches `resolve_tokenizer` and surfaces as a 500 `tokenizer_not_found`
+    /// instead of the 404 the client should see. Alias-safe: `contains_model`
+    /// resolves through `model_alias_index`, so this must run on the
+    /// client-supplied name, before [`Self::resolve_canonical_model_id`].
+    fn reject_unknown_model(&self, model_id: &str) -> Option<Response> {
+        validate_worker_availability(&self.worker_registry, model_id)
+    }
+
     /// Resolve `model_id` to its canonical form once, before the pipeline
     /// runs. Every dispatch attempt for that logical request reuses this
     /// value -- re-resolving mid-request would let an alias repointed during
@@ -507,15 +516,8 @@ impl GrpcRouter {
             return *response;
         }
 
-        // Fail fast on an unknown model, before canonicalization and before the
-        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
-        // stage runs ahead of worker selection; without this check an unknown
-        // model reaches `resolve_tokenizer` and surfaces as a 500
-        // `tokenizer_not_found` instead of the 404 the client should see.
-        // Mirrors `route_responses_impl`.
-        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
-        {
-            return error_response;
+        if let Some(response) = self.reject_unknown_model(model_id) {
+            return response;
         }
 
         // EPD has no Harmony pipeline, so its chat requests all use the single
@@ -574,15 +576,14 @@ impl GrpcRouter {
     ) -> Response {
         debug!("Processing generate request for model: {}", model_id);
 
-        // Fail fast on an unknown model, before canonicalization and before the
-        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
-        // stage runs ahead of worker selection; without this check an unknown
-        // model reaches `resolve_tokenizer` and surfaces as a 500
-        // `tokenizer_not_found` instead of the 404 the client should see.
-        // Mirrors `route_responses_impl`.
-        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
-        {
-            return error_response;
+        // The wildcard sentinel is not a model name: `GenerateRequest.model`
+        // defaults to it when the body names no model, and worker selection
+        // widens it to the global pool (`get_routing_pool`). Only /generate
+        // carries that default, so only /generate exempts it here.
+        if model_id != UNKNOWN_MODEL_ID {
+            if let Some(response) = self.reject_unknown_model(model_id) {
+                return response;
+            }
         }
 
         // Canonicalize once, up front -- see `resolve_canonical_model_id`'s
@@ -631,9 +632,8 @@ impl GrpcRouter {
         };
 
         // 0. Fast worker validation (fail-fast before expensive operations)
-        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
-        {
-            return error_response;
+        if let Some(response) = self.reject_unknown_model(model_id) {
+            return response;
         }
 
         let (body, canonical_model_id) =
@@ -697,15 +697,8 @@ impl GrpcRouter {
         };
         debug!("Processing embedding request for model: {}", model_id);
 
-        // Fail fast on an unknown model, before canonicalization and before the
-        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
-        // stage runs ahead of worker selection; without this check an unknown
-        // model reaches `resolve_tokenizer` and surfaces as a 500
-        // `tokenizer_not_found` instead of the 404 the client should see.
-        // Mirrors `route_responses_impl`.
-        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
-        {
-            return error_response;
+        if let Some(response) = self.reject_unknown_model(model_id) {
+            return response;
         }
 
         embedding_pipeline
@@ -729,15 +722,8 @@ impl GrpcRouter {
     ) -> Response {
         debug!("Processing messages request for model: {}", model_id);
 
-        // Fail fast on an unknown model, before canonicalization and before the
-        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
-        // stage runs ahead of worker selection; without this check an unknown
-        // model reaches `resolve_tokenizer` and surfaces as a 500
-        // `tokenizer_not_found` instead of the 404 the client should see.
-        // Mirrors `route_responses_impl`.
-        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
-        {
-            return error_response;
+        if let Some(response) = self.reject_unknown_model(model_id) {
+            return response;
         }
 
         // Canonicalize once, up front -- see `resolve_canonical_model_id`'s
@@ -776,15 +762,8 @@ impl GrpcRouter {
     ) -> Response {
         debug!("Processing completion request for model: {}", model_id);
 
-        // Fail fast on an unknown model, before canonicalization and before the
-        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
-        // stage runs ahead of worker selection; without this check an unknown
-        // model reaches `resolve_tokenizer` and surfaces as a 500
-        // `tokenizer_not_found` instead of the 404 the client should see.
-        // Mirrors `route_responses_impl`.
-        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
-        {
-            return error_response;
+        if let Some(response) = self.reject_unknown_model(model_id) {
+            return response;
         }
 
         // Canonicalize once, up front -- see `resolve_canonical_model_id`'s
@@ -826,15 +805,8 @@ impl GrpcRouter {
         };
         debug!("Processing classify request for model: {}", model_id);
 
-        // Fail fast on an unknown model, before canonicalization and before the
-        // pipeline. The gRPC pipeline tokenizes locally, so its preparation
-        // stage runs ahead of worker selection; without this check an unknown
-        // model reaches `resolve_tokenizer` and surfaces as a 500
-        // `tokenizer_not_found` instead of the 404 the client should see.
-        // Mirrors `route_responses_impl`.
-        if let Some(error_response) = validate_worker_availability(&self.worker_registry, model_id)
-        {
-            return error_response;
+        if let Some(response) = self.reject_unknown_model(model_id) {
+            return response;
         }
 
         classify_pipeline
@@ -1296,6 +1268,12 @@ mod pd_tests {
         }
     }
 
+    fn regular_routing_mode() -> RoutingMode {
+        RoutingMode::Regular {
+            worker_urls: vec![],
+        }
+    }
+
     fn epd_routing_mode() -> RoutingMode {
         RoutingMode::EncodePrefillDecode {
             encode_urls: vec![],
@@ -1513,6 +1491,156 @@ mod pd_tests {
         );
         assert!(matches!(body, Cow::Borrowed(_)));
         assert!(matches!(model_id, Cow::Borrowed(_)));
+    }
+
+    fn json_request<T: serde::de::DeserializeOwned>(value: serde_json::Value) -> T {
+        serde_json::from_value(value).expect("request body")
+    }
+
+    /// Every entry point that tokenizes locally must reject an unknown model
+    /// with 404 before its pipeline runs, without needing a worker or engine.
+    /// The pipeline's preparation stage otherwise reaches `resolve_tokenizer`
+    /// first and surfaces the miss as a 500 `tokenizer_not_found`. Regular
+    /// mode is the one mode that serves all six (embeddings and classify are
+    /// single-worker only).
+    #[tokio::test]
+    async fn unknown_model_is_rejected_before_the_pipeline_on_every_endpoint() {
+        let ctx = grpc_ctx(regular_routing_mode()).await;
+        let router = GrpcRouter::new(&ctx, Mode::Regular).expect("regular router");
+        let tenant_meta = TenantRequestMeta::new(TenantKey::new("test-tenant"));
+        let model = "nonexistent-model-xyz";
+        let user_message = json!([{"role": "user", "content": "hi"}]);
+
+        let responses: Vec<(&str, Response)> = vec![
+            (
+                "chat",
+                router
+                    .route_chat(
+                        None,
+                        &tenant_meta,
+                        json_request(json!({"model": model, "messages": user_message})),
+                        model,
+                    )
+                    .await,
+            ),
+            (
+                "generate",
+                router
+                    .route_generate(
+                        None,
+                        &tenant_meta,
+                        json_request(json!({"model": model, "text": "hi"})),
+                        model,
+                    )
+                    .await,
+            ),
+            (
+                "completion",
+                router
+                    .route_completion(
+                        None,
+                        &tenant_meta,
+                        json_request(json!({"model": model, "prompt": "hi"})),
+                        model,
+                    )
+                    .await,
+            ),
+            (
+                "embeddings",
+                router
+                    .route_embeddings(
+                        None,
+                        &tenant_meta,
+                        json_request(json!({"model": model, "input": "hi"})),
+                        model,
+                    )
+                    .await,
+            ),
+            (
+                "messages",
+                router
+                    .route_messages(
+                        None,
+                        &tenant_meta,
+                        json_request(json!({
+                            "model": model,
+                            "max_tokens": 16,
+                            "messages": user_message,
+                        })),
+                        model,
+                    )
+                    .await,
+            ),
+            (
+                "classify",
+                router
+                    .route_classify(
+                        None,
+                        &tenant_meta,
+                        json_request(json!({"model": model, "input": "hi"})),
+                        model,
+                    )
+                    .await,
+            ),
+        ];
+
+        for (endpoint, response) in responses {
+            assert_eq!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "{endpoint}: unknown model must be rejected before the pipeline"
+            );
+        }
+    }
+
+    /// `/generate` is the one entry point whose `model` defaults to the
+    /// wildcard sentinel, which worker selection widens to the global pool.
+    /// The pre-pipeline guard must not mistake it for a model name.
+    #[tokio::test]
+    async fn generate_wildcard_model_is_not_rejected_as_unknown() {
+        let ctx = grpc_ctx(pd_routing_mode()).await;
+        let worker = BasicWorkerBuilder::new("grpc://decode:30000")
+            .worker_type(WorkerType::Decode)
+            .connection_mode(ConnectionMode::Grpc)
+            .model(ModelCard::new("canonical-model"))
+            .health_config(HealthCheckConfig {
+                disable_health_check: true,
+                ..Default::default()
+            })
+            .build();
+        ctx.worker_registry
+            .register(Arc::new(worker))
+            .expect("register worker");
+        let router = GrpcRouter::new(&ctx, Mode::PrefillDecode).expect("pd router");
+        let tenant_meta = TenantRequestMeta::new(TenantKey::new("test-tenant"));
+
+        // A model-less body deserializes with the wildcard, exactly as the
+        // server hands it to the router.
+        let body: GenerateRequest = json_request(json!({"text": "hi"}));
+        assert_eq!(body.model, UNKNOWN_MODEL_ID);
+        let response = router
+            .route_generate(None, &tenant_meta, body, UNKNOWN_MODEL_ID)
+            .await;
+        assert_ne!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "the /generate wildcard must reach the pipeline, not be rejected as an unknown model"
+        );
+
+        // The exemption is /generate-only: a literal "unknown" model name on
+        // any other endpoint is still just an unknown model.
+        let response = router
+            .route_chat(
+                None,
+                &tenant_meta,
+                json_request(json!({
+                    "model": UNKNOWN_MODEL_ID,
+                    "messages": [{"role": "user", "content": "hi"}],
+                })),
+                UNKNOWN_MODEL_ID,
+            )
+            .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     /// A per-model retry override must survive an alias. The override is keyed

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -4,6 +4,7 @@ mod chat_utils;
 mod logprobs;
 pub(crate) mod message_utils;
 mod metrics;
+mod model_guard;
 mod parsers;
 pub(crate) mod tonic_ext;
 
@@ -20,6 +21,7 @@ pub(crate) use logprobs::{
     convert_proto_to_openai_logprobs,
 };
 pub(crate) use metrics::{error_type_from_status, route_to_endpoint};
+pub(crate) use model_guard::validate_worker_availability;
 pub(crate) use parsers::{
     check_reasoning_parser_availability, check_tool_parser_availability, create_reasoning_parser,
     create_tool_parser, get_tool_parser, reasoning_parser_requires_special_tokens, ParserResolver,

--- a/model_gateway/src/routers/grpc/utils/model_guard.rs
+++ b/model_gateway/src/routers/grpc/utils/model_guard.rs
@@ -1,0 +1,68 @@
+//! Pre-pipeline model validation shared by every gRPC entry point.
+
+use std::sync::Arc;
+
+use axum::response::Response;
+
+use crate::{routers::error, worker::WorkerRegistry};
+
+/// Validate that workers are available for the requested model.
+///
+/// Runs on the client-supplied name, before the pipeline canonicalizes it, so
+/// it has to accept aliases as well as canonical model IDs. `contains_model`
+/// covers both; listing `get_models()` and testing membership would reject
+/// every alias here.
+pub(crate) fn validate_worker_availability(
+    worker_registry: &Arc<WorkerRegistry>,
+    model: &str,
+) -> Option<Response> {
+    if !worker_registry.contains_model(model) {
+        return Some(error::model_not_found(model));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::{model_card::ModelCard, worker::HealthCheckConfig};
+
+    use super::*;
+    use crate::worker::{BasicWorkerBuilder, UNKNOWN_MODEL_ID};
+
+    fn registry_with_aliased_worker() -> Arc<WorkerRegistry> {
+        let registry = Arc::new(WorkerRegistry::new());
+        let worker = BasicWorkerBuilder::new("http://worker:8080")
+            .model(ModelCard::new("canonical-model").with_alias("model-alias"))
+            .health_config(HealthCheckConfig {
+                disable_health_check: true,
+                ..Default::default()
+            })
+            .build();
+        registry.register_or_replace(Arc::new(worker));
+        registry
+    }
+
+    #[test]
+    fn worker_availability_accepts_alias_and_preserves_unknown_rejection() {
+        let registry = registry_with_aliased_worker();
+
+        assert!(validate_worker_availability(&registry, "canonical-model").is_none());
+        assert!(validate_worker_availability(&registry, "model-alias").is_none());
+
+        let response = validate_worker_availability(&registry, UNKNOWN_MODEL_ID)
+            .expect("unknown model should remain rejected for Responses");
+        assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn worker_availability_rejects_alias_once_its_worker_is_gone() {
+        let registry = registry_with_aliased_worker();
+        let worker_id = registry.get_id_by_url("http://worker:8080").unwrap();
+        assert!(registry.remove(&worker_id).is_some());
+
+        let response = validate_worker_availability(&registry, "model-alias")
+            .expect("alias must stop resolving with no workers behind it");
+        assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## Description

### Problem

An unknown model on the gRPC chat path is reported as a server fault rather than a client error. Same gateway, same unknown model, two endpoints:

```
/v1/responses        -> 404 model_not_found     No worker available for model 'nonexistent-model-xyz'
/v1/chat/completions -> 500 tokenizer_not_found Tokenizer not found for model: nonexistent-model-xyz
```

Found by MiniMax's Provider-Verifier contract suite (`test_20_02_invalid_model`, which requires a 4xx) while validating MiniMax-M3, but it is not model-specific — any unknown model on any gRPC entry point except responses hits it.

### Root cause

It is an ordering problem in the gRPC pipeline. Because the gateway tokenizes locally in gRPC mode, `ChatGeneratePreparationStage` runs **ahead of** `WorkerSelectionStage`:

```
1. ChatGeneratePreparationStage   <- resolve_tokenizer fails here with 500
2. RateLimitReserveStage
3. WorkerSelectionStage           <- the correct 404 lives here, never reached
4. ClientAcquisitionStage
```

The HTTP router does not have this problem because it proxies rather than tokenizes, so worker selection is naturally its first step. In IGW mode an unknown model happens to fall back to the `http-regular` default router and is rejected correctly there — but the gRPC router, which is what a `--worker-urls grpc://` deployment runs, has no such guard.

`validate_worker_availability` already exists as a fail-fast for exactly this (its comment: *"Fast worker validation (fail-fast before expensive operations)"*), but was wired only into `route_responses_impl`.

### Solution

Apply the same guard to every other gRPC entry point — chat, generate, embeddings, messages, completion, classify — placed **before** canonicalization, as the guard's contract requires (it runs on the client-supplied name so aliases still resolve).

The guard is a single `GrpcRouter::reject_unknown_model` helper, and `validate_worker_availability` now lives in `grpc/utils/model_guard.rs` rather than under `common/responses/`, since it is no longer responses-specific.

**`/generate` wildcard.** `GenerateRequest.model` defaults to `UNKNOWN_MODEL_ID` when the body names no model, and worker selection widens that sentinel to the global pool — it is not a model name. `/generate` therefore skips the guard for the sentinel explicitly; before, this only worked because untagged workers happen to index under the literal `"unknown"` entry. Only `/generate` carries that default, so a literal `"unknown"` on any other endpoint is still just an unknown model.

### Why `resolve_tokenizer` still returns 500

This was considered and deliberately **not** changed. With the guard in front of it, `resolve_tokenizer` is reached only for a model that *is* served but whose tokenizer has not finished loading. `health.rs` documents that exact condition:

> the gateway autoloads each gRPC-pipeline worker's tokenizer asynchronously afterward … Until that lands, generation requests fail with `tokenizer_not_found`, so `/readiness` must not report ready yet.

That is a genuine server-side state — the client asked for a valid model — and a 404 there would claim a real model does not exist, and would break the readiness contract built around this code. The guard separates the two cases cleanly: unknown model → 404 before the pipeline; served model with a pending tokenizer → 500 that now means precisely what it says.

## Changes

- `model_gateway/src/routers/grpc/router.rs` — `reject_unknown_model` helper applied at every entry point (the six that lacked it plus `/v1/responses`); `/generate` exempts the wildcard sentinel. Two no-GPU unit tests: a table over all six entry points asserting 404 before the pipeline (Regular mode, since embeddings/classify are single-worker only), and one pinning the `/generate` wildcard exemption.
- `model_gateway/src/routers/grpc/utils/model_guard.rs` — new home for `validate_worker_availability` and its tests, moved out of `common/responses/utils.rs` and re-exported from `grpc/utils`.
- `e2e_test/chat_completions/test_validation.py` — `TestUnknownModelRejected`, asserting 404 `model_not_found` on chat and completions for an unknown model over the gRPC backend, parametrised over the `openai` and `smg` clients like the neighbouring tests.

## Test Plan

- `cargo +nightly fmt --all --check` — clean
- `cargo clippy -p smg --all-targets -- -D warnings` — clean
- `ruff check` — clean
- `cargo test -p smg --lib -- routers::grpc::router::pd_tests routers::grpc::utils::model_guard` — 10 passed

Verified against a live gRPC deployment (MiniMax-M3, vLLM 0.27.1, `--worker-urls grpc://`). A valid-model control returned 200 first, confirming a healthy registered worker so the result cannot be "everything is 404":

```
v1/chat/completions -> 404 model_not_found
v1/completions      -> 404 model_not_found
v1/messages         -> 404 model_not_found
v1/embeddings       -> 404 model_not_found
v1/responses        -> 404 model_not_found
generate            -> 404 model_not_found
```

### One observation, not changed here

In IGW mode, `select_router_for_request` ends with `.or_else(default_router)`, which routes an unknown model to the default router after `pick_router_by_weights` has correctly returned `None` for it. Today this is harmless — the default is `http-regular`, which rejects the model itself — but it depends on registration order. Worth a look separately; left alone here to keep this change to the gRPC ordering bug.
