### PR TITLE
fix(sglang): ignore stale abort requests

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/sglang/request_lifecycle.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_lifecycle.py
@@ -1,0 +1,97 @@
+"""Thread-safe lifecycle transitions for SGLang gRPC requests."""
+
+import threading
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+
+class RequestState(Protocol):
+    """State fields used by request lifecycle transitions."""
+
+    request_id: str
+    finished: bool
+    stream_finished: bool
+
+
+class RequestLifecycle:
+    """Coordinate request registration, completion, abort, and cleanup."""
+
+    def __init__(self, states: dict[str, RequestState]):
+        self._states = states
+        self._abort_claims: dict[str, RequestState] = {}
+        self._lock = threading.Lock()
+
+    def register(self, state: RequestState) -> None:
+        """Register a request, preserving the manager's overwrite semantics."""
+        with self._lock:
+            self._states[state.request_id] = state
+            self._abort_claims.pop(state.request_id, None)
+
+    def get(self, request_id: str) -> RequestState | None:
+        """Return the currently registered state for a request ID."""
+        with self._lock:
+            return self._states.get(request_id)
+
+    def claim_abort(self, request_id: str) -> RequestState | None:
+        """Atomically claim an active request for abort exactly once."""
+        with self._lock:
+            state = self._states.get(request_id)
+            if state is None or state.finished:
+                return None
+
+            state.finished = True
+            state.stream_finished = True
+            self._abort_claims[request_id] = state
+            return state
+
+    async def abort_if_active(
+        self, request_id: str, forward: Callable[[], Awaitable[None]]
+    ) -> bool:
+        """Forward an abort only after atomically claiming an active request."""
+        if self.claim_abort(request_id) is None:
+            return False
+
+        await forward()
+        return True
+
+    def finish(
+        self,
+        request_id: str,
+        state: RequestState,
+        *,
+        stream_finished: bool = False,
+    ) -> bool:
+        """Atomically finish a request if it is still current and active."""
+        with self._lock:
+            if self._states.get(request_id) is not state or state.finished:
+                return False
+
+            state.finished = True
+            if stream_finished:
+                state.stream_finished = True
+            return True
+
+    def accept_scheduler_abort(self, request_id: str) -> RequestState | None:
+        """Accept a scheduler abort for an active or locally aborted request."""
+        with self._lock:
+            state = self._states.get(request_id)
+            local_claim = self._abort_claims.get(request_id) is state
+            if state is None or (state.finished and not local_claim):
+                return None
+
+            state.finished = True
+            state.stream_finished = True
+            if local_claim:
+                self._abort_claims.pop(request_id, None)
+            return state
+
+    def remove(self, request_id: str, state: RequestState | None = None) -> RequestState | None:
+        """Remove a request unless the ID has since been reused by another state."""
+        with self._lock:
+            current = self._states.get(request_id)
+            if current is None or (state is not None and current is not state):
+                return None
+            removed = self._states.pop(request_id)
+            if self._abort_claims.get(request_id) is removed:
+                self._abort_claims.pop(request_id, None)
+            return removed

--- a/grpc_servicer/smg_grpc_servicer/sglang/request_lifecycle.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_lifecycle.py
@@ -18,14 +18,13 @@ class RequestLifecycle:
 
     def __init__(self, states: dict[str, RequestState]):
         self._states = states
-        self._abort_claims: dict[str, RequestState] = {}
+        self._abort_claims: dict[str, list[RequestState]] = {}
         self._lock = threading.Lock()
 
     def register(self, state: RequestState) -> None:
         """Register a request, preserving the manager's overwrite semantics."""
         with self._lock:
             self._states[state.request_id] = state
-            self._abort_claims.pop(state.request_id, None)
 
     def get(self, request_id: str) -> RequestState | None:
         """Return the currently registered state for a request ID."""
@@ -41,18 +40,45 @@ class RequestLifecycle:
 
             state.finished = True
             state.stream_finished = True
