### PR TITLE
fix(ci): consume the TokenSpeed CI image by extraction — lanes run bare, not in containers

### DIFF
--- a/.github/actions/setup-tokenspeed/action.yml
+++ b/.github/actions/setup-tokenspeed/action.yml
@@ -1,9 +1,19 @@
 name: 'Setup TokenSpeed Backend'
-description: 'Create Python venv and install TokenSpeed (engine + kernel + scheduler) from source.'
+description: 'Create Python venv and install TokenSpeed (engine + kernel + scheduler), from the prebuilt CI image when available, from source otherwise.'
 
 runs:
   using: 'composite'
   steps:
+    # Extracts the baked venv + checkout onto the bare runner and exports
+    # SMG_BAKED_VENV for the venv step below. Tolerant: any failure logs and
+    # leaves the source-build path to run instead.
+    - name: Fetch prebuilt TokenSpeed
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_ACTOR: ${{ github.actor }}
+      run: bash scripts/ci_fetch_tokenspeed_prebuilt.sh
+
     - name: Setup Python venv
       shell: bash
       run: bash scripts/ci_setup_python_venv.sh

--- a/.github/workflows/ci-tokenspeed-image.yml
+++ b/.github/workflows/ci-tokenspeed-image.yml
@@ -1,11 +1,13 @@
 name: CI TokenSpeed Image
 
-# Bakes the pinned TokenSpeed build (engine + kernel + scheduler) on top of
-# the plain GPU CI container and pushes it under the content-addressed tag
-# printed by scripts/ci_tokenspeed_image_tag.sh (engine ref + a hash of the
-# image tooling). The tokenspeed e2e lanes in pr-test-rust.yml pull this
-# image (resolved in detect-changes) instead of spending ~25
-# GPU-runner-minutes compiling from source in every job.
+# Bakes the pinned TokenSpeed build (engine + kernel + scheduler) into a
+# runner-matched carrier image (ubuntu:24.04 — the GPU e2e jobs run bare on
+# the runner pods, so this is extracted at job time, not used as a job
+# container; see docker/ci-tokenspeed.Dockerfile) and pushes it under the
+# content-addressed tag printed by scripts/ci_tokenspeed_image_tag.sh
+# (engine ref + a hash of the image tooling). The tokenspeed e2e lanes in
+# pr-test-rust.yml pull this image (resolved in detect-changes) instead of
+# spending ~25 GPU-runner-minutes compiling from source in every job.
 #
 # The kernel compile needs nvcc but no GPU (arch list is pinned in
 # scripts/ci_install_tokenspeed.sh), so this runs on the docker runner pool.
@@ -33,7 +35,7 @@ on:
         default: false
         type: boolean
       base_image:
-        description: 'Base image override (default: vars.SMG_CI_GPU_CONTAINER_IMAGE)'
+        description: 'Base image override (default: ubuntu:24.04, matching the runner pods)'
         required: false
         type: string
 
@@ -58,16 +60,13 @@ jobs:
         id: resolve
         env:
           BASE_OVERRIDE: ${{ inputs.base_image }}
-          BASE_DEFAULT: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
         run: |
           # Unlike the tolerant resolution in detect-changes, THIS workflow
           # must fail loudly on a broken ref — its whole job is the image.
           tag="$(bash scripts/ci_tokenspeed_image_tag.sh)"
-          base="${BASE_OVERRIDE:-$BASE_DEFAULT}"
-          if [ -z "$base" ]; then
-            echo "ERROR: no base image (vars.SMG_CI_GPU_CONTAINER_IMAGE unset and no override)" >&2
-            exit 1
-          fi
+          # ubuntu:24.04 matches the runner pods (see the Dockerfile's
+          # portability contract); the dispatch input can override it.
+          base="${BASE_OVERRIDE:-ubuntu:24.04}"
           image="ghcr.io/${{ github.repository_owner }}/smg:${tag}"
           echo "image=${image}" >> "$GITHUB_OUTPUT"
           echo "base=${base}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -82,9 +82,6 @@ jobs:
     timeout-minutes: ${{ inputs.timeout }}
     permissions:
       contents: read
