### PR TITLE
fix(router): distinguish worker overload shed responses

### DIFF
--- a/model_gateway/src/middleware/metrics.rs
+++ b/model_gateway/src/middleware/metrics.rs
@@ -280,9 +280,9 @@ mod tests {
             routers::error::HEADER_X_SMG_ERROR_CODE,
         };
 
-        // Simulates a backend minting a fresh X-SMG-Error-Code per response
-        // (rebuilt responses preserve upstream headers). Only gateway-set
-        // codes may become metric labels, so the interner must stay flat.
+        // Simulates a handler returning a fresh X-SMG-Error-Code per response.
+        // Only gateway-set codes may become metric labels, so the interner
+        // must stay flat.
         let app = Router::new()
             .route(
                 "/echo/{id}",

--- a/model_gateway/src/routers/anthropic/sse.rs
+++ b/model_gateway/src/routers/anthropic/sse.rs
@@ -19,7 +19,10 @@ use tracing::{debug, error, warn};
 
 use super::mcp::{IterationResult, McpToolCall};
 use crate::routers::{
-    common::sse::{SseDecodeError, SseDecoder, SseEncodeError, SseEncoder, SseFrame},
+    common::{
+        header_utils::is_smg_owned_response_header,
+        sse::{SseDecodeError, SseDecoder, SseEncodeError, SseEncoder, SseFrame},
+    },
     error::internal_error,
 };
 
@@ -70,14 +73,16 @@ pub(crate) fn build_sse_response(
 
     for (key, value) in &upstream_headers {
         let key_str = key.as_str();
-        if !matches!(
-            key_str,
-            "content-type"
-                | "cache-control"
-                | "connection"
-                | "transfer-encoding"
-                | "content-length"
-        ) {
+        if !is_smg_owned_response_header(key_str)
+            && !matches!(
+                key_str,
+                "content-type"
+                    | "cache-control"
+                    | "connection"
+                    | "transfer-encoding"
+                    | "content-length"
+            )
+        {
             builder = builder.header(key, value);
         }
     }
@@ -692,6 +697,23 @@ fn resolve_event(frame: SseFrame<'_>) -> Option<(Cow<'_, str>, Cow<'_, str>)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::routers::error::HEADER_X_SMG_ERROR_CODE;
+
+    #[test]
+    fn build_sse_response_drops_smg_owned_error_code() {
+        let mut upstream_headers = HeaderMap::new();
+        upstream_headers.insert(HEADER_X_SMG_ERROR_CODE, "forged".parse().unwrap());
+        upstream_headers.insert("x-upstream-id", "worker-a".parse().unwrap());
+
+        let response = build_sse_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            upstream_headers,
+            Body::empty(),
+        );
+
+        assert!(response.headers().get(HEADER_X_SMG_ERROR_CODE).is_none());
+        assert_eq!(response.headers().get("x-upstream-id").unwrap(), "worker-a");
+    }
 
     /// Decode `bytes` through the shared `SseDecoder` and resolve each frame
     /// to `(event_type, data)` the way `consume_and_forward` does.

--- a/model_gateway/src/routers/anthropic/sse.rs
+++ b/model_gateway/src/routers/anthropic/sse.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, warn};
 use super::mcp::{IterationResult, McpToolCall};
 use crate::routers::{
     common::{
-        header_utils::is_smg_owned_response_header,
+        header_utils::is_smg_owned_error_code_header,
         sse::{SseDecodeError, SseDecoder, SseEncodeError, SseEncoder, SseFrame},
     },
     error::internal_error,
@@ -73,7 +73,7 @@ pub(crate) fn build_sse_response(
 
     for (key, value) in &upstream_headers {
         let key_str = key.as_str();
-        if !is_smg_owned_response_header(key_str)
+        if !is_smg_owned_error_code_header(key_str)
             && !matches!(
                 key_str,
                 "content-type"

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -144,17 +144,17 @@ pub fn insert_routed_worker_id(headers: &mut HeaderMap, worker_url: &str) {
     }
 }
 
-/// Whether `name` is reserved for a response created by SMG itself.
+/// Whether `name` is SMG's own error-code response header.
 ///
 /// Backend responses must not mint this marker: downstream gateways use it to
 /// distinguish a gateway decision from an upstream response.
-pub(crate) fn is_smg_owned_response_header(name: &str) -> bool {
+pub(crate) fn is_smg_owned_error_code_header(name: &str) -> bool {
     name.eq_ignore_ascii_case(HEADER_X_SMG_ERROR_CODE)
 }
 
 /// Determine if a header should be forwarded without allocating (case-insensitive)
 fn should_forward_header_no_alloc(name: &str) -> bool {
-    // List of headers that should NOT be forwarded (hop-by-hop or SMG-owned).
+    // List of headers that should NOT be forwarded (hop-by-hop or SMG error-code).
     !(name.eq_ignore_ascii_case("connection")
         || name.eq_ignore_ascii_case("keep-alive")
         || name.eq_ignore_ascii_case("proxy-authenticate")
@@ -165,7 +165,7 @@ fn should_forward_header_no_alloc(name: &str) -> bool {
         || name.eq_ignore_ascii_case("upgrade")
         || name.eq_ignore_ascii_case("content-encoding")
         || name.eq_ignore_ascii_case("host")
-        || is_smg_owned_response_header(name))
+        || is_smg_owned_error_code_header(name))
 }
 
 /// API provider types for provider-specific header handling
@@ -419,7 +419,7 @@ mod tests {
 
         assert!(forwarded.get(HEADER_X_SMG_ERROR_CODE).is_none());
         assert_eq!(forwarded.get("x-upstream-id").unwrap(), "worker-a");
-        assert!(is_smg_owned_response_header("X-SMG-Error-Code"));
+        assert!(is_smg_owned_error_code_header("X-SMG-Error-Code"));
     }
 
     #[test]

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -7,6 +7,8 @@ use axum::{
 };
 use http::header::HeaderName;
 
+use crate::routers::error::HEADER_X_SMG_ERROR_CODE;
+
 static HEADER_TARGET_WORKER: HeaderName = HeaderName::from_static("x-smg-target-worker");
 static HEADER_ROUTING_KEY: HeaderName = HeaderName::from_static("x-smg-routing-key");
 static HEADER_ROUTING_TOKENS: HeaderName = HeaderName::from_static("x-smg-routing-tokens");
@@ -110,14 +112,14 @@ pub fn copy_request_headers(req: &Request<Body>) -> Vec<(String, String)> {
         .collect()
 }
 
-/// Convert headers from reqwest Response to axum HeaderMap
-/// Filters out hop-by-hop headers that shouldn't be forwarded
+/// Convert headers from reqwest Response to axum HeaderMap.
+///
+/// Filters out hop-by-hop and SMG-owned headers that must not be forwarded.
 pub fn preserve_response_headers(reqwest_headers: &HeaderMap) -> HeaderMap {
     let mut headers = HeaderMap::new();
 
     for (name, value) in reqwest_headers {
-        // Skip hop-by-hop headers that shouldn't be forwarded
-        // Use eq_ignore_ascii_case to avoid string allocation
+        // Use case-insensitive checks to avoid string allocation.
         if should_forward_header_no_alloc(name.as_str()) {
             // The original name and value are already valid, so we can just clone them
             headers.insert(name.clone(), value.clone());
@@ -142,10 +144,17 @@ pub fn insert_routed_worker_id(headers: &mut HeaderMap, worker_url: &str) {
     }
 }
 
+/// Whether `name` is reserved for a response created by SMG itself.
+///
+/// Backend responses must not mint this marker: downstream gateways use it to
+/// distinguish a gateway decision from an upstream response.
+pub(crate) fn is_smg_owned_response_header(name: &str) -> bool {
+    name.eq_ignore_ascii_case(HEADER_X_SMG_ERROR_CODE)
+}
+
 /// Determine if a header should be forwarded without allocating (case-insensitive)
 fn should_forward_header_no_alloc(name: &str) -> bool {
-    // List of headers that should NOT be forwarded (hop-by-hop headers)
-    // Use eq_ignore_ascii_case to avoid to_lowercase() allocation
+    // List of headers that should NOT be forwarded (hop-by-hop or SMG-owned).
     !(name.eq_ignore_ascii_case("connection")
         || name.eq_ignore_ascii_case("keep-alive")
         || name.eq_ignore_ascii_case("proxy-authenticate")
@@ -155,7 +164,8 @@ fn should_forward_header_no_alloc(name: &str) -> bool {
         || name.eq_ignore_ascii_case("transfer-encoding")
         || name.eq_ignore_ascii_case("upgrade")
         || name.eq_ignore_ascii_case("content-encoding")
-        || name.eq_ignore_ascii_case("host"))
+        || name.eq_ignore_ascii_case("host")
+        || is_smg_owned_response_header(name))
 }
 
 /// API provider types for provider-specific header handling
@@ -398,6 +408,19 @@ pub fn should_forward_request_header(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn preserve_response_headers_drops_smg_owned_error_code() {
+        let mut upstream = HeaderMap::new();
+        upstream.insert(HEADER_X_SMG_ERROR_CODE, HeaderValue::from_static("forged"));
+        upstream.insert("x-upstream-id", HeaderValue::from_static("worker-a"));
+
+        let forwarded = preserve_response_headers(&upstream);
+
+        assert!(forwarded.get(HEADER_X_SMG_ERROR_CODE).is_none());
+        assert_eq!(forwarded.get("x-upstream-id").unwrap(), "worker-a");
+        assert!(is_smg_owned_response_header("X-SMG-Error-Code"));
+    }
 
     #[test]
     fn apply_forwarded_request_headers_user_auth_wins_without_duplicate() {

--- a/model_gateway/src/routers/common/overload.rs
+++ b/model_gateway/src/routers/common/overload.rs
@@ -35,6 +35,13 @@ use crate::{
 /// a client hint, not a correctness input. Default matches the config default.
 static SHED_RETRY_AFTER_SECS: AtomicU64 = AtomicU64::new(10);
 
+/// Client-visible, gateway-owned code for a worker-overload-protection shed.
+///
+/// This deliberately covers both an all-overloaded candidate pool and the
+/// selection-to-dispatch re-check, where another worker may still be eligible.
+pub(crate) const WORKER_OVERLOAD_PROTECTION_SHED_ERROR_CODE: &str =
+    "worker_overload_protection_shed";
+
 /// Latch the poll interval the shed responses advertise. Called once at
 /// startup when the load monitor is built.
 pub fn set_shed_retry_after_secs(secs: u64) {
@@ -90,7 +97,8 @@ pub fn shed_if_worker_overloaded(worker: &dyn Worker, model_id: &str) -> Option<
 fn shed(branch: &'static str, stage: &'static str, worker: &str, message: String) -> Response {
     Metrics::record_worker_overload_shed(stage);
     debug!(branch, stage, worker, "Overload shed");
-    let mut response = error::service_unavailable("no_available_workers", message);
+    let mut response =
+        error::service_unavailable(WORKER_OVERLOAD_PROTECTION_SHED_ERROR_CODE, message);
     response.headers_mut().insert(
         RETRY_AFTER,
         HeaderValue::from(SHED_RETRY_AFTER_SECS.load(Ordering::Relaxed)),
@@ -127,10 +135,10 @@ mod tests {
         )
     }
 
-    /// The shed is the existing `no_available_workers` 503, taken from the
-    /// candidate pool rather than the model index.
+    /// The shed is a distinct 503, taken from the candidate pool rather than
+    /// the model index.
     #[test]
-    fn all_overloaded_sheds_with_no_available_workers_503() {
+    fn all_overloaded_sheds_with_distinct_503_code() {
         let a = worker("http://127.0.0.1:9801", "m");
         let b = worker("http://127.0.0.1:9802", "m");
         let pool = vec![Arc::clone(&a), Arc::clone(&b)];
@@ -146,7 +154,14 @@ mod tests {
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             extract_error_code_from_response(&response),
-            "no_available_workers"
+            "worker_overload_protection_shed"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(error::HEADER_X_SMG_ERROR_CODE)
+                .expect("gateway error code header"),
+            "worker_overload_protection_shed"
         );
     }
 
@@ -212,7 +227,14 @@ mod tests {
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             extract_error_code_from_response(&response),
-            "no_available_workers"
+            "worker_overload_protection_shed"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(error::HEADER_X_SMG_ERROR_CODE)
+                .expect("gateway error code header"),
+            "worker_overload_protection_shed"
         );
     }
 }

--- a/model_gateway/src/routers/error.rs
+++ b/model_gateway/src/routers/error.rs
@@ -25,8 +25,9 @@ struct ErrorDetail<'a> {
 pub const HEADER_X_SMG_ERROR_CODE: &str = "X-SMG-Error-Code";
 
 /// Gateway-minted error code, carried as a process-local response extension.
-/// Upstream responses can forge the `X-SMG-Error-Code` header (rebuilt
-/// responses preserve upstream headers) but can never inject an extension.
+///
+/// Keep metrics independent of client-visible headers: only [`create_error`]
+/// adds this extension.
 #[derive(Clone)]
 struct GatewayErrorCode(String);
 
@@ -117,8 +118,7 @@ pub fn model_not_found(model: &str) -> Response {
 /// Error-code metric label for a response.
 ///
 /// Reads only the [`GatewayErrorCode`] extension set by [`create_error`],
-/// never the `X-SMG-Error-Code` header: a backend-supplied header value would
-/// otherwise mint unbounded metric label values.
+/// never the client-visible `X-SMG-Error-Code` header.
 pub fn extract_error_code_from_response<B>(response: &Response<B>) -> &str {
     response
         .extensions()
@@ -194,9 +194,9 @@ mod tests {
     }
 
     #[test]
-    fn extract_error_code_ignores_upstream_supplied_header() {
-        // A response rebuilt from preserved upstream headers carries the
-        // header but no extension; it must not become a metric label.
+    fn extract_error_code_ignores_header_without_gateway_extension() {
+        // A response without a gateway extension must not mint a metric label,
+        // even if another response decorator adds the public header.
         let mut response = StatusCode::INTERNAL_SERVER_ERROR.into_response();
         response.headers_mut().insert(
             HEADER_X_SMG_ERROR_CODE,

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -970,7 +970,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             error::extract_error_code_from_response(&response),
-            "no_available_workers"
+            "worker_overload_protection_shed"
         );
         assert!(
             !is_retryable_response(&response),
@@ -1208,8 +1208,8 @@ mod tests {
         }
     }
 
-    /// The gRPC transport must shed an all-overloaded model with the same 503
-    /// `no_available_workers` the HTTP router uses. Its usual empty-pool answer
+    /// The gRPC transport must shed an all-overloaded model with the same
+    /// distinct overload 503 the HTTP router uses. Its usual empty-pool answer
     /// is a 404, which would both misreport pressure as model absence and skip
     /// the retry path (404 is not retryable).
     #[test]
@@ -1262,7 +1262,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             extract_error_code_from_response(&response),
-            "no_available_workers"
+            "worker_overload_protection_shed"
         );
 
         // Recovery re-admits, and the failure response goes back to 404 for a

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -2154,7 +2154,7 @@ mod tests {
         sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
     };
 
-    use axum::http::header::CONTENT_LENGTH;
+    use axum::http::header::{CONTENT_LENGTH, RETRY_AFTER};
     use openai_protocol::worker::HealthCheckConfig;
 
     use super::*;
@@ -2363,6 +2363,36 @@ mod tests {
         assert!(router
             .select_worker_for_model(crate::worker::UNKNOWN_MODEL_ID, None, None, None, None)
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn unavailable_workers_keep_generic_503_without_retry_after() {
+        let router = create_test_regular_router();
+        for worker in router.worker_registry.get_all() {
+            worker.set_status(openai_protocol::worker::WorkerStatus::NotReady);
+        }
+
+        let response = router
+            .route_typed_request(
+                None,
+                DropProbeRequest {
+                    text: "unavailable".to_string(),
+                    _probe: Arc::new(()),
+                },
+                "/generate",
+                crate::worker::UNKNOWN_MODEL_ID,
+            )
+            .await;
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response
+                .headers()
+                .get(error::HEADER_X_SMG_ERROR_CODE)
+                .expect("gateway error code header"),
+            "no_available_workers"
+        );
+        assert!(response.headers().get(RETRY_AFTER).is_none());
     }
 
     fn rerank_request() -> RerankRequest {


### PR DESCRIPTION
## Description

### Problem

`--worker-overload-protection` returns the same `503/no_available_workers` response for overload sheds as it does for genuine worker-availability failures. A downstream gateway cannot safely recognize an overload shed and apply its own client-facing policy.

### Solution

Keep the HTTP status as `503` and retain `Retry-After`, but emit the stable SMG-owned `worker_overload_protection_shed` code only when the overload guard sheds a request. Reserve `X-SMG-Error-Code` on upstream response forwarding so a worker cannot forge that signal.

## Changes

- Return `503/worker_overload_protection_shed` for both all-overloaded candidate pools and the selection-to-dispatch overload re-check.
- Preserve `503/no_available_workers` for ordinary unavailable-worker and circuit-breaker paths.
- Remove SMG-owned error-code headers from regular upstream pass-through and Anthropic SSE responses.
- Cover HTTP, gRPC/PD, dispatch-time, and upstream-header behavior.

Closes #2406

## Test Plan

- `cargo +nightly fmt --all`
- `cargo +nightly clippy --workspace --all-targets -- -D warnings`
- `cargo +nightly test -p smg --lib` — 1,920 passed, 5 ignored.
- Focused coverage verifies all-overloaded and dispatch-time sheds, the gRPC/PD path, ordinary unavailable workers, and regular plus Anthropic SSE upstream header filtering.
- `cargo +nightly test` still has one pre-existing local failure in `test_router_with_tracing`: the OTLP collector receives zero spans. The same test fails on untouched `origin/main` at `7e602665`.
- The all-features clippy gate requires a local OpenCV `opencv4.pc`; it is unavailable on this host, so the documented workspace fallback above was used.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (requires local OpenCV)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