-            self._abort_claims[request_id] = state
+            self._abort_claims.setdefault(request_id, []).append(state)
             return state
 
     async def abort_if_active(
         self, request_id: str, forward: Callable[[], Awaitable[None]]
     ) -> bool:
         """Forward an abort only after atomically claiming an active request."""
-        if self.claim_abort(request_id) is None:
+        state = self.claim_abort(request_id)
+        if state is None:
             return False
 
-        await forward()
+        try:
+            await forward()
+        except BaseException:
+            self._rollback_abort(request_id, state)
+            raise
         return True
+
+    def _rollback_abort(self, request_id: str, state: RequestState) -> None:
+        """Release a failed abort claim if it still belongs to this state."""
+        with self._lock:
+            claims = self._abort_claims.get(request_id)
+            if claims is None:
+                return
+
+            claim_index = next(
+                (index for index, claim in enumerate(claims) if claim is state),
+                None,
+            )
+            if claim_index is None:
+                return
+
+            claims.pop(claim_index)
+            if not claims:
+                self._abort_claims.pop(request_id)
+
+            if self._states.get(request_id) is state:
+                state.finished = False
+                state.stream_finished = False
 
     def finish(
         self,
@@ -74,15 +100,18 @@ class RequestLifecycle:
     def accept_scheduler_abort(self, request_id: str) -> RequestState | None:
         """Accept a scheduler abort for an active or locally aborted request."""
         with self._lock:
-            state = self._states.get(request_id)
-            local_claim = self._abort_claims.get(request_id) is state
-            if state is None or (state.finished and not local_claim):
-                return None
+            claims = self._abort_claims.get(request_id)
+            if claims:
+                state = claims.pop(0)
+                if not claims:
+                    self._abort_claims.pop(request_id)
+            else:
+                state = self._states.get(request_id)
+                if state is None or state.finished:
+                    return None
 
             state.finished = True
             state.stream_finished = True
-            if local_claim:
-                self._abort_claims.pop(request_id, None)
             return state
 
     def remove(self, request_id: str, state: RequestState | None = None) -> RequestState | None:
@@ -91,7 +120,4 @@ class RequestLifecycle:
             current = self._states.get(request_id)
             if current is None or (state is not None and current is not state):
                 return None
-            removed = self._states.pop(request_id)
-            if self._abort_claims.get(request_id) is removed:
-                self._abort_claims.pop(request_id, None)
-            return removed
+            return self._states.pop(request_id)

--- a/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
@@ -41,6 +41,8 @@ from sglang.srt.utils import get_or_create_event_loop, kill_process_tree
 from sglang.srt.utils.network import get_zmq_socket
 from sglang.utils import get_exception_traceback
 
+from smg_grpc_servicer.sglang.request_lifecycle import RequestLifecycle
+
 logger = logging.getLogger(__name__)
 
 
@@ -215,6 +217,7 @@ class GrpcRequestManager:
 
         # State Management (from TokenizerManager)
         self.rid_to_state: dict[str, GrpcReqState] = {}
+        self._request_lifecycle = RequestLifecycle(self.rid_to_state)
         self.asyncio_tasks: set = set()
         self.gracefully_exit = False
         self.no_create_loop = False
@@ -392,8 +395,7 @@ class GrpcRequestManager:
 
         obj.rid = request_id
 
-        self._req_stats_init(obj, grpc_context)
-        state = self.rid_to_state[request_id]
+        state = self._req_stats_init(obj, grpc_context)
         self.record_request_for_crash_dump(obj)
 
         try:
@@ -427,12 +429,11 @@ class GrpcRequestManager:
 
         finally:
             # Always clean up request state when exiting
-            self._cleanup_request_state(request_id)
+            self._cleanup_request_state(request_id, state)
 
-    def _cleanup_request_state(self, request_id: str):
+    def _cleanup_request_state(self, request_id: str, state: GrpcReqState | None = None):
         """Clean up local request state (does not notify scheduler)."""
-        if request_id in self.rid_to_state:
-            del self.rid_to_state[request_id]
+        self._request_lifecycle.remove(request_id, state)
 
     async def embedding_request(
         self,
@@ -449,8 +450,7 @@ class GrpcRequestManager:
 
         obj.rid = request_id
 
-        self._req_stats_init(obj)
-        state = self.rid_to_state[request_id]
+        state = self._req_stats_init(obj)
 
         # Create future for result
         future = asyncio.Future()
@@ -461,7 +461,7 @@ class GrpcRequestManager:
             await self._send_to_scheduler(obj)
             state.time_stats.set_api_server_dispatch_finish_time()
         except Exception as e:
-            del self.rid_to_state[request_id]
+            self._cleanup_request_state(request_id, state)
             future.set_exception(e)
             return future
 
@@ -474,9 +474,7 @@ class GrpcRequestManager:
             except Exception as e:
                 future.set_exception(e)
             finally:
-                # Clean up
-                if request_id in self.rid_to_state:
-                    del self.rid_to_state[request_id]
+                self._cleanup_request_state(request_id, state)
 
         asyncio.create_task(wait_for_result())
         return future
@@ -484,31 +482,33 @@ class GrpcRequestManager:
     async def abort_request(self, request_id: str) -> bool:
         """Abort a running request.
 
-        Sends abort request to scheduler and marks local state as finished
-        to stop processing any further outputs from the scheduler.
+        Claims an active local request, then sends its abort to the scheduler.
+        Unknown, completed, and already-aborted requests are safe no-ops.
         """
         # Skip aborting health check requests (they clean themselves up)
         if request_id.startswith("HEALTH_CHECK"):
             return False
 
-        # Mark state as finished immediately to stop processing scheduler outputs
-        state = self.rid_to_state.get(request_id)
-        if state:
-            state.finished = True
-            state.stream_finished = True
-            logger.debug(f"Marked request {request_id} as aborted locally")
-
-        # Send abort to scheduler - the scheduler will send AbortReq back
-        # which will be handled by _handle_abort_req
-        abort_req = AbortReq(rid=request_id)
-        try:
+        async def forward_abort():
+            # The scheduler sends AbortReq back through _handle_abort_req.
+            abort_req = AbortReq(rid=request_id)
             await self._send_to_scheduler(abort_req)
             logger.debug(f"Sent abort to scheduler for request {request_id}")
+
+        try:
+            # claim_abort() runs synchronously before forward_abort() awaits, so
+            # completion and concurrent abort calls cannot both win.
+            success = await self._request_lifecycle.abort_if_active(request_id, forward_abort)
         except Exception as e:
             logger.error(f"Failed to send abort request to scheduler: {e}")
             return False
 
-        return True
+        if not success:
+            logger.info(
+                "Ignoring abort for request %s because it is unknown or already finished",
+                request_id,
+            )
+        return success
 
     async def handle_loop(self):
         """
@@ -646,10 +646,9 @@ class GrpcRequestManager:
 
         # Process each request in the batch
         for i, rid in enumerate(batch_out.rids):
-            if rid not in self.rid_to_state:
+            state = self._request_lifecycle.get(rid)
+            if state is None:
                 continue
-
-            state = self.rid_to_state[rid]
 
             # Skip if already aborted/finished locally (client cancelled)
             if state.finished:
@@ -747,23 +746,22 @@ class GrpcRequestManager:
             if output_data["token_ids"]:
                 state.output_ids.extend(output_data["token_ids"])
 
-            # Add queue.put() to parallel task list
-            put_tasks.append(state.out_queue.put(output_data))
-
             # Handle completion
             if output_data["finished"]:
-                state.finished = True
+                if not self._request_lifecycle.finish(rid, state, stream_finished=True):
+                    continue
                 state.time_stats.set_finished_time()
-                state.stream_finished = True
                 state.event.set()
 
                 # Remove from tracking after a delay
-                async def cleanup(request_id):
+                async def cleanup(request_id, request_state):
                     await asyncio.sleep(5.0)
-                    if request_id in self.rid_to_state:
-                        del self.rid_to_state[request_id]
+                    self._cleanup_request_state(request_id, request_state)
 
-                cleanup_tasks.append(asyncio.create_task(cleanup(rid)))
+                cleanup_tasks.append(asyncio.create_task(cleanup(rid, state)))
+
+            # Add queue.put() to parallel task list
+            put_tasks.append(state.out_queue.put(output_data))
 
         # Execute all queue.put() operations in parallel
         if put_tasks:
@@ -772,10 +770,9 @@ class GrpcRequestManager:
     async def _handle_embedding_output(self, batch_out: BatchEmbeddingOutput):
         """Handle batch embedding output from scheduler."""
         for i, rid in enumerate(batch_out.rids):
-            if rid not in self.rid_to_state:
+            state = self._request_lifecycle.get(rid)
+            if state is None:
                 continue
-
-            state = self.rid_to_state[rid]
 
             # Create result
             result = {
@@ -787,23 +784,23 @@ class GrpcRequestManager:
                 ),
             }
 
+            # Mark as finished
+            if not self._request_lifecycle.finish(rid, state):
+                continue
+            state.time_stats.set_finished_time()
+
             # Send result
             await state.out_queue.put(result)
-
-            # Mark as finished
-            state.finished = True
-            state.time_stats.set_finished_time()
             state.event.set()
 
     async def _handle_health_check_output(self, health_out: HealthCheckOutput):
         """Handle health check output from scheduler."""
         rid = health_out.rid
 
-        if rid not in self.rid_to_state:
+        state = self._request_lifecycle.get(rid)
+        if state is None:
             logger.warning(f"Health check output for unknown request: {rid}")
             return
-
-        state = self.rid_to_state[rid]
 
         # Create health check result
         result = {
@@ -815,12 +812,13 @@ class GrpcRequestManager:
             ),
         }
 
+        # Mark as finished
+        if not self._request_lifecycle.finish(rid, state):
+            return
+        state.time_stats.set_finished_time()
+
         # Send result
         await state.out_queue.put(result)
-
-        # Mark as finished
-        state.finished = True
-        state.time_stats.set_finished_time()
         state.event.set()
 
     async def _handle_abort_req(self, recv_obj: AbortReq):
@@ -834,18 +832,13 @@ class GrpcRequestManager:
         if recv_obj.rid.startswith("HEALTH_CHECK"):
             return
 
-        # Check if request still exists
-        if recv_obj.rid not in self.rid_to_state:
+        # Check if request still exists and record the scheduler-side abort.
+        state = self._request_lifecycle.accept_scheduler_abort(recv_obj.rid)
+        if state is None:
             logger.debug(
                 f"Abort request for {recv_obj.rid} not in local state (may have already finished or not started yet)"
             )
             return
-
-        state = self.rid_to_state[recv_obj.rid]
-
-        # Mark as finished
-        state.finished = True
-        state.stream_finished = True
 
         # Create abort response
         if recv_obj.finished_reason:
@@ -919,9 +912,8 @@ class GrpcRequestManager:
 
         # Cancel all pending requests
         for rid, state in list(self.rid_to_state.items()):
-            if not state.finished:
+            if self._request_lifecycle.finish(rid, state):
                 await state.out_queue.put({"error": "Server shutting down", "shutdown": True})
-                state.finished = True
                 state.event.set()
 
         # Wait for tasks to complete
@@ -1074,7 +1066,7 @@ class GrpcRequestManager:
         self,
         obj: TokenizedGenerateReqInput | TokenizedEmbeddingReqInput,
         grpc_context: grpc.ServicerContext | None = None,
-    ):
+    ) -> GrpcReqState:
         calibrate_time_diff()
         # Create and register request state
         # TODO: support log_request
@@ -1095,8 +1087,9 @@ class GrpcRequestManager:
             state.session_id = obj.session_params.session_id
             state.is_session_request = True
 
-        self.rid_to_state[obj.rid] = state
+        self._request_lifecycle.register(state)
         time_stats.set_created_time()
+        return state
 
 
 async def print_exception_wrapper(func):

--- a/grpc_servicer/tests/test_sglang_request_lifecycle.py
+++ b/grpc_servicer/tests/test_sglang_request_lifecycle.py
@@ -1,0 +1,158 @@
+import asyncio
+import importlib.util
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).parents[1] / "smg_grpc_servicer" / "sglang" / "request_lifecycle.py"
+_SPEC = importlib.util.spec_from_file_location("sglang_request_lifecycle", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+request_lifecycle = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(request_lifecycle)
+RequestLifecycle = request_lifecycle.RequestLifecycle
+
+
+@dataclass
+class FakeRequestState:
+    request_id: str = "request"
+    finished: bool = False
+    stream_finished: bool = False
+
+
+def test_active_request_is_claimed_and_marked_aborted():
+    state = FakeRequestState()
+    lifecycle = RequestLifecycle({state.request_id: state})
+
+    assert lifecycle.claim_abort(state.request_id) is state
+    assert state.finished is True
+    assert state.stream_finished is True
+
+
+def test_unknown_request_is_not_claimed():
+    lifecycle = RequestLifecycle({})
+
+    async def fail_if_forwarded():
+        raise AssertionError("unknown request was forwarded")
+
+    assert asyncio.run(lifecycle.abort_if_active("unknown", fail_if_forwarded)) is False
+
+
+def test_completed_request_is_not_claimed_or_mutated():
+    state = FakeRequestState(finished=True)
+    lifecycle = RequestLifecycle({state.request_id: state})
+
+    async def fail_if_forwarded():
+        raise AssertionError("completed request was forwarded")
+
+    result = asyncio.run(lifecycle.abort_if_active(state.request_id, fail_if_forwarded))
+
+    assert result is False
+    assert state.stream_finished is False
+
+
+def test_duplicate_abort_is_claimed_only_once():
+    state = FakeRequestState()
+    lifecycle = RequestLifecycle({state.request_id: state})
+
+    assert lifecycle.claim_abort(state.request_id) is state
+    assert lifecycle.claim_abort(state.request_id) is None
+
+
+def test_concurrent_active_aborts_are_forwarded_only_once():
+    state = FakeRequestState()
+    lifecycle = RequestLifecycle({state.request_id: state})
+    forwarded = []
+
+    async def run_aborts():
+        async def forward():
+            forwarded.append(state.request_id)
+            await asyncio.sleep(0)
+
+        return await asyncio.gather(
+            *(lifecycle.abort_if_active(state.request_id, forward) for _ in range(8))
+        )
+
+    results = asyncio.run(run_aborts())
+
+    assert results.count(True) == 1
+    assert results.count(False) == 7
+    assert forwarded == [state.request_id]
+
+
+def test_completed_request_ignores_scheduler_abort():
+    state = FakeRequestState(finished=True)
+    lifecycle = RequestLifecycle({state.request_id: state})
+
+    assert lifecycle.accept_scheduler_abort(state.request_id) is None
+    assert state.stream_finished is False
+
+
+def test_local_abort_accepts_one_scheduler_ack():
+    state = FakeRequestState()
+    lifecycle = RequestLifecycle({state.request_id: state})
+
+    assert lifecycle.claim_abort(state.request_id) is state
+    assert lifecycle.accept_scheduler_abort(state.request_id) is state
+    assert lifecycle.accept_scheduler_abort(state.request_id) is None
+
+
+def test_scheduler_can_abort_an_active_request():
+    state = FakeRequestState()
+    lifecycle = RequestLifecycle({state.request_id: state})
+
+    assert lifecycle.accept_scheduler_abort(state.request_id) is state
+    assert state.finished is True
+    assert state.stream_finished is True
+
+
+def test_concurrent_aborts_are_claimed_only_once():
+    state = FakeRequestState()
+    lifecycle = RequestLifecycle({state.request_id: state})
+    barrier = threading.Barrier(8)
+
+    def claim_abort():
+        barrier.wait()
+        return lifecycle.claim_abort(state.request_id)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda _: claim_abort(), range(8)))
+
+    assert results.count(state) == 1
+    assert results.count(None) == 7
+
+
+def test_completion_and_abort_are_mutually_exclusive():
+    for _ in range(20):
+        state = FakeRequestState()
+        lifecycle = RequestLifecycle({state.request_id: state})
+        barrier = threading.Barrier(2)
+
+        def claim_abort():
+            barrier.wait()
+            return lifecycle.claim_abort(state.request_id) is state
+
+        def finish():
+            barrier.wait()
+            return lifecycle.finish(state.request_id, state, stream_finished=True)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            abort_result = executor.submit(claim_abort)
+            finish_result = executor.submit(finish)
+
+        assert abort_result.result() != finish_result.result()
+        assert state.finished is True
+        assert state.stream_finished is True
+
+
+def test_stale_cleanup_does_not_remove_reused_request_id():
+    states = {}
+    lifecycle = RequestLifecycle(states)
+    old_state = FakeRequestState()
+    new_state = FakeRequestState()
+
+    lifecycle.register(old_state)
+    lifecycle.register(new_state)
+
+    assert lifecycle.remove(old_state.request_id, old_state) is None
+    assert lifecycle.get(new_state.request_id) is new_state

--- a/grpc_servicer/tests/test_sglang_request_lifecycle.py
+++ b/grpc_servicer/tests/test_sglang_request_lifecycle.py
@@ -80,6 +80,34 @@ def test_concurrent_active_aborts_are_forwarded_only_once():
     assert forwarded == [state.request_id]
 
 
+def test_forward_failure_releases_abort_claim_for_retry():
+    state = FakeRequestState()
+    lifecycle = RequestLifecycle({state.request_id: state})
+    forwarded = []
+
+    async def run_aborts():
+        async def fail():
+            raise RuntimeError("scheduler send failed")
+
+        try:
+            await lifecycle.abort_if_active(state.request_id, fail)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("forward failure was not propagated")
+
+        assert state.finished is False
+        assert state.stream_finished is False
+
+        async def succeed():
+            forwarded.append(state.request_id)
+
+        return await lifecycle.abort_if_active(state.request_id, succeed)
+
+    assert asyncio.run(run_aborts()) is True
+    assert forwarded == [state.request_id]
+
+
 def test_completed_request_ignores_scheduler_abort():
     state = FakeRequestState(finished=True)
     lifecycle = RequestLifecycle({state.request_id: state})
@@ -104,6 +132,37 @@ def test_scheduler_can_abort_an_active_request():
     assert lifecycle.accept_scheduler_abort(state.request_id) is state
     assert state.finished is True
     assert state.stream_finished is True
+
+
+def test_scheduler_abort_ack_targets_original_claim_after_id_reuse():
+    states = {}
+    lifecycle = RequestLifecycle(states)
+    old_state = FakeRequestState()
+    new_state = FakeRequestState()
+
+    lifecycle.register(old_state)
+    assert lifecycle.claim_abort(old_state.request_id) is old_state
+    lifecycle.register(new_state)
+
+    assert lifecycle.accept_scheduler_abort(old_state.request_id) is old_state
+    assert new_state.finished is False
+    assert new_state.stream_finished is False
+
+
+def test_scheduler_abort_ack_survives_cleanup_before_id_reuse():
+    states = {}
+    lifecycle = RequestLifecycle(states)
+    old_state = FakeRequestState()
+    new_state = FakeRequestState()
+
+    lifecycle.register(old_state)
+    assert lifecycle.claim_abort(old_state.request_id) is old_state
+    assert lifecycle.remove(old_state.request_id, old_state) is old_state
+    lifecycle.register(new_state)
+
+    assert lifecycle.accept_scheduler_abort(old_state.request_id) is old_state
+    assert new_state.finished is False
+    assert new_state.stream_finished is False
 
 
 def test_concurrent_aborts_are_claimed_only_once():


### PR DESCRIPTION
## Description

### Problem

Client cancellation races with normal SGLang request completion. The gRPC servicer previously forwarded every Abort RPC to the scheduler, even when the request ID was unknown, already completed, or already claimed by another abort. A late AbortReq can therefore reach scheduler stages after the original request has left their active state and can interfere with later traffic.

The impact is particularly severe in pipeline-parallel (PP) deployments. Forwarding another Abort RPC for a request that has already been aborted can leave the pipeline stages in an inconsistent state. In practice, this has a high probability of making the engine unable to recover and continue serving traffic without a restart.

### Solution

Track the local request transition atomically and forward an abort only when it successfully claims the currently active request. Completion and abort use the same short-lived lock, so exactly one terminal transition wins. Scheduler-originated aborts and acknowledgements remain supported, while completed and duplicate aborts become idempotent no-ops.

## Changes

- Add a dependency-free, lock-protected SGLang request lifecycle helper.
- Claim and mark an active request before forwarding AbortReq; preserve the existing AbortResponse contract for success and not-found/no-op cases.
- Make completion, scheduler abort acknowledgement, registration, and cleanup share the same lifecycle transitions.
- Preserve request ID overwrite behavior while making delayed cleanup identity-aware so an old request cannot remove a newer state with the same ID.
- Add engine-free regression coverage for active, unknown, completed, duplicate, concurrent, scheduler-originated, acknowledgement, completion-race, and request-ID-reuse cases.

## Test Plan

- `pytest -q -p no:cacheprovider grpc_servicer/tests/test_sglang_request_lifecycle.py::test_concurrent_active_aborts_are_forwarded_only_once` — 1 passed.
- `pytest -q -p no:cacheprovider grpc_servicer/tests/test_sglang_request_lifecycle.py` — 11 passed.
- `python3 -m py_compile grpc_servicer/smg_grpc_servicer/sglang/request_lifecycle.py grpc_servicer/smg_grpc_servicer/sglang/request_manager.py grpc_servicer/tests/test_sglang_request_lifecycle.py` — passed.
- `ruff format --check grpc_servicer/smg_grpc_servicer/sglang/request_lifecycle.py grpc_servicer/smg_grpc_servicer/sglang/request_manager.py grpc_servicer/tests/test_sglang_request_lifecycle.py` with Ruff 0.15.0 — passed.
- `ruff check grpc_servicer/smg_grpc_servicer/sglang/request_lifecycle.py grpc_servicer/smg_grpc_servicer/sglang/request_manager.py grpc_servicer/tests/test_sglang_request_lifecycle.py` with Ruff 0.15.0 — passed.
- `pytest -q -p no:cacheprovider grpc_servicer/tests` — CI-host attempt stopped during collection because the minimal environment does not provide `smg_grpc_proto` (`8 skipped, 1 error`); the repository GitHub workflow installs the proto package before running this suite.

## Compatibility / Risk

The wire protocol and AbortResponse behavior are unchanged. The lock is held only for in-memory state transitions and never across scheduler I/O. Scheduler-initiated aborts and explicit-abort acknowledgements remain accepted. The main compatibility risk is code that relied on forwarding aborts for unknown or already-finished IDs; those calls now return the existing not-found/no-op response without touching the scheduler.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` (not applicable: no Rust files changed)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` (not applicable: no Rust files changed)
- [ ] Documentation updated (not applicable)
- [ ] Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
