### PR TITLE
ci: give GPU lanes timeout headroom and retry network steps

### DIFF
--- a/.github/workflows/_build-engine-image.yml
+++ b/.github/workflows/_build-engine-image.yml
@@ -248,14 +248,16 @@ jobs:
           TARGET_IMAGE="ghcr.io/${OWNER}/smg:${IMAGE_TAG}"
           echo "image_name=${TARGET_IMAGE}" >> "$GITHUB_OUTPUT"
           docker tag "${BASE_IMAGE_TAG}" "${TARGET_IMAGE}"
-          docker push "${TARGET_IMAGE}"
+          # GHCR blob uploads time out sporadically on multi-GB layers; a
+          # retry resumes with the layers already accepted.
+          bash scripts/ci_retry.sh 3 30 docker push "${TARGET_IMAGE}"
           echo "**Pushed:** \`${TARGET_IMAGE}\`" >> $GITHUB_STEP_SUMMARY
           # Push any additional (e.g. floating) tags from the same local image.
           while IFS= read -r extra; do
             [ -z "${extra}" ] && continue
             EXTRA_IMAGE="ghcr.io/${OWNER}/smg:${extra}"
             docker tag "${BASE_IMAGE_TAG}" "${EXTRA_IMAGE}"
-            docker push "${EXTRA_IMAGE}"
+            bash scripts/ci_retry.sh 3 30 docker push "${EXTRA_IMAGE}"
             echo "**Pushed:** \`${EXTRA_IMAGE}\`" >> $GITHUB_STEP_SUMMARY
           done <<< "${EXTRA_TAGS}"
 

--- a/.github/workflows/ci-tokenspeed-image.yml
+++ b/.github/workflows/ci-tokenspeed-image.yml
@@ -25,6 +25,7 @@ on:
       - '.github/versions/tokenspeed.ref'
       - 'docker/ci-tokenspeed.Dockerfile'
       - 'scripts/ci_install_tokenspeed.sh'
+      - 'scripts/ci_retry.sh'
       - 'scripts/ci_setup_python_venv.sh'
       - 'scripts/ci_tokenspeed_image_tag.sh'
       - '.github/workflows/ci-tokenspeed-image.yml'

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -501,6 +501,7 @@ jobs:
               - '.github/workflows/pr-test-rust.yml'
               - '.github/workflows/e2e-gpu-job.yml'
               - 'scripts/ci_setup_python_venv.sh'
+              - 'scripts/ci_retry.sh'
               - 'scripts/ci_install_sglang.sh'
               - 'scripts/ci_install_vllm.sh'
               - 'scripts/ci_install_tokenspeed.sh'
@@ -604,8 +605,8 @@ jobs:
             test_timeout: 18
             min_selected: 202 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: trtllm
-            timeout: 32
-            test_timeout: 18
+            timeout: 36
+            test_timeout: 24
             min_selected: 180 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           # tokenspeed builds from source (~30m cold), so keep the job
           # timeout generous even though the test step is short.
@@ -614,8 +615,8 @@ jobs:
           # installs sglang/vllm only. The engine marker filter keeps the
           # rest of e2e_test/router out of this job.
           - engine: tokenspeed
-            timeout: 50
-            test_timeout: 18
+            timeout: 56
+            test_timeout: 26
             test_dirs: e2e_test/chat_completions e2e_test/router/test_admin_ops.py
             min_selected: 114 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
@@ -657,8 +658,8 @@ jobs:
             test_timeout: 40
             min_selected: 202 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: tokenspeed
-            timeout: 50
-            test_timeout: 40
+            timeout: 60
+            test_timeout: 48
             min_selected: 109 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
@@ -857,8 +858,8 @@ jobs:
       engine: sglang
       gpu_tier: "1"
       runner: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
-      timeout: 28
-      test_timeout: 20
+      timeout: 32
+      test_timeout: 24
       test_dirs: e2e_test/responses
       setup_agentic_deps: true
       min_selected: 92 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
@@ -880,14 +881,14 @@ jobs:
       matrix:
         include:
           - engine: sglang
-            timeout: 30
+            timeout: 40
             min_selected: 15 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: vllm
