### PR TITLE
fix(protocols): accept every OpenAI reasoning effort tier on Responses

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1528,13 +1528,47 @@ fn default_reasoning_effort() -> Option<ReasoningEffort> {
     Some(ReasoningEffort::Medium)
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+/// OpenAI `reasoning.effort` tiers, lowest to highest. `none` turns reasoning
+/// off; it is distinct from an absent field, which defaults to `medium`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
+    None,
     Minimal,
     Low,
     Medium,
     High,
+    Xhigh,
+    Max,
+}
+
+impl ReasoningEffort {
+    /// The wire value, which is also the Chat `reasoning_effort` string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Minimal => "minimal",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Xhigh => "xhigh",
+            Self::Max => "max",
+        }
+    }
+
+    /// Parse a wire value; `None` for anything outside the OpenAI tiers.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "none" => Some(Self::None),
+            "minimal" => Some(Self::Minimal),
+            "low" => Some(Self::Low),
+            "medium" => Some(Self::Medium),
+            "high" => Some(Self::High),
+            "xhigh" => Some(Self::Xhigh),
+            "max" => Some(Self::Max),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
@@ -3974,5 +4008,44 @@ mod tests {
             let serde_tag = serialized.get("type").and_then(|v| v.as_str()).unwrap();
             assert_eq!(tool.as_str(), serde_tag);
         }