-      # For the authenticated-ghcr-pull fallback in setup-tokenspeed's
-      # fetch step (scripts/ci_fetch_tokenspeed_prebuilt.sh).
-      packages: read
     env:
       E2E_ENGINE: ${{ inputs.engine }}
       E2E_RUNTIME: ${{ inputs.engine }}

--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -69,19 +69,22 @@ on:
         type: number
         default: 0
         description: "Minimum effective (selected) test count; exported as E2E_MIN_SELECTED for the pytest harness floor check (0 = disabled)"
-      container_image:
+      tokenspeed_prebuilt_image:
         required: false
         type: string
         default: ""
-        description: "Container image override (e.g. the prebuilt ci-tokenspeed image); empty = the plain GPU CI container"
+        description: "Prebuilt TokenSpeed carrier image to extract onto the runner (resolved by detect-changes); empty = build from source"
 
 jobs:
   run:
     runs-on: ${{ inputs.runner }}
-    container: ${{ inputs.container_image || vars.SMG_CI_GPU_CONTAINER_IMAGE }}
+    container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
     timeout-minutes: ${{ inputs.timeout }}
     permissions:
       contents: read
+      # For the authenticated-ghcr-pull fallback in setup-tokenspeed's
+      # fetch step (scripts/ci_fetch_tokenspeed_prebuilt.sh).
+      packages: read
     env:
       E2E_ENGINE: ${{ inputs.engine }}
       E2E_RUNTIME: ${{ inputs.engine }}
@@ -89,6 +92,7 @@ jobs:
       E2E_VLLM_KV_BACKEND: ${{ inputs.vllm_kv_backend }}
       E2E_CONNECTION_MODE: ${{ inputs.connection_mode }}
       E2E_ZMQ_ENGINE_COUNT: ${{ inputs.zmq_engine_count }}
