### PR TITLE
feat(api): serve engine load from the gateway's cached snapshot

### DIFF
--- a/clients/openapi-gen/src/main.rs
+++ b/clients/openapi-gen/src/main.rs
@@ -51,6 +51,15 @@ struct Operation {
     #[serde(rename = "requestBody")]
     request_body: Option<RequestBody>,
     responses: BTreeMap<String, Response>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    deprecated: bool,
+}
+
+impl Operation {
+    fn deprecated(mut self) -> Self {
+        self.deprecated = true;
+        self
+    }
 }
 
 #[derive(Clone, Serialize)]
@@ -227,6 +236,17 @@ fn path_param(name: &str) -> Parameter {
     }
 }
 
+fn optional_query_param(name: &str) -> Parameter {
+    Parameter {
+        name: name.to_string(),
+        location: "query".to_string(),
+        required: false,
+        schema: ParameterSchema {
+            schema_type: "string".to_string(),
+        },
+    }
+}
+
 fn operation(
     op_id: &str,
     summary: &str,
@@ -240,6 +260,7 @@ fn operation(
         parameters: params,
         request_body,
         responses,
+        deprecated: false,
     }
 }
 
@@ -575,6 +596,35 @@ fn main() -> anyhow::Result<()> {
                 None,
                 worker_accepted_response("Worker deletion accepted"),
             )),
+            ..PathItem::default()
+        },
+    );
+
+    // ---- Fleet load ----
+    let worker_load_name = collect_schema(schema_for!(WorkerLoadResponse), &mut schemas)?;
+    let loads_operation = |op_id: &str, summary: &str| {
+        operation(
+            op_id,
+            summary,
+            Some(vec![optional_query_param("model")]),
+            None,
+            json_response(&worker_load_name, summary),
+        )
+    };
+    paths.insert(
+        "/loads".to_string(),
+        PathItem {
+            get: Some(loads_operation(
+                "getLoads",
+                "Cached engine load for every worker, plus a fleet aggregate",
+            )),
+            ..PathItem::default()
+        },
+    );
+    paths.insert(
+        "/get_loads".to_string(),
+        PathItem {
+            get: Some(loads_operation("getLoadsLegacy", "Deprecated alias of /loads").deprecated()),
             ..PathItem::default()
         },
     );

--- a/crates/grpc_client/src/sglang_scheduler.rs
+++ b/crates/grpc_client/src/sglang_scheduler.rs
@@ -780,6 +780,10 @@ impl From<proto::SchedulerLoad> for openai_protocol::worker::SchedulerLoadSnapsh
                 },
             );
         Self {
+            // Set only by a gateway reporting a fleet; an engine reports
+            // ranks, not which worker they came from.
+            worker: None,
+            worker_type: None,
             dp_rank: load.dp_rank,
             num_running_reqs: load.num_running_reqs,
             num_waiting_reqs: load.num_waiting_reqs,

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -15,7 +15,7 @@ use axum::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "axum")]
-use serde_json::{json, Value};
+use serde_json::json;
 
 use super::model_card::ModelCard;
 
@@ -866,6 +866,13 @@ pub struct WorkerInfo {
     #[serde(default)]
     pub http2: bool,
 
+    /// The worker's last polled engine load, as published by the load
+    /// monitor. `None` when load monitoring has produced nothing for this
+    /// worker yet. Unrelated to `load` above, which counts in-flight
+    /// requests the router has sent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine_load: Option<WorkerLoadResponse>,
+
     /// Job status for async operations (if available).
     pub job_status: Option<JobStatus>,
 }
@@ -881,6 +888,7 @@ impl WorkerInfo {
             status: Some(WorkerStatus::Pending),
             load: 0,
             http2: false,
+            engine_load: None,
             job_status,
         }
     }
@@ -1251,22 +1259,20 @@ pub struct StopProfileRequest {
     pub url: Option<String>,
 }
 
-/// Result from getting worker loads
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct WorkerLoadsResult {
-    pub loads: Vec<WorkerLoadInfo>,
-    pub total_workers: usize,
-    pub successful: usize,
-    pub failed: usize,
-}
-
 /// Per-DP-rank load snapshot from a backend.
 ///
 /// Contains core metrics from the sglang `/v1/loads` endpoint or `GetLoads` gRPC RPC.
 /// Each snapshot represents one data-parallel rank's scheduler state.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub struct SchedulerLoadSnapshot {
+    /// URL of the worker this rank belongs to. Set by a gateway serving a
+    /// fleet-wide `/loads`; engines reporting their own load leave it unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worker: Option<String>,
+    /// `regular`, `prefill`, `decode`, or `encode`. Set alongside `worker`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worker_type: Option<String>,
     pub dp_rank: i32,
     pub num_running_reqs: i32,
     pub num_waiting_reqs: i32,
