### PR TITLE
fix(ci): install Python dev headers on the runner for TokenSpeed lanes

### DIFF
--- a/docker/ci-tokenspeed.Dockerfile
+++ b/docker/ci-tokenspeed.Dockerfile
@@ -16,8 +16,9 @@
 #   - the payload lives under /opt/smg-ci (venv + stamp) and
 #     /opt/tokenspeed-src (checkout the venv's editable installs point at),
 #     extracted to identical absolute paths;
-#   - the CUDA toolkit is NOT part of the payload; the install script
-#     apt-installs it on the runner when missing, same as the source path.
+#   - the CUDA toolkit and the Python dev headers are NOT part of the
+#     payload; the install script apt-installs them on the runner when
+#     missing, same as the source path.
 #
 # Built by .github/workflows/ci-tokenspeed-image.yml on every bump of
 # .github/versions/tokenspeed.ref or of the image tooling, and tagged

--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -116,6 +116,48 @@ setup_cuda_env() {
     export C_INCLUDE_PATH="${_cuda_inc}${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
 }
 
+ensure_python_headers() {
+    # ── Python dev headers ─────────────────────────────────────────────────
+    # Triton (and torch's cpp_extension) compile C sources against the
+    # interpreter's headers at RUNTIME, not at install time: the first
+    # TokenSpeed import builds tokenspeed_triton's cuda_utils and dies with
+    # "Python.h: No such file or directory", which Triton then reports as
+    # "Triton is not supported on the current platform".
+    #
+    # Like the CUDA toolkit above, the headers belong to the runner and are
+    # not part of the prebuilt payload. The source path only ever got them by
+    # accident -- python3-dev is an apt Recommends of python3-pip, which
+    # ci_setup_python_venv.sh installs when host venv creation fails -- so
+    # adopting the baked venv skipped that repair and left the runner without
+    # them. Install them explicitly instead, on both paths.
+    #
+    # posix_prefix resolves against the BASE interpreter, not the venv -- that
+    # is the include dir Triton hands to gcc.
+    local include_dir
+    include_dir="$(python3 -c 'import sysconfig; print(sysconfig.get_paths(scheme="posix_prefix")["include"])')"
+    if [ -f "${include_dir}/Python.h" ]; then
+        echo "Python headers: present at ${include_dir}"
+        return
+    fi
+
+    local py_version
+    py_version="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+    echo "Python.h missing from ${include_dir}; installing python${py_version}-dev"
+    if ! command -v apt-get &> /dev/null; then
+        echo "ERROR: no apt-get to install python${py_version}-dev with" >&2
+        exit 1
+    fi
+    export DEBIAN_FRONTEND=noninteractive
+    $SUDO apt-get update -qq
+    $SUDO apt-get install -y --no-install-recommends "python${py_version}-dev"
+
+    # Fail here rather than 20 minutes later inside a Triton JIT compile.
+    if [ ! -f "${include_dir}/Python.h" ]; then
+        echo "ERROR: python${py_version}-dev did not provide ${include_dir}/Python.h" >&2
+        exit 1
+    fi
+}
+
 install_tokenspeed_from_source() {
     # ── Clone TokenSpeed ───────────────────────────────────────────────────
     # ``git clone --branch`` only accepts branch/tag names, not SHAs, so we
@@ -258,6 +300,7 @@ if [ "${TOKENSPEED_BUILD_ONLY:-0}" != "1" ] && [ "${TOKENSPEED_FORCE_SOURCE:-0}"
 fi
 
 setup_cuda_env
+ensure_python_headers
 
 if [ "$use_prebuilt" = "0" ]; then
     install_tokenspeed_from_source


### PR DESCRIPTION
## Description

### Problem

Every TokenSpeed e2e lane has failed since the prebuilt TokenSpeed CI image
started being used, on `main` and on PR branches alike:

```
/opt/smg-ci/.venv/lib/python3.12/site-packages/tokenspeed_triton/backends/nvidia/driver.c:9:10:
    fatal error: Python.h: No such file or directory
subprocess.CalledProcessError: Command '['/usr/bin/gcc', '.../driver.c', ..., '-I/usr/include/python3.12']'
    returned non-zero exit status 1
RuntimeError: Triton is not supported on the current platform.
```

Triton compiles its CUDA driver shim with gcc on first import, at run time,
against the interpreter's headers. The GPU runners do not ship those headers.

They used to arrive by accident. `ci_setup_python_venv.sh` finds python3.12 on
the host, tries `python3 -m venv`, and that fails because the runner has no
`python3-venv`. The repair step then runs `apt-get install python3-pip
python3-venv`, and `python3-pip` recommends `python3-dev` — so `Python.h`
landed on the runner as a side effect, every job.

The prebuilt payload removed that side effect. The baked venv is adopted, the
repair never runs, the source build is skipped, and nothing installs the
headers. Nothing was wrong with the image; the gap is on the runner.

The source path has the same latent problem: it only works because an apt
recommendation happens to pull the right package.

### Solution

Install the headers explicitly in `ci_install_tokenspeed.sh`, on both the
prebuilt and the source path. That script already provisions the CUDA toolkit
on the runner the same way, for the same reason — it is a runner prerequisite
the payload deliberately does not carry.

The check reads the include directory from `sysconfig` with the `posix_prefix`
scheme, which resolves against the base interpreter and so returns exactly the
`-I` path Triton passes to gcc. Present means no-op, which is the case during
the image build and on any runner that already has the headers.

## Changes

- `scripts/ci_install_tokenspeed.sh`: add `ensure_python_headers`, called from
  main right after `setup_cuda_env`. Installs `python<major>.<minor>-dev` when
  `Python.h` is absent, and fails immediately with a clear message if the
  package does not provide it, rather than 20 minutes later inside a Triton
  JIT compile.
- `docker/ci-tokenspeed.Dockerfile`: the runner portability contract now lists
  the Python dev headers alongside the CUDA toolkit as runner-installed.

## Test Plan

Diagnosis is from the CI logs of two consecutive `main` pushes:

| Run | Commit | Prebuilt image | TokenSpeed lanes |
|---|---|---|---|
| 33784640874 | 7e602665 | not yet published, lane built from source | 3/3 pass |
| 33792567222 | 9b4b6dfb | pulled and extracted | 3/3 fail |

In the passing run the log shows `Host python3 is 3.12 - creating venv with
it`, then the ensurepip failure, then apt unpacking `python3-dev` and
`libpython3.12-dev`. In the failing run it shows `Adopting baked venv
/opt/smg-ci/.venv`, `skipping source build`, no apt, then the Triton error
above. All three lanes (`e2e-1gpu-chat`, `e2e-1gpu-chat-zmq`,
`e2e-2gpu-chat-zmq-dp`) fail with the identical signature.

Verification of the fix:

- `bash -n scripts/ci_install_tokenspeed.sh` passes.
- The `posix_prefix` include path resolves to the base interpreter from inside
  a venv, matching the `-I/usr/include/python3.12` in the failing gcc command.
- The TokenSpeed lanes on this PR are the real test. Note this changes the
  image tooling hash, so the lanes build from source until
  `ci-tokenspeed-image.yml` publishes the new tag; both paths are covered by
  the fix.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes (no Rust changed)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changed)
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
