### PR TITLE
feat(mock-worker): sim engine for cache-aware routing tests

### DIFF
--- a/crates/mock_worker/src/config.rs
+++ b/crates/mock_worker/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use crate::engine::EngineParams;
+use crate::{engine::EngineParams, sim::SimParams};
 
 /// Configuration shared by every mocked HTTP and gRPC worker in the process.
 #[derive(Debug, Clone)]
@@ -36,8 +36,17 @@ pub struct Config {
     /// When true, each worker runs the realistic continuous-batching engine
     /// simulator ([`EngineParams`]); when false, the cheap canned path.
     pub realistic: bool,
+    /// When true, each HTTP worker runs the scale-simulation engine
+    /// ([`SimParams`]): SGLang-native `/generate`, prefix-cache accounting,
+    /// analytic timing. gRPC/ZMQ workers fall back to canned behavior.
+    pub sim: bool,
     /// Engine-simulator parameters (only used when `realistic`).
     pub engine: EngineParams,
+    /// Scale-simulation parameters (only used when `sim`). The shared
+    /// `--prefill-tps/--max-running/--kv-tokens/--block-size` flags write
+    /// both engine structs, so each mode keeps its own defaults while an
+    /// explicit flag applies to whichever mode runs.
+    pub sim_params: SimParams,
 }
 
 impl Config {
@@ -57,7 +66,9 @@ impl Config {
             gen_delay: Duration::from_millis(0),
             output_tokens: 8,
             realistic: false,
+            sim: false,
             engine: EngineParams::default(),
+            sim_params: SimParams::default(),
         };
 
         let mut args = std::env::args().skip(1);
@@ -79,16 +90,36 @@ impl Config {
                     cfg.gen_delay = Duration::from_millis(parse(value(&mut args, &flag)?, &flag)?);
                 }
                 "--output-tokens" => cfg.output_tokens = parse(value(&mut args, &flag)?, &flag)?,
-                "--engine" => {
-                    cfg.realistic = match value(&mut args, &flag)?.as_str() {
-                        "realistic" => true,
-                        "canned" => false,
-                        other => {
-                            return Err(format!("--engine must be canned|realistic, got {other}"))
-                        }
+                "--engine" => match value(&mut args, &flag)?.as_str() {
+                    "realistic" => (cfg.realistic, cfg.sim) = (true, false),
+                    "sim" => (cfg.realistic, cfg.sim) = (false, true),
+                    "canned" => (cfg.realistic, cfg.sim) = (false, false),
+                    other => {
+                        return Err(format!(
+                            "--engine must be canned|realistic|sim, got {other}"
+                        ))
                     }
+                },
+                "--sim-itl-ms" => {
+                    cfg.sim_params.itl_ms = parse(value(&mut args, &flag)?, &flag)?;
                 }
-                "--prefill-tps" => cfg.engine.prefill_tps = parse(value(&mut args, &flag)?, &flag)?,
+                "--sim-ttft-base-ms" => {
+                    cfg.sim_params.ttft_base_ms = parse(value(&mut args, &flag)?, &flag)?;
+                }
+                "--image-placeholder-id" => {
+                    cfg.sim_params.image_placeholder_id = parse(value(&mut args, &flag)?, &flag)?;
+                }
+                "--image-tokens-per-image" => {
+                    cfg.sim_params.image_tokens_per_image = parse(value(&mut args, &flag)?, &flag)?;
+                }
+                "--image-bytes-per-token" => {
+                    cfg.sim_params.image_bytes_per_token = parse(value(&mut args, &flag)?, &flag)?;
+                }
+                "--prefill-tps" => {
+                    let tps: f64 = parse(value(&mut args, &flag)?, &flag)?;
+                    cfg.engine.prefill_tps = tps;
+                    cfg.sim_params.prefill_tps = tps;
+                }
                 "--decode-base-ms" => {
                     cfg.engine.decode_base_ms = parse(value(&mut args, &flag)?, &flag)?;
                 }
@@ -98,11 +129,21 @@ impl Config {
                 "--prefill-chunk" => {
                     cfg.engine.prefill_chunk_tokens = parse(value(&mut args, &flag)?, &flag)?;
                 }
-                "--max-running" => cfg.engine.max_running = parse(value(&mut args, &flag)?, &flag)?,
-                "--kv-tokens" => {
-                    cfg.engine.kv_capacity_tokens = parse(value(&mut args, &flag)?, &flag)?;
+                "--max-running" => {
+                    let n: usize = parse(value(&mut args, &flag)?, &flag)?;
+                    cfg.engine.max_running = n;
+                    cfg.sim_params.max_running = n;
                 }
-                "--block-size" => cfg.engine.block_size = parse(value(&mut args, &flag)?, &flag)?,
+                "--kv-tokens" => {
+                    let n: u64 = parse(value(&mut args, &flag)?, &flag)?;
+                    cfg.engine.kv_capacity_tokens = n;
+                    cfg.sim_params.kv_capacity_tokens = n;
+                }
+                "--block-size" => {
+                    let n: u32 = parse(value(&mut args, &flag)?, &flag)?;
+                    cfg.engine.block_size = n;
+                    cfg.sim_params.block_size = n as usize;
+                }
                 "--prefix-cache" => {
                     cfg.engine.prefix_cache = parse(value(&mut args, &flag)?, &flag)?
                 }
@@ -160,7 +201,7 @@ fn usage() -> String {
        --output-tokens <n>      output tokens per request when unspecified (default 8)\n\
      \n\
      Realistic engine simulator (continuous batching; opt-in):\n\
-       --engine <canned|realistic>  engine mode (default canned)\n\
+       --engine <canned|realistic|sim>  engine mode (default canned)\n\
        --prefill-tps <f>        prefill throughput, tokens/sec (default 8000)\n\
        --decode-base-ms <f>     fixed decode-step latency, ms (default 6.0)\n\
        --decode-per-req-ms <f>  added decode-step latency per running req (default 0.35)\n\
@@ -168,6 +209,15 @@ fn usage() -> String {
        --max-running <n>        max concurrent running requests (default 256)\n\
        --kv-tokens <n>          KV cache capacity in tokens (default 524288)\n\
        --block-size <n>         cache block/page size in tokens (default 16)\n\
-       --prefix-cache <bool>    enable prefix caching + KV events (default true)"
+       --prefix-cache <bool>    enable prefix caching + KV events (default true)\n\
+     \n\
+     Scale-simulation engine (SGLang-native /generate; HTTP only; opt-in):\n\
+       --sim-itl-ms <f>              per-output-token latency, ms (default 43)\n\
+       --sim-ttft-base-ms <f>        fixed pre-first-token overhead, ms (default 30)\n\
+       --image-placeholder-id <id>   image placeholder token id (default 151655)\n\
+       --image-tokens-per-image <n>  appended tokens per extra image; 0 = by size (default 0)\n\
+       --image-bytes-per-token <n>   payload bytes per derived image token (default 2800)\n\
+       (shares --prefill-tps --max-running --kv-tokens --block-size; sim\n\
+        defaults: kv 1200000 tokens, block 128)"
         .to_string()
 }

--- a/crates/mock_worker/src/grpc.rs
+++ b/crates/mock_worker/src/grpc.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use futures::{stream, Stream};
+use futures::{stream, Stream, StreamExt as _};
 use smg_grpc_client::{common_proto as common, tokenspeed_scheduler::tokenspeed_proto as ts};
 use tokio::sync::mpsc;
 use tonic::{transport::Server, Request, Response, Status};
@@ -19,6 +19,7 @@ use ts::{
 use crate::{
     config::Config,
     engine::{self, Engine, NewRequest},
+    sim::{SimKvEvent, SimWorker},
 };
 
 /// Serve the mock TokenSpeed gRPC service on `port` until the process exits.
@@ -33,7 +34,11 @@ pub async fn serve(cfg: Arc<Config>, host: String, port: u16) {
     let addr = SocketAddr::new(ip, port);
     // One simulated engine per listener (i.e. per virtual worker).
     let engine = cfg.realistic.then(|| Engine::spawn(cfg.engine.clone()));
-    let service = MockScheduler { cfg, engine };
+    // Sim engine with KV-event emission on: gRPC subscribers exist.
+    let sim = cfg
+        .sim
+        .then(|| SimWorker::new_with_events(cfg.sim_params.clone(), port));
+    let service = MockScheduler { cfg, engine, sim };
     if let Err(e) = Server::builder()
         .add_service(TokenSpeedSchedulerServer::new(service))
         .serve(addr)
@@ -48,6 +53,8 @@ struct MockScheduler {
     cfg: Arc<Config>,
     /// Present iff the worker runs the realistic engine simulator.
     engine: Option<Engine>,
+    /// Present iff the worker runs the scale-sim engine (`--engine sim`).
+    sim: Option<Arc<SimWorker>>,
 }
 
 type GenStream = Pin<Box<dyn Stream<Item = Result<ts::GenerateResponse, Status>> + Send>>;
@@ -65,6 +72,84 @@ impl TokenSpeedScheduler for MockScheduler {
         &self,
         request: Request<ts::GenerateRequest>,
     ) -> Result<Response<Self::GenerateStream>, Status> {
+        // Sim mode: analytic timeline — one sleep to first token, one to
+        // completion — mirroring the HTTP sim handler. The gateway
+        // tokenizes upstream, so the request carries token ids and never
+        // image payloads; the effective sequence is the ids as sent. The
+        // timeline is driven by the response stream itself, so a dropped
+        // stream (gateway abort) cancels mid-sleep and the admission guard
+        // releases immediately.
+        if let Some(sim) = &self.sim {
+            let sim = Arc::clone(sim);
+            let req = request.into_inner();
+            let request_id = req.request_id;
+            let input_ids = req.tokenized.map(|t| t.input_ids).unwrap_or_default();
+            let max_new = req
+                .sampling_params
+                .and_then(|s| s.max_new_tokens)
+                .unwrap_or(self.cfg.output_tokens);
+            let init = SimGen::Admit {
+                sim,
+                request_id,
+                input_ids,
+                max_new,
+            };
+            let stream = stream::unfold(init, |state| async move {
+                match state {
+                    SimGen::Admit {
+                        sim,
+                        request_id,
+                        input_ids,
+                        max_new,
+                    } => {
+                        let mut adm = sim.admit(input_ids, max_new).await;
+                        tokio::time::sleep(adm.ttft).await;
+                        adm.finish_prefill();
+                        let first = ts::GenerateResponse {
+                            request_id: request_id.clone(),
+                            response: Some(GenResp::Chunk(ts::GenerateStreamChunk {
+                                token_ids: adm.output_ids.first().copied().into_iter().collect(),
+                                prompt_tokens: adm.prompt_tokens as u32,
+                                completion_tokens: 1,
+                                cached_tokens: adm.cached_tokens as u32,
+                                output_logprobs: None,
+                                index: 0,
+                            })),
+                        };
+                        let next = SimGen::Decode {
+                            request_id,
+                            max_new,
+                            adm: Box::new(adm),
+                        };
+                        Some((Ok(first), next))
+                    }
+                    SimGen::Decode {
+                        request_id,
+                        max_new,
+                        mut adm,
+                    } => {
+                        tokio::time::sleep(adm.decode).await;
+                        let done = ts::GenerateResponse {
+                            request_id,
+                            response: Some(GenResp::Complete(ts::GenerateComplete {
+                                output_ids: std::mem::take(&mut adm.output_ids),
+                                finish_reason: "stop".to_string(),
+                                prompt_tokens: adm.prompt_tokens as u32,
+                                completion_tokens: max_new,
+                                cached_tokens: adm.cached_tokens as u32,
+                                output_logprobs: None,
+                                matched_stop: None,
+                                index: 0,
+                            })),
+                        };
+                        Some((Ok(done), SimGen::Done))
+                    }
+                    SimGen::Done => None,
+                }
+            });
+            return Ok(Response::new(Box::pin(stream)));
+        }
+
         // Realistic mode: submit to the engine simulator and stream its output.
         if let Some(engine) = &self.engine {
             let req = request.into_inner();
@@ -193,9 +278,10 @@ impl TokenSpeedScheduler for MockScheduler {
         &self,
         _request: Request<ts::GetLoadsRequest>,
     ) -> Result<Response<ts::GetLoadsResponse>, Status> {
-        let load = match &self.engine {
-            Some(engine) => snapshot_to_scheduler_load(&engine.load()),
-            None => ts::SchedulerLoad {
+        let load = match (&self.sim, &self.engine) {
+            (Some(sim), _) => sim_to_scheduler_load(&sim.load()),
+            (None, Some(engine)) => snapshot_to_scheduler_load(&engine.load()),
+            (None, None) => ts::SchedulerLoad {
                 dp_rank: 0,
                 num_running_reqs: 0,
                 num_waiting_reqs: 0,
@@ -225,6 +311,32 @@ impl TokenSpeedScheduler for MockScheduler {
         &self,
         request: Request<common::SubscribeKvEventsRequest>,
     ) -> Result<Response<Self::SubscribeKvEventsStream>, Status> {
+        // Sim mode: replay the ring past the cursor, then the live stream.
+        if let Some(sim) = &self.sim {
+            let start = request.into_inner().start_sequence_number;
+            let Some((replay, live)) = sim.subscribe_kv_events(start) else {
+                return Err(Status::unimplemented("mock-worker (sim KV events off)"));
+            };
+            let block_size = sim.block_size() as i32;
+            let replayed = stream::iter(
+                replay
+                    .into_iter()
+                    .map(move |b| Ok::<_, Status>(sim_batch_to_proto(&b, block_size))),
+            );
+            // A lagged receiver skips ahead; the gateway sees the sequence
+            // gap and reconnects with its cursor, replaying from the ring.
+            let live = stream::unfold(live, move |mut rx| async move {
+                loop {
+                    match rx.recv().await {
+                        Ok(batch) => return Some((Ok(sim_batch_to_proto(&batch, block_size)), rx)),
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+                    }
+                }
+            });
+            return Ok(Response::new(Box::pin(replayed.chain(live))));
+        }
+
         match &self.engine {
             // Realistic mode with prefix caching: stream the engine's KV events.
             Some(engine) if engine.kv_enabled() => {
@@ -334,6 +446,89 @@ fn generate_stream(
             }
         },
     ))
+}
+
+/// Sim generate timeline as stream states: admission + prefill sleep yields
+/// the first chunk; the decode sleep yields the completion. Dropping the
+/// stream mid-state drops the admission guard immediately.
+enum SimGen {
+    Admit {
+        sim: Arc<SimWorker>,
+        request_id: String,
+        input_ids: Vec<u32>,
+        max_new: u32,
+    },
+    Decode {
+        request_id: String,
+        max_new: u32,
+        adm: Box<crate::sim::Admitted>,
+    },
+    Done,
+}
+
+/// Map one sim KV batch to the wire type. The sim's chained block hash is
+/// the wire `block_hash` (parent/removal key); token ids are what the
+/// gateway hashes for matching.
+fn sim_batch_to_proto(batch: &crate::sim::SimKvBatch, block_size: i32) -> common::KvEventBatch {
+    let events = batch
+        .events
+        .iter()
+        .map(|event| {
+            let data = match event {
+                SimKvEvent::Stored { parent, blocks } => {
+                    common::kv_cache_event::Data::Stored(common::KvBlocksStored {
+                        blocks: blocks
+                            .iter()
+                            .map(|b| common::KvBlock {
+                                block_hash: b.hash as i64,
+                                token_ids: b.token_ids.clone(),
+                                block_size,
+                                lora_id: None,
+                                cache_level: None,
+                            })
+                            .collect(),
+                        parent_block_hash: parent.map(|h| h as i64),
+                    })
+                }
+                SimKvEvent::Removed { hashes } => {
+                    common::kv_cache_event::Data::Removed(common::KvBlocksRemoved {
+                        block_hashes: hashes.iter().map(|&h| h as i64).collect(),
+                        cache_level: None,
+                    })
+                }
+            };
+            common::KvCacheEvent {
+                event_id: batch.seq,
+                data: Some(data),
+            }
+        })
+        .collect();
+    common::KvEventBatch {
+        sequence_number: batch.seq,
+        timestamp: 0.0,
+        events,
+        dp_rank: None,
+    }
+}
+
+/// Map a sim load view to the TokenSpeed `SchedulerLoad` wire type.
+fn sim_to_scheduler_load(s: &crate::sim::SimLoad) -> ts::SchedulerLoad {
+    ts::SchedulerLoad {
+        dp_rank: 0,
+        num_running_reqs: s.num_running_reqs as i32,
+        num_waiting_reqs: s.num_waiting_reqs as i32,
+        num_waiting_uncached_tokens: s.num_waiting_uncached_tokens as i32,
+        num_total_reqs: (s.num_running_reqs + s.num_waiting_reqs) as i32,
+        num_used_tokens: s.num_used_tokens as i32,
+        max_total_num_tokens: s.max_total_num_tokens as i32,
+        max_running_requests: s.max_running_requests as i32,
+        token_usage: s.token_usage,
+        gen_throughput: s.gen_throughput,
+        cache_hit_rate: s.cache_hit_rate,
+        utilization: s.token_usage,
+        memory: None,
+        queues: None,
+    }
 }
 
 /// Map an engine load snapshot to the TokenSpeed `SchedulerLoad` wire type.

--- a/crates/mock_worker/src/http.rs
+++ b/crates/mock_worker/src/http.rs
@@ -33,12 +33,15 @@ use tokio::{net::TcpListener, sync::mpsc};
 use crate::{
     config::Config,
     engine::{self, Engine, NewRequest},
+    sim::{self, SimWorker},
 };
 
 /// Per-listener HTTP state: shared config plus an optional engine simulator.
 pub struct AppState {
     cfg: Arc<Config>,
     engine: Option<Engine>,
+    /// Scale-simulation worker (`--engine sim`); `None` in the other modes.
+    sim: Option<Arc<SimWorker>>,
 }
 
 /// Build the router serving the mock HTTP worker contract.
@@ -48,7 +51,7 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/v1/models", get(models))
         .route("/v1/chat/completions", post(chat_completions))
         .route("/v1/completions", post(completions))
-        .route("/generate", post(chat_completions))
+        .route("/generate", post(generate))
         .route("/v1/loads", get(loads))
         .with_state(state)
 }
@@ -64,7 +67,10 @@ pub async fn serve(cfg: Arc<Config>, host: String, port: u16) {
     };
     // One simulated engine per listener (i.e. per virtual worker).
     let engine = cfg.realistic.then(|| Engine::spawn(cfg.engine.clone()));
-    let state = Arc::new(AppState { cfg, engine });
+    let sim = cfg
+        .sim
+        .then(|| SimWorker::new(cfg.sim_params.clone(), port));
+    let state = Arc::new(AppState { cfg, engine, sim });
     if let Err(e) = axum::serve(listener, router(state)).await {
         tracing::error!("http worker {port} stopped: {e}");
     }
@@ -90,6 +96,25 @@ async fn models(State(state): State<Arc<AppState>>) -> Response {
 }
 
 async fn loads(State(state): State<Arc<AppState>>) -> Response {
+    if let Some(sim) = &state.sim {
+        let s = sim.load();
+        let value = json!({
+            "dp_rank": 0,
+            "num_running_reqs": s.num_running_reqs,
+            "num_waiting_reqs": s.num_waiting_reqs,
+            "num_waiting_uncached_tokens": s.num_waiting_uncached_tokens,
+            "num_total_reqs": s.num_running_reqs + s.num_waiting_reqs,
+            "num_used_tokens": s.num_used_tokens,
+            "max_total_num_tokens": s.max_total_num_tokens,
+            "token_usage": s.token_usage,
+            "gen_throughput": s.gen_throughput,
+            "cache_hit_rate": s.cache_hit_rate,
+            "utilization": s.token_usage,
+            "max_running_requests": s.max_running_requests,
+        });
+        return Json(json!({ "timestamp": "", "dp_rank_count": 1, "loads": [value] }))
+            .into_response();
+    }
     let load = state.engine.as_ref().map(|e| e.load());
     let value = match load {
         Some(s) => json!({
@@ -140,6 +165,73 @@ async fn chat_completions(State(state): State<Arc<AppState>>, body: Bytes) -> Re
 
 async fn completions(State(state): State<Arc<AppState>>, body: Bytes) -> Response {
     handle(Endpoint::Completions, state, body).await
+}
+
+/// `/generate`: SGLang-native semantics in sim mode; the historical
+/// chat-shaped alias in canned/realistic modes (existing rigs depend on it).
+async fn generate(State(state): State<Arc<AppState>>, body: Bytes) -> Response {
+    match &state.sim {
+        Some(sim) => sim_generate(Arc::clone(sim), &state.cfg, body).await,
+        None => handle(Endpoint::Chat, state, body).await,
+    }
+}
+
+/// Sim-mode `/generate`: parse the SGLang request shape, drop the (large)
+/// body immediately, admit into the per-worker simulator, then answer on
+/// the analytic timeline — first SSE frame at TTFT, completion at the end
+/// of decode. All accounting is released by the admission guard even when
+/// the client disconnects mid-stream.
+async fn sim_generate(sim: Arc<SimWorker>, cfg: &Config, body: Bytes) -> Response {
+    let parsed: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    drop(body);
+    let stream_requested = parsed
+        .get("stream")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let input_ids = sim::extract_input_ids(&parsed)
+        .unwrap_or_else(|| synth_token_ids(&extract_prompt_text(&parsed)));
+    let images = sim::extract_images(&parsed);
+    let max_new = sim::extract_max_new_tokens(&parsed).unwrap_or(cfg.output_tokens);
+    let effective = sim.effective_sequence(&input_ids, &images);
+    drop(parsed);
+
+    let mut adm = sim.admit(effective, max_new).await;
+    if !stream_requested {
+        tokio::time::sleep(adm.ttft).await;
+        adm.finish_prefill();
+        tokio::time::sleep(adm.decode).await;
+        return Json(sim::native_response(&adm, true)).into_response();
+    }
+
+    enum St {
+        Ttft(sim::Admitted),
+        Decode(sim::Admitted),
+        Done,
+        End,
+    }
+    let body = stream::unfold(St::Ttft(adm), |st| async move {
+        match st {
+            St::Ttft(mut adm) => {
+                tokio::time::sleep(adm.ttft).await;
+                adm.finish_prefill();
+                let frame = sim::native_response(&adm, false);
+                Some((
+                    Ok::<_, Infallible>(Event::default().data(frame.to_string())),
+                    St::Decode(adm),
+                ))
+            }
+            St::Decode(adm) => {
+                tokio::time::sleep(adm.decode).await;
+                let frame = sim::native_response(&adm, true);
+                // `adm` drops here: admission slot + KV pin released, full
+                // sequence folded into the prefix cache.
+                Some((Ok(Event::default().data(frame.to_string())), St::Done))
+            }
+            St::Done => Some((Ok(Event::default().data("[DONE]")), St::End)),
+            St::End => None,
+        }
+    });
+    Sse::new(body).into_response()
 }
 
 async fn handle(endpoint: Endpoint, state: Arc<AppState>, body: Bytes) -> Response {
@@ -422,4 +514,27 @@ fn extract_max_tokens(v: &Value) -> Option<u32> {
 fn next_request_id() -> String {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     format!("mock-http-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_prompts_derive_stable_prefix_preserving_ids() {
+        // The loadgen's text payload is the token context space-joined as
+        // decimal words; extending the context must extend the derived ids
+        // so prefix-cache accounting matches the ids path semantically.
+        let turn1 = synth_token_ids("12 3");
+        let turn2 = synth_token_ids("12 3 45");
+        assert_eq!(turn1.len(), 2);
+        assert_eq!(turn2.len(), 3);
+        assert_eq!(turn2[..2], turn1[..], "shared text head, shared id head");
+        // Distinct words diverge (word identity, not position).
+        assert_ne!(synth_token_ids("12 4")[1], turn1[1]);
+
+        // The `text` field is one of the accepted prompt carriers.
+        let v: Value = serde_json::from_str(r#"{"text":"12 3 45"}"#).unwrap();
+        assert_eq!(synth_token_ids(&extract_prompt_text(&v)), turn2);
+    }
 }

--- a/crates/mock_worker/src/lib.rs
+++ b/crates/mock_worker/src/lib.rs
@@ -5,4 +5,5 @@ pub mod config;
 pub mod engine;
 pub mod grpc;
 pub mod http;
+pub mod sim;
 pub mod zmq;

--- a/crates/mock_worker/src/sim.rs
+++ b/crates/mock_worker/src/sim.rs
@@ -1,0 +1,1132 @@
+//! Scale-simulation engine (`--engine sim`): SGLang-native `/generate`
+//! semantics — `input_ids`, base64 multimodal identity, per-worker prefix
+//! cache, long request holds — at a cost that lets one machine host
+//! thousands of endpoints under hundreds of thousands of concurrent
+//! requests.
+//!
+//! Unlike the realistic engine's stepped continuous-batching actor (whose
+//! per-step wakeups are prohibitive at fleet scale), sim mode computes each
+//! request's timeline analytically at admission and then sleeps: one timer
+//! to first token, one to completion. Cache and KV accounting stay per
+//! worker and O(prompt blocks) per request.
+//!
+//! The multimodal model reproduces production's routing/cache mismatch: the
+//! gateway routes on `input_ids`, where images appear only as placeholder
+//! runs (identical regardless of pixel content), while the worker's cached
+//! sequence splices in ids derived from the image bytes — so two requests
+//! that look identical to routing can still miss each other's KV.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use serde_json::{json, Value};
+use tokio::sync::{broadcast, OwnedSemaphorePermit, Semaphore};
+
+/// Tunables for the sim engine, resolved from CLI flags.
+#[derive(Debug, Clone)]
+pub struct SimParams {
+    /// Per-output-token decode latency (ms); with the output-length
+    /// distribution this sets the mean request lifetime.
+    pub itl_ms: f64,
+    /// Fixed pre-first-token overhead (ms) added to prefill time.
+    pub ttft_base_ms: f64,
+    /// Prefill throughput over UNCACHED prompt tokens (tokens/sec).
+    pub prefill_tps: f64,
+    /// Admission width: requests beyond it queue FIFO as "waiting".
+    pub max_running: usize,
+    /// KV capacity in tokens, shared by running requests and the prefix
+    /// cache (cache evicts LRU to make room for running work).
+    pub kv_capacity_tokens: u64,
+    /// Cache block (page) size in tokens.
+    pub block_size: usize,
+    /// Token id marking an image's position inside `input_ids`.
+    pub image_placeholder_id: u32,
+    /// Cached-sequence tokens contributed per image; `0` derives the count
+    /// from the payload size via `image_bytes_per_token`.
+    pub image_tokens_per_image: usize,
+    /// Bytes of (base64) image payload per derived image token.
+    pub image_bytes_per_token: usize,
+}
+
+impl Default for SimParams {
+    fn default() -> Self {
+        Self {
+            itl_ms: 43.0,
+            ttft_base_ms: 30.0,
+            prefill_tps: 8000.0,
+            max_running: 256,
+            kv_capacity_tokens: 1_200_000,
+            block_size: 128,
+            image_placeholder_id: 151_655,
+            image_tokens_per_image: 0,
+            image_bytes_per_token: 2800,
+        }
+    }
+}
+
+/// One simulated worker: admission semaphore + mutexed accounting state.
+pub struct SimWorker {
+    params: SimParams,
+    admission: Arc<Semaphore>,
+    state: Mutex<SimState>,
+    port: u16,
+}
+
+// ── KV cache events (gateway event-driven routing) ──────────────────────────
+
+/// One block's wire view: the sim's chained hash (stable, unique per
+/// prefix) plus the block's own token ids — the gateway recomputes its
+/// content hash from the ids, so they are load-bearing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimKvBlock {
+    pub hash: u64,
+    pub token_ids: Vec<u32>,
+}
+
+/// A cache transition, proto-agnostic (grpc.rs maps to the wire types).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SimKvEvent {
+    /// Blocks became matchable, in sequence order, positioned after
+    /// `parent` (`None` = sequence start).
+    Stored {
+        parent: Option<u64>,
+        blocks: Vec<SimKvBlock>,
+    },
+    /// Blocks were evicted.
+    Removed { hashes: Vec<u64> },
+}
+
+/// One numbered batch; the gateway requires consecutive sequence numbers.
+#[derive(Debug, Clone)]
+pub struct SimKvBatch {
+    pub seq: u64,
+    pub events: Vec<SimKvEvent>,
+}
+
+/// Replay batches kept for late/reconnecting subscribers. A subscriber
+/// whose cursor predates the ring sees a sequence gap and reconnects,
+/// which the gateway treats as a normal recovery path.
+const KV_EVENT_RING: usize = 65_536;
+
+/// A subscription: the ring batches to replay first, then the live feed.
+pub type KvEventSubscription = (Vec<Arc<SimKvBatch>>, broadcast::Receiver<Arc<SimKvBatch>>);
+
+/// Broadcast + replay ring. Lives inside the state mutex so batch order
+/// matches the accounting transitions that produced it.
+struct KvEventHub {
+    seq: u64,
+    ring: VecDeque<Arc<SimKvBatch>>,
+    tx: broadcast::Sender<Arc<SimKvBatch>>,
+}
+
+impl KvEventHub {
+    fn new() -> Self {
+        Self {
+            seq: 0,
+            ring: VecDeque::new(),
+            tx: broadcast::channel(8192).0,
+        }
+    }
+
+    fn emit(&mut self, events: Vec<SimKvEvent>) {
+        if events.is_empty() {
+            return;
+        }
+        self.seq += 1;
+        let batch = Arc::new(SimKvBatch {
+            seq: self.seq,
+            events,
+        });
+        if self.ring.len() == KV_EVENT_RING {
+            self.ring.pop_front();
+        }
+        self.ring.push_back(Arc::clone(&batch));
+        // No receivers is fine — the ring still records for later replay.
+        let _ = self.tx.send(batch);
+    }
+}
+
+/// Point-in-time load view for `/v1/loads`.
+pub struct SimLoad {
+    pub num_running_reqs: i64,
+    pub num_waiting_reqs: i64,
+    pub num_waiting_uncached_tokens: i64,
+    pub num_used_tokens: i64,
+    pub max_total_num_tokens: i64,
+    pub token_usage: f64,
+    pub gen_throughput: f64,
+    pub cache_hit_rate: f64,
+    pub max_running_requests: i64,
+}
+
+struct SimState {
+    running: usize,
+    waiting: usize,
+    waiting_uncached_tokens: i64,
+    /// Tokens claimed by running requests: uncached prompt + output
+    /// reservation, held until COMPLETION (a decoding request depends on
+    /// its whole prompt, so none of it may stop counting mid-flight).
+    running_tokens: u64,
+    kv: KvIndex,
+    /// EWMA of per-request cached/prompt.
+    hit_rate_ewma: f64,
+    /// KV-event broadcast for gRPC subscribers; `None` when the worker is
+    /// served over HTTP (no subscription protocol, no emission cost).
+    events: Option<KvEventHub>,
+}
+
+impl SimState {
+    /// Emit `Stored` for the chain range `[from, to)` of `seq`'s blocks,
+    /// chained after the preceding block (the gateway derives positions
+    /// from that parent link).
+    fn emit_stored(&mut self, chain: &[u64], seq: &[u32], from: usize, to: usize, block: usize) {
+        let Some(hub) = self.events.as_mut() else {
+            return;
+        };
+        if from >= to {
+            return;
+        }
+        let blocks = (from..to)
+            .map(|i| SimKvBlock {
+                hash: chain[i],
+                token_ids: seq[i * block..(i + 1) * block].to_vec(),
+            })
+            .collect();
+        let parent = (from > 0).then(|| chain[from - 1]);
+        hub.emit(vec![SimKvEvent::Stored { parent, blocks }]);
+    }
+
+    fn emit_removed(&mut self, hashes: Vec<u64>) {
+        if hashes.is_empty() {
+            return;
+        }
+        if let Some(hub) = self.events.as_mut() {
+            hub.emit(vec![SimKvEvent::Removed { hashes }]);
+        }
+    }
+}
+
+/// Everything a response needs, computed at admission under one lock hold.
+pub struct Admitted {
+    pub prompt_tokens: usize,
+    pub cached_tokens: usize,
+    pub output_ids: Vec<u32>,
+    pub ttft: Duration,
+    pub decode: Duration,
+    pub request_id: String,
+    pub worker_port: u16,
+    /// Held for the request's lifetime; dropping it releases admission and
+    /// KV accounting and folds the finished sequence into the cache.
+    guard: CompletionGuard,
+}
+
+impl Admitted {
+    /// Mark simulated prefill complete: only now do the prompt's freshly
+    /// computed blocks become matchable by other requests (a concurrent
+    /// request must not hit KV that hasn't been computed). They enter the
+    /// index PINNED — this request still decodes against them, so they
+    /// stay non-evictable and its KV claim keeps counting until
+    /// completion. Idempotent.
+    pub fn finish_prefill(&mut self) {
+        self.guard.finish_prefill();
+    }
+}
+
+impl SimWorker {
+    pub fn new(params: SimParams, port: u16) -> Arc<Self> {
+        Self::build(params, port, false)
+    }
+
+    /// Worker with KV-event emission on (gRPC-served workers, where the
+    /// gateway can subscribe via `SubscribeKvEvents`).
+    pub fn new_with_events(params: SimParams, port: u16) -> Arc<Self> {
+        Self::build(params, port, true)
+    }
+
+    fn build(params: SimParams, port: u16, events: bool) -> Arc<Self> {
+        let admission = Arc::new(Semaphore::new(params.max_running.max(1)));
+        Arc::new(Self {
+            admission,
+            state: Mutex::new(SimState {
+                running: 0,
+                waiting: 0,
+                waiting_uncached_tokens: 0,
+                running_tokens: 0,
+                kv: KvIndex::new(),
+                hit_rate_ewma: 0.0,
+                events: events.then(KvEventHub::new),
+            }),
+            params,
+            port,
+        })
+    }
+
+    /// Subscribe to KV-event batches: every ring batch with `seq >
+    /// start_seq` in order, then the live stream. Snapshot and receiver are
+    /// taken under the state lock, so the boundary has no gap — emission
+    /// also happens under that lock. Returns `None` when events are off.
+    pub fn subscribe_kv_events(&self, start_seq: u64) -> Option<KvEventSubscription> {
+        let st = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        let hub = st.events.as_ref()?;
+        let replay = hub
+            .ring
+            .iter()
+            .filter(|b| b.seq > start_seq)
+            .cloned()
+            .collect();
+        Some((replay, hub.tx.subscribe()))
+    }
+
+    /// The engine-side cache page size (each event block carries this many
+    /// token ids).
+    pub fn block_size(&self) -> usize {
+        self.params.block_size
+    }
+
+    pub fn load(&self) -> SimLoad {
+        let st = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        // Reported usage covers RUNNING work only: the prefix cache is
+        // evictable headroom, and engines report it that way (the
+        // production sample — 38 running, 41% usage — only reconciles if
+        // cached-but-idle KV is excluded). Counting the cache here drives
+        // usage to 1.0 at steady state and trips the gateway's overload
+        // veto fleet-wide, which production does not observe.
+        let used = st.running_tokens;
+        let cap = self.params.kv_capacity_tokens.max(1);
+        SimLoad {
+            num_running_reqs: st.running as i64,
+            num_waiting_reqs: st.waiting as i64,
+            num_waiting_uncached_tokens: st.waiting_uncached_tokens,
+            num_used_tokens: used.min(cap) as i64,
+            max_total_num_tokens: cap as i64,
+            token_usage: (used as f64 / cap as f64).min(1.0),
+            // Decode-rate estimate: every running request emits one token
+            // per ITL. Good enough for expected-wait ranking.
+            gen_throughput: st.running as f64 * 1000.0 / self.params.itl_ms.max(1e-6),
+            cache_hit_rate: st.hit_rate_ewma,
+            max_running_requests: self.params.max_running as i64,
+        }
+    }
+
+    /// Test-only view of the evictable cache size in tokens (not part of
+    /// reported usage; see [`Self::load`]).
+    #[cfg(test)]
+    fn cache_tokens_for_test(&self) -> u64 {
+        let st = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        st.kv.evictable_tokens(self.params.block_size)
+    }
+
+    /// Test-only view of pinned (active, non-evictable) KV in tokens.
+    #[cfg(test)]
+    fn pinned_tokens_for_test(&self) -> u64 {
+        let st = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        st.kv.pinned_tokens(self.params.block_size)
+    }
+
+    /// Effective cached sequence: `input_ids` with each placeholder run
+    /// replaced positionally by ids derived from the matching image's
+    /// bytes; leftover images append. The gateway never sees this
+    /// substitution — that blindness is the point.
+    pub fn effective_sequence(&self, input_ids: &[u32], images: &[&str]) -> Vec<u32> {
+        let ph = self.params.image_placeholder_id;
+        let mut out = Vec::with_capacity(input_ids.len());
+        let mut image_idx = 0usize;
+        let mut i = 0usize;
+        while i < input_ids.len() {
+            if input_ids[i] == ph {
+                let run_start = i;
+                while i < input_ids.len() && input_ids[i] == ph {
+                    i += 1;
+                }
+                let run_len = i - run_start;
+                match images.get(image_idx) {
+                    Some(image) => {
+                        let seed = splitmix64(fnv64(image.as_bytes()));
+                        for k in 0..run_len {
+                            out.push((splitmix64(seed ^ k as u64) % 1_000_000) as u32 + 1_000_000);
+                        }
+                    }
+                    // No payload for this run: keep the placeholders so the
+                    // sequence still matches other payload-less requests.
+                    None => out.extend(std::iter::repeat_n(ph, run_len)),
+                }
+                image_idx += 1;
+            } else {
+                out.push(input_ids[i]);
+                i += 1;
+            }
+        }
+        // Images beyond the placeholder runs contribute appended tokens
+        // sized by config or payload length.
+        for image in images.iter().skip(image_idx) {
+            let n = if self.params.image_tokens_per_image > 0 {
+                self.params.image_tokens_per_image
+            } else {
+                (image.len() / self.params.image_bytes_per_token.max(1)).max(1)
+            };
+            let seed = splitmix64(fnv64(image.as_bytes()));
+            for k in 0..n {
+                out.push((splitmix64(seed ^ k as u64) % 1_000_000) as u32 + 1_000_000);
+            }
+        }
+        out
+    }
+
+    /// Queue for admission, then compute this request's cache outcome and
+    /// timeline. The returned [`Admitted`] carries a guard that releases
+    /// admission and KV accounting when dropped — including when the
+    /// client disconnects mid-stream.
+    pub async fn admit(self: &Arc<Self>, effective: Vec<u32>, max_new: u32) -> Admitted {
+        let uncached_estimate = effective.len() as i64;
+        {
+            let mut st = self.state.lock().unwrap_or_else(|p| p.into_inner());
+            st.waiting += 1;
+            st.waiting_uncached_tokens += uncached_estimate;
+        }
+        // Queue wait happens here; it is naturally part of client TTFT.
+        let permit = Arc::clone(&self.admission)
+            .acquire_owned()
+            .await
+            .expect("admission semaphore never closes");
+
+        let block = self.params.block_size;
+        let prompt_tokens = effective.len();
+        let chain = chain_hashes(&effective, block);
+        // The request's KV claim while running: uncached prompt + output
+        // reservation, held until COMPLETION. Matched blocks are pinned so
+        // eviction cannot remove KV a running request depends on; they stay
+        // accounted by whoever computed them, never twice.
+        let cached_tokens;
+        let private_tokens;
+        {
+            let mut st = self.state.lock().unwrap_or_else(|p| p.into_inner());
+            st.waiting -= 1;
+            st.waiting_uncached_tokens -= uncached_estimate;
+            st.running += 1;
+            let matched_blocks = st.kv.match_blocks(&chain);
+            cached_tokens = (matched_blocks * block).min(prompt_tokens);
+            st.kv.pin(&chain[..matched_blocks]);
+            private_tokens = (prompt_tokens - cached_tokens) as u64 + u64::from(max_new);
+            st.running_tokens += private_tokens;
+            let ratio = if prompt_tokens == 0 {
+                0.0
+            } else {
+                cached_tokens as f64 / prompt_tokens as f64
+            };
+            st.hit_rate_ewma = st.hit_rate_ewma * 0.95 + ratio * 0.05;
+            let budget = self
+                .params
+                .kv_capacity_tokens
+                .saturating_sub(st.running_tokens);
+            let evicted = st.kv.evict_to(budget, block);
+            st.emit_removed(evicted);
+        }
+
+        let uncached = (prompt_tokens - cached_tokens) as f64;
+        let ttft = Duration::from_secs_f64(
+            (self.params.ttft_base_ms / 1000.0) + uncached / self.params.prefill_tps.max(1.0),
+        );
+        let decode = Duration::from_secs_f64(f64::from(max_new) * self.params.itl_ms / 1000.0);
+
+        // Deterministic from request CONTENT alone (full-sequence chain hash
+        // + length + output budget) — never from admission order — so the
+        // same seed produces byte-identical A/B traffic, and a follow-up
+        // echoing these outputs is reproducible across runs.
+        let request_seed = splitmix64(
+            chain.last().copied().unwrap_or(FNV_SEED)
+                ^ (prompt_tokens as u64)
+                ^ (u64::from(max_new) << 32),
+        );
+        let output_ids: Vec<u32> = (0..max_new as u64)
+            .map(|k| (splitmix64(request_seed ^ k) % 30_000) as u32)
+            .collect();
+        let matched_blocks = cached_tokens / block;
+
+        Admitted {
+            prompt_tokens,
+            cached_tokens,
+            ttft,
+            decode,
+            request_id: format!("sim-{}-{request_seed:016x}", self.port),
+            worker_port: self.port,
+            guard: CompletionGuard {
+                worker: Arc::clone(self),
+                effective,
+                output_ids: output_ids.clone(),
+                chain,
+                pinned_blocks: matched_blocks,
+                private_tokens,
+                prefill_done: false,
+                permit: Some(permit),
+            },
+            output_ids,
+        }
+    }
+}
+
+/// Releases a request's admission slot and KV accounting. The request's
+/// claim (uncached prompt + output reservation) is held until COMPLETION —
+/// decoding depends on the whole prompt, so none of it stops counting
+/// mid-flight. Matchability is staged: matched blocks are pinned from
+/// admission; the rest of the prompt becomes matchable (pinned) at prefill
+/// completion; at completion everything unpins into the evictable cache
+/// with the output appended (later-turn affinity depends on the output
+/// being cached). A request dropped before prefill publishes nothing new.
+/// Runs on normal completion AND on client disconnect.
+struct CompletionGuard {
+    worker: Arc<SimWorker>,
+    effective: Vec<u32>,
+    output_ids: Vec<u32>,
+    /// Chained block hashes of the prompt.
+    chain: Vec<u64>,
+    /// Leading chain blocks this request currently pins.
+    pinned_blocks: usize,
+    /// Uncached prompt + output reservation, released at drop.
+    private_tokens: u64,
+    prefill_done: bool,
+    permit: Option<OwnedSemaphorePermit>,
+}
+
+impl CompletionGuard {
+    fn finish_prefill(&mut self) {
+        if self.prefill_done {
+            return;
+        }
+        self.prefill_done = true;
+        let block = self.worker.params.block_size;
+        let mut st = self.worker.state.lock().unwrap_or_else(|p| p.into_inner());
+        // The freshly computed prompt blocks become matchable, pinned (not
+        // evictable) because this request still decodes against them. The
+        // KV claim is unchanged — the tokens were counted from admission.
+        st.kv.pin(&self.chain[self.pinned_blocks..]);
+        st.emit_stored(
+            &self.chain,
+            &self.effective,
+            self.pinned_blocks,
+            self.chain.len(),
+            block,
+        );
+        self.pinned_blocks = self.chain.len();
+    }
+}
+
+impl Drop for CompletionGuard {
+    fn drop(&mut self) {
+        let params = self.worker.params.clone();
+        let mut st = self.worker.state.lock().unwrap_or_else(|p| p.into_inner());
+        st.running = st.running.saturating_sub(1);
+        st.running_tokens = st.running_tokens.saturating_sub(self.private_tokens);
+        st.kv.unpin(&self.chain[..self.pinned_blocks]);
+        if self.prefill_done {
+            // Publish the finished sequence (prompt ⊕ output) as evictable
+            // cache; an abort before prefill publishes nothing new. The
+            // output-extension blocks are new — announce them chained after
+            // the prompt's last block.
+            let mut full = std::mem::take(&mut self.effective);
+            full.extend_from_slice(&self.output_ids);
+            let full_chain = chain_hashes(&full, params.block_size);
+            st.kv.insert_evictable(&full_chain);
+            st.emit_stored(
+                &full_chain,
+                &full,
+                self.chain.len(),
+                full_chain.len(),
+                params.block_size,
+            );
+        }
+        let budget = params.kv_capacity_tokens.saturating_sub(st.running_tokens);
+        let evicted = st.kv.evict_to(budget, params.block_size);
+        st.emit_removed(evicted);
+        drop(st);
+        self.permit.take();
+    }
+}
+
+// ── KV index: pinned (active) + evictable (LRU) block hashes ────────────────
+
+/// Block-hash view of a worker's KV: `pinned` holds refcounted blocks that
+/// running requests depend on (never evicted); `lru` holds completed,
+/// evictable cache. Both are matchable.
+struct KvIndex {
+    pinned: HashMap<u64, u32>,
+    lru: BlockLru,
+}
+
+impl KvIndex {
+    fn new() -> Self {
+        Self {
+            pinned: HashMap::new(),
+            lru: BlockLru::new(),
+        }
+    }
+
+    /// Leading chain blocks present in pinned or evictable KV.
+    fn match_blocks(&mut self, chain: &[u64]) -> usize {
+        let mut matched = 0usize;
+        for &hash in chain {
+            if self.pinned.contains_key(&hash) {
+                matched += 1;
+            } else if self.lru.contains(hash) {
+                self.lru.touch(hash);
+                matched += 1;
+            } else {
+                break;
+            }
+        }
+        matched
+    }
+
+    /// Pin blocks (refcounted); a block pinned out of the LRU stops being
+    /// evictable until its last unpin.
+    fn pin(&mut self, hashes: &[u64]) {
+        for &hash in hashes {
+            *self.pinned.entry(hash).or_insert(0) += 1;
+            self.lru.remove(hash);
+        }
+    }
+
+    /// Drop one pin per block; the last unpin moves the block into the
+    /// evictable LRU.
+    fn unpin(&mut self, hashes: &[u64]) {
+        for &hash in hashes {
+            if let Some(count) = self.pinned.get_mut(&hash) {
+                *count -= 1;
+                if *count == 0 {
+                    self.pinned.remove(&hash);
+                    self.lru.touch(hash);
+                }
+            }
+        }
+    }
+
+    fn insert_evictable(&mut self, hashes: &[u64]) {
+        for &hash in hashes {
+            if !self.pinned.contains_key(&hash) {
+                self.lru.touch(hash);
+            }
+        }
+    }
+
+    /// Evict LRU blocks until evictable tokens fit `budget_tokens`; pinned
+    /// blocks are untouchable by construction. Returns the evicted hashes.
+    fn evict_to(&mut self, budget_tokens: u64, block_size: usize) -> Vec<u64> {
+        self.lru.evict_to(budget_tokens, block_size)
+    }
+
+    #[cfg(test)]
+    fn evictable_tokens(&self, block_size: usize) -> u64 {
+        self.lru.tokens(block_size)
+    }
+
+    #[cfg(test)]
+    fn pinned_tokens(&self, block_size: usize) -> u64 {
+        (self.pinned.len() * block_size) as u64
+    }
+}
+
+/// Chained block hashes for `seq` (one entry per full `block_size` block).
+fn chain_hashes(seq: &[u32], block_size: usize) -> Vec<u64> {
+    let mut chain = Vec::with_capacity(seq.len() / block_size.max(1));
+    let mut prev = FNV_SEED;
+    for block in seq.chunks_exact(block_size) {
+        prev = chain_hash(prev, block);
+        chain.push(prev);
+    }
+    chain
+}
+
+// ── Block-hash LRU prefix cache ─────────────────────────────────────────────
+
+/// Chained block-hash set with amortized-O(1) LRU eviction (lazy-deletion
+/// queue). One entry = one `block_size`-token block.
+struct BlockLru {
+    /// block hash → last-touch tick.
+    live: HashMap<u64, u64>,
+    /// (hash, tick) in touch order; stale pairs skipped at eviction.
+    order: std::collections::VecDeque<(u64, u64)>,
+    tick: u64,
+}
+
+impl BlockLru {
+    fn new() -> Self {
+        Self {
+            live: HashMap::new(),
+            order: std::collections::VecDeque::new(),
+            tick: 0,
+        }
+    }
+
+    fn tokens(&self, block_size: usize) -> u64 {
+        (self.live.len() * block_size) as u64
+    }
+
+    fn contains(&self, hash: u64) -> bool {
+        self.live.contains_key(&hash)
+    }
+
+    /// Drop a block outright (used when a block gets pinned); stale queue
+    /// entries are skipped lazily at eviction.
+    fn remove(&mut self, hash: u64) {
+        self.live.remove(&hash);
+    }
+
+    fn touch(&mut self, hash: u64) {
+        self.tick += 1;
+        self.live.insert(hash, self.tick);
+        self.order.push_back((hash, self.tick));
+    }
+
+    /// Evict least-recently-touched blocks until cached tokens fit
+    /// `budget_tokens`. Returns the evicted hashes.
+    fn evict_to(&mut self, budget_tokens: u64, block_size: usize) -> Vec<u64> {
+        let mut evicted = Vec::new();
+        while self.tokens(block_size) > budget_tokens {
+            match self.order.pop_front() {
+                Some((hash, tick)) => {
+                    if self.live.get(&hash) == Some(&tick) {
+                        self.live.remove(&hash);
+                        evicted.push(hash);
+                    }
+                }
+                None => break,
+            }
+        }
+        evicted
+    }
+}
+
+const FNV_SEED: u64 = 0xcbf2_9ce4_8422_2325;
+
+fn chain_hash(prev: u64, block: &[u32]) -> u64 {
+    let mut h = prev ^ 0x100_0000_01b3;
+    for &id in block {
+        h ^= u64::from(id);
+        h = h.wrapping_mul(0x100_0000_01b3);
+    }
+    h
+}
+
+fn fnv64(bytes: &[u8]) -> u64 {
+    let mut h = FNV_SEED;
+    for &b in bytes {
+        h ^= u64::from(b);
+        h = h.wrapping_mul(0x100_0000_01b3);
+    }
+    h
+}
+
+fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^ (x >> 31)
+}
+
+// ── Request-body extraction (SGLang /generate shape) ────────────────────────
+
+/// `input_ids` as u32s: single sequence or first of a batch; absent → None.
+pub fn extract_input_ids(v: &Value) -> Option<Vec<u32>> {
+    let ids = v.get("input_ids")?;
+    let seq = match ids.as_array()?.first() {
+        Some(Value::Array(_)) => ids.as_array()?.first()?.as_array()?,
+        _ => ids.as_array()?,
+    };
+    Some(
+        seq.iter()
+            .filter_map(Value::as_u64)
+            .map(|id| id as u32)
+            .collect(),
+    )
+}
+
+/// Image payloads (raw base64 strings; never decoded — identity is bytes).
+pub fn extract_images(v: &Value) -> Vec<&str> {
+    match v.get("image_data") {
+        Some(Value::String(s)) => vec![s.as_str()],
+        Some(Value::Array(items)) => items.iter().filter_map(Value::as_str).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// `sampling_params.max_new_tokens`, else top-level
+/// `max_new_tokens`/`max_tokens`.
+pub fn extract_max_new_tokens(v: &Value) -> Option<u32> {
+    if let Some(n) = v
+        .get("sampling_params")
+        .and_then(|sp| sp.get("max_new_tokens"))
+        .and_then(Value::as_u64)
+    {
+        return Some(n as u32);
+    }
+    for key in ["max_new_tokens", "max_tokens"] {
+        if let Some(n) = v.get(key).and_then(Value::as_u64) {
+            return Some(n as u32);
+        }
+    }
+    None
+}
+
+/// SGLang-native `/generate` response body.
+pub fn native_response(adm: &Admitted, finished: bool) -> Value {
+    let completion = if finished { adm.output_ids.len() } else { 0 };
+    json!({
+        "text": if finished { "mock" } else { "" },
+        "output_ids": if finished { Value::from(adm.output_ids.clone()) } else { Value::from(Vec::<u32>::new()) },
+        "meta_info": {
+            "id": adm.request_id,
+            "prompt_tokens": adm.prompt_tokens,
+            "completion_tokens": completion,
+            "cached_tokens": adm.cached_tokens,
+            "finish_reason": if finished {
+                json!({"type": "length", "length": completion})
+            } else {
+                Value::Null
+            },
+            "worker_port": adm.worker_port,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params(block: usize) -> SimParams {
+        SimParams {
+            itl_ms: 1.0,
+            ttft_base_ms: 0.0,
+            prefill_tps: 1_000_000.0,
+            max_running: 8,
+            kv_capacity_tokens: 100_000,
+            block_size: block,
+            ..SimParams::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn repeat_prompt_hits_cache() {
+        let w = SimWorker::new(params(4), 9100);
+        let ids: Vec<u32> = (0..64).collect();
+        let mut a = w.admit(ids.clone(), 4).await;
+        assert_eq!(a.cached_tokens, 0);
+        a.finish_prefill();
+        drop(a);
+        let b = w.admit(ids, 4).await;
+        assert_eq!(b.cached_tokens, 64, "identical prompt must fully hit");
+    }
+
+    #[tokio::test]
+    async fn cache_not_published_before_prefill_completes() {
+        // A cold request's prompt must not be hittable while its prefill is
+        // still simulated as running, and never if it aborts before then.
+        let w = SimWorker::new(params(4), 9100);
+        let ids: Vec<u32> = (0..64).collect();
+        let mut a = w.admit(ids.clone(), 4).await;
+        let b = w.admit(ids.clone(), 4).await;
+        assert_eq!(b.cached_tokens, 0, "concurrent cold request must miss");
+        drop(b);
+
+        a.finish_prefill();
+        let c = w.admit(ids.clone(), 4).await;
+        assert_eq!(c.cached_tokens, 64, "after prefill the prompt is cached");
+        drop(c);
+        drop(a);
+
+        // An aborted-before-prefill request publishes nothing.
+        let novel: Vec<u32> = (5000..5064).collect();
+        let aborted = w.admit(novel.clone(), 4).await;
+        drop(aborted);
+        let d = w.admit(novel, 4).await;
+        assert_eq!(d.cached_tokens, 0, "aborted prefill must not publish KV");
+    }
+
+    #[tokio::test]
+    async fn active_prompt_kv_stays_counted_and_pinned_until_completion() {
+        // 64-token cold prompt + 8 reserved output, block 4. A decoding
+        // request depends on its whole prompt, so its 72-token claim holds
+        // from admission to COMPLETION; prefill completion makes the prompt
+        // matchable (pinned, non-evictable) without changing usage or
+        // double-counting; completion releases the claim and publishes the
+        // full sequence as evictable cache.
+        let w = SimWorker::new(params(4), 9100);
+        let mut a = w.admit((0..64).collect(), 8).await;
+        assert_eq!(w.load().num_used_tokens, 72);
+        assert_eq!(w.cache_tokens_for_test(), 0);
+        assert_eq!(w.pinned_tokens_for_test(), 0);
+        a.finish_prefill();
+        assert_eq!(
+            w.load().num_used_tokens,
+            72,
+            "the prompt keeps counting while decode depends on it"
+        );
+        assert_eq!(w.pinned_tokens_for_test(), 64, "prompt pinned, matchable");
+        assert_eq!(w.cache_tokens_for_test(), 0, "nothing evictable yet");
+        drop(a);
+        assert_eq!(w.load().num_used_tokens, 0);
+        assert_eq!(w.pinned_tokens_for_test(), 0);
+        assert_eq!(
+            w.cache_tokens_for_test(),
+            72,
+            "prompt \u{2295} output evictable after completion"
+        );
+        assert_eq!(w.load().num_running_reqs, 0);
+    }
+
+    #[tokio::test]
+    async fn pinned_blocks_survive_eviction_pressure() {
+        // Capacity 128 tokens; an active request's 64-token prompt is
+        // pinned after prefill. Churn from completing requests must evict
+        // only the evictable cache — the active prompt stays matchable.
+        let w = SimWorker::new(
+            SimParams {
+                kv_capacity_tokens: 128,
+                ..params(4)
+            },
+            9100,
+        );
+        let ids: Vec<u32> = (0..64).collect();
+        let mut active = w.admit(ids.clone(), 8).await;
+        active.finish_prefill();
+        for start in (1000..3000u32).step_by(100) {
+            let mut churn = w.admit((start..start + 32).collect(), 4).await;
+            churn.finish_prefill();
+            drop(churn);
+        }
+        assert_eq!(w.pinned_tokens_for_test(), 64, "active prompt not evicted");
+        let hit = w.admit(ids, 4).await;
+        assert_eq!(hit.cached_tokens, 64, "pinned prompt stays matchable");
+    }
+
+    #[tokio::test]
+    async fn output_ids_are_deterministic_from_content() {
+        // Identical (sequence, max_new) must yield identical outputs on
+        // different workers and regardless of admission order; different
+        // content must diverge — A/B traffic reproducibility depends on it.
+        let w1 = SimWorker::new(params(4), 9100);
+        let w2 = SimWorker::new(params(4), 9200);
+        let ids: Vec<u32> = (0..64).collect();
+        let other = w1.admit((500..564).collect(), 8).await; // admission-order noise
+        let a = w1.admit(ids.clone(), 8).await;
+        let b = w2.admit(ids.clone(), 8).await;
+        assert_eq!(a.output_ids, b.output_ids, "content-determined outputs");
+        drop(other);
+        let c = w1.admit((2000..2064).collect(), 8).await;
+        assert_ne!(a.output_ids, c.output_ids, "different content diverges");
+    }
+
+    #[tokio::test]
+    async fn turn_two_hits_turn_one_prompt_and_output() {
+        let w = SimWorker::new(params(4), 9100);
+        let t1: Vec<u32> = (0..64).collect();
+        let mut a = w.admit(t1.clone(), 8).await;
+        let output = a.output_ids.clone();
+        a.finish_prefill();
+        drop(a); // completion caches prompt ⊕ output
+        let mut t2 = t1;
+        t2.extend_from_slice(&output);
+        t2.extend(1000..1040u32);
+        let b = w.admit(t2, 4).await;
+        // 64 prompt + 8 output = 72 tokens, block 4 → 72 cached.
+        assert_eq!(b.cached_tokens, 72, "turn 2 must hit turn 1 prompt+output");
+    }
+
+    #[tokio::test]
+    async fn image_identity_changes_effective_sequence() {
+        let w = SimWorker::new(params(4), 9100);
+        let mut ids: Vec<u32> = (0..16).collect();
+        ids.extend(std::iter::repeat_n(w.params.image_placeholder_id, 8));
+        ids.extend(100..116u32);
+
+        let eff_a = w.effective_sequence(&ids, &["imagebytesA"]);
+        let eff_b = w.effective_sequence(&ids, &["imagebytesB"]);
+        assert_eq!(eff_a.len(), ids.len());
+        assert_ne!(
+            eff_a, eff_b,
+            "different image bytes must change the cached sequence"
+        );
+        assert_eq!(eff_a[..16], ids[..16], "text before the image is untouched");
+
+        // Same text, different image ⇒ the cache misses past the image.
+        let mut a = w.admit(eff_a.clone(), 2).await;
+        a.finish_prefill();
+        drop(a);
+        let b = w.admit(eff_b, 2).await;
+        assert_eq!(b.cached_tokens, 16, "hit stops at the image boundary");
+        let c = w.admit(eff_a, 2).await;
+        assert_eq!(c.cached_tokens, 40, "same image hits through it");
+    }
+
+    #[tokio::test]
+    async fn admission_queues_beyond_max_running_and_reports_waiting() {
+        let w = SimWorker::new(
+            SimParams {
+                max_running: 1,
+                ..params(4)
+            },
+            9100,
+        );
+        let first = w.admit((0..8).collect(), 4).await;
+        let w2 = Arc::clone(&w);
+        let mut queued = tokio::task::JoinSet::new();
+        queued.spawn(async move { w2.admit((100..108).collect(), 4).await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let load = w.load();
+        assert_eq!(load.num_running_reqs, 1);
+        assert_eq!(load.num_waiting_reqs, 1);
+        assert!(load.num_waiting_uncached_tokens > 0);
+        drop(first);
+        let second = queued.join_next().await.unwrap().unwrap();
+        assert_eq!(w.load().num_waiting_reqs, 0);
+        drop(second);
+        assert_eq!(w.load().num_running_reqs, 0);
+    }
+
+    #[tokio::test]
+    async fn kv_accounting_and_eviction_stay_bounded() {
+        let w = SimWorker::new(
+            SimParams {
+                kv_capacity_tokens: 256,
+                ..params(4)
+            },
+            9100,
+        );
+        for start in (0..2000u32).step_by(100) {
+            let mut a = w.admit((start..start + 64).collect(), 4).await;
+            a.finish_prefill();
+            drop(a);
+        }
+        assert!(
+            w.cache_tokens_for_test() <= 256,
+            "cache must evict to capacity"
+        );
+        let load = w.load();
+        assert_eq!(load.num_used_tokens, 0, "nothing running after completion");
+        assert!(load.token_usage <= 1.0);
+    }
+
+    #[test]
+    fn body_extraction_reads_all_generate_fields() {
+        let body = json!({
+            "input_ids": [1, 2, 3],
+            "image_data": ["aGVsbG8=", "d29ybGQ="],
+            "sampling_params": {"max_new_tokens": 7},
+            "max_tokens": 99,
+        });
+        assert_eq!(extract_input_ids(&body), Some(vec![1, 2, 3]));
+        assert_eq!(extract_images(&body).len(), 2);
+        assert_eq!(extract_max_new_tokens(&body), Some(7));
+
+        let batch = json!({"input_ids": [[4, 5], [6]]});
+        assert_eq!(extract_input_ids(&batch), Some(vec![4, 5]));
+
+        let single_image = json!({"image_data": "abc"});
+        assert_eq!(extract_images(&single_image), vec!["abc"]);
+
+        let top_level = json!({"max_new_tokens": 3});
+        assert_eq!(extract_max_new_tokens(&top_level), Some(3));
+    }
+
+    /// Drain every ring batch after `start_seq` (test helper).
+    fn replay(w: &SimWorker, start_seq: u64) -> Vec<Arc<SimKvBatch>> {
+        w.subscribe_kv_events(start_seq).expect("events enabled").0
+    }
+
+    #[tokio::test]
+    async fn kv_events_chain_prompt_then_output_blocks() {
+        // 8 tokens, block 4 -> 2 prompt blocks; 4 outputs -> 1 more block.
+        let w = SimWorker::new_with_events(params(4), 9100);
+        let ids: Vec<u32> = (0..8).collect();
+        let mut a = w.admit(ids.clone(), 4).await;
+        assert!(replay(&w, 0).is_empty(), "nothing stored before prefill");
+
+        a.finish_prefill();
+        let batches = replay(&w, 0);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].seq, 1, "sequence numbers start at 1");
+        let SimKvEvent::Stored { parent, blocks } = &batches[0].events[0] else {
+            panic!("prefill completion must emit Stored");
+        };
+        assert_eq!(*parent, None, "prompt starts the sequence");
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].token_ids, vec![0, 1, 2, 3]);
+        assert_eq!(blocks[1].token_ids, vec![4, 5, 6, 7]);
+        let prompt_chain = chain_hashes(&ids, 4);
+        assert_eq!(blocks[1].hash, prompt_chain[1]);
+
+        let outputs = a.output_ids.clone();
+        drop(a);
+        let batches = replay(&w, 1);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].seq, 2, "consecutive batch numbering");
+        let SimKvEvent::Stored { parent, blocks } = &batches[0].events[0] else {
+            panic!("completion must emit the output-extension Stored");
+        };
+        assert_eq!(
+            *parent,
+            Some(prompt_chain[1]),
+            "output blocks chain after the prompt's last block"
+        );
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(
+            blocks[0].token_ids, outputs,
+            "output block carries the output ids"
+        );
+    }
+
+    #[tokio::test]
+    async fn kv_events_report_evictions() {
+        // Capacity 16 tokens, block 4: the second finished sequence must
+        // evict the first's blocks, and the eviction must be announced with
+        // the same hashes the Stored events used.
+        let mut p = params(4);
+        p.kv_capacity_tokens = 16;
+        let w = SimWorker::new_with_events(p, 9100);
+
+        let first: Vec<u32> = (0..12).collect();
+        let mut a = w.admit(first.clone(), 4).await;
+        a.finish_prefill();
+        drop(a);
+
+        let second: Vec<u32> = (100..116).collect();
+        let mut b = w.admit(second, 4).await;
+        b.finish_prefill();
+        drop(b);
+
+        let mut stored: Vec<u64> = Vec::new();
+        let mut removed: Vec<u64> = Vec::new();
+        for batch in replay(&w, 0) {
+            for event in &batch.events {
+                match event {
+                    SimKvEvent::Stored { blocks, .. } => {
+                        stored.extend(blocks.iter().map(|b| b.hash));
+                    }
+                    SimKvEvent::Removed { hashes } => removed.extend(hashes),
+                }
+            }
+        }
+        assert!(!removed.is_empty(), "capacity pressure must evict");
+        assert!(
+            removed.iter().all(|h| stored.contains(h)),
+            "evictions must reference previously stored hashes"
+        );
+    }
+
+    #[tokio::test]
+    async fn kv_events_replay_cursor_and_http_default() {
+        let w = SimWorker::new_with_events(params(4), 9100);
+        let mut a = w.admit((0..8).collect(), 4).await;
+        a.finish_prefill();
+        drop(a); // seq 1 (prefill Stored) + seq 2 (output Stored)
+        assert_eq!(replay(&w, 0).len(), 2);
+        let after = replay(&w, 1);
+        assert_eq!(after.len(), 1, "cursor filters already-seen batches");
+        assert_eq!(after[0].seq, 2);
+
+        // HTTP-served workers keep events off entirely.
+        let http = SimWorker::new(params(4), 9101);
+        assert!(http.subscribe_kv_events(0).is_none());
+    }
+}

--- a/crates/mock_worker/src/zmq.rs
+++ b/crates/mock_worker/src/zmq.rs
@@ -291,7 +291,9 @@ mod tests {
             gen_delay: Duration::ZERO,
             output_tokens: 4,
             realistic: false,
+            sim: false,
             engine: EngineParams::default(),
+            sim_params: crate::sim::SimParams::default(),
         }
     }
 


### PR DESCRIPTION
> [!NOTE]
> **Draft.** Base PR for the radix-index experiment stack — #2394 (the index + gateway seam) stacks on this. Shared test fixture only; no production code path.

## What this is

A faithful `/generate` **simulation mode** for the mock worker, so gateway integration tests and the cache-aware routing sim rig can exercise realistic behavior without real GPUs:

- deterministic prefill/decode timing,
- KV-cache **block accounting** (what the worker holds after a request),
- **`SubscribeKvEvents`** emission (Stored/Removed/Cleared), the event stream the gateway's KV monitor and the radix index consume.

`src/sim.rs` is the engine; `config`/`grpc`/`http` gain the sim wiring; `lib.rs` exports `pub mod sim`. No new dependencies.

## Scope / safety

- **Dev-dependency only** — `mock-worker` is used under `[dev-dependencies]` by `model_gateway` and `crates/radix_index`; there is **no production code path** through this crate.
- Self-contained: every change is inside `crates/mock_worker/` (no cross-crate edits, no `Cargo.toml`/lockfile changes).
- Split out of the radix-index experiment so the index PR reviews as just the DB + gateway seam.

## Verification
`cargo test -p mock-worker` green (22 tests); builds standalone on `main`.
