### PR TITLE
ci: stop gating merges on the perf benchmark and third-party tests

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -17,11 +17,13 @@ on:
 permissions:
   contents: read
 
-# Per-PR groups cancel superseded runs; pushes to main key on the commit SHA so
-# every commit on main gets its own run and is never cancelled by a later push.
+# One group per PR and one for main: a newer push cancels the superseded run.
+# On main this tests HEAD rather than every intermediate commit: back-to-back
+# merges otherwise stack full GPU matrices on one runner pool and time each
+# other out. Re-run an intermediate commit via workflow_dispatch if needed.
 concurrency:
-  group: gateway-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: gateway-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main' }}
+  cancel-in-progress: true
 
 env:
   RUSTC_WRAPPER: sccache
@@ -354,10 +356,14 @@ jobs:
 
   # --- Benchmarks (standalone) ---
 
+  # Advisory: the thresholds in e2e_test/benchmarks are absolute latencies on
+  # a shared runner pool and sit inside its noise band, so a miss is a warning,
+  # not a merge blocker. Results are still uploaded and summarized.
   benchmarks:
     needs: build-wheel
     runs-on: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
     container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
+    continue-on-error: true
     timeout-minutes: 36
     permissions:
       contents: read
@@ -975,12 +981,14 @@ jobs:
             test_path: e2e_test/messages
             timeout: 20
             setup_agentic_deps: true
+            external_tests: true
 
           - name: openai-responses
             vendor: openai
             test_path: e2e_test/responses
             timeout: 30
             setup_agentic_deps: true
+            external_tests: true
 
           - name: openai-realtime
             vendor: openai
@@ -1050,6 +1058,20 @@ jobs:
         run: |
           ROUTER_LOCAL_MODEL_PATH="/models" pytest ${{ matrix.test_path }} \
             -m "not external" \
+            --reruns 2 --reruns-delay 5 \
+            -s -vv
+
+      # Tests that depend on services beyond the vendor API itself (hosted
+      # tool execution, web search) fail for reasons this repo cannot fix, so
+      # they report but never gate.
+      - name: Run external-service E2E tests (advisory)
+        if: matrix.external_tests
+        continue-on-error: true
+        env:
+          BRAVE_MCP_HOST: brave-search-mcp
+        run: |
+          ROUTER_LOCAL_MODEL_PATH="/models" pytest ${{ matrix.test_path }} \
+            -m external \
             --reruns 2 --reruns-delay 5 \
             -s -vv
 
@@ -1301,7 +1323,6 @@ jobs:
                 "${{ needs.build-wheel.result }}" == "failure" || \
                 "${{ needs.python-unit-tests.result }}" == "failure" || \
                 "${{ needs.unit-tests.result }}" == "failure" || \
-                "${{ needs.benchmarks.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-chat.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-chat-zmq.result }}" == "failure" || \
                 "${{ needs.e2e-2gpu-chat-zmq-dp.result }}" == "failure" || \
@@ -1326,7 +1347,7 @@ jobs:
   summarize-benchmarks:
     needs: [benchmarks]
     runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
-    if: success()
+    if: always() && contains(fromJSON('["success", "failure"]'), needs.benchmarks.result)
     permissions:
       contents: read
     steps:

--- a/e2e_test/responses/test_builtin_tools.py
+++ b/e2e_test/responses/test_builtin_tools.py
@@ -414,6 +414,7 @@ class TestBuiltinToolRouting:
 
 @pytest.mark.vendor("openai")
 @pytest.mark.gpu(0)
+@pytest.mark.external
 @pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
 class TestMcpWebSearchStreamingEvents:
     """Test MCP tool SSE streaming events (baseline behavior).


### PR DESCRIPTION
## Description

### Problem

Over the last eleven days, 12 of 65 `PR Test (SMG)` runs on `main` failed outright and 17 more needed a manual re-run. Three things in this workflow's gating policy caused a large share of that:

- The `benchmarks` job gates merge on an absolute TTFT threshold of 0.86s measured on shared 4-GPU runners. Eleven of the failures were `TTFT 0.87 to 0.96 > 0.86`. That is noise on shared hardware, not a regression signal.
- The `openai-responses` vendor lane gates merge on a test that depends on OpenAI executing a hosted MCP web search. It failed both attempts of one `main` run because the provider returned `failed`. Nothing in this repo can fix that.
- Every push to `main` runs the full GPU matrix, keyed by commit SHA so nothing is ever cancelled. Three dependabot merges within one minute on Sep 1 ran three full matrices on the same runner pool at once, and two of them failed on timeouts.

### Solution

- `benchmarks` becomes advisory: `continue-on-error: true` on the job, removed from the `finish` failure check, results still uploaded and summarized. A threshold miss now shows as a warning on the run instead of blocking it.
- Tests that depend on services beyond the vendor API itself are marked `external`. The vendor lane keeps gating on `-m "not external"` and runs the `external` set in a second advisory step, so they still report on every PR without blocking.
- Pushes to `main` share one concurrency group with cancel-in-progress. A newer push cancels the superseded run, so `main` is tested at HEAD instead of once per intermediate commit. An intermediate commit can still be run through `workflow_dispatch`.

## Changes

- `.github/workflows/pr-test-rust.yml`: concurrency group for `main`; `benchmarks` advisory and out of the `finish` check; `summarize-benchmarks` runs on success or failure; advisory external-service step in `e2e-vendor` for the lanes that have such tests.
- `e2e_test/responses/test_builtin_tools.py`: `TestMcpWebSearchStreamingEvents` marked `external`.

## Test Plan

- The workflow parses as YAML, and the `finish` gate-integrity lint still passes locally: all 13 `e2e-*` jobs remain in `finish.needs` and in the failure check.
- `benchmarks` is still in `finish.needs` so ordering and the summary job are unchanged; it is only absent from the failure condition.
- The first `main` run after merge should show the benchmark job as allowed-failure when it misses the threshold and the run itself as green.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
