### PR TITLE
fix(ci): authenticate github.com git access on cluster runners

### DIFF
--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -89,6 +89,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # The cluster runners share one NAT egress IP and GitHub intermittently
+      # 401s anonymous git from it, even for public repos — the TokenSpeed
+      # source fetch dies on "could not read Username". Carry the workflow
+      # token on every github.com git operation instead.
+      - name: Authenticate git for github.com
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git config --global \
+            url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf \
+            "https://github.com/"
+
       # Engine-specific setup
       - name: Setup SGLang backend
         if: inputs.engine == 'sglang'

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -36,6 +36,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The cluster runners share one NAT egress IP and GitHub intermittently
+      # 401s anonymous git from it, even for public repos — pre-commit's
+      # hook-repo fetches die on "could not read Username". Carry the workflow
+      # token on every github.com git operation instead.
+      - name: Authenticate git for github.com
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git config --global \
+            url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf \
+            "https://github.com/"
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:


### PR DESCRIPTION
## Description

### Problem

CI jobs on the cluster runners fail intermittently (lately, most of the time) with:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
```

The runners all egress through one shared NAT IP, and GitHub intermittently answers **anonymous** `git-upload-pack` requests from that IP with a `401 www-authenticate: Basic` challenge — even for public repositories (reproduced from inside a runner pod: ~85–90% of anonymous `git ls-remote` calls against a public repo fail, while `gitlab.com`/`codeberg.org` succeed 8/8 from the same pod, and the REST rate limit shows unused). With no terminal to prompt for credentials, git dies with the error above.

Two CI paths do anonymous git against github.com and are the ones failing:

- **pre-commit** — fetches its hook repos into `~/.cache/pre-commit`
- **e2e GPU jobs (tokenspeed)** — `scripts/ci_install_tokenspeed.sh` fetches the TokenSpeed source

`actions/checkout` is unaffected because it already authenticates with the workflow token.

### Solution

Add a step to both jobs that rewrites `https://github.com/` git URLs to carry the workflow token:

```
git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
```

Every subsequent git operation in the job (pre-commit's hook clones, the TokenSpeed fetch) is then authenticated and attributed to the token, bypassing the anonymous per-IP throttle. The default `github.token` is sufficient — authenticated read of public repos needs no extra scopes, so no new secret is introduced.

## Changes

- `.github/workflows/pr-test-rust.yml`: add an "Authenticate git for github.com" step to the `pre-commit` job, before anything fetches from github.com.
- `.github/workflows/e2e-gpu-job.yml`: add the same step to the shared `run` job, before the engine setup actions (covers the TokenSpeed source fetch and any future engine clones).

## Test Plan

- This PR's own CI exercises both paths on the affected runners: the `pre-commit` job (previously failing near-deterministically, since it makes one anonymous fetch per hook repo) and the tokenspeed e2e jobs.
- Before: on PR #2398, `pre-commit`, `e2e-1gpu-chat-zmq (tokenspeed)`, and `e2e-4gpu-epd (tokenspeed)` failed across three consecutive runs with the error above.
- Diagnosis evidence from a runner pod: anonymous `GET /info/refs` on a public repo returns 200, the follow-up `POST /git-upload-pack` intermittently returns `401 Basic realm="GitHub"`; token-authenticated operations (`actions/checkout`) never hit it.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
