### PR TITLE
fix(tool_parser): resolve MiniMax-M3 composite property schemas

### DIFF
--- a/crates/tool_parser/src/parsers/minimax_m3.rs
+++ b/crates/tool_parser/src/parsers/minimax_m3.rs
@@ -244,6 +244,29 @@ impl MinimaxM3Parser {
         schema?.get("type")?.as_str()
     }
 
+    /// Find a named property in this schema or a nested composition branch.
+    fn property_schema<'a>(schema: Option<&'a Value>, name: &str) -> Option<&'a Value> {
+        let schema = schema?;
+        if let Some(property) = schema.get("properties").and_then(|value| value.get(name)) {
+            return Some(property);
+        }
+
+        for keyword in ["oneOf", "anyOf", "allOf"] {
+            for branch in schema
+                .get(keyword)
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                if let Some(property) = Self::property_schema(Some(branch), name) {
+                    return Some(property);
+                }
+            }
+        }
+
+        None
+    }
+
     /// Convert a parsed parameter value into a JSON value, coercing leaves by
     /// the schema node they sit under: array elements descend into `items`,
     /// object members into their `properties` entry.
@@ -265,12 +288,9 @@ impl MinimaxM3Parser {
                     return Value::Array(items);
                 }
 
-                let properties = schema
-                    .and_then(|s| s.get("properties"))
-                    .and_then(Value::as_object);
                 let mut map: Map<String, Value> = Map::new();
                 for (name, child) in children {
-                    let child_schema = properties.and_then(|p| p.get(&name));
+                    let child_schema = Self::property_schema(schema, &name);
                     let child_json = Self::value_to_json(child, child_schema);
                     match map.get_mut(&name) {
                         Some(Value::Array(arr)) => arr.push(child_json),
@@ -294,9 +314,6 @@ impl MinimaxM3Parser {
     /// arguments collected so far would run the tool with silently missing
     /// parameters.
     fn parse_invoke_params(body: &str, params_schema: Option<&Value>) -> Option<Value> {
-        let properties = params_schema
-            .and_then(|s| s.get("properties"))
-            .and_then(Value::as_object);
         let mut map: Map<String, Value> = Map::new();
         let mut pos = 0;
 
@@ -314,7 +331,7 @@ impl MinimaxM3Parser {
             pos += trim_len;
             let (name, value, consumed) = Self::parse_element(&body[pos..])?;
             pos += consumed;
-            let json = Self::value_to_json(value, properties.and_then(|p| p.get(&name)));
+            let json = Self::value_to_json(value, Self::property_schema(params_schema, &name));
             match map.get_mut(&name) {
                 Some(Value::Array(arr)) => arr.push(json),
                 Some(existing) => {

--- a/crates/tool_parser/tests/tool_parser_minimax_m3.rs
+++ b/crates/tool_parser/tests/tool_parser_minimax_m3.rs
@@ -918,29 +918,36 @@ async fn test_empty_leaf_without_schema_is_unchanged() {
     reason = "test helper; allow-unwrap-in-tests only covers #[test] fns"
 )]
 fn composite_schema_tools(combinator: &str) -> Vec<Tool> {
+    let branches = json!([
+        {
+            "type": "object",
+            "properties": {
+                "string_list": {"type": "array", "items": {"type": "string"}}
+            }
+        },
+        {
+            "type": "object",
+            "properties": {
+                "number_list": {"type": "array", "items": {"type": "number"}}
+            }
+        }
+    ]);
+    let mut nested = json!({"type": "object"});
+    nested
+        .as_object_mut()
+        .unwrap()
+        .insert(combinator.to_string(), branches.clone());
     let mut parameters = json!({
         "type": "object",
         "properties": {
-            "plain": {"type": "string"}
+            "plain": {"type": "string"},
+            "nested": nested
         }
     });
-    parameters.as_object_mut().unwrap().insert(
-        combinator.to_string(),
-        json!([
-            {
-                "type": "object",
-                "properties": {
-                    "string_list": {"type": "array", "items": {"type": "string"}}
-                }
-            },
-            {
-                "type": "object",
-                "properties": {
-                    "number_list": {"type": "array", "items": {"type": "number"}}
-                }
-            }
-        ]),
-    );
+    parameters
+        .as_object_mut()
+        .unwrap()
+        .insert(combinator.to_string(), branches);
 
     vec![Tool {
         tool_type: "function".to_string(),
@@ -995,6 +1002,46 @@ async fn test_m3_resolves_property_schemas_in_top_level_any_of() {
 #[tokio::test]
 async fn test_m3_resolves_property_schemas_in_top_level_all_of() {
     assert_composite_property_schemas("allOf").await;
+}
+
+#[tokio::test]
+async fn test_m3_resolves_nested_composite_property_schemas() {
+    for combinator in ["oneOf", "anyOf", "allOf"] {
+        let parser = MinimaxM3Parser::new();
+        let tools = composite_schema_tools(combinator);
+        let string_items = format!("{}{}", element("item", "12"), element("item", "34"));
+        let number_items = format!("{}{}", element("item", "12"), element("item", "34"));
+        let input = tool_block(&[
+            (
+                "composite_schema",
+                element("nested", &element("string_list", &string_items)),
+            ),
+            (
+                "composite_schema",
+                element("nested", &element("number_list", &number_items)),
+            ),
+        ]);
+
+        let (_, calls) = parser
+            .parse_complete_with_tools(&input, &tools)
+            .await
+            .unwrap();
+        let string_args: serde_json::Value =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let number_args: serde_json::Value =
+            serde_json::from_str(&calls[1].function.arguments).unwrap();
+
+        assert_eq!(
+            string_args,
+            json!({"nested": {"string_list": ["12", "34"]}}),
+            "{combinator} must preserve nested string array items"
+        );
+        assert_eq!(
+            number_args,
+            json!({"nested": {"number_list": [12, 34]}}),
+            "{combinator} must coerce nested number array items"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/tool_parser/tests/tool_parser_minimax_m3.rs
+++ b/crates/tool_parser/tests/tool_parser_minimax_m3.rs
@@ -913,6 +913,90 @@ async fn test_empty_leaf_without_schema_is_unchanged() {
     assert_eq!(args["avoid_aisles"], json!(""));
 }
 
+#[expect(
+    clippy::unwrap_used,
+    reason = "test helper; allow-unwrap-in-tests only covers #[test] fns"
+)]
+fn composite_schema_tools(combinator: &str) -> Vec<Tool> {
+    let mut parameters = json!({
+        "type": "object",
+        "properties": {
+            "plain": {"type": "string"}
+        }
+    });
+    parameters.as_object_mut().unwrap().insert(
+        combinator.to_string(),
+        json!([
+            {
+                "type": "object",
+                "properties": {
+                    "string_list": {"type": "array", "items": {"type": "string"}}
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "number_list": {"type": "array", "items": {"type": "number"}}
+                }
+            }
+        ]),
+    );
+
+    vec![Tool {
+        tool_type: "function".to_string(),
+        function: Function {
+            name: "composite_schema".to_string(),
+            description: None,
+            parameters,
+            strict: None,
+        },
+    }]
+}
+
+#[expect(
+    clippy::unwrap_used,
+    reason = "test helper; allow-unwrap-in-tests only covers #[test] fns"
+)]
+async fn assert_composite_property_schemas(combinator: &str) {
+    let parser = MinimaxM3Parser::new();
+    let tools = composite_schema_tools(combinator);
+    let string_items = format!("{}{}", element("item", "12"), element("item", "34"));
+    let number_items = format!("{}{}", element("item", "12"), element("item", "34"));
+    let input = tool_block(&[
+        ("composite_schema", element("plain", "007")),
+        ("composite_schema", element("string_list", &string_items)),
+        ("composite_schema", element("number_list", &number_items)),
+    ]);
+
+    let (_, calls) = parser
+        .parse_complete_with_tools(&input, &tools)
+        .await
+        .unwrap();
+    let arguments = calls
+        .iter()
+        .map(|call| serde_json::from_str::<serde_json::Value>(&call.function.arguments).unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(arguments[0], json!({"plain": "007"}));
+    assert_eq!(arguments[1], json!({"string_list": ["12", "34"]}));
+    assert_eq!(arguments[2], json!({"number_list": [12, 34]}));
+}
+
+#[tokio::test]
+async fn test_m3_resolves_property_schemas_in_top_level_one_of() {
+    assert_composite_property_schemas("oneOf").await;
+}
+
+#[tokio::test]
+async fn test_m3_resolves_property_schemas_in_top_level_any_of() {
+    assert_composite_property_schemas("anyOf").await;
+}
+
+#[tokio::test]
+async fn test_m3_resolves_property_schemas_in_top_level_all_of() {
+    assert_composite_property_schemas("allOf").await;
+}
+
 #[tokio::test]
 async fn test_populated_array_still_parses_after_empty_container_fix() {
     let parser = MinimaxM3Parser::new();


### PR DESCRIPTION
## Description

### Problem

The MiniMax-M3 parser only looked in a tool parameter schema's direct
`properties` map when converting parsed arguments. When a property was declared
inside a top-level `oneOf`, `anyOf`, or `allOf` branch, its schema was missed.
Array arguments were consequently emitted as objects such as
`{"item":[12,34]}`, and declared string/number item coercion was lost.

### Solution

Resolve a named property from direct `properties` first, then recursively search
the branches of `oneOf`, `anyOf`, and `allOf`. Reuse that lookup for top-level
invoke arguments and nested object members while leaving duplicate-field
aggregation and array/object conversion unchanged.

## Changes

- Add recursive composite-branch property schema lookup to `MinimaxM3Parser`.
- Cover top-level `oneOf`, `anyOf`, and `allOf` schemas with string-array and
  number-array assertions.
- Cover nested object members whose properties are declared in each composite
  keyword, including string-array and number-array coercion.
- Verify direct top-level `properties` still take precedence and preserve string
  coercion.

## Test Plan

Reproduced before the implementation:

- `cargo test -p tool-parser --test tool_parser_minimax_m3 resolves_property_schemas_in_top_level_one_of -- --nocapture`
  failed because `string_list` was `{"item":[12,34]}` instead of
  `["12","34"]`.
- `cargo test -p tool-parser --test tool_parser_minimax_m3 resolves_nested_composite_property_schemas -- --nocapture`
  failed because the nested `string_list` was `{"item":[12,34]}` instead of
  `["12","34"]`.

Validated after the implementation:

- `cargo +nightly fmt -p tool-parser -- --check` — passed.
- `cargo test -p tool-parser --test tool_parser_minimax_m3 resolves_property_schemas_in_top_level_ -- --nocapture`
  — 3 passed.
- `cargo test -p tool-parser --test tool_parser_minimax_m3 resolves_nested_composite_property_schemas -- --nocapture`
  — passed, covering `oneOf`, `anyOf`, and `allOf` with nested string and number
  arrays.
- `cargo test -p tool-parser --test tool_parser_minimax_m3` — 44 passed.
- `cargo clippy -p tool-parser --lib --tests -- -D warnings` — passed.
- `cargo +nightly fmt --all -- --check` — passed.

## Compatibility / Risk

Risk is limited to schema selection for named MiniMax-M3 properties. Direct
`properties` retain priority, and schemas without composite branches follow the
same path as before. If multiple composite branches declare the same property,
the first declaration in `oneOf`, `anyOf`, then `allOf` order is selected.

<details>
<summary>Checklist</summary>

- [x] Nightly rustfmt passes for the crate and workspace.
- [x] Scoped strict clippy passes for the affected crate library and tests.
- [x] Targeted and full MiniMax-M3 parser tests pass.
- [ ] Documentation updated (not applicable; parser bug fix only).

</details>