+      TOKENSPEED_PREBUILT_IMAGE: ${{ inputs.tokenspeed_prebuilt_image }}
       ROUTER_LOCAL_MODEL_PATH: /models
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -448,14 +448,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Resolve the prebuilt TokenSpeed CI image (built by
+      # Resolve the prebuilt TokenSpeed carrier image (built by
       # ci-tokenspeed-image.yml, content-addressed by the pinned engine ref +
-      # image-tooling hash — see scripts/ci_tokenspeed_image_tag.sh). Any
-      # failure — a missing image (e.g. a PR that bumps the ref or edits the
-      # tooling before the image exists), a broken ref file, a registry
-      # hiccup — resolves to empty, and the tokenspeed lanes fall back to the
-      # plain CI container + source build. This step must NEVER fail the job:
-      # a failed detect-changes silently skips every gated lane.
+      # image-tooling hash — see scripts/ci_tokenspeed_image_tag.sh). The
+      # lanes run bare on the runner pods, so the image is not a job
+      # container: setup-tokenspeed extracts its payload onto the runner
+      # (scripts/ci_fetch_tokenspeed_prebuilt.sh). Any failure — a missing
+      # image (e.g. a PR that bumps the ref or edits the tooling before the
+      # image exists), a broken ref file, a registry hiccup — resolves to
+      # empty, and the tokenspeed lanes fall back to the source build. This
+      # step must NEVER fail the job: a failed detect-changes silently skips
+      # every gated lane.
       - name: Resolve TokenSpeed CI image
         id: tokenspeed-image
         env:
@@ -617,7 +620,7 @@ jobs:
       test_timeout: ${{ matrix.test_timeout }}
       test_dirs: ${{ matrix.test_dirs || 'e2e_test/chat_completions' }}
       min_selected: ${{ matrix.min_selected }}
-      container_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
+      tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
     secrets: inherit
 
   e2e-1gpu-chat-zmq:
@@ -660,7 +663,7 @@ jobs:
       test_dirs: e2e_test/chat_completions
       connection_mode: zmq
       min_selected: ${{ matrix.min_selected }}
-      container_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
+      tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
     secrets: inherit
 
   e2e-2gpu-chat-zmq-dp:
@@ -708,7 +711,7 @@ jobs:
       connection_mode: zmq
       zmq_engine_count: "2"
       min_selected: ${{ matrix.min_selected }}
-      container_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
+      tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
     secrets: inherit
 
   e2e-1gpu-completions:
@@ -944,7 +947,7 @@ jobs:
       test_dirs: e2e_test/chat_completions/test_epd_multimodal.py
       extra_models: "Qwen/Qwen3.5-9B"
       min_selected: 6 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
-      container_image: ${{ needs.detect-changes.outputs.tokenspeed-image }}
+      tokenspeed_prebuilt_image: ${{ needs.detect-changes.outputs.tokenspeed-image }}
     secrets: inherit
 
   # --- Vendor E2E: CPU-only cloud backend tests ---

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -527,6 +527,7 @@ jobs:
               - 'scripts/ci_install_trtllm.sh'
               - 'scripts/ci_install_tokenspeed.sh'
               - 'scripts/ci_tokenspeed_image_tag.sh'
+              - 'scripts/ci_fetch_tokenspeed_prebuilt.sh'
               - '.github/versions/tokenspeed.ref'
             agentic:
               - 'crates/mcp/**'

--- a/docker/ci-tokenspeed.Dockerfile
+++ b/docker/ci-tokenspeed.Dockerfile
@@ -1,5 +1,23 @@
-# CI image for the TokenSpeed e2e lanes: the plain GPU CI container plus a
-# fully-built TokenSpeed (engine + kernel + scheduler) baked into a venv.
+# CI image carrying a fully-built TokenSpeed (engine + kernel + scheduler)
+# for the tokenspeed e2e lanes.
+#
+# The GPU e2e jobs run BARE on the k8s runner pods (no job container —
+# vars.SMG_CI_GPU_CONTAINER_IMAGE has never been set, so the container: line
+# in e2e-gpu-job.yml resolves to "no container"). This image is therefore a
+# CARRIER, not a job container: at job time
+# scripts/ci_fetch_tokenspeed_prebuilt.sh pulls it and docker-cp's the baked
+# payload onto the runner, where scripts/ci_install_tokenspeed.sh's stamp
+# fast path takes over.
+#
+# Portability contract with the runner (Ubuntu 24.04 pods):
+#   - base is ubuntu:24.04 so the baked venv's interpreter symlink resolves
+#     to the same /usr/bin path on the runner (the venv-adoption check in
+#     ci_setup_python_venv.sh re-validates the interpreter there);
+#   - the payload lives under /opt/smg-ci (venv + stamp) and
+#     /opt/tokenspeed-src (checkout the venv's editable installs point at),
+#     extracted to identical absolute paths;
+#   - the CUDA toolkit is NOT part of the payload; the install script
+#     apt-installs it on the runner when missing, same as the source path.
 #
 # Built by .github/workflows/ci-tokenspeed-image.yml on every bump of
 # .github/versions/tokenspeed.ref or of the image tooling, and tagged
@@ -7,15 +25,17 @@
 # scripts/ci_tokenspeed_image_tag.sh. The build needs nvcc but no GPU
 # (the kernel arch list is pinned in the install script), so it runs on the
 # CPU/docker runner pool.
-#
-# scripts/ci_install_tokenspeed.sh stamps the built ref at
-# /opt/smg-ci/tokenspeed.ref; at job time the same script sees a matching
-# stamp and skips the ~25-minute source build, leaving only the per-PR SMG
-# gRPC glue install. scripts/ci_setup_python_venv.sh adopts the baked venv
-# via the SMG_BAKED_VENV env below.
 
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
+
+# Build prerequisites the bare base lacks (the runner pods already carry
+# these). python3 is 3.12 on noble, matching the CI interpreter pin.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git build-essential pkg-config \
+        python3 python3-venv python3-pip \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/smg-ci
 
@@ -23,8 +43,9 @@ COPY scripts/ci_setup_python_venv.sh scripts/ci_install_tokenspeed.sh scripts/
 COPY .github/versions/tokenspeed.ref .github/versions/tokenspeed.ref
 
 # Keep the TokenSpeed checkout inside the image: the venv's editable installs
-# point at it. uv is promoted to /usr/local/bin because the per-job HOME
-# differs from the build-time HOME, so ~/.local/bin would not be found.
+# point at it. uv is promoted to /usr/local/bin for anyone exec-ing into the
+# image directly; the job-side fast path installs its own (per-job HOME
+# differs from the build-time HOME).
 RUN bash scripts/ci_setup_python_venv.sh \
     && TOKENSPEED_BUILD_ONLY=1 TOKENSPEED_DIR=/opt/tokenspeed-src \
        bash scripts/ci_install_tokenspeed.sh \
@@ -32,7 +53,3 @@ RUN bash scripts/ci_setup_python_venv.sh \
            cp "$HOME/.local/bin/uv" /usr/local/bin/uv; \
        fi \
     && rm -rf /root/.cache/uv /root/.cache/pip /var/lib/apt/lists/*
-
-# Advertise the baked venv; scripts/ci_setup_python_venv.sh symlinks the
-# per-job .venv to it when the interpreter matches the CI pin.
-ENV SMG_BAKED_VENV=/opt/smg-ci/.venv

--- a/scripts/ci_fetch_tokenspeed_prebuilt.sh
+++ b/scripts/ci_fetch_tokenspeed_prebuilt.sh
@@ -77,8 +77,15 @@ fi
 rm -rf "$staging"
 
 # The payload was baked as root; the job user needs write access for the
-# per-PR glue installs (uv pip uninstall/install -e into the venv).
-$SUDO chown -R "$(id -u):$(id -g)" /opt/smg-ci /opt/tokenspeed-src || true
+# per-PR glue installs (uv pip uninstall/install -e into the venv). A
+# root-owned payload would still pass venv adoption (world-readable) and the
+# stamp check, and only fail later at the glue writes — a hard lane failure.
+# So a failed repair must remove the payload and fall back instead.
+if ! $SUDO chown -R "$(id -u):$(id -g)" /opt/smg-ci /opt/tokenspeed-src; then
+    log "ownership repair failed; lane will build from source"
+    $SUDO rm -rf /opt/smg-ci /opt/tokenspeed-src
+    exit 0
+fi
 
 if [ -n "${GITHUB_ENV:-}" ]; then
     echo "SMG_BAKED_VENV=/opt/smg-ci/.venv" >> "$GITHUB_ENV"

--- a/scripts/ci_fetch_tokenspeed_prebuilt.sh
+++ b/scripts/ci_fetch_tokenspeed_prebuilt.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Fetch the prebuilt TokenSpeed payload onto the bare runner, if available.
+#
+# The GPU e2e jobs run directly on the runner pods (no job container), so the
+# prebuilt CI image (docker/ci-tokenspeed.Dockerfile) is consumed as a
+# CARRIER: pull it, create a stopped container, and docker-cp the baked
+# payload out:
+#   /opt/smg-ci          venv + prebuilt stamp
+#   /opt/tokenspeed-src  checkout the venv's editable installs point at
+# then advertise the venv via SMG_BAKED_VENV (GITHUB_ENV, i.e. subsequent
+# steps) so ci_setup_python_venv.sh adopts it and
+# ci_install_tokenspeed.sh's stamp check skips the source build.
+#
+# TOLERANT BY DESIGN: this script must never fail the job. No image resolved,
+# no docker on the runner, a failed pull or extraction — each just means the
+# lane falls back to the source build, with a log line saying why.
+
+set -uo pipefail # deliberately NOT -e: every failure is a soft fallback
+
+IMAGE="${TOKENSPEED_PREBUILT_IMAGE:-}"
+
+log() { echo "[fetch-tokenspeed-prebuilt] $*"; }
+
+if [ -z "$IMAGE" ]; then
+    log "TOKENSPEED_PREBUILT_IMAGE unset; lane will build from source"
+    exit 0
+fi
+if ! command -v docker &> /dev/null; then
+    log "docker not available on this runner; lane will build from source"
+    exit 0
+fi
+if command -v sudo &> /dev/null; then SUDO="sudo"; else SUDO=""; fi
+
+log "Pulling ${IMAGE}..."
+if ! docker pull "$IMAGE"; then
+    # A private GHCR package rejects anonymous pulls; retry authenticated
+    # when the workflow token is available.
+    if [ -n "${GITHUB_TOKEN:-}" ] \
+        && docker login ghcr.io -u "${GITHUB_ACTOR:-github-actions}" --password-stdin <<< "$GITHUB_TOKEN" > /dev/null 2>&1 \
+        && docker pull "$IMAGE"; then
+        log "pull succeeded after ghcr login"
+    else
+        log "pull failed; lane will build from source"
+        exit 0
+    fi
+fi
+
+cid="$(docker create "$IMAGE")"
+if [ -z "$cid" ]; then
+    log "docker create failed; lane will build from source"
+    exit 0
+fi
+trap 'docker rm -f "$cid" > /dev/null 2>&1 || true' EXIT
+
+staging="$(mktemp -d /tmp/tokenspeed-prebuilt.XXXXXX)"
+if [ -z "$staging" ]; then
+    log "mktemp failed; lane will build from source"
+    exit 0
+fi
+
+if ! docker cp "$cid:/opt/smg-ci" "$staging/smg-ci" \
+    || ! docker cp "$cid:/opt/tokenspeed-src" "$staging/tokenspeed-src"; then
+    log "extraction failed; lane will build from source"
+    rm -rf "$staging"
+    exit 0
+fi
+
+# Fixed destination paths (the venv's shebangs and editable installs are
+# absolute). Same-filesystem move, effectively instant.
+if ! { $SUDO rm -rf /opt/smg-ci /opt/tokenspeed-src \
+    && $SUDO mv "$staging/smg-ci" /opt/smg-ci \
+    && $SUDO mv "$staging/tokenspeed-src" /opt/tokenspeed-src; }; then
+    log "install to /opt failed; lane will build from source"
+    rm -rf "$staging"
+    exit 0
+fi
+rm -rf "$staging"
+
+# The payload was baked as root; the job user needs write access for the
+# per-PR glue installs (uv pip uninstall/install -e into the venv).
+$SUDO chown -R "$(id -u):$(id -g)" /opt/smg-ci /opt/tokenspeed-src || true
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "SMG_BAKED_VENV=/opt/smg-ci/.venv" >> "$GITHUB_ENV"
+fi
+log "Prebuilt payload installed (stamp: $(cat /opt/smg-ci/tokenspeed.ref 2> /dev/null || echo missing))"


### PR DESCRIPTION
## Description

### Problem

The `CI TokenSpeed Image` workflow from #2393 failed on main ([run](https://github.com/smg-project/smg/actions/runs/33701474516/job/100481500648)): `ERROR: no base image (vars.SMG_CI_GPU_CONTAINER_IMAGE unset and no override)`.

Root cause: **that variable does not exist** — the repo has no Actions variables at all. The `container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}` line in `e2e-gpu-job.yml` (predating #2393) has always resolved to *no container*: the GPU e2e jobs run bare on the runner pods (verified against a green tokenspeed lane log — no container setup, and its "Setup TokenSpeed backend" took 16.9 min of source build). #2393's design assumed an existing CI job container to base and run on; there isn't one, and containerizing the lanes for real would drag in GPU passthrough (`--gpus`), the `/models` hostPath mount, and IB device config — far riskier than intended.

Meanwhile the safety property held: with the image unresolved, the tokenspeed lanes fell back to the source build and the main run stayed green.

### Solution

Consume the prebuilt image as a **carrier**, extracted onto the bare runner, instead of as a job container:

- `docker/ci-tokenspeed.Dockerfile` rebases on `ubuntu:24.04` (runner-matched: python3.12 at the same `/usr/bin` path, so the baked venv's interpreter symlink resolves on the runner; the adoption check in `ci_setup_python_venv.sh` re-validates it there). The portability contract is documented in the Dockerfile.
- New `scripts/ci_fetch_tokenspeed_prebuilt.sh`: pulls the image (anonymous, then an authenticated-ghcr retry), `docker create` + `docker cp`'s `/opt/smg-ci` (venv + stamp) and `/opt/tokenspeed-src` onto the runner, chowns to the job user, exports `SMG_BAKED_VENV`. **Tolerant by design**: no docker on the pod, failed pull, failed extraction — each logs why and exits 0, leaving the source-build path to run. It can never fail a lane.
- `setup-tokenspeed` action runs the fetch before venv setup. The stamp fast path in `ci_install_tokenspeed.sh` needs zero changes — it validates the extracted stamp + `import tokenspeed` exactly as before.
- `e2e-gpu-job.yml`: `container:` reverts to its original form; the `container_image` input becomes `tokenspeed_prebuilt_image`, surfaced as job env. (No `packages: read` on the job: the ghcr package is public so anonymous pulls work, and a called reusable-workflow job may not request permissions beyond the caller's `contents: read` grant — doing so failed workflow startup, fixed in the third commit.)
- `ci-tokenspeed-image.yml`: base defaults to `ubuntu:24.04`; the failed guard is gone.

The Dockerfile change rotates the content-addressed tag, so the image workflow rebuilds automatically when this merges.

## Changes

- `docker/ci-tokenspeed.Dockerfile` — ubuntu:24.04 base, build prereqs layer, carrier/portability docs.
- `scripts/ci_fetch_tokenspeed_prebuilt.sh` — new tolerant fetch/extract script.
- `.github/actions/setup-tokenspeed/action.yml` — fetch step (with `github.token` for the pull retry).
- `.github/workflows/e2e-gpu-job.yml` — input rename + job env; `container:` back to original.
- `.github/workflows/pr-test-rust.yml` — lane wiring renamed; detect-changes comment updated.
- `.github/workflows/ci-tokenspeed-image.yml` — base default, comments.

## Test Plan

Verified locally:

- `bash -n` on the new script; the no-image no-op path executed (`TOKENSPEED_PREBUILT_IMAGE unset; lane will build from source`, exit 0).
- Tag script output rotated as expected (`ci-tokenspeed-7cd7ca0b3028-43a3226abf12`) since the Dockerfile is hashed into it.
- YAML parse on all four workflow/action files; `actionlint` shows only the pre-existing findings; zero `container_image` references remain.
- The workflow's gate-integrity lint passes (13 e2e jobs still gate merge).
- `pre-commit` on all changed files: no failures.

Not verifiable locally (stated plainly): the actual image build on ubuntu:24.04 and the docker-pull/extract path on the GPU pods (docker is confirmed on the 4-GPU pool via the benchmarks lane, unverified on 1-GPU). Both are safe to trial because every failure degrades to the current source build with a log line.

After merge:

1. `ci-tokenspeed-image.yml` fires (new tag) and builds on the docker runner pool. Watch it produce `ghcr.io/smg-project/smg:ci-tokenspeed-7cd7ca0b3028-43a3226abf12`.
2. Next tokenspeed lane run: expect `[fetch-tokenspeed-prebuilt] Prebuilt payload installed`, `Adopting baked venv`, `skipping source build`, and a ~15–25 min drop in "Setup TokenSpeed backend". If instead a fallback line appears (e.g. no docker on 1-GPU pods), the lane still passes at today's speed and the log tells us the next move.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust files changed; runs in CI)
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
