### PR TITLE
fix(multimodal): tighten MiniMax-M3 video grid, cap, and limit validation

### DIFF
--- a/crates/multimodal/src/hasher.rs
+++ b/crates/multimodal/src/hasher.rs
@@ -1,7 +1,13 @@
 use std::collections::BTreeMap;
 
-/// Domain tag for digests that mix media bytes with request parameters, so a
-/// parameterised digest can never equal a plain byte digest.
+/// Domain tag for digests that mix media bytes with request parameters.
+///
+/// Together with the length prefix this makes the `(bytes, params)` encoding
+/// injective, so no two distinct parameter sets share a digest. It separates
+/// parameterised digests from plain byte digests only because a plain digest's
+/// payload is a real image or video container, which never begins with this
+/// tag; the plain digests are deliberately left untagged so existing cache
+/// entries stay valid.
 const MEDIA_PARAM_DOMAIN: &[u8] = b"smg.media.params.v1";
 
 /// Absorb `bytes` behind its own length.
@@ -196,10 +202,10 @@ mod video_sampling_hash_tests {
     }
 
     #[test]
-    fn parameterised_digest_never_equals_a_plain_digest() {
-        // The domain tag keeps the two families disjoint.
-        // Same payload both sides, so this tests the domain tag rather than
-        // two different byte strings.
+    fn parameterised_digest_differs_from_the_plain_digest_of_the_same_payload() {
+        // Same payload both sides, so this exercises the domain tag rather
+        // than two different byte strings. It checks this one instance, not a
+        // universal: see the note on `MEDIA_PARAM_DOMAIN`.
         assert_ne!(hash_video_with_sampling(CLIP, 1.0, None), hash_video(CLIP));
         assert_ne!(
             hash_image_with_resolution_cap(CLIP, Some(504)),

--- a/crates/multimodal/src/media.rs
+++ b/crates/multimodal/src/media.rs
@@ -506,6 +506,7 @@ impl MediaConnector {
         cfg: VideoFetchConfig,
         source: VideoSource,
     ) -> Result<Arc<VideoClip>, MediaConnectorError> {
+        validate_max_long_side_pixel(cfg.max_long_side_pixel)?;
         ensure_input_byte_limit(bytes.len(), video_max_input_bytes(), "video")?;
         if cfg.max_frames == 0 {
             return Err(MediaConnectorError::VideoDecode(
@@ -2125,7 +2126,8 @@ mod tests {
         effective_sample_fps, ensure_input_byte_limit, expected_sampled_frame_count,
         fps_filter_for_metadata, parse_ffmpeg_duration_seconds, parse_ffprobe_video_info,
         parse_ppm_stream, read_file_with_limit, split_png_stream, video_temp_suffix,
-        MediaConnectorError, VideoFetchConfig, VideoMetadata,
+        MediaConnector, MediaConnectorConfig, MediaConnectorError, MediaSource, VideoFetchConfig,
+        VideoMetadata,
     };
 
     const TINY_PNG: &[u8] = &[
@@ -2398,6 +2400,34 @@ mod tests {
         assert_eq!(super::adaptive_opencv_decoder_threads(8, 32), 1);
         assert_eq!(super::adaptive_opencv_decoder_threads(1, 0), 2);
     }
+
+    /// Defense in depth for the video path: the tracker validates M3's range,
+    /// but the decoder must reject a zero or off-grid cap itself, before it
+    /// spends a decode on the clip, exactly as the image decoder does.
+    #[tokio::test]
+    async fn decode_video_rejects_an_invalid_long_side_cap() {
+        let connector =
+            MediaConnector::new(reqwest::Client::new(), MediaConnectorConfig::default())
+                .expect("default connector");
+        for value in [0, 505] {
+            let cfg = VideoFetchConfig {
+                max_long_side_pixel: Some(value),
+                ..VideoFetchConfig::default()
+            };
+            let err = connector
+                .fetch_video(MediaSource::InlineBytes(vec![0u8; 16]), cfg)
+                .await
+                .expect_err("an invalid cap must be rejected");
+            assert!(
+                matches!(
+                    err,
+                    MediaConnectorError::InvalidMaxLongSidePixel { value: got, factor: 28 }
+                        if got == value
+                ),
+                "cap {value}: unexpected error {err:?}"
+            );
+        }
+    }
 }
 
 /// The vision patch factor MiniMax-M3's `max_long_side_pixel` must align to
@@ -2593,6 +2623,11 @@ fn cap_decoded_frames(
 
             // Size from the capped geometry; the pre-cap length would leave a
             // large allocation attached to the clip for its whole lifetime.
+            // Clamped to the source buffer: the descriptors are only validated
+            // per frame inside the loop below, so they must not drive the
+            // allocation on their own. The clamp never under-reserves, since
+            // the capped total is at most the uncapped total, which is at most
+            // the buffer.
             let capacity: usize = video
                 .frames
                 .iter()
@@ -2600,7 +2635,8 @@ fn cap_decoded_frames(
                     Some((w, h)) => (w as usize) * (h as usize) * 3,
                     None => f.len,
                 })
-                .sum();
+                .fold(0usize, usize::saturating_add)
+                .min(video.data.len());
             let mut data: Vec<u8> = Vec::with_capacity(capacity);
             let mut frames = Vec::with_capacity(video.frames.len());
 
@@ -2670,6 +2706,47 @@ mod video_frame_cap_tests {
             video: DecodedRgbVideo::new(Bytes::from(data), descs),
             sample_fps: 2.0,
         }
+    }
+
+    /// A descriptor that disagrees with its buffer must not size the
+    /// allocation: the capacity is clamped to the source buffer, and the
+    /// per-frame bounds check then hands the clip back untouched.
+    #[test]
+    fn inconsistent_frame_descriptors_do_not_drive_the_allocation() {
+        let small = (100 * 100 * 3) as usize;
+        let big = (1920 * 1080 * 3) as usize;
+        let data = vec![0u8; small + big];
+        let frames = vec![
+            // Inside the cap, so its `len` feeds the capacity sum directly,
+            // and that `len` is nonsense.
+            DecodedRgbFrame {
+                width: 100,
+                height: 100,
+                offset: 0,
+                len: isize::MAX as usize,
+            },
+            // Over the cap, so the "nothing to cap" early return does not fire.
+            DecodedRgbFrame {
+                width: 1920,
+                height: 1080,
+                offset: small,
+                len: big,
+            },
+        ];
+        let decoded = DecodedVideoFrames::Rgb {
+            video: DecodedRgbVideo::new(Bytes::from(data), frames),
+            sample_fps: 2.0,
+        };
+
+        let DecodedVideoFrames::Rgb { video, .. } = cap_decoded_frames(decoded, Some(504)) else {
+            panic!("expected RGB");
+        };
+        // Left to downstream validation rather than reshaped or reallocated.
+        assert_eq!(video.frames[0].len, isize::MAX as usize);
+        assert_eq!(
+            (video.frames[1].width, video.frames[1].height),
+            (1920, 1080)
+        );
     }
 
     #[test]

--- a/crates/multimodal/src/registry/minimax_m3.rs
+++ b/crates/multimodal/src/registry/minimax_m3.rs
@@ -11,8 +11,14 @@ use crate::{
 /// Maximum images accepted in one request (MiniMax-M3 spec 1.3.6).
 const MAX_IMAGES_PER_REQUEST: usize = 200;
 
-/// Maximum videos accepted in one request (MiniMax-M3 spec 1.3.6).
-const MAX_VIDEOS_PER_REQUEST: usize = 20;
+/// Maximum videos accepted in one request.
+///
+/// MiniMax-M3 spec 1.3.6 allows 20, but the gateway preprocesses one clip per
+/// modality batch today (`preprocess_modality` bails on more). Advertising the
+/// spec limit would turn a clean up-front rejection into an internal error
+/// after every clip had been fetched and decoded, so the limit stays at the
+/// pipeline's capacity until batched video preprocessing lands.
+const MAX_VIDEOS_PER_REQUEST: usize = 1;
 
 /// MiniMax-M3 vision spec.
 ///
@@ -108,14 +114,22 @@ impl MiniMaxM3VisionSpec {
     }
 
     /// Temporal grid depth for one video, from `video_grid_thw[0]`.
-    fn video_grid_t(preprocessed: &PreprocessedEncoderInputs) -> Option<usize> {
+    ///
+    /// The video path always emits this tensor and the per-frame layout is
+    /// built from it, so an absent or malformed grid is a broken preprocessing
+    /// output. It is rejected rather than papered over with a flat block the
+    /// model would read differently.
+    fn video_grid_t(preprocessed: &PreprocessedEncoderInputs) -> RegistryResult<usize> {
+        let invalid = || ModelRegistryError::InvalidPreprocessedField {
+            field: "video_grid_thw".to_string(),
+        };
         match preprocessed.model_specific.get("video_grid_thw") {
             Some(ModelSpecificValue::IntTensor { data, shape })
                 if shape == &[1, 3] && !data.is_empty() =>
             {
-                usize::try_from(data[0]).ok()
+                usize::try_from(data[0]).map_err(|_| invalid())
             }
-            _ => None,
+            _ => Err(invalid()),
         }
     }
 
@@ -137,17 +151,23 @@ impl MiniMaxM3VisionSpec {
     /// per-frame metadata, so the timestamp markers are omitted and the frame
     /// blocks alone are emitted.
     ///
-    /// Returns `None` when the layout cannot apply (unknown or single frame, or
-    /// a token count that does not divide evenly), leaving the caller on the
-    /// single-block path.
+    /// Returns `None` for a single-frame clip, where one block is the same
+    /// layout, leaving the caller on the single-block path. A token count that
+    /// does not divide by the frame count means the grid and the features
+    /// disagree; that is rejected rather than flattened.
     fn per_frame_video_tokens(
         metadata: &ModelMetadata,
         pad_token_id: TokenId,
         num_tokens: usize,
         grid_t: usize,
     ) -> RegistryResult<Option<Vec<TokenId>>> {
-        if grid_t <= 1 || num_tokens == 0 || !num_tokens.is_multiple_of(grid_t) {
+        if grid_t <= 1 || num_tokens == 0 {
             return Ok(None);
+        }
+        if !num_tokens.is_multiple_of(grid_t) {
+            return Err(ModelRegistryError::InvalidPreprocessedField {
+                field: "video_grid_thw".to_string(),
+            });
         }
         let start_id = metadata.token_id(Self::VIDEO_START_TOKEN)?;
         let end_id = metadata.token_id(Self::VIDEO_END_TOKEN)?;
@@ -295,29 +315,28 @@ impl ModelProcessorSpec for MiniMaxM3VisionSpec {
             Modality::Video => {
                 let pad_token_id = Self::video_token_id(metadata)?;
                 let placeholder_token = self.placeholder_token_for(metadata, Modality::Video)?;
-                let grid_t = Self::video_grid_t(preprocessed);
+                let grid_t = Self::video_grid_t(preprocessed)?;
 
                 preprocessed
                     .feature_token_counts
                     .iter()
                     .map(|&num_tokens| {
-                        let per_frame = grid_t.and_then(|grid_t| {
-                            Self::per_frame_video_tokens(metadata, pad_token_id, num_tokens, grid_t)
-                                .transpose()
-                                .map(|tokens| tokens.map(|tokens| (tokens, grid_t)))
-                        });
+                        let per_frame = Self::per_frame_video_tokens(
+                            metadata,
+                            pad_token_id,
+                            num_tokens,
+                            grid_t,
+                        )?;
 
                         match per_frame {
-                            Some(Ok((tokens, grid_t))) => Ok(PromptReplacement::sequence(
+                            Some(tokens) => Ok(PromptReplacement::sequence(
                                 Modality::Video,
                                 &placeholder_token,
                                 tokens,
                             )
-                            .with_feature_ranges(Self::per_frame_feature_ranges(
-                                grid_t,
-                                num_tokens / grid_t,
-                            ))),
-                            Some(Err(err)) => Err(err),
+                            .with_feature_ranges(
+                                Self::per_frame_feature_ranges(grid_t, num_tokens / grid_t),
+                            )),
                             None => Self::wrapped_replacement(
                                 metadata,
                                 Modality::Video,
@@ -512,7 +531,11 @@ mod tests {
     fn video_replacement_uses_the_video_pad_token() {
         let spec = MiniMaxM3VisionSpec;
         let replacements = spec
-            .prompt_replacements_for(&metadata(), &preprocessed(vec![3]), Modality::Video)
+            .prompt_replacements_for(
+                &metadata(),
+                &preprocessed_video(vec![3], 1),
+                Modality::Video,
+            )
             .unwrap();
 
         // Video uses M3's own video markers, not the image pair.
@@ -535,8 +558,8 @@ mod tests {
         )
     }
 
-    #[tokio::test]
-    async fn multi_frame_video_emits_one_block_per_frame() {
+    #[test]
+    fn multi_frame_video_emits_one_block_per_frame() {
         let spec = MiniMaxM3VisionSpec;
         // 3 temporal frames, 12 tokens total => 4 pad tokens per frame.
         let replacements = spec
@@ -548,20 +571,18 @@ mod tests {
             .unwrap();
 
         let tokens = &replacements[0].tokens;
-        // Each frame is [start] + 4 pads + [end]; vLLM builds the same shape.
-        let frame = |_| {
-            let mut v = vec![VIDEO_START_ID];
-            v.extend(std::iter::repeat_n(VIDEO_ID, 4));
-            v.push(VIDEO_END_ID);
-            v
-        };
-        let expected: Vec<TokenId> = (0..3).flat_map(frame).collect();
+        // Each frame is [start] + 4 pads + [end], repeated once per frame;
+        // vLLM builds the same shape.
+        let mut frame_tokens = vec![VIDEO_START_ID];
+        frame_tokens.extend(std::iter::repeat_n(VIDEO_ID, 4));
+        frame_tokens.push(VIDEO_END_ID);
+        let expected: Vec<TokenId> = std::iter::repeat_n(frame_tokens, 3).flatten().collect();
         assert_eq!(tokens, &expected);
         assert_eq!(tokens.len(), 3 * (4 + 2));
     }
 
-    #[tokio::test]
-    async fn multi_frame_feature_ranges_skip_each_frames_markers() {
+    #[test]
+    fn multi_frame_feature_ranges_skip_each_frames_markers() {
         let spec = MiniMaxM3VisionSpec;
         let replacements = spec
             .prompt_replacements_for(
@@ -579,8 +600,8 @@ mod tests {
         assert_eq!((ranges[2].offset, ranges[2].length), (13, 4));
     }
 
-    #[tokio::test]
-    async fn single_frame_video_stays_one_block() {
+    #[test]
+    fn single_frame_video_stays_one_block() {
         let spec = MiniMaxM3VisionSpec;
         let replacements = spec
             .prompt_replacements_for(
@@ -603,19 +624,40 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn ragged_token_count_falls_back_to_one_block() {
+    #[test]
+    fn ragged_token_count_is_rejected() {
         let spec = MiniMaxM3VisionSpec;
-        // 10 tokens over 3 frames does not divide evenly.
-        let replacements = spec
+        // 10 tokens over 3 frames does not divide evenly, so the grid and the
+        // token count disagree. Falling back to one flat block would silently
+        // hand the model the framing the per-frame layout exists to avoid.
+        let err = spec
             .prompt_replacements_for(
                 &metadata(),
                 &preprocessed_video(vec![10], 3),
                 Modality::Video,
             )
-            .unwrap();
+            .unwrap_err();
 
-        assert_eq!(replacements[0].tokens.len(), 10 + 2);
+        assert!(matches!(
+            err,
+            ModelRegistryError::InvalidPreprocessedField { ref field } if field == "video_grid_thw"
+        ));
+    }
+
+    #[test]
+    fn missing_video_grid_is_rejected() {
+        let spec = MiniMaxM3VisionSpec;
+        // Without `video_grid_thw` the frame count is unknown, so the layout
+        // cannot be built and a flat block would be wrong for any multi-frame
+        // clip. The video path always emits the grid; its absence is a bug.
+        let err = spec
+            .prompt_replacements_for(&metadata(), &preprocessed(vec![12]), Modality::Video)
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ModelRegistryError::InvalidPreprocessedField { ref field } if field == "video_grid_thw"
+        ));
     }
 
     #[test]
@@ -626,7 +668,10 @@ mod tests {
         assert_eq!(limits.get(&Modality::Image), Some(&MAX_IMAGES_PER_REQUEST));
         assert_eq!(MAX_IMAGES_PER_REQUEST, 200);
         assert_eq!(limits.get(&Modality::Video), Some(&MAX_VIDEOS_PER_REQUEST));
-        assert_eq!(MAX_VIDEOS_PER_REQUEST, 20);
+        // The spec allows 20, but preprocessing handles one clip per request
+        // today; advertising more would turn a clean rejection into a 500
+        // after the clips were fetched and decoded.
+        assert_eq!(MAX_VIDEOS_PER_REQUEST, 1);
         assert!(!limits.contains_key(&Modality::Audio));
     }
 

--- a/crates/multimodal/src/vision/processors/minimax_m3.rs
+++ b/crates/multimodal/src/vision/processors/minimax_m3.rs
@@ -165,10 +165,12 @@ impl MiniMaxM3VisionProcessor {
 
     /// Build a processor from a preprocessor config, falling back to M3's
     /// defaults for anything the config does not specify.
-    pub fn from_preprocessor_config(config: &PreProcessorConfig) -> Self {
-        Self::new()
-            .layered_over(config)
-            .unwrap_or_else(|_| Self::new())
+    ///
+    /// A present but malformed `img_token_compression_config` value fails
+    /// here, at construction, rather than silently falling back to the
+    /// defaults and hiding the real cause until the first request.
+    pub fn from_preprocessor_config(config: &PreProcessorConfig) -> Result<Self, TransformError> {
+        Self::new().layered_over(config)
     }
 
     /// Layer a request's config over this processor's settings.
@@ -328,7 +330,8 @@ mod tests {
 
     #[test]
     fn reads_merge_params_from_the_nested_compression_block() {
-        let processor = MiniMaxM3VisionProcessor::from_preprocessor_config(&m3_config());
+        let processor = MiniMaxM3VisionProcessor::from_preprocessor_config(&m3_config())
+            .expect("checkpoint config is valid");
 
         // Neither key exists at the top level of M3's config; both must be
         // picked up from img_token_compression_config.
@@ -341,7 +344,8 @@ mod tests {
     fn checkpoint_config_keeps_m3_pixel_bounds() {
         // M3's config carries no min_pixels/max_pixels, so the M3 defaults must
         // survive rather than falling back to Qwen2-VL's much larger bounds.
-        let processor = MiniMaxM3VisionProcessor::from_preprocessor_config(&m3_config());
+        let processor = MiniMaxM3VisionProcessor::from_preprocessor_config(&m3_config())
+            .expect("checkpoint config is valid");
         assert_eq!(processor.min_pixels(), 3136);
         assert_eq!(processor.max_pixels(), 451_584);
     }
@@ -352,7 +356,8 @@ mod tests {
         config.merge_size = Some(4);
         config.temporal_patch_size = Some(1);
 
-        let processor = MiniMaxM3VisionProcessor::from_preprocessor_config(&config);
+        let processor = MiniMaxM3VisionProcessor::from_preprocessor_config(&config)
+            .expect("checkpoint config is valid");
         assert_eq!(processor.merge_size(), 4);
         assert_eq!(processor.temporal_patch_size(), 1);
     }
@@ -418,6 +423,18 @@ mod tests {
             .unwrap();
         assert_eq!(layered.merge_size(), DEFAULT_MERGE_SIZE);
         assert_eq!(layered.temporal_patch_size(), DEFAULT_TEMPORAL_PATCH_SIZE);
+    }
+
+    #[test]
+    fn from_preprocessor_config_rejects_a_malformed_compression_block() {
+        // Construction must fail loudly rather than fall back to the defaults
+        // and hide the real cause until the first request.
+        let config: PreProcessorConfig = serde_json::from_str(
+            r#"{"patch_size": 14,
+                 "img_token_compression_config": {"spatial_merge_size": "two"}}"#,
+        )
+        .unwrap();
+        assert!(MiniMaxM3VisionProcessor::from_preprocessor_config(&config).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

Seven review threads on #2371 (MiniMax-M3 vision support) were never answered before merge. None of them is a live bug in the served path, but together they leave a spec limit the pipeline cannot honour, two silent fallbacks in a layout that is now known to be load-bearing, a swallowed validation error, an unvalidated decoder input, an allocation sized from untrusted descriptors, and a doc comment that overclaims what a hash prefix guarantees.

This is the first of several follow-ups to #2371, and the one with the smallest blast radius: every change is inside `crates/multimodal`, and the only API change is one constructor's return type, which has no callers outside its own tests. The remaining items from #2371's known-failure list (per-frame video sizing and the `max_long_side_pixel` long-side rule, batched video preprocessing, the 200-image inline payload, and image+video in one vLLM request) each get their own PR.

### Solution

Answer each thread with the fix the reviewer asked for, test-first.

## Changes

- **Video limit** (`registry/minimax_m3.rs`) — `MAX_VIDEOS_PER_REQUEST` drops from 20 to 1. The spec allows 20, but `preprocess_modality` bails on a second clip only after every clip has been fetched and decoded, so advertising 20 turned a clean up-front rejection into an internal error. The constant's doc says why and that batched video preprocessing restores it.
- **Ragged or missing video grid** (`registry/minimax_m3.rs`) — `video_grid_t` now returns `InvalidPreprocessedField { field: "video_grid_thw" }` when the tensor is absent or malformed, and `per_frame_video_tokens` rejects a token count that does not divide by the frame count, instead of silently emitting the flat single-block layout the per-frame framing exists to avoid. Single-frame clips keep the single block, which is the same layout. Neither error case is reachable through today's processor, but a future change that dropped the grid or altered the token formula would otherwise degrade into wrong framing with no signal. The `Option`-of-`Result` plumbing in `prompt_replacements_for` collapses to a `?`.
- **Constructor error** (`vision/processors/minimax_m3.rs`) — `from_preprocessor_config` returns `Result<Self, TransformError>` so a present-but-malformed `img_token_compression_config` fails at construction rather than being mapped back to `Self::new()`. Only tests called it.
- **Decoder validation** (`media.rs`) — `decode_video` validates `max_long_side_pixel` (non-zero, multiple of 28) before spending a decode, as `decode_image` already did.
- **Allocation clamp** (`media.rs`) — the capped-frame capacity is summed with `saturating_add` and clamped to `video.data.len()`, so an inconsistent frame descriptor cannot drive the allocation; the per-frame `checked_add` guard then returns the clip untouched. The clamp never under-reserves: the capped total is at most the uncapped total, which is at most the buffer.
- **Hash doc** (`hasher.rs`) — the `MEDIA_PARAM_DOMAIN` doc is scoped to what a prefix tag plus length prefix actually guarantees (injective `(bytes, params)` encoding; separation from plain digests only because a real container never starts with the tag), and the test is renamed to what it checks.
- **Test hygiene** (`registry/minimax_m3.rs`) — the four video layout tests are plain `#[test]` (nothing in them awaits), and the repeat-three-times closure is `repeat_n`.

## Test Plan

Every behavior change was written as a failing test first and watched fail for the intended reason (20 vs 1; `unwrap_err` on an `Ok`; `capacity overflow` panic; the decoder reaching ffmpeg instead of validating; missing `expect`/`is_err` on the old signature) before the fix.

Run on the B300 node (`moirai-b300`), which has OpenCV, so `--all-features` covers the `opencv-video` paths too:

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy -p llm-multimodal -p smg --all-targets --all-features -- -D warnings` — clean (every gateway test target type-checks against the change)
- `cargo test -p llm-multimodal --all-features` — **365 passed, 0 failed**
- `cargo test -p smg` — **all test binaries pass, 0 failed**
- Across both crates: 36 test binaries, **3042 passed, 0 failed**

New or changed tests:

| Test | Asserts |
|---|---|
| `declares_image_and_video_limits` | video limit is 1 |
| `ragged_token_count_is_rejected` | 10 tokens over 3 frames → `InvalidPreprocessedField` |
| `missing_video_grid_is_rejected` | video item without `video_grid_thw` → `InvalidPreprocessedField` |
| `video_replacement_uses_the_video_pad_token` | now supplies a single-frame grid |
| `from_preprocessor_config_rejects_a_malformed_compression_block` | `"two"` fails at construction |
| `decode_video_rejects_an_invalid_long_side_cap` | caps 0 and 505 → `InvalidMaxLongSidePixel`, before any decode |
| `inconsistent_frame_descriptors_do_not_drive_the_allocation` | a descriptor with `len = isize::MAX` no longer panics; the clip is returned untouched |
| `parameterised_digest_differs_from_the_plain_digest_of_the_same_payload` | renamed from `..._never_equals_...` |

No model serving was involved: nothing here changes the tensors or the prompt layout that reach the backend on the paths that exist today. The only externally visible change is that a request with two or more videos to MiniMax-M3 is now rejected up front instead of failing after fetch and decode.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
