### PR TITLE
test: deflake ZMQ handshake and rate-limit tests; probe PD gateways before testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4288,6 +4288,7 @@ dependencies = [
  "smg-grpc-client",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tracing",
  "tracing-subscriber",

--- a/crates/mock_worker/Cargo.toml
+++ b/crates/mock_worker/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 smg-grpc-client.workspace = true
 engine-zmq-client = { workspace = true, features = ["mock-engine"] }
 tokio = { workspace = true, features = ["full"] }
+tokio-stream = { version = "0.1", features = ["net"] }
 tonic.workspace = true
 axum.workspace = true
 serde_json.workspace = true

--- a/crates/mock_worker/src/grpc.rs
+++ b/crates/mock_worker/src/grpc.rs
@@ -9,7 +9,8 @@ use std::{
 
 use futures::{stream, Stream};
 use smg_grpc_client::{common_proto as common, tokenspeed_scheduler::tokenspeed_proto as ts};
-use tokio::sync::mpsc;
+use tokio::{net::TcpListener, sync::mpsc};
+use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{transport::Server, Request, Response, Status};
 use ts::{
     generate_response::Response as GenResp,
@@ -30,16 +31,29 @@ pub async fn serve(cfg: Arc<Config>, host: String, port: u16) {
             return;
         }
     };
-    let addr = SocketAddr::new(ip, port);
+    let listener = match TcpListener::bind(SocketAddr::new(ip, port)).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            tracing::error!("grpc worker {port} failed to bind: {e}");
+            return;
+        }
+    };
+    serve_with_listener(cfg, listener).await;
+}
+
+/// Serve on an already-bound listener. Callers that need a free port bind
+/// port 0 and read it back instead of picking one and binding it later.
+pub async fn serve_with_listener(cfg: Arc<Config>, listener: TcpListener) {
+    let addr = listener.local_addr().ok();
     // One simulated engine per listener (i.e. per virtual worker).
     let engine = cfg.realistic.then(|| Engine::spawn(cfg.engine.clone()));
     let service = MockScheduler { cfg, engine };
     if let Err(e) = Server::builder()
         .add_service(TokenSpeedSchedulerServer::new(service))
-        .serve(addr)
+        .serve_with_incoming(TcpListenerStream::new(listener))
         .await
     {
-        tracing::error!("grpc worker {port} stopped: {e}");
+        tracing::error!("grpc worker {addr:?} stopped: {e}");
     }
 }
 

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 
 import anthropic
 import openai