-            timeout: 30
+            timeout: 40
             min_selected: 15 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: vllm
             kv_backend: mooncake
-            timeout: 30
+            timeout: 40
             min_selected: 15 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
@@ -895,6 +896,7 @@ jobs:
       gpu_tier: "2"
       runner: ${{ vars.SMG_RUNNER_GPU_2 || '2-gpu-h100' }}
       timeout: ${{ matrix.timeout }}
+      test_timeout: 34
       test_dirs: e2e_test/router
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
       min_selected: ${{ matrix.min_selected }}

--- a/docker/ci-tokenspeed.Dockerfile
+++ b/docker/ci-tokenspeed.Dockerfile
@@ -29,18 +29,22 @@
 ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
+WORKDIR /opt/smg-ci
+
+# Copied ahead of the apt bootstrap so that bootstrap can retry too.
+COPY scripts/ci_retry.sh scripts/
+
 # Build prerequisites the bare base lacks (the runner pods already carry
 # these). python3 is 3.12 on noble, matching the CI interpreter pin.
 # python3-dev: tokenspeed-scheduler's CMake does
 # find_package(Python COMPONENTS Interpreter Development.Module), which
 # needs Python.h — without it the configure step fails.
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN bash scripts/ci_retry.sh 3 10 apt-get update \
+    && bash scripts/ci_retry.sh 3 10 apt-get install -y --no-install-recommends \
         ca-certificates curl git build-essential pkg-config \
         python3 python3-dev python3-venv python3-pip \
     && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /opt/smg-ci
 
 COPY scripts/ci_setup_python_venv.sh scripts/ci_install_tokenspeed.sh scripts/
 COPY .github/versions/tokenspeed.ref .github/versions/tokenspeed.ref

--- a/scripts/ci_install_e2e_deps.sh
+++ b/scripts/ci_install_e2e_deps.sh
@@ -4,22 +4,25 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RETRY="bash ${SCRIPT_DIR}/ci_retry.sh"
+
 # Activate venv if it exists
 if [ -f ".venv/bin/activate" ]; then
     source .venv/bin/activate
 fi
 
 echo "Installing e2e test dependencies..."
-python3 -m pip install e2e_test/
+$RETRY 3 10 python3 -m pip install e2e_test/
 
 # Install SmgClient (pure Python client for cross-SDK parity testing)
 echo "Installing smg-client..."