@@ -1303,7 +1309,7 @@ pub struct SchedulerLoadSnapshot {
     pub disagg_mode: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub struct EngineMemoryMetricsSnapshot {
     pub weight_gb: f64,
@@ -1312,7 +1318,7 @@ pub struct EngineMemoryMetricsSnapshot {
     pub token_capacity: i32,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub struct EngineQueueMetricsSnapshot {
     pub waiting: i32,
@@ -1321,7 +1327,7 @@ pub struct EngineQueueMetricsSnapshot {
     pub retracted: i32,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub struct EngineAggregateMetricsSnapshot {
     pub total_running_reqs: i32,
@@ -1332,8 +1338,41 @@ pub struct EngineAggregateMetricsSnapshot {
     pub avg_utilization: f64,
 }
 
+impl EngineAggregateMetricsSnapshot {
+    /// Roll per-rank snapshots up into one summary. Counts sum, ratios
+    /// average, rounded the way the engine servicers round so a gateway
+    /// aggregate and an engine aggregate read the same.
+    ///
+    /// Returns `None` for an empty slice: no ranks reported means no load
+    /// data, which must not read as an idle fleet.
+    pub fn from_ranks(loads: &[SchedulerLoadSnapshot]) -> Option<Self> {
+        if loads.is_empty() {
+            return None;
+        }
+        let n = loads.len() as f64;
+        let sum_i32 = |f: fn(&SchedulerLoadSnapshot) -> i32| {
+            loads.iter().map(f).fold(0i32, i32::saturating_add)
+        };
+        let avg = |f: fn(&SchedulerLoadSnapshot) -> f64, decimals: i32| {
+            let scale = 10f64.powi(decimals);
+            (loads.iter().map(f).sum::<f64>() / n * scale).round() / scale
+        };
+
+        let total_running_reqs = sum_i32(|l| l.num_running_reqs);
+        let total_waiting_reqs = sum_i32(|l| l.num_waiting_reqs);
+        Some(Self {
+            total_running_reqs,
+            total_waiting_reqs,
+            total_reqs: total_running_reqs.saturating_add(total_waiting_reqs),
+            avg_token_usage: avg(|l| l.token_usage, 4),
+            avg_throughput: avg(|l| l.gen_throughput, 2),
+            avg_utilization: avg(|l| l.utilization, 4),
+        })
+    }
+}
+
 /// Full load response for a single worker across all DP ranks.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub struct WorkerLoadResponse {
     pub timestamp: String,
@@ -1365,9 +1404,10 @@ impl WorkerLoadResponse {
     /// A running engine always reports its KV token capacity, so a positive
     /// `max_total_num_tokens` on any rank marks the absolute-token fields
     /// (`num_used_tokens`, `dp_rank_loads`, `total_used_tokens`) as
-    /// meaningful. Callers that need absolute tokens — the `/get_loads`
-    /// scalar and the DP-rank load cache — should gate on this so a
-    /// ratio-only snapshot is not read as "0 tokens used".
+    /// meaningful. Callers that need absolute tokens — the DP-rank load
+    /// cache — should gate on this so a ratio-only snapshot is not read as
+    /// "0 tokens used", and on [`Self::ranks_are_dp_ranks`] so a fleet
+    /// rollup is not read as one engine's ranks.
     pub fn has_absolute_token_data(&self) -> bool {
         self.loads.iter().any(|l| l.max_total_num_tokens > 0)
     }
@@ -1390,6 +1430,17 @@ impl WorkerLoadResponse {
         self.loads.iter().map(|l| l.gen_throughput).sum()
     }
 
+    /// Whether these ranks are one engine's DP ranks rather than a
+    /// gateway's fleet rollup, where every entry names its own `worker`.
+    ///
+    /// `dp_rank` is only unique within an engine, so a rollup repeats
+    /// `dp_rank: 0` once per non-DP worker. Callers that key by rank — the
+    /// DP-rank load cache — must gate on this, or one worker's entry
+    /// overwrites another's.
+    pub fn ranks_are_dp_ranks(&self) -> bool {
+        self.loads.iter().all(|l| l.worker.is_none())
+    }
+
     pub fn dp_rank_loads(&self) -> HashMap<isize, isize> {
         let mut map = HashMap::new();
         for snapshot in &self.loads {
@@ -1397,17 +1448,6 @@ impl WorkerLoadResponse {
         }
         map
     }
-}
-
-/// Individual worker load information
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct WorkerLoadInfo {
-    pub worker: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub worker_type: Option<String>,
-    pub load: isize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub details: Option<WorkerLoadResponse>,
 }
 
 #[cfg(feature = "axum")]
@@ -1475,24 +1515,6 @@ impl IntoResponse for ProfileResult {
         }
 
         (status, Json(body)).into_response()
-    }
-}
-
-#[cfg(feature = "axum")]
-impl IntoResponse for WorkerLoadsResult {
-    fn into_response(self) -> Response {
-        let loads: Vec<Value> = self
-            .loads
-            .iter()
-            .map(|info| {
-                let mut entry = json!({"worker": &info.worker, "load": info.load});
-                if let Some(ref details) = info.details {
-                    entry["details"] = json!(details);
-                }
-                entry
-            })
-            .collect();
-        Json(json!({"workers": loads})).into_response()
     }
 }
 
@@ -1716,5 +1738,75 @@ mod overload_update_tests {
             token_usage: Some(1.0),
         };
         assert!(!update.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod aggregate_rollup_tests {
+    use super::{EngineAggregateMetricsSnapshot, SchedulerLoadSnapshot};
+
+    fn rank(
+        num_running_reqs: i32,
+        num_waiting_reqs: i32,
+        token_usage: f64,
+        gen_throughput: f64,
+        utilization: f64,
+    ) -> SchedulerLoadSnapshot {
+        SchedulerLoadSnapshot {
+            num_running_reqs,
+            num_waiting_reqs,
+            token_usage,
+            gen_throughput,
+            utilization,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn no_ranks_is_none_not_idle() {
+        assert!(EngineAggregateMetricsSnapshot::from_ranks(&[]).is_none());
+    }
+
+    #[test]
+    fn counts_sum_and_ratios_average() {
+        let aggregate = EngineAggregateMetricsSnapshot::from_ranks(&[
+            rank(4, 1, 0.2, 100.0, 0.3),
+            rank(6, 3, 0.6, 200.0, 0.7),
+        ])
+        .expect("aggregate");
+
+        assert_eq!(aggregate.total_running_reqs, 10);
+        assert_eq!(aggregate.total_waiting_reqs, 4);
+        assert_eq!(aggregate.total_reqs, 14);
+        assert_eq!(aggregate.avg_token_usage, 0.4);
+        assert_eq!(aggregate.avg_throughput, 150.0);
+        assert_eq!(aggregate.avg_utilization, 0.5);
+    }
+
+    #[test]
+    fn averages_round_the_way_the_engines_round() {
+        // 1/3 at 4 decimals for ratios, 2 for throughput.
+        let aggregate = EngineAggregateMetricsSnapshot::from_ranks(&[
+            rank(0, 0, 1.0, 1.0, 1.0),
+            rank(0, 0, 0.0, 0.0, 0.0),
+            rank(0, 0, 0.0, 0.0, 0.0),
+        ])
+        .expect("aggregate");
+
+        assert_eq!(aggregate.avg_token_usage, 0.3333);
+        assert_eq!(aggregate.avg_throughput, 0.33);
+        assert_eq!(aggregate.avg_utilization, 0.3333);
+    }
+
+    #[test]
+    fn counts_saturate_instead_of_overflowing() {
+        let aggregate = EngineAggregateMetricsSnapshot::from_ranks(&[
+            rank(i32::MAX, i32::MAX, 0.0, 0.0, 0.0),
+            rank(1, 1, 0.0, 0.0, 0.0),
+        ])
+        .expect("aggregate");
+
+        assert_eq!(aggregate.total_running_reqs, i32::MAX);
+        assert_eq!(aggregate.total_reqs, i32::MAX);
     }
 }

--- a/model_gateway/benches/workers_endpoint.rs
+++ b/model_gateway/benches/workers_endpoint.rs
@@ -97,6 +97,7 @@ fn deep_clone_info(w: &Arc<dyn Worker>) -> WorkerInfo {
         status: Some(status),
         load: w.load(),
         http2: meta.http2,
+        engine_load: None,
         job_status: None,
     }
 }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -564,16 +564,21 @@ async fn stop_profile(
         .into_response()
 }
 
-async fn get_loads(State(state): State<Arc<AppState>>, _req: Request) -> Response {
-    WorkerManager::get_all_worker_loads(
+async fn get_loads(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ListWorkersQuery>,
+) -> Response {
+    let snapshot = state
+        .context
+        .worker_monitor
+        .as_ref()
+        .map(|monitor| monitor.load_snapshot())
+        .unwrap_or_default();
+    Json(WorkerManager::fleet_loads(
         &state.context.worker_registry,
-        state
-            .context
-            .worker_monitor
-            .as_ref()
-            .map(|monitor| monitor.native_loads_absent()),
-    )
-    .await
+        &snapshot,
+        query.model.as_deref(),
+    ))
     .into_response()
 }
 
@@ -591,11 +596,17 @@ async fn list_workers_rest(
     State(state): State<Arc<AppState>>,
     Query(query): Query<ListWorkersQuery>,
 ) -> Response {
-    state
+    let mut result = state
         .context
         .worker_service
-        .list_workers(query.model.as_deref())
-        .into_response()
+        .list_workers(query.model.as_deref());
+    if let Some(monitor) = state.context.worker_monitor.as_ref() {
+        let snapshot = monitor.load_snapshot();
+        for info in &mut result.workers {
+            info.engine_load = snapshot.get(&info.spec.url).cloned();
+        }
+    }
+    result.into_response()
 }
 
 async fn get_worker(
@@ -603,7 +614,13 @@ async fn get_worker(
     Path(worker_id_raw): Path<String>,
 ) -> Response {
     match state.context.worker_service.get_worker(&worker_id_raw) {
-        Ok(result) => result.into_response(),
+        Ok(mut result) => {
+            if let Some(monitor) = state.context.worker_monitor.as_ref() {
+                let snapshot = monitor.load_snapshot();
+                result.0.engine_load = snapshot.get(&result.0.spec.url).cloned();
+            }
+            result.into_response()
+        }
         Err(err) => err.into_response(),
     }
 }
@@ -919,6 +936,7 @@ pub fn build_app(
         .route("/health", get(health))
         .route("/health_generate", get(health_generate))
         .route("/engine_metrics", get(engine_metrics))
+        .route("/loads", get(get_loads))
         .route("/v1/models", get(v1_models))
         .route("/get_model_info", get(get_model_info))
         .route("/get_server_info", get(get_server_info));
@@ -928,6 +946,7 @@ pub fn build_app(
         .route("/flush_cache", post(flush_cache))
         .route("/start_profile", post(start_profile))
         .route("/stop_profile", post(stop_profile))
+        // Deprecated alias of the public `/loads`.
         .route("/get_loads", get(get_loads))
         .route("/parse/function_call", post(parse_function_call))
         .route("/parse/reasoning", post(parse_reasoning))

--- a/model_gateway/src/worker/load_state.rs
+++ b/model_gateway/src/worker/load_state.rs
@@ -133,7 +133,6 @@ impl LoadState {
     }
 
     /// The current snapshot — one `Arc` clone, no lock held afterwards.
-    #[cfg(test)]
     pub(crate) fn snapshot(&self) -> Arc<LoadSnapshot> {
         self.tx.borrow().clone()
     }

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -11,15 +11,12 @@ use std::{
 };
 
 use axum::response::{IntoResponse, Response};
-use dashmap::DashSet;
-use futures::{
-    future,
-    stream::{self, FuturesUnordered, StreamExt},
-};
+use chrono::Utc;
+use futures::stream::{self, FuturesUnordered, StreamExt};
 use http::StatusCode;
 use openai_protocol::worker::{
-    FlushCacheResult, HealthCheckConfig, ProfileOptions, ProfileResult, WorkerLoadInfo,
-    WorkerLoadsResult, WorkerStatus,
+    EngineAggregateMetricsSnapshot, FlushCacheResult, HealthCheckConfig, ProfileOptions,
+    ProfileResult, SchedulerLoadSnapshot, WorkerLoadResponse, WorkerStatus,
 };
 use tokio::{
     sync::{broadcast, mpsc, Notify},
@@ -31,11 +28,11 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     worker::{
         event::{WorkerConnected, WorkerEvent},
+        load_state::LoadSnapshot,
         metrics_aggregator::{self, MetricPack},
-        monitor::WorkerMonitor,
         registry::{WorkerDescriptor, WorkerId},
         worker::WorkerTypeExt,
-        ConnectionMode, Worker, WorkerOrigin, WorkerRegistry, WorkerResult, WorkerType,
+        ConnectionMode, Worker, WorkerOrigin, WorkerRegistry, WorkerResult,
     },
     workflow::{Job, JobQueue},
 };
@@ -112,9 +109,9 @@ impl IntoResponse for EngineMetricsResult {
 /// events to keep its internal schedule in sync with registrations,
 /// removals, and replacements.
 ///
-/// The static fan-out helpers (`get_worker_urls`, `flush_cache_all`,
-/// `get_all_worker_loads`, `get_engine_metrics`) are operational commands
-/// that don't depend on lifecycle state and remain associated functions.
+/// The static helpers (`get_worker_urls`, `flush_cache_all`,
+/// `get_engine_metrics`, `fleet_loads`) are operational commands that
+/// don't depend on lifecycle state and remain associated functions.
 pub struct WorkerManager {
     handle: Option<JoinHandle<()>>,
     shutdown_notify: Arc<Notify>,
@@ -1065,60 +1062,47 @@ impl WorkerManager {
         }
     }
 
-    pub async fn get_all_worker_loads(
+    /// Build the fleet-wide load body from the monitor's published
+    /// snapshot: the same numbers the routing policies are acting on.
+    ///
+    /// No request reaches a worker. That is what makes the route safe to
+    /// stack — a gateway registered as a worker under another gateway
+    /// answers from its cache instead of fanning one upstream poll out
+    /// across its whole fleet.
+    ///
+    /// Workers the monitor has no load for are left out rather than reported
+    /// as idle, so a gateway that has not polled yet answers with an empty
+    /// `loads` array.
+    pub(crate) fn fleet_loads(
         worker_registry: &WorkerRegistry,
-        native_loads_absent: Option<&DashSet<String>>,
-    ) -> WorkerLoadsResult {
-        let workers = worker_registry.get_all();
-        let total_workers = workers.len();
+        snapshot: &LoadSnapshot,
+        model_id: Option<&str>,
+    ) -> WorkerLoadResponse {
+        let mut workers = worker_registry.get_all();
+        workers.sort_by(|a, b| a.url().cmp(b.url()));
 
-        let futures: Vec<_> = workers
-            .iter()
-            .map(|worker| {
-                let worker_type = match worker.worker_type() {
-                    WorkerType::Regular => None,
-                    WorkerType::Prefill => Some("prefill".to_string()),
-                    WorkerType::Decode => Some("decode".to_string()),
-                    WorkerType::Encode => Some("encode".to_string()),
-                };
-                let connection_mode = worker.connection_mode();
-                let worker = Arc::clone(worker);
+        let mut loads = Vec::new();
+        for worker in workers {
+            if model_id.is_some_and(|model| !worker.supports_model(model)) {
+                continue;
+            }
+            let Some(report) = snapshot.get(worker.url()) else {
+                continue;
+            };
+            let worker_type = worker.worker_type().to_string();
+            loads.extend(report.loads.iter().map(|rank| SchedulerLoadSnapshot {
+                worker: Some(worker.url().to_string()),
+                worker_type: Some(worker_type.clone()),
+                ..rank.clone()
+            }));
+        }
 
-                async move {
-                    let details = match connection_mode {
-                        ConnectionMode::Http => {
-                            WorkerMonitor::fetch_http_load(&worker, native_loads_absent).await
-                        }
-                        ConnectionMode::Grpc | ConnectionMode::Zmq => {
-                            WorkerMonitor::fetch_backend_load(&worker).await
-                        }
-                    };
-                    // `load` is the absolute used-token count. Report it only
-                    // when the backend actually provides absolute tokens
-                    let load = details
-                        .as_ref()
-                        .filter(|d| d.has_absolute_token_data())
-                        .map(|d| d.total_used_tokens() as isize)
-                        .unwrap_or(-1);
-                    WorkerLoadInfo {
-                        worker: worker.url().to_string(),
-                        worker_type,
-                        load,
-                        details,
-                    }
-                }
-            })
-            .collect();
-
-        let loads = future::join_all(futures).await;
-        let successful = loads.iter().filter(|l| l.load >= 0).count();
-        let failed = loads.iter().filter(|l| l.load < 0).count();
-
-        WorkerLoadsResult {
+        WorkerLoadResponse {
+            timestamp: Utc::now().to_rfc3339(),
+            version: format!("smg-{}", env!("CARGO_PKG_VERSION")),
+            dp_rank_count: loads.len() as i32,
+            aggregate: EngineAggregateMetricsSnapshot::from_ranks(&loads),
             loads,
-            total_workers,
-            successful,
-            failed,
         }
     }
 
@@ -1175,7 +1159,10 @@ mod tests {
         },
     };
 
-    use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
+    use openai_protocol::{
+        model_card::ModelCard,
+        worker::{HealthCheckConfig, WorkerStatus},
+    };
 
     use super::*;
     use crate::worker::{
@@ -1950,6 +1937,141 @@ mod tests {
         let result = WorkerManager::stop_profile_all(&registry, Some(url_a.as_str())).await;
         assert_eq!(result.total_workers, 1);
         assert_eq!(result.successful, vec![url_a]);
+    }
+
+    fn load_report(ranks: &[(i32, i32, i32, f64)]) -> WorkerLoadResponse {
+        let loads: Vec<SchedulerLoadSnapshot> = ranks
+            .iter()
+            .map(
+                |&(dp_rank, num_running_reqs, num_waiting_reqs, token_usage)| {
+                    SchedulerLoadSnapshot {
+                        dp_rank,
+                        num_running_reqs,
+                        num_waiting_reqs,
+                        token_usage,
+                        ..Default::default()
+                    }
+                },
+            )
+            .collect();
+        WorkerLoadResponse {
+            timestamp: "2026-09-03T00:00:00Z".to_string(),
+            version: "engine-test".to_string(),
+            dp_rank_count: loads.len() as i32,
+            aggregate: None,
+            loads,
+        }
+    }
+
+    fn make_model_worker(url: &str, model: &str) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(WorkerType::Regular)
+                .models(vec![ModelCard::new(model)])
+                .build(),
+        )
+    }
+
+    #[test]
+    fn fleet_loads_tags_ranks_and_aggregates() {
+        let registry = WorkerRegistry::new();
+        // Registered out of order to prove the response sorts by URL.
+        registry.register(make_worker("http://w:2", 1, 1)).unwrap();
+        registry.register(make_worker("http://w:1", 1, 1)).unwrap();
+
+        let snapshot = LoadSnapshot::from_loads_for_test(vec![
+            (
+                "http://w:1".to_string(),
+                load_report(&[(0, 4, 1, 0.25), (1, 6, 3, 0.75)]),
+            ),
+            ("http://w:2".to_string(), load_report(&[(0, 2, 0, 0.5)])),
+        ]);
+
+        let body = WorkerManager::fleet_loads(&registry, &snapshot, None);
+
+        assert_eq!(body.dp_rank_count, 3);
+        assert_eq!(body.loads.len(), 3);
+        assert!(body.version.starts_with("smg-"));
+        assert!(!body.timestamp.is_empty());
+
+        let tagged: Vec<(&str, &str, i32)> = body
+            .loads
+            .iter()
+            .map(|rank| {
+                (
+                    rank.worker.as_deref().expect("worker url"),
+                    rank.worker_type.as_deref().expect("worker type"),
+                    rank.dp_rank,
+                )
+            })
+            .collect();
+        assert_eq!(
+            tagged,
+            vec![
+                ("http://w:1", "regular", 0),
+                ("http://w:1", "regular", 1),
+                ("http://w:2", "regular", 0),
+            ]
+        );
+
+        let aggregate = body.aggregate.expect("aggregate");
+        assert_eq!(aggregate.total_running_reqs, 12);
+        assert_eq!(aggregate.total_waiting_reqs, 4);
+        assert_eq!(aggregate.total_reqs, 16);
+        assert_eq!(aggregate.avg_token_usage, 0.5);
+    }
+
+    #[test]
+    fn fleet_loads_filters_by_model() {
+        let registry = WorkerRegistry::new();
+        registry
+            .register(make_model_worker("http://a:1", "gpt-4o"))
+            .unwrap();
+        registry
+            .register(make_model_worker("http://b:1", "o3"))
+            .unwrap();
+
+        let snapshot = LoadSnapshot::from_loads_for_test(vec![
+            ("http://a:1".to_string(), load_report(&[(0, 5, 0, 0.5)])),
+            ("http://b:1".to_string(), load_report(&[(0, 9, 0, 0.9)])),
+        ]);
+
+        let body = WorkerManager::fleet_loads(&registry, &snapshot, Some("gpt-4o"));
+
+        assert_eq!(body.dp_rank_count, 1);
+        assert_eq!(body.loads[0].worker.as_deref(), Some("http://a:1"));
+        assert_eq!(body.aggregate.expect("aggregate").total_running_reqs, 5);
+    }
+
+    #[test]
+    fn fleet_loads_omits_workers_without_a_report() {
+        let registry = WorkerRegistry::new();
+        registry.register(make_worker("http://w:1", 1, 1)).unwrap();
+        registry.register(make_worker("http://w:2", 1, 1)).unwrap();
+
+        // Only one worker has been polled: the other must be absent rather
+        // than reported as idle.
+        let snapshot = LoadSnapshot::from_loads_for_test(vec![(
+            "http://w:2".to_string(),
+            load_report(&[(0, 7, 2, 0.4)]),
+        )]);
+
+        let body = WorkerManager::fleet_loads(&registry, &snapshot, None);
+
+        assert_eq!(body.dp_rank_count, 1);
+        assert_eq!(body.loads[0].worker.as_deref(), Some("http://w:2"));
+    }
+
+    #[test]
+    fn fleet_loads_with_no_polled_workers_has_no_aggregate() {
+        let registry = WorkerRegistry::new();
+        registry.register(make_worker("http://w:1", 1, 1)).unwrap();
+
+        let body = WorkerManager::fleet_loads(&registry, &LoadSnapshot::default(), None);
+
+        assert_eq!(body.dp_rank_count, 0);
+        assert!(body.loads.is_empty());
+        assert!(body.aggregate.is_none());
     }
 
     #[tokio::test]

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -54,7 +54,7 @@ use std::{
     time::Duration,
 };
 
-use dashmap::DashSet;
+use dashmap::DashMap;
 use futures::future;
 use openai_protocol::worker::{
     RuntimeType, SchedulerLoadSnapshot, WorkerGroupKey, WorkerLoadResponse, WorkerStatus,
@@ -69,7 +69,7 @@ use crate::{
     policies::PolicyRegistry,
     worker::{
         event::WorkerEvent,
-        load_state::{LoadReceiver, LoadState},
+        load_state::{LoadReceiver, LoadSnapshot, LoadState},
         ConnectionMode, Worker, WorkerRegistry,
     },
 };
@@ -209,13 +209,105 @@ struct GroupState {
     interval: Duration,
 }
 
-/// Outcome of probing a worker's `/v1/loads` endpoint.
+/// Outcome of probing one native load endpoint.
 enum NativeLoads {
     Available(WorkerLoadResponse),
     /// The backend answered, and the endpoint is not there. Memoizable.
     Absent,
     /// Nothing was learned about the endpoint — retry on the next tick.
     Inconclusive,
+}
+
+/// A route that answers with the native load schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NativeLoadsPath {
+    /// `/loads` — an SMG gateway registered as a worker.
+    Gateway,
+    /// `/v1/loads` — the engine-native route.
+    Engine,
+}
+
+impl NativeLoadsPath {
+    /// Probe order for a worker nothing is memoized about. Gateway first:
+    /// a gateway serves only `/loads`, and an engine 404s it once and is
+    /// then memoized onto its own route.
+    const DISCOVERY: [Self; 2] = [Self::Gateway, Self::Engine];
+
+    fn index(self) -> usize {
+        match self {
+            Self::Gateway => 0,
+            Self::Engine => 1,
+        }
+    }
+
+    /// Where to probe this route on `worker`.
+    fn probe_url(self, worker: &Arc<dyn Worker>) -> String {
+        let base = worker.url();
+        match self {
+            // Sections beyond `core` degrade gracefully: an engine that does
+            // not report them omits the fields, which deserialize to `None`.
+            Self::Engine => format!("{base}/v1/loads?include=core,disagg,queues,memory"),
+            // A gateway serves a whole fleet, so an unscoped `/loads` blends
+            // every model it fronts. A worker registered for exactly one
+            // model must be asked about that model alone.
+            Self::Gateway => match worker.models().as_slice() {
+                [card] => {
+                    let model: String =
+                        url::form_urlencoded::byte_serialize(card.id.as_bytes()).collect();
+                    format!("{base}/loads?model={model}")
+                }
+                _ => format!("{base}/loads"),
+            },
+        }
+    }
+}
+
+/// What a worker's probes have established about its native load routes.
+///
+/// Absence is tracked per route, not per worker: a 404 on one route is a
+/// fact that outlives a timeout on the other. Collapsing the two into a
+/// single "answered nothing" flag would discard the 404 whenever the other
+/// route was merely inconclusive, and the dead route would be re-asked on
+/// every tick forever.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct NativeLoadsMemo {
+    answered: Option<NativeLoadsPath>,
+    absent: [bool; NativeLoadsPath::DISCOVERY.len()],
+}
+
+impl NativeLoadsMemo {
+    /// Routes worth probing this tick, in discovery order: the route that
+    /// answered last if there is one, else everything not known absent.
+    fn candidates(self) -> impl Iterator<Item = NativeLoadsPath> {
+        NativeLoadsPath::DISCOVERY
+            .into_iter()
+            .filter(move |&path| match self.answered {
+                Some(answered) => path == answered,
+                None => !self.absent[path.index()],
+            })
+    }
+
+    fn record_answered(&mut self, path: NativeLoadsPath) {
+        self.answered = Some(path);
+        self.absent[path.index()] = false;
+    }
+
+    fn record_absent(&mut self, path: NativeLoadsPath) {
+        self.absent[path.index()] = true;
+        if self.answered == Some(path) {
+            self.answered = None;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn answered(self) -> Option<NativeLoadsPath> {
+        self.answered
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_absent(self, path: NativeLoadsPath) -> bool {
+        self.absent[path.index()]
+    }
 }
 
 /// Load monitoring service that subscribes to `WorkerRegistry` events.
@@ -235,11 +327,13 @@ pub struct WorkerMonitor {
     /// Shared immutable load snapshots: group ticks and the eviction flusher
     /// publish here; routing readers grab `Arc` snapshots.
     load_state: Arc<LoadState>,
-    /// Worker URLs that answered definitively that they do not serve
-    /// `/v1/loads`, so the probe is not repeated every tick. Cleared by
+    /// What each worker's probes established about its native load routes,
+    /// so discovery is not repeated every tick. A worker whose routes are
+    /// all absent is served from `/metrics`. Cleared by
     /// [`Self::evict_worker_loads`], which also runs on `Replaced` — an
-    /// in-place image upgrade that adds the endpoint is re-probed.
-    native_loads_absent: Arc<DashSet<String>>,
+    /// in-place image upgrade that adds or removes an endpoint is
+    /// re-discovered.
+    native_loads_memo: Arc<DashMap<String, NativeLoadsMemo>>,
     group_handles: Mutex<HashMap<WorkerGroupKey, GroupState>>,
     event_task: Mutex<Option<JoinHandle<()>>>,
     eviction_flush_task: Mutex<Option<JoinHandle<()>>>,
@@ -281,17 +375,17 @@ impl WorkerMonitor {
             engine_metrics,
             conditional_polling,
             load_state,
-            native_loads_absent: Arc::new(DashSet::new()),
+            native_loads_memo: Arc::new(DashMap::new()),
             group_handles: Mutex::new(HashMap::new()),
             event_task: Mutex::new(None),
             eviction_flush_task: Mutex::new(None),
         }
     }
 
-    /// The shared `/v1/loads` probe memo, so on-demand load sweeps skip
-    /// backends the polling loop has already found to lack the endpoint.
-    pub(crate) fn native_loads_absent(&self) -> &DashSet<String> {
-        &self.native_loads_absent
+    /// The current published load snapshot — what routing is acting on, and
+    /// what `GET /loads` serves.
+    pub(crate) fn load_snapshot(&self) -> Arc<LoadSnapshot> {
+        self.load_state.snapshot()
     }
 
     /// Subscribe to the shared per-worker load snapshots.
@@ -389,7 +483,7 @@ impl WorkerMonitor {
         // worker on a path that only runs on lag recovery.
         self.load_state.clear();
         self.worker_load_manager.clear();
-        self.native_loads_absent.clear();
+        self.native_loads_memo.clear();
         // The feed that would clear the vetoes is being torn down: fail open,
         // but say so — a wiped gauge is otherwise indistinguishable from a
         // genuine recovery. With no thresholds anywhere no flag was ever
@@ -508,7 +602,7 @@ impl WorkerMonitor {
         // out of routing with nothing to ever clear it.
         self.worker_registry.set_worker_overloaded(worker, false);
         self.worker_load_manager.remove_worker(url);
-        self.native_loads_absent.remove(url);
+        self.native_loads_memo.remove(url);
         self.load_state.enqueue_eviction(Arc::clone(worker));
     }
 
@@ -549,63 +643,76 @@ impl WorkerMonitor {
         handles.insert(key, GroupState { handle, interval });
     }
 
-    /// Fetch load over HTTP, preferring `/v1/loads` on any backend that
-    /// serves it and falling back to the runtime's Prometheus gauges.
+    /// Fetch load over HTTP, preferring a native load endpoint over the
+    /// runtime's Prometheus gauges.
     ///
-    /// `/v1/loads` is the canonical load schema: it reports the same
-    /// scheduler state the `/metrics` arms reconstruct from gauges, in two
-    /// orders of magnitude fewer bytes, and carries fields — queued tokens,
-    /// generation throughput, the disagg section — that no gauge exposes.
-    /// Preferring it is both cheaper and more informative wherever it exists.
+    /// The native schema reports the same scheduler state the `/metrics` arms
+    /// reconstruct from gauges, in two orders of magnitude fewer bytes, and
+    /// carries fields — queued tokens, generation throughput, the disagg
+    /// section — that no gauge exposes. Preferring it is both cheaper and
+    /// more informative wherever it exists.
+    ///
+    /// Two routes serve that schema: `/loads` on an SMG gateway registered as
+    /// a worker, and `/v1/loads` on an engine. Which one a worker answered on
+    /// is memoized, so the extra attempt costs one 404 per worker, once.
     ///
     /// Every backend is normalized into a single-rank [`WorkerLoadResponse`]
     /// whose `token_usage` field drives the load-aware policies. Returns
     /// `None` on failure so the caller records the load as unavailable (`-1`).
     ///
-    /// `native_loads_absent` is the shared probe memo, or `None` for callers
-    /// with no monitor to borrow it from (they simply always probe).
+    /// `native_loads_memo` is the shared probe memo, or `None` for callers
+    /// with no monitor to borrow it from (they simply always discover).
     pub(crate) async fn fetch_http_load(
         worker: &Arc<dyn Worker>,
-        native_loads_absent: Option<&DashSet<String>>,
+        native_loads_memo: Option<&DashMap<String, NativeLoadsMemo>>,
     ) -> Option<WorkerLoadResponse> {
         // Only workers already `Ready` are polled, so a definitive "no such
         // endpoint" cannot be a warm-up artifact and is safe to memoize.
-        let known_absent = native_loads_absent.is_some_and(|memo| memo.contains(worker.url()));
-        if !known_absent {
-            match Self::probe_native_loads(worker).await {
-                NativeLoads::Available(response) => return Some(response),
-                NativeLoads::Absent => {
-                    if let Some(memo) = native_loads_absent {
-                        memo.insert(worker.url().to_string());
-                    }
+        let known = native_loads_memo
+            .and_then(|store| store.get(worker.url()).map(|hit| *hit))
+            .unwrap_or_default();
+        let mut memo = known;
+
+        let mut response = None;
+        for path in known.candidates() {
+            match Self::probe_native_loads(worker, path).await {
+                NativeLoads::Available(load) => {
+                    memo.record_answered(path);
+                    response = Some(load);
+                    break;
                 }
+                NativeLoads::Absent => memo.record_absent(path),
                 NativeLoads::Inconclusive => {}
             }
+        }
+        // Write back only what a probe actually settled, so a tick that
+        // learned nothing leaves the memo alone and retries next time.
+        if let Some(store) = native_loads_memo {
+            if memo != known {
+                store.insert(worker.url().to_string(), memo);
+            }
+        }
+        if response.is_some() {
+            return response;
         }
 
         match worker.metadata().spec.runtime_type {
             RuntimeType::Vllm => Self::fetch_http_load_vllm(worker).await,
             RuntimeType::Sglang => Self::fetch_http_load_sglang(worker).await,
-            // Custom engines expose no gauge schema we can parse; `/v1/loads`
-            // above was their only path.
+            // Custom engines expose no gauge schema we can parse; the native
+            // routes above were their only path.
             _ => None,
         }
     }
 
-    /// Probe `GET /v1/loads?include=core,disagg,queues,memory`.
-    ///
-    /// Extra sections beyond `core` degrade gracefully: engines that do not
-    /// report them simply omit the fields, which deserialize to `None`.
+    /// Probe one native load route.
     ///
     /// Distinguishing [`NativeLoads::Absent`] from [`NativeLoads::Inconclusive`]
     /// is what makes the memo safe. Collapsing both into "unsupported" would
     /// let one timeout demote a healthy backend to the expensive `/metrics`
     /// path permanently.
-    async fn probe_native_loads(worker: &Arc<dyn Worker>) -> NativeLoads {
-        let url = format!(
-            "{}/v1/loads?include=core,disagg,queues,memory",
-            worker.url()
-        );
+    async fn probe_native_loads(worker: &Arc<dyn Worker>, path: NativeLoadsPath) -> NativeLoads {
+        let url = path.probe_url(worker);
         let resp = match Self::authed_request(worker, &url).send().await {
             Ok(resp) => resp,
             // Transport error or timeout: says nothing about the route.
@@ -712,8 +819,7 @@ impl WorkerMonitor {
     /// Such a snapshot carries the KV-usage ratio (`token_usage`) but no
     /// absolute token counts (`max_total_num_tokens`/`num_used_tokens` stay
     /// `0`), so `WorkerLoadResponse::has_absolute_token_data` reports `false`
-    /// for it — keeping it out of the DP-rank cache and the `/get_loads`
-    /// absolute-token scalar.
+    /// for it — keeping it out of the DP-rank cache.
     fn single_rank(snapshot: SchedulerLoadSnapshot) -> WorkerLoadResponse {
         WorkerLoadResponse {
             dp_rank_count: 1,
@@ -963,14 +1069,13 @@ async fn group_monitor_loop(
         let futures: Vec<_> = workers
             .iter()
             .map(|worker| {
-                let native_loads_absent = Arc::clone(&monitor.native_loads_absent);
+                let native_loads_memo = Arc::clone(&monitor.native_loads_memo);
                 let worker = Arc::clone(worker);
                 let connection_mode = group_key.connection_mode;
                 async move {
                     let response = match connection_mode {
                         ConnectionMode::Http => {
-                            WorkerMonitor::fetch_http_load(&worker, Some(&native_loads_absent))
-                                .await
+                            WorkerMonitor::fetch_http_load(&worker, Some(&native_loads_memo)).await
                         }
                         ConnectionMode::Grpc | ConnectionMode::Zmq => {
                             WorkerMonitor::fetch_backend_load(&worker).await
@@ -1006,7 +1111,11 @@ async fn group_monitor_loop(
                 // absolute per-rank token counts. Ratio-only snapshots,
                 // which would otherwise poison with a fake `{0: 0}`
                 // entry and collapse DP routing onto rank 0.
-                if load.has_absolute_token_data() {
+                //
+                // A fleet rollup from a gateway worker is keyed by downstream
+                // worker, not by rank, so its repeated `dp_rank: 0` entries
+                // would overwrite each other down to a single bogus rank.
+                if load.has_absolute_token_data() && load.ranks_are_dp_ranks() {
                     group_dp_loads.insert(url.clone(), load.dp_rank_loads());
                 } else {
                     dp_evict.push(url.clone());
@@ -1275,7 +1384,9 @@ mod worker_monitor_tests {
             vec![(Arc::clone(&worker), Arc::new(WorkerLoadResponse::default()))],
         );
         assert!(monitor.load_state.snapshot().contains(&url));
-        monitor.native_loads_absent.insert(url.clone());
+        monitor
+            .native_loads_memo
+            .insert(url.clone(), NativeLoadsMemo::default());
         let mut dp_loads: HashMap<String, HashMap<isize, isize>> = HashMap::new();
         let mut inner = HashMap::new();
         inner.insert(0, 5);
@@ -1300,7 +1411,7 @@ mod worker_monitor_tests {
             "DP cache must not retain entries for removed workers"
         );
         assert!(
-            !monitor.native_loads_absent.contains(&url),
+            !monitor.native_loads_memo.contains_key(&url),
             "probe memo must not retain entries for removed workers"
         );
     }
@@ -1311,12 +1422,12 @@ mod worker_monitor_tests {
         // fires an eviction, so the reset path must drop the memo too.
         let (_registry, monitor) = build_monitor();
         monitor
-            .native_loads_absent
-            .insert("http://w1:8080".to_string());
+            .native_loads_memo
+            .insert("http://w1:8080".to_string(), NativeLoadsMemo::default());
 
         monitor.stop_all_groups();
 
-        assert!(monitor.native_loads_absent.is_empty());
+        assert!(monitor.native_loads_memo.is_empty());
     }
 
     #[tokio::test]
@@ -1528,8 +1639,8 @@ sglang:utilization{model="llama"} 0.9
     #[test]
     fn metric_derived_snapshot_has_no_absolute_token_data() {
         // A ratio-only snapshot (from `/metrics`) must not be treated as
-        // carrying absolute token counts: it stays out of the DP cache and
-        // the `/get_loads` scalar, even at high KV usage.
+        // carrying absolute token counts: it stays out of the DP cache,
+        // even at high KV usage.
         let resp = WorkerMonitor::single_rank(SchedulerLoadSnapshot {
             token_usage: 0.75,
             num_running_reqs: 3,
@@ -1551,6 +1662,56 @@ sglang:utilization{model="llama"} 0.9
         });
         assert!(resp.has_absolute_token_data());
         assert_eq!(resp.total_used_tokens(), 1024);
+    }
+
+    #[test]
+    fn fleet_rollup_is_not_dp_ranks() {
+        // A gateway worker answers `/loads` with one entry per downstream
+        // worker, all at `dp_rank: 0`. Keying those by rank collapses them
+        // onto a single entry, so the DP cache must reject the response.
+        let fleet = WorkerLoadResponse {
+            dp_rank_count: 2,
+            loads: vec![
+                SchedulerLoadSnapshot {
+                    worker: Some("http://a:8000".to_string()),
+                    max_total_num_tokens: 8192,
+                    num_used_tokens: 1024,
+                    ..Default::default()
+                },
+                SchedulerLoadSnapshot {
+                    worker: Some("http://b:8000".to_string()),
+                    max_total_num_tokens: 8192,
+                    num_used_tokens: 4096,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        assert!(fleet.has_absolute_token_data());
+        assert!(!fleet.ranks_are_dp_ranks());
+        assert_eq!(fleet.dp_rank_loads().len(), 1);
+
+        // One engine's own ranks are distinct and stay eligible.
+        let engine = WorkerLoadResponse {
+            dp_rank_count: 2,
+            loads: vec![
+                SchedulerLoadSnapshot {
+                    dp_rank: 0,
+                    max_total_num_tokens: 8192,
+                    num_used_tokens: 1024,
+                    ..Default::default()
+                },
+                SchedulerLoadSnapshot {
+                    dp_rank: 1,
+                    max_total_num_tokens: 8192,
+                    num_used_tokens: 4096,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        assert!(engine.ranks_are_dp_ranks());
+        assert_eq!(engine.dp_rank_loads().len(), 2);
     }
 }
 
@@ -1580,25 +1741,48 @@ mod native_loads_tests {
 
     struct Stub {
         url: String,
+        /// `/v1/loads` hits.
         probes: Arc<AtomicUsize>,
+        /// `/loads` hits.
+        gateway_probes: Arc<AtomicUsize>,
+        /// Query string of the last `/loads` hit.
+        gateway_query: Arc<Mutex<Option<String>>>,
     }
 
-    /// Loopback engine stub. `/v1/loads` answers with the given status and
-    /// body and counts its hits; `/metrics` always serves the vLLM gauges.
-    async fn spawn_engine(status: StatusCode, body: &'static str) -> Stub {
-        let probes = Arc::new(AtomicUsize::new(0));
-        let counter = Arc::clone(&probes);
-        let app = axum::Router::new()
-            .route(
-                "/v1/loads",
-                axum::routing::get(move || {
+    /// Loopback backend stub. Each native route answers with the status and
+    /// body it was given and counts its hits; `/metrics` always serves the
+    /// vLLM gauges.
+    async fn spawn_backend(
+        gateway: (StatusCode, &'static str),
+        engine: (StatusCode, &'static str),
+    ) -> Stub {
+        fn route(
+            hits: &Arc<AtomicUsize>,
+            query: &Arc<Mutex<Option<String>>>,
+            (status, body): (StatusCode, &'static str),
+        ) -> axum::routing::MethodRouter {
+            let counter = Arc::clone(hits);
+            let sink = Arc::clone(query);
+            axum::routing::get(
+                move |axum::extract::RawQuery(raw): axum::extract::RawQuery| {
                     let counter = Arc::clone(&counter);
+                    let sink = Arc::clone(&sink);
                     async move {
                         counter.fetch_add(1, Ordering::SeqCst);
+                        *sink.lock() = raw;
                         (status, body)
                     }
-                }),
+                },
             )
+        }
+
+        let probes = Arc::new(AtomicUsize::new(0));
+        let gateway_probes = Arc::new(AtomicUsize::new(0));
+        let gateway_query = Arc::new(Mutex::new(None));
+        let engine_query = Arc::new(Mutex::new(None));
+        let app = axum::Router::new()
+            .route("/loads", route(&gateway_probes, &gateway_query, gateway))
+            .route("/v1/loads", route(&probes, &engine_query, engine))
             .route("/metrics", axum::routing::get(|| async { VLLM_METRICS }));
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -1616,7 +1800,19 @@ mod native_loads_tests {
         Stub {
             url: format!("http://{addr}"),
             probes,
+            gateway_probes,
+            gateway_query,
         }
+    }
+
+    /// An engine: serves `/v1/loads`, 404s the gateway route.
+    async fn spawn_engine(status: StatusCode, body: &'static str) -> Stub {
+        spawn_backend((StatusCode::NOT_FOUND, ""), (status, body)).await
+    }
+
+    /// A gateway registered as a worker: serves `/loads` only.
+    async fn spawn_gateway(body: &'static str) -> Stub {
+        spawn_backend((StatusCode::OK, body), (StatusCode::NOT_FOUND, "")).await
     }
 
     fn vllm_worker(url: &str) -> Arc<dyn Worker> {
@@ -1626,12 +1822,20 @@ mod native_loads_tests {
     /// Worker carrying a per-worker overload block — protection for it is
     /// enabled by the spec alone, with no gateway thresholds anywhere.
     fn vllm_worker_with_overload(url: &str, overload: OverloadUpdate) -> Arc<dyn Worker> {
+        vllm_worker_built(url, "a", overload)
+    }
+
+    fn vllm_worker_with_model(url: &str, model: &str) -> Arc<dyn Worker> {
+        vllm_worker_built(url, model, OverloadUpdate::default())
+    }
+
+    fn vllm_worker_built(url: &str, model: &str, overload: OverloadUpdate) -> Arc<dyn Worker> {
         Arc::new(
             BasicWorkerBuilder::new(url)
                 .worker_type(WorkerType::Regular)
                 .connection_mode(ConnectionMode::Http)
                 .runtime_type(RuntimeType::Vllm)
-                .model(ModelCard::new("a"))
+                .model(ModelCard::new(model))
                 .overload(overload)
                 .health_config(HealthCheckConfig {
                     disable_health_check: true,
@@ -1926,7 +2130,7 @@ mod native_loads_tests {
     async fn native_loads_preferred_over_metrics_on_vllm() {
         let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
         let worker = vllm_worker(&stub.url);
-        let memo = DashSet::new();
+        let memo = DashMap::new();
 
         let resp = WorkerMonitor::fetch_http_load(&worker, Some(&memo))
             .await
@@ -1935,14 +2139,17 @@ mod native_loads_tests {
         // `/metrics` cannot report queued tokens; only the native path can.
         assert_eq!(resp.loads[0].num_waiting_uncached_tokens, 900);
         assert_eq!(resp.loads[0].num_running_reqs, 3);
-        assert!(memo.is_empty(), "a serving endpoint must not be memoized");
+        assert_eq!(
+            memo.get(worker.url()).and_then(|hit| hit.answered()),
+            Some(NativeLoadsPath::Engine)
+        );
     }
 
     #[tokio::test]
     async fn absent_native_endpoint_falls_back_and_is_probed_once() {
         let stub = spawn_engine(StatusCode::NOT_FOUND, "").await;
         let worker = vllm_worker(&stub.url);
-        let memo = DashSet::new();
+        let memo = DashMap::new();
 
         for _ in 0..3 {
             let resp = WorkerMonitor::fetch_http_load(&worker, Some(&memo))
@@ -1952,21 +2159,28 @@ mod native_loads_tests {
             assert_eq!(resp.loads[0].num_waiting_reqs, 11);
         }
 
-        assert!(memo.contains(worker.url()));
+        let hit = memo.get(worker.url()).map(|hit| *hit).expect("memo entry");
+        assert_eq!(hit.answered(), None);
+        assert!(hit.is_absent(NativeLoadsPath::Gateway));
+        assert!(hit.is_absent(NativeLoadsPath::Engine));
         assert_eq!(
             stub.probes.load(Ordering::SeqCst),
             1,
             "a 404 is definitive; the probe must not repeat every tick"
         );
+        assert_eq!(stub.gateway_probes.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
     async fn transient_native_failure_is_not_memoized() {
         // 503 says the backend is unwell, not that the route is missing.
         // Memoizing it would demote a healthy engine to `/metrics` forever.
+        // The gateway route's 404 next to it is a fact, though, and tracking
+        // absence per route is what lets the dead one be dropped while the
+        // unwell one keeps being asked.
         let stub = spawn_engine(StatusCode::SERVICE_UNAVAILABLE, "").await;
         let worker = vllm_worker(&stub.url);
-        let memo = DashSet::new();
+        let memo = DashMap::new();
 
         for _ in 0..3 {
             WorkerMonitor::fetch_http_load(&worker, Some(&memo))
@@ -1974,21 +2188,25 @@ mod native_loads_tests {
                 .expect("metrics fallback");
         }
 
-        assert!(memo.is_empty());
+        let hit = memo.get(worker.url()).map(|hit| *hit).expect("memo entry");
+        assert!(!hit.is_absent(NativeLoadsPath::Engine));
+        assert_eq!(hit.answered(), None);
         assert_eq!(stub.probes.load(Ordering::SeqCst), 3, "probe must retry");
+        assert_eq!(stub.gateway_probes.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
     async fn non_load_body_on_200_is_treated_as_absent() {
         let stub = spawn_engine(StatusCode::OK, "<html>nope</html>").await;
         let worker = vllm_worker(&stub.url);
-        let memo = DashSet::new();
+        let memo = DashMap::new();
 
         WorkerMonitor::fetch_http_load(&worker, Some(&memo))
             .await
             .expect("metrics fallback");
 
-        assert!(memo.contains(worker.url()));
+        let hit = memo.get(worker.url()).map(|hit| *hit).expect("memo entry");
+        assert!(hit.is_absent(NativeLoadsPath::Engine));
     }
 
     #[tokio::test]
@@ -1996,7 +2214,7 @@ mod native_loads_tests {
         // Our schema, no ranks yet — the endpoint exists, so keep asking.
         let stub = spawn_engine(StatusCode::OK, r#"{"loads":[]}"#).await;
         let worker = vllm_worker(&stub.url);
-        let memo = DashSet::new();
+        let memo = DashMap::new();
 
         for _ in 0..2 {
             WorkerMonitor::fetch_http_load(&worker, Some(&memo))
@@ -2004,8 +2222,10 @@ mod native_loads_tests {
                 .expect("metrics fallback");
         }
 
-        assert!(memo.is_empty());
+        let hit = memo.get(worker.url()).map(|hit| *hit).expect("memo entry");
+        assert!(!hit.is_absent(NativeLoadsPath::Engine));
         assert_eq!(stub.probes.load(Ordering::SeqCst), 2);
+        assert_eq!(stub.gateway_probes.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -2020,5 +2240,82 @@ mod native_loads_tests {
         }
 
         assert_eq!(stub.probes.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn gateway_route_answers_and_is_memoized() {
+        // A gateway registered as a worker: `/loads` is the only route it
+        // has, and it must be tried before the engine one.
+        let stub = spawn_gateway(NATIVE_BODY).await;
+        let worker = vllm_worker(&stub.url);
+        let memo = DashMap::new();
+
+        for _ in 0..3 {
+            let resp = WorkerMonitor::fetch_http_load(&worker, Some(&memo))
+                .await
+                .expect("load response");
+            assert_eq!(resp.loads[0].num_waiting_uncached_tokens, 900);
+        }
+
+        assert_eq!(
+            memo.get(worker.url()).and_then(|hit| hit.answered()),
+            Some(NativeLoadsPath::Gateway)
+        );
+        assert_eq!(stub.gateway_probes.load(Ordering::SeqCst), 3);
+        assert_eq!(
+            stub.probes.load(Ordering::SeqCst),
+            0,
+            "the engine route must not be probed once the gateway one answers"
+        );
+    }
+
+    #[tokio::test]
+    async fn memoized_route_that_stops_answering_is_rediscovered() {
+        // An engine-only stub with the gateway route memoized: the stale
+        // memo must be dropped, not treated as "serves neither".
+        let stub = spawn_engine(StatusCode::OK, NATIVE_BODY).await;
+        let worker = vllm_worker(&stub.url);
+        let memo = DashMap::new();
+        let mut stale = NativeLoadsMemo::default();
+        stale.record_answered(NativeLoadsPath::Gateway);
+        memo.insert(worker.url().to_string(), stale);
+
+        let resp = WorkerMonitor::fetch_http_load(&worker, Some(&memo))
+            .await
+            .expect("metrics fallback");
+        assert_eq!(resp.loads[0].num_running_reqs, 7, "served by /metrics");
+        let hit = memo.get(worker.url()).map(|hit| *hit).expect("memo entry");
+        assert_eq!(hit.answered(), None, "a stale memo must be forgotten");
+
+        let resp = WorkerMonitor::fetch_http_load(&worker, Some(&memo))
+            .await
+            .expect("load response");
+        assert_eq!(resp.loads[0].num_running_reqs, 3, "served by /v1/loads");
+        assert_eq!(
+            memo.get(worker.url()).and_then(|hit| hit.answered()),
+            Some(NativeLoadsPath::Engine)
+        );
+        assert_eq!(
+            stub.gateway_probes.load(Ordering::SeqCst),
+            1,
+            "the route that 404'd must not be probed again"
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_probe_is_scoped_to_the_worker_model() {
+        // A gateway fronts many models; the load of the one this worker was
+        // registered for is the only load that belongs to it.
+        let stub = spawn_gateway(NATIVE_BODY).await;
+        let worker = vllm_worker_with_model(&stub.url, "meta-llama/Llama-3.1-8B");
+
+        WorkerMonitor::fetch_http_load(&worker, None)
+            .await
+            .expect("load response");
+
+        assert_eq!(
+            stub.gateway_query.lock().clone(),
+            Some("model=meta-llama%2FLlama-3.1-8B".to_string())
+        );
     }
 }

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -1883,6 +1883,7 @@ pub fn worker_to_info(worker: &Arc<dyn Worker>) -> WorkerInfo {
         status: Some(status),
         load: worker.load(),
         http2: metadata.http2,
+        engine_load: None,
         job_status: None,
     }
 }

--- a/model_gateway/tests/api/api_endpoints_test.rs
+++ b/model_gateway/tests/api/api_endpoints_test.rs
@@ -1414,6 +1414,20 @@ mod cache_tests {
         ctx.shutdown().await;
     }
 
+    async fn loads_body(ctx: &AppTestContext, uri: &str) -> serde_json::Value {
+        let req = Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap();
+        let resp = ctx.create_app().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "{uri}");
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
     #[tokio::test]
     async fn test_get_loads() {
         let ctx = AppTestContext::new(vec![
@@ -1434,25 +1448,57 @@ mod cache_tests {
         ])
         .await;
 
-        let app = ctx.create_app();
+        // Both mocks serve `/v1/loads`, and the monitor polls each group as
+        // it is created. Wait for that first tick so the assertions run
+        // against a populated snapshot rather than an empty one.
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(10);
+        loop {
+            let body = loads_body(&ctx, "/loads").await;
+            if body["loads"].as_array().is_some_and(|l| l.len() == 2) {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for both workers to report load: {body}"
+            );
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        }
 
-        let req = Request::builder()
-            .method("GET")
-            .uri("/get_loads")
-            .body(Body::empty())
-            .unwrap();
+        // `/get_loads` is a deprecated alias and must answer identically.
+        for uri in ["/loads", "/get_loads"] {
+            let body_json = loads_body(&ctx, uri).await;
 
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
+            let loads = body_json["loads"].as_array().expect("loads array");
+            assert_eq!(body_json["dp_rank_count"], loads.len(), "{uri}");
+            assert!(body_json["version"].as_str().is_some_and(|v| !v.is_empty()));
+            assert!(body_json["timestamp"]
+                .as_str()
+                .is_some_and(|t| !t.is_empty()));
 
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            // Every rank names the worker it came from — the two fields a
+            // fleet view adds to the engine schema.
+            let mut reporters: Vec<&str> = loads
+                .iter()
+                .map(|entry| entry["worker"].as_str().expect("worker"))
+                .collect();
+            reporters.sort_unstable();
+            assert_eq!(
+                reporters,
+                vec!["http://127.0.0.1:18502", "http://127.0.0.1:18503"],
+                "{uri}"
+            );
+            for entry in loads {
+                assert_eq!(entry["worker_type"], "regular", "{uri}");
+                assert_eq!(entry["num_running_reqs"], 2, "{uri}");
+                assert_eq!(entry["num_used_tokens"], 1024, "{uri}");
+            }
 
-        assert!(body_json.is_object());
-        // The exact structure depends on the implementation
-        // but should contain worker load information
+            // The aggregate rolls up the fleet, not one engine.
+            assert_eq!(body_json["aggregate"]["total_running_reqs"], 4, "{uri}");
+            assert_eq!(body_json["aggregate"]["total_waiting_reqs"], 2, "{uri}");
+            assert_eq!(body_json["aggregate"]["total_reqs"], 6, "{uri}");
+            assert_eq!(body_json["aggregate"]["avg_token_usage"], 0.125, "{uri}");
+        }
 
         ctx.shutdown().await;
     }

--- a/model_gateway/tests/common/mock_worker.rs
+++ b/model_gateway/tests/common/mock_worker.rs
@@ -356,6 +356,7 @@ impl MockWorker {
                 post(responses_cancel_handler),
             )
             .route("/flush_cache", post(flush_cache_handler))
+            .route("/v1/loads", get(loads_handler))
             .route("/v1/models", get(v1_models_handler))
             .with_state(config);
 
@@ -1503,6 +1504,29 @@ async fn responses_handler(
             .into_response()
         }
     }
+}
+
+/// Engine-native load report. The gateway's load monitor prefers this route
+/// over `/metrics`, so serving it is what puts a mock worker into `/loads`.
+async fn loads_handler() -> Response {
+    Json(json!({
+        "dp_rank_count": 1,
+        "loads": [{
+            "dp_rank": 0,
+            "num_running_reqs": 2,
+            "num_waiting_reqs": 1,
+            "num_used_tokens": 1024,
+            "max_total_num_tokens": 8192,
+            "token_usage": 0.125,
+        }],
+        "aggregate": {
+            "total_running_reqs": 2,
+            "total_waiting_reqs": 1,
+            "total_reqs": 3,
+            "avg_token_usage": 0.125,
+        },
+    }))
+    .into_response()
 }
 
 async fn flush_cache_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) -> Response {


### PR DESCRIPTION
## Description

### Problem

SMG polls every worker for engine load and routes on it, but never exposes it. Three things exist today and none of them answer the question:

- `GET /get_loads` calls every engine on every request, returns no fleet total, and drops the worker type.
- `GET /workers` has a `load` field, but that number is the router's count of requests currently in flight to the worker, not engine load. The shared name misleads.
- `GET /metrics` has the numbers as Prometheus text — right for a dashboard, wrong for a program that wants to read one number.

There is a second reason to fix this. When a gateway runs in front of other gateways, the upper one registers each lower gateway as a worker and asks it for load the same way it asks an engine. A gateway has nothing to answer with, so the upper layer routes across pools blind.

The data already exists in the process: the load monitor keeps the latest load reply from every worker in a cached snapshot, refreshed on its poll interval, and the routing policies read it. Nothing serves it.

### Solution

Serve the snapshot.

`GET /loads` returns one entry per worker per DP rank plus a fleet `aggregate`, in the same schema SMG already receives from engines, so nothing new has to be parsed anywhere. Each entry names its `worker` and `worker_type`; a caller reading the response as if it were one large engine ignores both.

It reads the monitor's published snapshot — the same numbers the routing policies are acting on — so no request reaches a worker. That is what makes the route safe to stack: an upper gateway's poll cannot fan out into hundreds of engine requests below. The cost is staleness, at most one poll interval (ten seconds by default), and the body carries the `timestamp` so callers can judge for themselves.

The load monitor now tries `/loads` before `/v1/loads`. A gateway registered as a worker answers on the first try; an engine 404s it once and is then memoized onto its own route, so the extra attempt costs one failed request per engine, once. Neither layer has to be configured to know what kind of thing the other is.

We deliberately do not add `/v1/loads` to the gateway. Two names for one thing is the confusion this removes. And we do not ask every engine to serve `/loads`, because the engines are not all ours — SGLang picked `/v1/loads` and vLLM has no such route, so the monitor has to keep speaking their paths regardless.

Example response:

```json
{
  "timestamp": "2026-09-03T18:20:11Z",
  "version": "smg-1.10.1",
  "dp_rank_count": 3,
  "loads": [
    {
      "worker": "http://pool-a-0:8000",
      "worker_type": "regular",
      "dp_rank": 0,
      "num_running_reqs": 12,
      "num_waiting_reqs": 3,
      "num_used_tokens": 48000,
      "max_total_num_tokens": 131072,
      "token_usage": 0.37
    }
  ],
  "aggregate": {
    "total_running_reqs": 61,
    "total_waiting_reqs": 8,
    "total_reqs": 69,
    "avg_token_usage": 0.41
  }
}
```

### Breaking change

`GET /get_loads` now returns the `/loads` body instead of `{"workers": [{"worker", "load", "details"}]}`. The route still exists, on the same admin tier, and is marked deprecated. Callers that read `.workers[].load` need to move to `.loads[]` or `.aggregate`.

## Changes

- `GET /loads`: new public route serving the cached fleet load, with an optional `?model=` filter.
- `GET /workers` and `GET /workers/{id}`: new `engine_load` field carrying that worker's entry from the same snapshot. The existing `load` field is unchanged, and its description now says plainly that it counts in-flight requests.
- `GET /get_loads`: now a deprecated alias of `/loads`, unchanged auth tier.
- `SchedulerLoadSnapshot` gains optional `worker` and `worker_type`. Engines reporting their own load leave both unset.
- `EngineAggregateMetricsSnapshot::from_ranks`: rolls per-rank snapshots into one summary — counts sum, ratios average, rounded the way the engine servicers round, so a gateway aggregate and an engine aggregate read the same. Returns nothing for zero ranks, which must not read as an idle fleet.
- The load monitor's probe memo now records which route a worker answered on rather than only whether `/v1/loads` was missing, and tracks absence per route: a 404 on one route survives a timeout on the other, so a dead route is dropped instead of being re-asked every tick. A memoized route that stops answering is forgotten and rediscovered.
- The gateway probe carries `?model=` when the worker is registered for exactly one model. An upper gateway must not read a lower gateway's whole fleet as the load of one pool.
- The DP-rank load cache now ignores a response whose entries name a worker. `dp_rank` is unique only within an engine, so a fleet rollup repeats `dp_rank: 0` and would collapse onto one bogus rank.
- Removed `WorkerManager::get_all_worker_loads`, `WorkerLoadsResult`, and `WorkerLoadInfo`, which the fan-out route was the only user of.
- Registered `/loads` and `/get_loads` in the OpenAPI generator, with `/get_loads` marked `deprecated` so generated clients carry the warning.

## Test Plan

- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p smg -p openai-protocol -p smg-grpc-client` — 0 failures across the library and every integration test binary.

New coverage:

- `fleet_loads`: rank tagging and URL sort order, `?model=` filtering, a worker with no report omitted rather than reported idle, and an empty snapshot producing no aggregate.
- `from_ranks`: empty input, sums and averages, the rounding the engines use, and saturation instead of `i32` overflow.
- Route discovery: a gateway-only worker is memoized on `/loads` and the engine route is never probed again; a stale memo on a worker that stopped answering there is dropped and rediscovered on the next tick; a route that 404s stays dropped while a route that only timed out keeps being retried; the gateway probe carries the worker's model, URL-encoded.
- Fleet rollup guard: a response whose entries name a worker is rejected by the DP-rank cache, while one engine's own ranks are still accepted.
- `test_get_loads`: the mock worker now serves `/v1/loads`, so the test waits for the monitor's first tick and then asserts what was actually served — both workers present by URL, their type, their per-rank counts, and a fleet aggregate that sums the two — against `/loads` and `/get_loads` alike.

Manual: `cargo run -p openapi-gen -- /tmp/smg-openapi.yaml` emits both paths with the `model` query parameter and a `WorkerLoadResponse` schema reference.

## Follow-ups

Not in this PR, tracked as the rest of the rollout:

- Level up the vLLM gRPC servicer where the data is already in reach: real DP ranks and the configured max running requests.
- Upstream in vLLM: a proper accessor for load on the engine, the same data on the direct wire, and an HTTP route to match. That also stops our servicer from reaching into private attributes, which is what keeps it from breaking on the next vLLM bump.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