@@ -133,6 +134,50 @@ def _gateway_readiness_timeout(
 
 def _make_openai_client(gateway: Gateway) -> openai.OpenAI:
     return openai.OpenAI(base_url=f"{gateway.base_url}/v1", api_key="not-used")
+
+
+# Statuses a fresh gateway returns while it is still wiring up (no worker
+# routable yet, tokenizer not registered) rather than rejecting the request.
+_NOT_SERVING_YET = frozenset({404, 408, 425, 429, 500, 502, 503, 504})
+
+
+def _wait_for_serving(
+    gateway: Gateway, model_id: str, model_path: str, timeout: float = 180.0
+) -> None:
+    """Block until the gateway answers a real chat request for ``model_path``.
+
+    PD lanes have returned 404 for a class's first request seconds after the
+    gateway reported ready, for reasons the readiness gate does not explain.
+    Wait for a request to succeed rather than trusting the gate.
+    """
+    if "chat" not in get_model_spec(model_id).get("features", []):
+        return
+    client = _make_openai_client(gateway).with_options(max_retries=0)
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            client.chat.completions.create(
+                model=model_path,
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=1,
+                timeout=min(60.0, remaining),
+            )
+            return
+        except openai.APIStatusError as exc:
+            if exc.status_code not in _NOT_SERVING_YET:
+                raise
+            last_error = exc
+        except (openai.APIConnectionError, openai.APITimeoutError) as exc:
+            last_error = exc
+        time.sleep(min(2.0, max(0.0, deadline - time.monotonic())))
+    raise TimeoutError(
+        f"Gateway at {gateway.base_url} did not serve a chat request for "
+        f"{model_path} within {timeout}s: {last_error}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -371,6 +416,7 @@ def _setup_pd(
             prefill_workers=prefill_workers,
             decode_workers=decode_workers,
         )
+        _wait_for_serving(gateway, model_id, model_path)
         logger.info("%s PD backend ready at %s", runtime_label, gateway.base_url)
         yield backend_name, model_path, _make_openai_client(gateway), gateway
     finally:

--- a/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
+++ b/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
@@ -29,7 +29,6 @@ use openai_protocol::{
     completion::CompletionRequest, generate::GenerateRequest, model_card::ModelCard,
     worker::HealthCheckConfig,
 };
-use portpicker::pick_unused_port;
 use smg::{
     config::RouterConfig,
     middleware::TenantRequestMeta,
@@ -37,28 +36,13 @@ use smg::{
     tenant::TenantKey,
     worker::{BasicWorkerBuilder, ConnectionMode, RuntimeType, WorkerType},
 };
-use tokio::net::TcpStream;
+use tokio::net::TcpListener;
 
 /// "Hello world" through `MockTokenizer`'s fixed vocab ("Hello"=1, "world"=2)
 /// tokenizes to exactly 2 ids -- the gateway's reserve-time estimate.
 const PROMPT_TEXT: &str = "Hello world";
 const ESTIMATED_INPUT_TOKENS: u32 = 2;
 const MODEL: &str = "tenant-rl-test-model";
-
-#[expect(
-    clippy::panic,
-    reason = "test helper - panicking on failure is intentional"
-)]
-async fn wait_for_port(port: u16) {
-    let addr = format!("127.0.0.1:{port}");
-    for _ in 0..100 {
-        if TcpStream::connect(&addr).await.is_ok() {
-            return;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    panic!("mock gRPC worker on {addr} never came up");
-}
 
 /// Spawn a real (mock) gRPC worker in-process, canned mode: always reports
 /// `prompt_tokens: 1` and `completion_tokens: output_tokens`, regardless of
@@ -70,7 +54,15 @@ async fn wait_for_port(port: u16) {
               mock server task is fire-and-forget for the test process's lifetime"
 )]
 async fn start_mock_grpc_worker(output_tokens: u32) -> u16 {
-    let port = pick_unused_port().expect("no free port for mock gRPC worker");
+    // Bind first and read the port back: picking a free port and binding it
+    // later races the other tests in this binary doing the same.
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock gRPC worker");
+    let port = listener
+        .local_addr()
+        .expect("mock gRPC worker address")
+        .port();
     let cfg = Arc::new(mock_worker::config::Config {
         host: "127.0.0.1".to_string(),
         http_base_port: 0,
@@ -87,8 +79,7 @@ async fn start_mock_grpc_worker(output_tokens: u32) -> u16 {
         realistic: false,
         engine: mock_worker::engine::EngineParams::default(),
     });
-    tokio::spawn(mock_worker::grpc::serve(cfg, "127.0.0.1".to_string(), port));
-    wait_for_port(port).await;
+    tokio::spawn(mock_worker::grpc::serve_with_listener(cfg, listener));
     port
 }
 

--- a/model_gateway/tests/zmq_backend_test.rs
+++ b/model_gateway/tests/zmq_backend_test.rs
@@ -25,6 +25,7 @@ use openai_protocol::{
     generate::GenerateRequest, model_card::ModelCard, worker::HealthCheckConfig,
 };
 use portpicker::pick_unused_port;
+use serial_test::serial;
 use smg::{
     config::RouterConfig,
     middleware::{RouteRequestMeta, TenantKey},
@@ -159,8 +160,9 @@ async fn build_router(fixture: &ZmqFixture, engine_count: usize) -> Box<dyn Rout
         .expect("router should build over a ZMQ worker");
 
     // Acquisition fails fast while the background driver completes the
-    // handshake; wait for it to land so requests hit a connected worker.
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    // handshake; wait for it to land so requests hit a connected worker. The
+    // budget covers a loaded CI runner, not the local ~100ms case.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
     while !matches!(worker.get_backend_client().await, Ok(Some(_))) {
         assert!(
             tokio::time::Instant::now() < deadline,
@@ -194,6 +196,7 @@ fn test_meta() -> RouteRequestMeta {
 /// anywhere in the ipc:// bind, handshake, or output translation fails here on
 /// CPU, without an H100 e2e lane.
 #[tokio::test]
+#[serial]
 async fn non_streaming_generate_over_zmq() {
     let fixture = zmq_fixture();
     start_mock_zmq_engines(&fixture.handshake, 1);
@@ -225,6 +228,7 @@ async fn non_streaming_generate_over_zmq() {
 /// buffers the same outputs, so a stream that stalls mid-generation would pass
 /// the test above and fail here.
 #[tokio::test]
+#[serial]
 async fn streaming_generate_over_zmq() {
     let fixture = zmq_fixture();
     start_mock_zmq_engines(&fixture.handshake, 1);
@@ -259,6 +263,7 @@ async fn streaming_generate_over_zmq() {
 /// connector demultiplexes outputs by request id off a single shared output
 /// socket, so a mix-up here would show as a request never terminating.
 #[tokio::test]
+#[serial]
 async fn concurrent_requests_share_one_zmq_transport() {
     let fixture = zmq_fixture();
     start_mock_zmq_engines(&fixture.handshake, 1);
@@ -278,6 +283,7 @@ async fn concurrent_requests_share_one_zmq_transport() {
 /// balances across them. This is the `dp_size`-on-one-worker topology
 /// `zmq_engine_group` builds, exercised end-to-end through the router.
 #[tokio::test]
+#[serial]
 async fn grouped_zmq_worker_serves_requests_from_either_rank() {
     let fixture = zmq_fixture();
     start_mock_zmq_engines(&fixture.handshake, 2);


### PR DESCRIPTION
## Description

### Problem

Three tests fail on `main` for timing reasons that have nothing to do with the code under test:

- `streaming_generate_over_zmq` waits ten seconds for the mock engine handshake and picks the handshake port before binding it. On a loaded runner, or when two tests in the same binary pick the same port, the handshake misses the deadline.
- `denial_returns_429_with_retry_after` picks a free port for its mock gRPC worker, binds it later, and only checks that something accepts TCP on that port. Its first request came back 503 once on `main` because the request reached a socket that was not this test's server yet.
- The PD e2e lanes (`test_pd_messages` on both sglang and vllm) got 404s from a freshly started gateway. In the failing run the gateway reported ready one second after starting, the first request failed with "Tokenizer not found" for the model, and eight seconds of retries later the prefill worker was reported unavailable. The gateway's readiness endpoint already gates on tokenizer registration, so the window between "ready" and "serving" on a fresh process is not fully explained; the harness should not start tests inside it.

### Solution

- The mock gRPC server gains `serve_with_listener`, and the rate-limit test binds `127.0.0.1:0` first and reads the port back. There is no longer a gap between choosing a port and owning it, and no TCP polling.
- The ZMQ test's handshake budget becomes sixty seconds, and its tests run serially so they cannot pick the same handshake port.
- The PD e2e fixture sends one real chat request with `max_tokens: 1` after the readiness gate and starts tests only once it succeeds. Statuses a starting gateway returns while wiring up are retried; anything else is raised immediately. Models without the `chat` feature are skipped.

Regular-worker lanes are left alone. Their readiness gate already covers model load for ZMQ engines, and the first version of this PR, which probed them too, saw the vLLM engine in `e2e-2gpu-chat-zmq-dp` stop producing output on the first structured-output request. That lane passes on `main`, so the probe stays where the race was actually observed.

## Changes

- `crates/mock_worker/src/grpc.rs`, `crates/mock_worker/Cargo.toml`: `serve_with_listener`; `serve` binds and delegates.
- `model_gateway/tests/tenant_rate_limiting_grpc_test.rs`: bind-first mock worker; the TCP wait and port picker go away.
- `model_gateway/tests/zmq_backend_test.rs`: sixty-second handshake budget; tests serialized.
- `e2e_test/fixtures/setup_backend.py`: `_wait_for_serving`, called after the gateway starts for PD backends.

## Test Plan

- `cargo test -p smg --test tenant_rate_limiting_grpc_test --test zmq_backend_test`: 14 and 13 passed.
- `cargo build -p mock-worker` builds; `cargo clippy --all-targets -- -D warnings` and `cargo +nightly fmt --all --check` clean.
- `e2e_test/fixtures/setup_backend.py` compiles; the PD lanes in CI exercise the new probe.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (`--all-features` pulls `opencv`, which does not build locally; CI covers it)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