-python3 -m pip install clients/python/
+$RETRY 3 10 python3 -m pip install clients/python/
 
 # Install any extra dependencies passed as arguments
 if [ $# -gt 0 ]; then
     echo "Installing extra dependencies: $@"
-    python3 -m pip --no-cache-dir install --upgrade "$@"
+    $RETRY 3 10 python3 -m pip --no-cache-dir install --upgrade "$@"
 fi
 
 # Pin the grpcio generated-code companions to the protobuf-6 stable line.
@@ -36,6 +39,6 @@ fi
 # whatever engine/extra-dep installs selected. (grpcio core has no generated
 # protobuf, so it is left at the engine-selected version.) Drop the cap once the
 # stack moves to a protobuf 7 runtime.
-python3 -m pip install "grpcio-health-checking==1.81.*" "grpcio-reflection==1.81.*"
+$RETRY 3 10 python3 -m pip install "grpcio-health-checking==1.81.*" "grpcio-reflection==1.81.*"
 
 echo "E2E test dependencies installed"

--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RETRY="bash ${SCRIPT_DIR}/ci_retry.sh"
+
 # Activate venv if it exists
 if [ -f ".venv/bin/activate" ]; then
     source .venv/bin/activate
@@ -12,7 +15,7 @@ fi
 # Install uv for faster package management (10-100x faster than pip)
 if ! command -v uv &> /dev/null; then
     echo "Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    $RETRY 3 5 bash -c 'set -o pipefail; curl -LsSf https://astral.sh/uv/install.sh | sh'
     export PATH="$HOME/.local/bin:$PATH"
 fi
 
@@ -26,12 +29,12 @@ echo "Using uv version: $(uv --version)"
 CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 if [ ! -x "${CUDA_HOME}/bin/nvcc" ] || ! "${CUDA_HOME}/bin/nvcc" --version | grep -q "release 13\."; then
     echo "Installing CUDA 13 toolkit (nvcc 13 not found at ${CUDA_HOME}/bin/nvcc)..."
-    curl -fsSL -o /tmp/cuda-keyring.deb \
+    $RETRY 3 10 curl -fsSL -o /tmp/cuda-keyring.deb \
         https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
     sudo dpkg -i /tmp/cuda-keyring.deb
     rm /tmp/cuda-keyring.deb
-    sudo apt-get update -qq
-    sudo apt-get install -y --no-install-recommends cuda-nvcc-13-0 cuda-cudart-dev-13-0
+    $RETRY 3 10 sudo apt-get update -qq
+    $RETRY 3 10 sudo apt-get install -y --no-install-recommends cuda-nvcc-13-0 cuda-cudart-dev-13-0
     # Ensure CUDA_HOME points to the installed toolkit
     if [ ! -d "${CUDA_HOME}/bin" ] && [ -d "/usr/local/cuda-13.0/bin" ]; then
         sudo ln -sfn /usr/local/cuda-13.0 "${CUDA_HOME}"
@@ -43,7 +46,7 @@ fi
 
 # Install SGLang with all dependencies
 echo "Installing SGLang..."
-uv pip install --prerelease=allow "sglang[all]==0.5.18"
+$RETRY 3 10 uv pip install --prerelease=allow "sglang[all]==0.5.18"
 
 # Install flashinfer-jit-cache: sglang bundles flashinfer_python but only for attention ops.
 # Multi-GPU models need trtllm_comm kernels (fused allreduce + layernorm) which FlashInfer
@@ -64,7 +67,7 @@ if [ -n "$FLASHINFER_VERSION" ]; then
     done
     CU_VERSION="cu${CUDA_TAG}"
     echo "Installing flashinfer-jit-cache==${FLASHINFER_VERSION} (${CU_VERSION})..."
-    uv pip install "flashinfer-jit-cache==${FLASHINFER_VERSION}" \
+    $RETRY 3 10 uv pip install "flashinfer-jit-cache==${FLASHINFER_VERSION}" \
         --index-url "https://flashinfer.ai/whl/${CU_VERSION}"
 else
     echo "WARNING: flashinfer-python not found, skipping flashinfer-jit-cache install"
@@ -76,13 +79,13 @@ fi
 # (cuda13 wheel variant + nvrtc, since torch 2.13 defaults to CUDA 13):
 # https://github.com/sgl-project/sglang/blob/v0.5.18/scripts/ci/cuda/ci_install_dependency.sh
 echo "Installing mooncake system dependencies..."
-sudo apt-get install -y --no-install-recommends libnuma-dev libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils
+$RETRY 3 10 sudo apt-get install -y --no-install-recommends libnuma-dev libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils
 echo "Installing mooncake..."
-uv pip install mooncake-transfer-engine-cuda13==0.3.12.post1 nvidia-cuda-nvrtc
+$RETRY 3 10 uv pip install mooncake-transfer-engine-cuda13==0.3.12.post1 nvidia-cuda-nvrtc
 
 # Install gRPC packages from source (not PyPI) so PR changes are always tested
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."
-uv pip install -e crates/grpc_client/python/
-uv pip install -e grpc_servicer/
+$RETRY 3 10 uv pip install -e crates/grpc_client/python/
+$RETRY 3 10 uv pip install -e grpc_servicer/
 
 echo "SGLang installation complete"

--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RETRY="bash ${SCRIPT_DIR}/ci_retry.sh"
 
 # sudo is absent when this runs as root inside `docker build`; degrade to
 # running the commands directly.
@@ -61,7 +62,7 @@ TOKENSPEED_PREBUILT_STAMP="${TOKENSPEED_PREBUILT_STAMP:-/opt/smg-ci/tokenspeed.r
 # Both the source build and the SMG glue below use it.
 if ! command -v uv &> /dev/null; then
     echo "Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    $RETRY 3 5 bash -c 'set -o pipefail; curl -LsSf https://astral.sh/uv/install.sh | sh'
     export PATH="$HOME/.local/bin:$PATH"
 fi
 echo "uv version: $(uv --version)"
@@ -75,16 +76,16 @@ setup_cuda_env() {
     CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
     if [ ! -x "${CUDA_HOME}/bin/nvcc" ] && [ ! -x "/usr/local/cuda-13.0/bin/nvcc" ]; then
         echo "Installing CUDA toolkit (nvcc not found)..."
-        curl -fsSL -o /tmp/cuda-keyring.deb \
+        $RETRY 3 10 curl -fsSL -o /tmp/cuda-keyring.deb \
             https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
         $SUDO dpkg -i /tmp/cuda-keyring.deb
         rm /tmp/cuda-keyring.deb
-        $SUDO apt-get update -qq
+        $RETRY 3 10 $SUDO apt-get update -qq
         # Install the FULL CUDA 13.0 toolkit (mirrors the proven TRT-LLM lane in
         # ci_install_trtllm.sh) so the system headers -- which the kernel build
         # compiles against -- are a complete, self-consistent 13.0.88 set matching
         # the system nvcc.
-        $SUDO apt-get install -y cuda-toolkit-13-0
+        $RETRY 3 10 $SUDO apt-get install -y cuda-toolkit-13-0
     fi
     # Point CUDA_HOME at the versioned toolkit dir directly (mirrors
     # ci_install_trtllm.sh). The job env sets CUDA_HOME=/usr/local/cuda, but on this
@@ -125,19 +126,19 @@ install_tokenspeed_from_source() {
         git init -q "$TOKENSPEED_DIR"
         (cd "$TOKENSPEED_DIR" \
             && git remote add origin "$TOKENSPEED_REPO" \
-            && git fetch --depth 1 origin "$TOKENSPEED_REF" \
+            && $RETRY 3 10 git fetch --depth 1 origin "$TOKENSPEED_REF" \
             && git checkout FETCH_HEAD)
     else
         echo "TokenSpeed clone exists at $TOKENSPEED_DIR, reusing"
-        (cd "$TOKENSPEED_DIR" && git fetch --depth 1 origin "$TOKENSPEED_REF" && git checkout "$TOKENSPEED_REF")
+        (cd "$TOKENSPEED_DIR" && $RETRY 3 10 git fetch --depth 1 origin "$TOKENSPEED_REF" && git checkout "$TOKENSPEED_REF")
     fi
 
     cd "$TOKENSPEED_DIR"
 
     # ── System dependencies (mirrors docker/Dockerfile) ────────────────────
     export DEBIAN_FRONTEND=noninteractive
-    $SUDO apt-get update -qq
-    $SUDO apt-get install -y --no-install-recommends libssl-dev libopenmpi-dev cmake
+    $RETRY 3 10 $SUDO apt-get update -qq
+    $RETRY 3 10 $SUDO apt-get install -y --no-install-recommends libssl-dev libopenmpi-dev cmake
 
     # ── TokenSpeed packages ────────────────────────────────────────────────
     export MAX_JOBS="${MAX_JOBS:-16}"
@@ -169,13 +170,13 @@ install_tokenspeed_from_source() {
     # Preseed build-time tooling: ``./python`` and ``tokenspeed-kernel`` use
     # ``setuptools.build_meta`` without declaring ``setuptools`` in
     # ``build-system.requires``, and we install with ``--no-build-isolation``.
-    uv pip install setuptools wheel pybind11
+    $RETRY 3 10 uv pip install setuptools wheel pybind11
 
     # Install the CUDA-13 torch build explicitly (the +cu130 local wheel) before the
     # --no-build-isolation kernel compile below, so the build links matching CUDA 13
     # headers instead of the default PyPI (cu12.x) torch. Pin tracks TokenSpeed's
     # torch requirement; bump alongside the ref in .github/versions/tokenspeed.ref.
-    uv pip install "torch==2.11.0+cu130"
+    $RETRY 3 10 uv pip install "torch==2.11.0+cu130"
 
     # The kernel's host-stub compile binds crt/host_runtime.h from torch's bundled
     # cu13 headers (site-packages/nvidia/cu*/include/crt) no matter the -I order,
@@ -204,8 +205,8 @@ install_tokenspeed_from_source() {
     fi
 
     uv pip install -e tokenspeed-kernel/python/ --no-build-isolation
-    uv pip install -e tokenspeed-scheduler/
-    uv pip install -e "./python" --no-build-isolation
+    $RETRY 3 10 uv pip install -e tokenspeed-scheduler/
+    $RETRY 3 10 uv pip install -e "./python" --no-build-isolation
 
     cd "$REPO_ROOT"
 }
@@ -239,8 +240,8 @@ install_smg_glue() {
     # would then serve stale proto descriptors ("Method not found!" for any
     # RPC added in the PR). Drop them first; the source installs replace them.
     uv pip uninstall tokenspeed-smg-grpc-proto tokenspeed-smg-grpc-servicer
-    uv pip install -e crates/grpc_client/python/
-    uv pip install -e grpc_servicer/
+    $RETRY 3 10 uv pip install -e crates/grpc_client/python/
+    $RETRY 3 10 uv pip install -e grpc_servicer/
 }
 
 # ── Main ───────────────────────────────────────────────────────────────────

--- a/scripts/ci_install_trtllm.sh
+++ b/scripts/ci_install_trtllm.sh
@@ -17,6 +17,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RETRY="bash ${SCRIPT_DIR}/ci_retry.sh"
+
 TRTLLM_VERSION="1.3.0rc24"
 NCCL_VERSION_CONSTRAINT="nvidia-nccl-cu13>=2.28.9,<=2.29.2"
 
@@ -32,14 +35,14 @@ sudo dpkg --configure -a --force-confnew 2>/dev/null || true
 # Add NVIDIA apt repository if needed
 if ! dpkg -l cuda-keyring 2>/dev/null | grep -q '^ii'; then
     echo "Setting up NVIDIA apt repository..."
-    curl -fsSL -o /tmp/cuda-keyring.deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+    $RETRY 3 10 curl -fsSL -o /tmp/cuda-keyring.deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
     sudo dpkg -i /tmp/cuda-keyring.deb
     rm -f /tmp/cuda-keyring.deb
 fi
 
-sudo apt-get update
+$RETRY 3 10 sudo apt-get update
 # Runtime deps: wheel links against CUDA 13 + TensorRT libs
-sudo apt-get install -y libopenmpi-dev libnvinfer10 cuda-toolkit-13-0
+$RETRY 3 10 sudo apt-get install -y libopenmpi-dev libnvinfer10 cuda-toolkit-13-0
 
 # ── CUDA runtime setup ───────────────────────────────────────────────────────
 if [ -d "/usr/local/cuda-13.0" ]; then
@@ -51,8 +54,8 @@ export PATH="$CUDA_HOME/bin:$PATH"
 export LD_LIBRARY_PATH="${CUDA_HOME}/lib64:${CUDA_HOME}/extras/CUPTI/lib64:${LD_LIBRARY_PATH:-}"
 
 # ── Install pip and NCCL runtime ─────────────────────────────────────────────
-pip install --upgrade pip
-pip install --no-cache-dir "$NCCL_VERSION_CONSTRAINT"
+$RETRY 3 10 pip install --upgrade pip
+$RETRY 3 10 pip install --no-cache-dir "$NCCL_VERSION_CONSTRAINT"
 
 # ── Install TensorRT-LLM pre-release wheel from NVIDIA's index ───────────────
 # PyPI only hosts the source tarball for tensorrt-llm — installing from there
@@ -63,7 +66,7 @@ pip install --no-cache-dir "$NCCL_VERSION_CONSTRAINT"
 # (cuda-bindings==13.x) instead of the default PyPI torch (cuda-bindings==12.9.4),
 # which conflicts with tensorrt-llm's cuda-python>=13 requirement.
 echo "Installing tensorrt-llm==${TRTLLM_VERSION} from pypi.nvidia.com..."
-pip install --no-cache-dir --pre \
+$RETRY 3 10 pip install --no-cache-dir --pre \
     --extra-index-url https://pypi.nvidia.com \
     --extra-index-url https://download.pytorch.org/whl/cu130 \
     "tensorrt-llm==${TRTLLM_VERSION}"
@@ -71,7 +74,7 @@ pip install --no-cache-dir --pre \
 # typer >= 0.26 leaks click.exceptions.Exit through its main on CLI exit, so
 # every `hf` invocation (model downloads) exits 1 even on success. The
 # transformers pulled by tensorrt-llm has an unbounded typer dependency.
-pip install --no-cache-dir "typer<0.26"
+$RETRY 3 10 pip install --no-cache-dir "typer<0.26"
 
 # ── Setup LD_LIBRARY_PATH ────────────────────────────────────────────────────
 SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")

--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RETRY="bash ${SCRIPT_DIR}/ci_retry.sh"
+
 # Activate venv if it exists
 if [ -f ".venv/bin/activate" ]; then
     source .venv/bin/activate
@@ -13,7 +16,7 @@ fi
 # Install uv for faster package management (10-100x faster than pip)
 if ! command -v uv &> /dev/null; then
     echo "Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    $RETRY 3 5 bash -c 'set -o pipefail; curl -LsSf https://astral.sh/uv/install.sh | sh'
     export PATH="$HOME/.local/bin:$PATH"
 fi
 
@@ -27,7 +30,7 @@ echo "Using uv version: $(uv --version)"
 # route; verified in 0.27.1's dependency constraints).
 # --torch-backend=auto matches the torch CUDA variant to the pod's driver.
 echo "Installing vLLM..."
-uv pip install "vllm==0.27.1" --torch-backend=auto
+$RETRY 3 10 uv pip install "vllm==0.27.1" --torch-backend=auto
 
 # vLLM >=0.25 eagerly imports torchcodec, which dlopens the FFmpeg shared
 # libraries (libavutil/libavcodec/libavformat/...) at import time. The runner
@@ -35,16 +38,16 @@ uv pip install "vllm==0.27.1" --torch-backend=auto
 # (the metapackage pulls the matching libav* sonames; torchcodec supports
 # FFmpeg 4-7). This step is unconditional, so refresh apt lists first.
 echo "Installing FFmpeg for torchcodec..."
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends ffmpeg
+$RETRY 3 10 sudo apt-get update
+$RETRY 3 10 sudo apt-get install -y --no-install-recommends ffmpeg
 
 # NIXL for vLLM PD disaggregation. The bare metapackage pulls both cu12 and
 # cu13 backends, so install the top-level shim alone, then the backend
 # matching torch's CUDA (same normalization as vLLM's own CI).
 echo "Installing nixl..."
 CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])")
-uv pip install --no-deps "nixl>=1.2.0"
-uv pip install "nixl-cu${CUDA_MAJOR}>=1.2.0"
+$RETRY 3 10 uv pip install --no-deps "nixl>=1.2.0"
+$RETRY 3 10 uv pip install "nixl-cu${CUDA_MAJOR}>=1.2.0"
 
 # Remove nixl_ep (MoE all-to-all, unused in CI): vLLM imports it eagerly when
 # present, tying every worker startup to its extra native deps
@@ -69,14 +72,14 @@ if [ "${E2E_VLLM_KV_BACKEND:-nixl}" = "mooncake" ]; then
     # when the transfer protocol is tcp — without these the import fails with
     # "libibverbs.so.1: cannot open shared object file".
     echo "Installing mooncake system dependencies..."
-    sudo apt-get install -y --no-install-recommends libnuma1 libibverbs1 ibverbs-providers
+    $RETRY 3 10 sudo apt-get install -y --no-install-recommends libnuma1 libibverbs1 ibverbs-providers
 
     # The cuda13 wheel variant matches vLLM's cu130 torch stack, so no
     # libcudart.so.12 shim is needed (torch's bundled CUDA 13 runtime
     # satisfies it once torch is imported first). Pinned — floating mooncake
     # resolves have broken CI before.
     echo "Installing mooncake-transfer-engine (cuda13)..."
-    uv pip install "mooncake-transfer-engine-cuda13==0.3.11.post1"
+    $RETRY 3 10 uv pip install "mooncake-transfer-engine-cuda13==0.3.11.post1"
 
     # Import canary: fail here (not mid-e2e) if the mooncake install is broken —
     # vLLM swallows this ImportError at module load (torch first for CUDA libs)
@@ -99,12 +102,12 @@ while [ "${CUDA_TAG}" -gt "${CUDA_MAJOR_FLOOR}" ] \
     && ! curl -sfo /dev/null "https://flashinfer.ai/whl/cu${CUDA_TAG}/flashinfer-jit-cache/"; do
     CUDA_TAG=$((CUDA_TAG - 1))
 done
-uv pip install "flashinfer-jit-cache==${FLASHINFER_VERSION}" \
+$RETRY 3 10 uv pip install "flashinfer-jit-cache==${FLASHINFER_VERSION}" \
     --index-url "https://flashinfer.ai/whl/cu${CUDA_TAG}"
 
 # Install gRPC packages from source (not PyPI) so PR changes are always tested
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."
-uv pip install -e crates/grpc_client/python/
-uv pip install -e grpc_servicer/
+$RETRY 3 10 uv pip install -e crates/grpc_client/python/
+$RETRY 3 10 uv pip install -e grpc_servicer/
 
 echo "vLLM installation complete"

--- a/scripts/ci_retry.sh
+++ b/scripts/ci_retry.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Retry a command that can fail transiently (registry pushes, apt mirrors,
+# package indexes, git fetches).
+#
+# Usage: ci_retry.sh <attempts> <delay-seconds> <command> [args...]
+#
+# The delay doubles after each failed attempt. The exit status is the last
+# attempt's, so a deterministic failure still fails the step.
+
+set -uo pipefail
+
+if [ "$#" -lt 3 ]; then
+    echo "usage: $0 <attempts> <delay-seconds> <command> [args...]" >&2
+    exit 2
+fi
+
+attempts="$1"
+delay="$2"
+shift 2
+
+# A non-numeric count would make the loop below run zero times and exit 0
+# without ever running the command.
+if ! [[ "$attempts" =~ ^[1-9][0-9]*$ ]] || ! [[ "$delay" =~ ^[0-9]+$ ]]; then
+    echo "ci_retry: attempts must be a positive integer and delay a non-negative integer (got '${attempts}' '${delay}')" >&2
+    exit 2
+fi
+
+status=0
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+    "$@" && exit 0
+    status=$?
+    if [ "$attempt" -lt "$attempts" ]; then
+        echo "ci_retry: attempt ${attempt}/${attempts} of '$*' failed (exit ${status}); retrying in ${delay}s" >&2
+        sleep "$delay"
+        delay=$((delay * 2))
+    fi
+done
+echo "ci_retry: '$*' failed after ${attempts} attempts (exit ${status})" >&2
+exit "$status"

--- a/scripts/ci_setup_python_venv.sh
+++ b/scripts/ci_setup_python_venv.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RETRY="bash ${SCRIPT_DIR}/ci_retry.sh"
+
 # Every CI lane must agree on the interpreter. A bare `python3 -m venv` resolves
 # to whatever the host ships (3.12 in the containerised pools, 3.10 on the
 # bare-metal GPU runners), so which Python a job ran on depended on which
@@ -61,8 +64,8 @@ elif [ "$HOST_VERSION" = "$PY_VERSION" ]; then
             exit 1
         fi
         echo "venv creation failed - installing python3-venv/python3-pip, then retrying"
-        $SUDO apt-get update
-        $SUDO apt-get install -y python3-pip python3-venv
+        $RETRY 3 10 $SUDO apt-get update
+        $RETRY 3 10 $SUDO apt-get install -y python3-pip python3-venv
         rm -rf .venv
         python3 -m venv .venv
     fi
@@ -75,10 +78,10 @@ else
         # install uv and they all skip when it is present, so the pin holds for
         # the whole job.
         echo "Installing uv $UV_VERSION..."
-        curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+        $RETRY 3 5 bash -c "set -o pipefail; curl -LsSf 'https://astral.sh/uv/${UV_VERSION}/install.sh' | sh"
         export PATH="$HOME/.local/bin:$PATH"
     fi
-    uv python install "$PY_VERSION"
+    $RETRY 3 10 uv python install "$PY_VERSION"
     # --seed: a uv venv ships without pip, and downstream CI steps run
     # `python3 -m pip install` inside this venv.
     uv venv --python "$PY_VERSION" --seed .venv

--- a/scripts/ci_tokenspeed_image_tag.sh
+++ b/scripts/ci_tokenspeed_image_tag.sh
@@ -7,7 +7,7 @@
 # drift.
 #
 # The tag covers the pinned engine ref AND a hash of the image tooling
-# (Dockerfile + install/venv scripts + this script): a fix to any of them
+# (Dockerfile + install/venv/retry scripts + this script): a fix to any of them
 # produces a new tag, so the image rebuilds on merge automatically instead
 # of serving stale tooling behind an unchanged ref.
 
@@ -33,6 +33,7 @@ fi
 tooling_hash="$(cat \
     docker/ci-tokenspeed.Dockerfile \
     scripts/ci_install_tokenspeed.sh \
+    scripts/ci_retry.sh \
     scripts/ci_setup_python_venv.sh \
     scripts/ci_tokenspeed_image_tag.sh \
     | "${SHA256[@]}" | cut -c1-12)"


### PR DESCRIPTION
## Description

### Problem

Two more sources of red `main` runs, both mechanical:

- **Timeout budgets with no headroom.** The e2e lanes were budgeted at about 95% of their measured duration, so a slow day tips them over. On healthy `main` runs over the last eleven days, the vLLM PD lane took 17 to 28 minutes against a 25 minute test budget, the TokenSpeed ZMQ chat lane took 39 to 47 minutes against a 50 minute job budget, and the TokenSpeed and TRT-LLM chat lanes hit their 18 minute test budgets. That accounts for about ten failed or cancelled lanes.
- **No retries around network steps.** The nightly engine image push failed on a GHCR blob upload timeout. Engine setup failed on apt and git fetch errors. Each of these steps runs once and fails the job on the first hiccup.

### Solution

- Raise each lane's budget to at least 25% above the maximum healthy duration measured on `main`.
- Add `scripts/ci_retry.sh`, a small retry wrapper with doubling delay, and use it for `docker push`, `apt-get`, `git fetch`, `curl`, and the pip and uv installs in the engine install scripts. Deterministic failures still fail: the wrapper returns the last exit status.
- Copy the retry helper into the TokenSpeed CI image ahead of the apt bootstrap so that bootstrap retries too, and include the helper in the image's tooling hash and trigger paths.

The `python3-dev` part of this work landed separately in #2415 and is dropped here.

## Changes

- `.github/workflows/pr-test-rust.yml`: lane budgets (`e2e-2gpu-pd` 30 to 40 with a 34 minute test step, TokenSpeed `e2e-1gpu-chat` 50/18 to 56/26, TokenSpeed `e2e-1gpu-chat-zmq` 50/40 to 60/48, TRT-LLM `e2e-1gpu-chat` 32/18 to 36/24, `e2e-1gpu-responses` 28/20 to 32/24); `scripts/ci_retry.sh` added to the `common` change filter.
- `scripts/ci_retry.sh`: new. Rejects a non-numeric attempt count instead of skipping the command silently.
- `scripts/ci_install_{tokenspeed,sglang,vllm,trtllm,e2e_deps}.sh`, `scripts/ci_setup_python_venv.sh`: network-bound commands wrapped in the retry helper. The piped uv installers run with pipefail, so a curl failure is not hidden by the shell it pipes into. The two TokenSpeed kernel compiles are left unwrapped because a compile failure is deterministic.
- `.github/workflows/_build-engine-image.yml`: `docker push` retried.
- `docker/ci-tokenspeed.Dockerfile`, `scripts/ci_tokenspeed_image_tag.sh`, `.github/workflows/ci-tokenspeed-image.yml`: retry helper copied in before the apt bootstrap, which now retries; helper is part of the tag hash and trigger paths.

## Test Plan

- `bash -n` on every touched script. The retry helper verified locally: returns 0 on first success, returns the command's last exit status after the final attempt, exits 2 on a non-numeric attempt count, and now surfaces curl's exit status through a piped installer instead of 0.
- All three touched workflows parse as YAML.
- `scripts/ci_tokenspeed_image_tag.sh` produces a new tag, so the image rebuilds on merge.
- Lane durations to watch after merge: the vLLM PD lane should stop hitting its test timeout, and the TokenSpeed chat-zmq lane should stop being cancelled at the job limit.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
