### PR TITLE
fix(router): preserve streaming error content type

### DIFF
--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -1243,8 +1243,10 @@ impl Router {
             // Preserve headers for streaming response
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
             header_utils::insert_routed_worker_id(&mut response_headers, worker_url);
-            // Ensure we set the correct content-type for SSE
-            response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+            if status.is_success() && !response_headers.contains_key(CONTENT_TYPE) {
+                response_headers
+                    .insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+            }
 
             let stream = res.bytes_stream();
             // Bounded channel applies backpressure: a slow client makes the

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -191,6 +191,7 @@ pub(super) async fn route_chat(
                 // For non-streaming: we record here too — body read errors
                 // are connection issues, not worker health issues.
                 worker.record_outcome(status.as_u16());
+                let content_type = resp.headers().get(CONTENT_TYPE).cloned();
 
                 if is_streaming {
                     let stream = resp.bytes_stream();
@@ -215,12 +216,15 @@ pub(super) async fn route_chat(
                     let mut response =
                         Response::new(Body::from_stream(ReceiverStream::new(rx)));
                     *response.status_mut() = status;
-                    response
-                        .headers_mut()
-                        .insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+                    if let Some(ct) = content_type {
+                        response.headers_mut().insert(CONTENT_TYPE, ct);
+                    } else if status.is_success() {
+                        response
+                            .headers_mut()
+                            .insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+                    }
                     response
                 } else {
-                    let content_type = resp.headers().get(CONTENT_TYPE).cloned();
                     match resp.bytes().await {
                         Ok(body) => {
                             let mut response = Response::new(Body::from(body));

--- a/model_gateway/tests/api/api_endpoints_test.rs
+++ b/model_gateway/tests/api/api_endpoints_test.rs
@@ -293,6 +293,45 @@ mod generation_tests {
 
         ctx.shutdown().await;
     }
+
+    #[tokio::test]
+    async fn test_v1_chat_completions_streaming_preserves_worker_json_error_content_type() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18006,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 1.0,
+        }])
+        .await;
+        let app = ctx.create_app();
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "Hello!"}],
+            "stream": true
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            resp.headers().get(CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body_json["error"]["type"], "internal_error");
+
+        ctx.shutdown().await;
+    }
 }
 
 #[cfg(test)]

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -843,6 +843,75 @@ async fn test_openai_router_chat_streaming_with_mock() {
     assert!(text.contains("[DONE]"));
 }
 
+/// A streaming request must keep the content type of an upstream JSON error.
+#[tokio::test]
+async fn test_openai_router_chat_streaming_preserves_json_error_content_type() {
+    for status in [StatusCode::BAD_REQUEST, StatusCode::INTERNAL_SERVER_ERROR] {
+        assert_streaming_json_error_content_type(status).await;
+    }
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    clippy::unwrap_used,
+    reason = "The test helper uses valid input."
+)]
+async fn assert_streaming_json_error_content_type(status: StatusCode) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(move || async move {
+            (
+                status,
+                Json(json!({
+                    "object": "error",
+                    "message": "invalid sampling parameter",
+                    "type": "BadRequestError",
+                    "code": status.as_u16()
+                })),
+            )
+        }),
+    );
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let ctx = create_test_app_context().await;
+    register_external_worker(&ctx, &format!("http://{addr}"), None);
+    let router = OpenAIRouter::new(&ctx).await.unwrap();
+    let chat_request: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_tokens": 10,
+        "stream": true
+    }))
+    .unwrap();
+
+    let response = router
+        .route_chat(
+            None,
+            &test_tenant_meta(),
+            chat_request.clone(),
+            &chat_request.model,
+        )
+        .await;
+
+    assert_eq!(response.status(), status);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "application/json",
+        "upstream status: {status}"
+    );
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(response_json["type"], "BadRequestError");
+
+    server.abort();
+}
+
 /// Test circuit breaker functionality
 #[tokio::test]
 async fn test_openai_router_circuit_breaker() {


### PR DESCRIPTION
## Description

### Problem

For a request with `stream: true`, an upstream server can return a JSON error before generation starts.
SMG keeps the status and body, but it changes the content type to `text/event-stream`.
An SSE client can then lose the error body.

### Solution

Preserve the upstream content type for streaming responses.
Use the SSE default only for a successful response that has no upstream content type.

## Changes

- Preserve error content types in the regular HTTP relay.
- Preserve error content types in the external OpenAI relay.
- Add regression tests for JSON 4xx and 5xx responses.
- Keep coverage for a successful SSE response.

Closes #2403.

## Test Plan

- Confirmed that both new tests fail on `2e76d877` before the production change.
- Ran `cargo test -p smg --test api_tests`: 108 tests passed.
- Ran `cargo test -p smg --test routing_tests`: 125 tests passed.
- Ran `cargo +nightly fmt --all -- --check`: passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- Ran `cargo test`: all tests passed until `test_router_with_tracing` received no spans from its local collector.
- Reran `test_router_with_tracing`: it failed for the same local collector condition.

The all-feature Clippy command requires local OpenCV metadata, which is not available in this environment.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join the Discord community

</details>
