### PR TITLE
fix(vllm): resolve PD connector from MultiConnector config

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py
@@ -45,7 +45,7 @@ def resolve_pd_connector(config: object) -> tuple[str, str]:
 
     child = pd_children[0]
     child_engine_id = child.get("engine_id", engine_id)
-    if not isinstance(child_engine_id, str):
+    if not isinstance(child_engine_id, str) or not child_engine_id:
         return connector, engine_id
     return child["kv_connector"], child_engine_id
 

--- a/grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py
@@ -7,6 +7,48 @@ from smg_grpc_proto import vllm_engine_pb2
 
 logger = logging.getLogger(__name__)
 
+_MULTI_CONNECTOR = "MultiConnector"
+_SUPPORTED_PD_CONNECTORS = frozenset({"MooncakeConnector", "NixlConnector"})
+
+
+def resolve_pd_connector(config: object) -> tuple[str, str]:
+    """Resolve the connector and engine id that SMG should report for PD.
+
+    MultiConnector is only projected when its config has exactly one supported
+    PD child. Invalid or ambiguous wrapper configs are returned unchanged so the
+    router does not guess which transfer protocol to use.
+    """
+    connector = getattr(config, "kv_connector", None) or ""
+    engine_id = getattr(config, "engine_id", None) or ""
+    if connector != _MULTI_CONNECTOR:
+        return connector, engine_id
+
+    extra_config = getattr(config, "kv_connector_extra_config", None)
+    if not isinstance(extra_config, dict):
+        return connector, engine_id
+    children = extra_config.get("connectors")
+    if not isinstance(children, list):
+        return connector, engine_id
+
+    pd_children = []
+    for child in children:
+        if not isinstance(child, dict):
+            return connector, engine_id
+        child_connector = child.get("kv_connector")
+        if not isinstance(child_connector, str) or not child_connector:
+            return connector, engine_id
+        if child_connector in _SUPPORTED_PD_CONNECTORS:
+            pd_children.append(child)
+
+    if len(pd_children) != 1:
+        return connector, engine_id
+
+    child = pd_children[0]
+    child_engine_id = child.get("engine_id", engine_id)
+    if not isinstance(child_engine_id, str):
+        return connector, engine_id
+    return child["kv_connector"], child_engine_id
+
 
 def params_from_request(
     request: vllm_engine_pb2.GenerateRequest,

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -44,7 +44,11 @@ from smg_grpc_servicer.vllm.kv_events import (
     resolve_kv_events_config,
     stream_kv_events,
 )
-from smg_grpc_servicer.vllm.kv_transfer import params_from_request, params_to_response_fields
+from smg_grpc_servicer.vllm.kv_transfer import (
+    params_from_request,
+    params_to_response_fields,
+    resolve_pd_connector,
+)
 from smg_grpc_servicer.vllm.mm_salt import has_preprocessed_mm_payload, mm_identity_cache_salt
 
 logger = init_logger(__name__)
@@ -508,11 +512,11 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         parallel = self.engine.vllm_config.parallel_config
         kv_transfer_config = self.engine.vllm_config.kv_transfer_config
         if kv_transfer_config is not None:
-            kv_connector = kv_transfer_config.kv_connector or ""
+            kv_connector, kv_engine_id = resolve_pd_connector(kv_transfer_config)
             kv_role = kv_transfer_config.kv_role or ""
-            # Base engine_id; with DP the engine cores serve `{id}_dp{rank}` and
-            # the router derives the suffix from the rank it pins per request
-            kv_engine_id = getattr(kv_transfer_config, "engine_id", "") or ""
+            # Effective PD engine_id; with DP the engine cores serve
+            # `{id}_dp{rank}` and the router derives the suffix from the rank it
+            # pins per request.
 
         return vllm_engine_pb2.GetServerInfoResponse(
             kv_connector=kv_connector,

--- a/grpc_servicer/tests/test_kv_transfer_params.py
+++ b/grpc_servicer/tests/test_kv_transfer_params.py
@@ -80,6 +80,34 @@ class TestResolvePdConnector:
             "child-engine",
         )
 
+    def test_empty_child_engine_id_is_not_projected(self):
+        config = _kv_config(
+            "MultiConnector",
+            extra={
+                "connectors": [
+                    {"kv_connector": "NixlConnector", "engine_id": ""},
+                    {"kv_connector": "MooncakeStoreConnector"},
+                ]
+            },
+        )
+
+        assert kv_transfer.resolve_pd_connector(config) == (
+            "MultiConnector",
+            "parent-engine",
+        )
+
+    def test_empty_parent_engine_id_is_not_projected(self):
+        config = _kv_config(
+            "MultiConnector",
+            engine_id="",
+            extra={"connectors": [{"kv_connector": "MooncakeConnector"}]},
+        )
+
+        assert kv_transfer.resolve_pd_connector(config) == (
+            "MultiConnector",
+            "",
+        )
+
     @pytest.mark.parametrize(
         "extra",
         [

--- a/grpc_servicer/tests/test_kv_transfer_params.py
+++ b/grpc_servicer/tests/test_kv_transfer_params.py
@@ -6,6 +6,7 @@ Run with: pytest grpc_servicer/tests/test_kv_transfer_params.py
 import importlib.util
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -28,6 +29,103 @@ NIXL_HANDOFF = {
     "remote_port": 5600,
     "tp_size": 2,
 }
+
+
+def _kv_config(connector, engine_id="parent-engine", extra=None):
+    return SimpleNamespace(
+        kv_connector=connector,
+        engine_id=engine_id,
+        kv_connector_extra_config=extra,
+    )
+
+
+class TestResolvePdConnector:
+    def test_ordinary_connector_is_unchanged(self):
+        config = _kv_config("ExampleConnector", engine_id="engine-1")
+
+        assert kv_transfer.resolve_pd_connector(config) == (
+            "ExampleConnector",
+            "engine-1",
+        )
+
+    def test_projects_mooncake_child_with_parent_engine_id(self):
+        config = _kv_config(
+            "MultiConnector",
+            extra={
+                "connectors": [
+                    {"kv_connector": "MooncakeConnector"},
+                    {"kv_connector": "MooncakeStoreConnector"},
+                ]
+            },
+        )
+
+        assert kv_transfer.resolve_pd_connector(config) == (
+            "MooncakeConnector",
+            "parent-engine",
+        )
+
+    def test_projects_nixl_child_with_child_engine_id(self):
+        config = _kv_config(
+            "MultiConnector",
+            extra={
+                "connectors": [
+                    {"kv_connector": "NixlConnector", "engine_id": "child-engine"},
+                    {"kv_connector": "MooncakeStoreConnector"},
+                ]
+            },
+        )
+
+        assert kv_transfer.resolve_pd_connector(config) == (
+            "NixlConnector",
+            "child-engine",
+        )
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            None,
+            {},
+            {"connectors": "not-a-list"},
+            {"connectors": [None, {"kv_connector": "NixlConnector"}]},
+            {"connectors": [{}, {"kv_connector": "NixlConnector"}]},
+            {"connectors": [{"kv_connector": 42}]},
+            {"connectors": [{"kv_connector": "NixlConnector", "engine_id": None}]},
+        ],
+    )
+    def test_malformed_multi_connector_is_not_projected(self, extra):
+        config = _kv_config("MultiConnector", extra=extra)
+
+        assert kv_transfer.resolve_pd_connector(config) == (
+            "MultiConnector",
+            "parent-engine",
+        )
+
+    def test_store_only_multi_connector_is_not_projected(self):
+        config = _kv_config(
+            "MultiConnector",
+            extra={"connectors": [{"kv_connector": "MooncakeStoreConnector"}]},
+        )
+
+        assert kv_transfer.resolve_pd_connector(config) == (
+            "MultiConnector",
+            "parent-engine",
+        )
+
+    def test_multiple_pd_children_are_not_projected(self):
+        config = _kv_config(
+            "MultiConnector",
+            extra={
+                "connectors": [
+                    {"kv_connector": "MooncakeConnector"},
+                    {"kv_connector": "NixlConnector"},
+                ]
+            },
+        )
+
+        assert kv_transfer.resolve_pd_connector(config) == (
+            "MultiConnector",
+            "parent-engine",
+        )
 
 
 class TestParamsFromRequest:


### PR DESCRIPTION
## Description

### Problem

`GetServerInfo` currently reports the outer `MultiConnector` name and engine ID verbatim. The router only recognizes concrete PD connectors, so a worker whose `MultiConnector` wraps one `MooncakeConnector` or `NixlConnector` loses PD capability discovery even though its configuration is valid.

### Solution

Resolve the effective PD connector before building `GetServerInfoResponse`. A `MultiConnector` is projected only when its child list is structurally valid, contains exactly one supported PD connector, and resolves to a non-empty engine ID. All malformed, store-only, empty-ID, or ambiguous configurations continue to report `MultiConnector` so discovery fails closed instead of guessing.

The child `engine_id` takes precedence when present; otherwise the parent ID is used, matching vLLM's own child `KVTransferConfig` construction.

## Changes

- Add a small engine-independent `resolve_pd_connector` helper in the vLLM KV-transfer module.
- Use the resolved connector and engine ID in `GetServerInfo` while preserving the existing role and ordinary-connector behavior.
- Add engine-free regression tests for Mooncake, NIXL, parent/child engine IDs, empty engine IDs, malformed children, store-only wrappers, ambiguous PD children, and ordinary connectors.

## Test Plan

Executed on the project's CI host:

- Before the empty-ID fix, `PYTHONDONTWRITEBYTECODE=1 /tmp/smg-pr2425-review-venv/bin/python -m pytest -q -p no:cacheprovider grpc_servicer/tests/test_kv_transfer_params.py::TestResolvePdConnector::test_empty_child_engine_id_is_not_projected grpc_servicer/tests/test_kv_transfer_params.py::TestResolvePdConnector::test_empty_parent_engine_id_is_not_projected` — 2 failed as expected; the child case returned `("NixlConnector", "")`, and the inherited-parent case returned `("MooncakeConnector", "")`.
- The same two-node command after the fix — 2 passed.
- `PYTHONDONTWRITEBYTECODE=1 /tmp/smg-pr2425-review-venv/bin/python -m pytest -q -p no:cacheprovider grpc_servicer/tests/test_kv_transfer_params.py::TestResolvePdConnector` — 14 passed.
- `PYTHONDONTWRITEBYTECODE=1 /tmp/smg-pr2425-review-venv/bin/python -m pytest -q -p no:cacheprovider grpc_servicer/tests/test_kv_transfer_params.py` — 34 passed.
- `PYTHONDONTWRITEBYTECODE=1 /tmp/smg-pr2425-review-venv/bin/python -m pytest -q -p no:cacheprovider grpc_servicer/tests` — 102 passed, 5 skipped.
- `PYTHONDONTWRITEBYTECODE=1 /tmp/smg-pr2425-review-venv/bin/python -m py_compile grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py grpc_servicer/smg_grpc_servicer/vllm/servicer.py grpc_servicer/tests/test_kv_transfer_params.py` — passed.
- `/tmp/smg-pr2425-review-venv/bin/ruff format --check grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py grpc_servicer/smg_grpc_servicer/vllm/servicer.py grpc_servicer/tests/test_kv_transfer_params.py` — 3 files already formatted.
- `/tmp/smg-pr2425-review-venv/bin/ruff check grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py grpc_servicer/smg_grpc_servicer/vllm/servicer.py grpc_servicer/tests/test_kv_transfer_params.py` — all checks passed.

## Compatibility and risk

SMG supports vLLM 0.19.0 and newer and currently tests 0.27.1. Both versions represent `MultiConnector` children as a list of `KVTransferConfig` dictionaries under `kv_connector_extra_config["connectors"]`, and both inherit the parent engine ID when a child omits it. The helper depends only on that stable public configuration shape and does not import vLLM.

Risk is limited to server-info projection for `MultiConnector`. Ordinary connectors are returned unchanged, and any unrecognized, empty-ID, or ambiguous wrapper remains a `MultiConnector`. No protobuf or routing contracts change.

<details>
<summary>Checklist</summary>

- [x] Changed Python files pass format and lint checks
- [x] Regression tests cover successful and fail-closed resolution
- [x] Cargo checks are not applicable because no Rust files changed
- [x] Documentation is not required for this internal discovery correction

</details>