+    }
+
+    const REASONING_EFFORT_TIERS: [ReasoningEffort; 7] = [
+        ReasoningEffort::None,
+        ReasoningEffort::Minimal,
+        ReasoningEffort::Low,
+        ReasoningEffort::Medium,
+        ReasoningEffort::High,
+        ReasoningEffort::Xhigh,
+        ReasoningEffort::Max,
+    ];
+
+    /// `as_str`/`parse` must agree with the serde tag: the Chat pipeline
+    /// receives the string form, and drift would change a tier in transit.
+    #[test]
+    fn reasoning_effort_str_forms_match_serde_tag() {
+        for effort in REASONING_EFFORT_TIERS {
+            let tag = serde_json::to_value(effort).unwrap();
+            assert_eq!(tag, Value::String(effort.as_str().to_string()));
+            assert_eq!(ReasoningEffort::parse(effort.as_str()), Some(effort));
+            assert_eq!(
+                serde_json::from_value::<ReasoningEffort>(tag).unwrap(),
+                effort
+            );
+        }
+        assert_eq!(ReasoningEffort::parse("bogus"), None);
+    }
+
+    /// Every OpenAI tier deserializes inside `reasoning`; an absent effort
+    /// still defaults to medium.
+    #[test]
+    fn reasoning_param_accepts_every_openai_tier() {
+        for tier in ["none", "minimal", "low", "medium", "high", "xhigh", "max"] {
+            let param: ResponseReasoningParam =
+                serde_json::from_value(serde_json::json!({ "effort": tier })).unwrap();
+            assert_eq!(param.effort.map(ReasoningEffort::as_str), Some(tier));
+        }
+        let param: ResponseReasoningParam = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(param.effort, Some(ReasoningEffort::Medium));
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -286,6 +286,26 @@ fn has_custom_tools(tool_types: &[&str]) -> bool {
 /// registration).
 pub(crate) struct HarmonyBuilder;
 
+/// Harmony knows only low/medium/high; the outer OpenAI tiers clamp inward.
+fn harmony_reasoning_effort(effort: ResponsesReasoningEffort) -> ReasoningEffort {
+    match effort {
+        ResponsesReasoningEffort::None
+        | ResponsesReasoningEffort::Minimal
+        | ResponsesReasoningEffort::Low => ReasoningEffort::Low,
+        ResponsesReasoningEffort::Medium => ReasoningEffort::Medium,
+        ResponsesReasoningEffort::High
+        | ResponsesReasoningEffort::Xhigh
+        | ResponsesReasoningEffort::Max => ReasoningEffort::High,
+    }
+}
+
+/// Chat carries the tier as a free-form string; unknown values keep the
+/// medium default.
+fn harmony_reasoning_effort_from_str(effort: &str) -> ReasoningEffort {
+    ResponsesReasoningEffort::parse(effort)
+        .map_or(ReasoningEffort::Medium, harmony_reasoning_effort)
+}
+
 impl HarmonyBuilder {
     /// Create a new Harmony builder
     pub fn new() -> Self {
@@ -444,14 +464,7 @@ impl HarmonyBuilder {
         let reasoning_effort = request
             .reasoning_effort
             .as_deref()
-            .map(|effort| match effort {
-                "high" => ReasoningEffort::High,
-                "medium" => ReasoningEffort::Medium,
-                "low" => ReasoningEffort::Low,
-                // Harmony does not support minimal reasoning effort
-                "minimal" => ReasoningEffort::Low,
-                _ => ReasoningEffort::Medium,
-            });
+            .map(harmony_reasoning_effort_from_str);
 
         let has_tools = request.tools.is_some();
         self.build_system_message(reasoning_effort, has_tools)
@@ -470,13 +483,8 @@ impl HarmonyBuilder {
         let reasoning_effort = request
             .reasoning
             .as_ref()
-            .and_then(|r| r.effort.as_ref())
-            .map(|effort| match effort {
-                ResponsesReasoningEffort::High => ReasoningEffort::High,
-                ResponsesReasoningEffort::Medium => ReasoningEffort::Medium,
-                ResponsesReasoningEffort::Low => ReasoningEffort::Low,
-                ResponsesReasoningEffort::Minimal => ReasoningEffort::Low,
-            });
+            .and_then(|r| r.effort)
+            .map(harmony_reasoning_effort);
 
         self.build_system_message(reasoning_effort, with_custom_tools)
     }
@@ -1443,6 +1451,36 @@ mod tests {
             "image_generation must appear exactly once in the rendered \
              function-tools namespace; found {occurrences} occurrences. \
              Decoded prompt:\n{decoded}",
+        );
+    }
+
+    #[test]
+    fn harmony_effort_clamps_outer_openai_tiers_inward() {
+        use ResponsesReasoningEffort as Tier;
+
+        for (tier, expected) in [
+            (Tier::None, ReasoningEffort::Low),
+            (Tier::Minimal, ReasoningEffort::Low),
+            (Tier::Low, ReasoningEffort::Low),
+            (Tier::Medium, ReasoningEffort::Medium),
+            (Tier::High, ReasoningEffort::High),
+            (Tier::Xhigh, ReasoningEffort::High),
+            (Tier::Max, ReasoningEffort::High),
+        ] {
+            assert_eq!(harmony_reasoning_effort(tier), expected, "{tier:?}");
+            assert_eq!(
+                harmony_reasoning_effort_from_str(tier.as_str()),
+                expected,
+                "{tier:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn harmony_effort_from_unknown_string_stays_medium() {
+        assert_eq!(
+            harmony_reasoning_effort_from_str("bogus"),
+            ReasoningEffort::Medium
         );
     }
 }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -11,10 +11,9 @@ use openai_protocol::{
     chat::{ChatCompletionRequest, ChatCompletionResponse, ChatMessage, MessageContent},
     common::{FunctionCallResponse, JsonSchemaFormat, ResponseFormat, ToolCall, UsageInfo},
     responses::{
-        ReasoningEffort, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
-        ResponseOutputItem, ResponseReasoningContent::ReasoningText, ResponseStatus,
-        ResponsesRequest, ResponsesResponse, ResponsesUsage, StringOrContentParts, TextConfig,
-        TextFormat,
+        ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
+        ResponseReasoningContent::ReasoningText, ResponseStatus, ResponsesRequest,
+        ResponsesResponse, ResponsesUsage, StringOrContentParts, TextConfig, TextFormat,
     },
     UNKNOWN_MODEL_ID,
 };
@@ -250,22 +249,10 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
         reasoning_effort: req
             .reasoning
             .as_ref()
-            .and_then(|r| r.effort.as_ref())
-            .map(reasoning_effort_to_str)
-            .map(str::to_string),
+            .and_then(|r| r.effort)
+            .map(|effort| effort.as_str().to_string()),
         ..Default::default()
     })
-}
-
-/// Map the Responses `reasoning.effort` enum to the Chat `reasoning_effort`
-/// string (verbatim snake_case, as the Chat pipeline expects).
-fn reasoning_effort_to_str(effort: &ReasoningEffort) -> &'static str {
-    match effort {
-        ReasoningEffort::Minimal => "minimal",
-        ReasoningEffort::Low => "low",
-        ReasoningEffort::Medium => "medium",
-        ReasoningEffort::High => "high",
-    }
 }
 
 /// Extract text content from ResponseContentPart array. `Refusal` is
@@ -447,6 +434,7 @@ mod tests {
     use openai_protocol::{
         chat::{ChatChoice, ChatCompletionMessage},
         common::{StreamOptions, Usage},
+        responses::ReasoningEffort,
     };
 
     use super::*;
@@ -529,6 +517,31 @@ mod tests {
 
         let chat_req = responses_to_chat(&req).unwrap();
         assert_eq!(chat_req.reasoning_effort.as_deref(), Some("high"));
+    }
+
+    /// The outer OpenAI tiers reach the Chat pipeline verbatim, where `none`
+    /// already means thinking off.
+    #[test]
+    fn test_reasoning_effort_outer_tiers_flow_through() {
+        use openai_protocol::responses::ResponseReasoningParam;
+
+        for effort in [
+            ReasoningEffort::None,
+            ReasoningEffort::Xhigh,
+            ReasoningEffort::Max,
+        ] {
+            let req = ResponsesRequest {
+                input: ResponseInput::Text("hi".to_string()),
+                reasoning: Some(ResponseReasoningParam {
+                    effort: Some(effort),
+                    summary: None,
+                }),
+                ..Default::default()
+            };
+
+            let chat_req = responses_to_chat(&req).unwrap();
+            assert_eq!(chat_req.reasoning_effort.as_deref(), Some(effort.as_str()));
+        }
     }
 
     #[test]

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -1211,6 +1211,21 @@ fn test_reasoning_param_default() {
     assert!(matches!(parsed.effort, Some(ReasoningEffort::Medium)));
 }
 
+/// Every OpenAI `reasoning.effort` tier deserializes at the request boundary.
+#[test]
+fn test_reasoning_effort_accepts_every_openai_tier() {
+    for tier in ["none", "minimal", "low", "medium", "high", "xhigh", "max"] {
+        let request: ResponsesRequest = serde_json::from_value(serde_json::json!({
+            "model": "gpt-5",
+            "input": "hi",
+            "reasoning": { "effort": tier }
+        }))
+        .unwrap();
+        let effort = request.reasoning.and_then(|r| r.effort);
+        assert_eq!(effort.map(ReasoningEffort::as_str), Some(tier));
+    }
+}
+
 #[test]
 fn test_json_serialization() {
     let request = ResponsesRequest {


### PR DESCRIPTION
## Description

### Problem

`/v1/responses` rejects three valid OpenAI `reasoning.effort` values. The `ReasoningEffort` enum in `crates/protocols/src/responses.rs` knows `minimal`, `low`, `medium` and `high`, but OpenAI defines seven tiers: `none`, `minimal`, `low`, `medium`, `high`, `xhigh` and `max`. A request with `none`, `xhigh` or `max` fails JSON deserialization with a 422 before any handler runs.

`/v1/chat/completions` takes the same value as a free-form string and accepts all seven, so the same model behaves differently depending on which endpoint you call.

Closes #2402.

### Solution

Add the three missing tiers to the enum, and make one place own the mapping between the enum and its wire strings.

- `none` is a real variant, `ReasoningEffort::None`, serialized as `none`. It means "do not reason" and is distinct from leaving the field out, which still defaults to `medium`.
- The enum gets `as_str()` and `parse()`. The Responses-to-Chat conversion uses `as_str()`, so a Responses request with `none` reaches the Chat pipeline as the string `none`, which the Chat path already treats as thinking off.
- Harmony (gpt-oss) only supports `low`, `medium` and `high`, so the outer tiers clamp inward: `none` and `minimal` become `low`, `xhigh` and `max` become `high`. One function does this for both the Chat and Responses paths. Before, the Chat path sent `none`, `xhigh` and `max` to Harmony as `medium`; the issue lists that as a separate problem, but the shared mapping fixes it for free, so this PR includes it.

## Changes

- `crates/protocols/src/responses.rs`: `None`, `Xhigh`, `Max` variants; `as_str()` and `parse()`; `Copy`, `PartialEq`, `Eq` derives.
- `model_gateway/src/routers/grpc/regular/responses/conversions.rs`: use `as_str()` instead of a local four-arm match.
- `model_gateway/src/routers/grpc/harmony/builder.rs`: one clamp function shared by the Chat and Responses system-message builders.
- Tests in all three places plus `tests/api/responses_api_test.rs`.

## Test Plan

- `crates/protocols`: `as_str()` and `parse()` agree with the serde tag for all seven tiers; `parse("bogus")` is `None`; every tier deserializes inside `reasoning`; an absent `effort` still defaults to `medium`.
- `conversions.rs`: `none`, `xhigh` and `max` reach the Chat request as the same strings.
- `harmony/builder.rs`: all seven tiers clamp to the expected Harmony level from both the enum and the string form; an unknown string stays `medium`.
- `tests/api/responses_api_test.rs`: a full `ResponsesRequest` JSON body deserializes for every tier.

```
$ cargo test -p openai-protocol -- reasoning                                    # 4 passed
$ cargo test -p smg --lib -- responses::conversions::tests                      # 13 passed
$ cargo test -p smg --lib -- harmony::builder::tests::harmony_effort            # 2 passed
$ cargo test -p smg --test api_tests -- reasoning                               # 8 passed
$ cargo clippy --all-targets -- -D warnings                                     # clean
$ cargo +nightly fmt --all --check                                              # clean
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (`--all-features` pulls `opencv`, which does not build locally; CI covers it)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
