### PR TITLE
fix(grpc): bind scheduler IPC before startup

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/sglang/scheduler_launcher.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/scheduler_launcher.py
@@ -74,7 +74,7 @@ def launch_scheduler_process_only(
     # Allocate ports for inter-process communications
     if port_args is None:
         port_args = PortArgs.init_new(server_args)
-        logger.info(f"{server_args=}")
+    logger.info(f"{server_args=}")
 
     scheduler_procs = []
 

--- a/grpc_servicer/smg_grpc_servicer/sglang/scheduler_launcher.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/scheduler_launcher.py
@@ -38,6 +38,24 @@ def run_scheduler_with_signal_handling(*args, **kwargs):
     run_scheduler_process(*args, **kwargs)
 
 
+def terminate_scheduler_processes(scheduler_procs: list[mp.Process]) -> None:
+    """Terminate and reap scheduler processes without abandoning later ranks."""
+    for i, proc in enumerate(scheduler_procs):
+        try:
+            if proc.is_alive():
+                logger.info(f"Terminating scheduler process {i}...")
+                proc.terminate()
+            proc.join(timeout=2.0)
+            if proc.is_alive():
+                logger.warning(f"Scheduler process {i} did not terminate, killing...")
+                proc.kill()
+                proc.join(timeout=1.0)
+        except Exception:
+            logger.exception(f"Failed to terminate scheduler process {i}")
+
+    logger.info("All scheduler processes terminated")
+
+
 def launch_scheduler_process_only(
     server_args: ServerArgs,
     port_args: PortArgs | None = None,
@@ -77,6 +95,25 @@ def launch_scheduler_process_only(
     logger.info(f"{server_args=}")
 
     scheduler_procs = []
+    try:
+        scheduler_info = _start_scheduler_processes(
+            server_args,
+            port_args,
+            scheduler_procs,
+        )
+    except BaseException:
+        terminate_scheduler_processes(scheduler_procs)
+        raise
+
+    return scheduler_info, port_args, scheduler_procs
+
+
+def _start_scheduler_processes(
+    server_args: ServerArgs,
+    port_args: PortArgs,
+    scheduler_procs: list[mp.Process],
+) -> dict:
+    """Start scheduler processes and wait for every ready handshake."""
 
     if server_args.dp_size == 1:
         # Single data parallel group - launch TP/PP schedulers
@@ -144,8 +181,8 @@ def launch_scheduler_process_only(
                     numa_utils.configure_subprocess(server_args, gpu_id),
                 ):
                     proc.start()
+                    scheduler_procs.append(proc)
 
-                scheduler_procs.append(proc)
                 scheduler_pipe_readers.append(reader)
     else:
         # Data parallelism - launch data parallel controller
@@ -181,4 +218,4 @@ def launch_scheduler_process_only(
     logger.info(f"All {len(scheduler_procs)} scheduler process(es) initialized successfully")
 
     # Return the first scheduler's info (they should all be the same)
-    return scheduler_infos[0], port_args, scheduler_procs
+    return scheduler_infos[0]

--- a/grpc_servicer/smg_grpc_servicer/sglang/server.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/server.py
@@ -29,7 +29,10 @@ from smg_grpc_proto import sglang_scheduler_pb2, sglang_scheduler_pb2_grpc
 
 from smg_grpc_servicer.sglang.health_servicer import SGLangHealthServicer
 from smg_grpc_servicer.sglang.request_manager import GrpcRequestManager
-from smg_grpc_servicer.sglang.scheduler_launcher import launch_scheduler_process_only
+from smg_grpc_servicer.sglang.scheduler_launcher import (
+    launch_scheduler_process_only,
+    terminate_scheduler_processes,
+)
 from smg_grpc_servicer.sglang.servicer import SGLangSchedulerServicer
 
 logger = logging.getLogger(__name__)
@@ -57,6 +60,33 @@ async def _launch_scheduler_with_request_manager(
         raise
 
     return scheduler_info, launched_port_args, scheduler_procs, request_manager
+
+
+async def _cleanup_failed_startup(
+    server,
+    health_servicer,
+    request_manager: GrpcRequestManager,
+    scheduler_procs,
+):
+    """Release resources retained by an incomplete gRPC startup."""
+    if health_servicer is not None:
+        try:
+            health_servicer.set_not_serving()
+        except Exception:
+            logger.exception("Failed to mark gRPC health as not serving")
+
+    if server is not None:
+        try:
+            await server.stop(0)
+        except Exception:
+            logger.exception("Failed to stop partially started gRPC server")
+
+    terminate_scheduler_processes(scheduler_procs)
+
+    try:
+        await request_manager.shutdown()
+    except Exception:
+        logger.exception("Failed to shut down request manager after startup failure")
 
 
 async def serve_grpc(
@@ -113,240 +143,242 @@ async def serve_grpc(
         bootstrap_server=bootstrap_server,
     )
 
-    # Load model config to get HF config info (same as TokenizerManager does)
-    model_config = ModelConfig.from_server_args(server_args)
+    server = None
+    health_servicer = None
+    try:
+        # Load model config to get HF config info (same as TokenizerManager does)
+        model_config = ModelConfig.from_server_args(server_args)
 
-    # Update model info from scheduler info and model config
-    if model_info is None:
-        # Extract classification labels from HuggingFace config (if available)
-        # Match logic in serving_classify.py::_get_id2label_mapping
-        hf_config = model_config.hf_config
-        id2label = getattr(hf_config, "id2label", None)
-        num_labels = getattr(hf_config, "num_labels", 0) or 0
+        # Update model info from scheduler info and model config
+        if model_info is None:
+            # Extract classification labels from HuggingFace config (if available)
+            # Match logic in serving_classify.py::_get_id2label_mapping
+            hf_config = model_config.hf_config
+            id2label = getattr(hf_config, "id2label", None)
+            num_labels = getattr(hf_config, "num_labels", 0) or 0
 
-        # If no id2label but num_labels exists, create default mapping
-        if not id2label and num_labels:
-            id2label = {i: f"LABEL_{i}" for i in range(num_labels)}
-        elif id2label and not num_labels:
-            num_labels = len(id2label)
+            # If no id2label but num_labels exists, create default mapping
+            if not id2label and num_labels:
+                id2label = {i: f"LABEL_{i}" for i in range(num_labels)}
+            elif id2label and not num_labels:
+                num_labels = len(id2label)
 
-        # Convert to JSON string for proto transport
-        # id2label is a dict like {0: "negative", 1: "positive"}
-        id2label_json = json.dumps(id2label) if id2label else ""
+            # Convert to JSON string for proto transport
+            # id2label is a dict like {0: "negative", 1: "positive"}
+            id2label_json = json.dumps(id2label) if id2label else ""
 
-        model_info = {
-            "model_name": server_args.model_path,
-            "max_context_length": scheduler_info.get(
-                "max_total_num_tokens", server_args.context_length or 8192
-            ),
-            "vocab_size": scheduler_info.get("vocab_size", 128256),
-            "supports_vision": scheduler_info.get("supports_vision", False),
-            "model_type": getattr(hf_config, "model_type", None),
-            "architectures": getattr(hf_config, "architectures", None),
-            "max_req_input_len": scheduler_info.get("max_req_input_len", 8192),
-            "eos_token_ids": scheduler_info.get("eos_token_ids", []),
-            "pad_token_id": scheduler_info.get("pad_token_id", 0),
-            "bos_token_id": scheduler_info.get("bos_token_id", 1),
-            # Classification model support
-            "id2label_json": id2label_json,
-            "num_labels": num_labels or 0,
-        }
+            model_info = {
+                "model_name": server_args.model_path,
+                "max_context_length": scheduler_info.get(
+                    "max_total_num_tokens", server_args.context_length or 8192
+                ),
+                "vocab_size": scheduler_info.get("vocab_size", 128256),
+                "supports_vision": scheduler_info.get("supports_vision", False),
+                "model_type": getattr(hf_config, "model_type", None),
+                "architectures": getattr(hf_config, "architectures", None),
+                "max_req_input_len": scheduler_info.get("max_req_input_len", 8192),
+                "eos_token_ids": scheduler_info.get("eos_token_ids", []),
+                "pad_token_id": scheduler_info.get("pad_token_id", 0),
+                "bos_token_id": scheduler_info.get("bos_token_id", 1),
+                # Classification model support
+                "id2label_json": id2label_json,
+                "num_labels": num_labels or 0,
+            }
 
-    if on_request_manager_ready is not None:
-        try:
+        if on_request_manager_ready is not None:
             await on_request_manager_ready(request_manager, server_args, scheduler_info)
-        except Exception:
-            # The shutdown guard below only covers the post-start path, so
-            # clean up the scheduler processes and sockets before re-raising.
-            logger.exception("on_request_manager_ready callback failed, shutting down")
-            await request_manager.shutdown()
-            for proc in scheduler_procs:
-                if proc.is_alive():
-                    proc.terminate()
-                    proc.join(timeout=2.0)
-                    if proc.is_alive():
-                        proc.kill()
-            raise
 
-    # Create gRPC server
-    server = grpc.aio.server(
-        futures.ThreadPoolExecutor(max_workers=10),
-        options=[
-            ("grpc.max_send_message_length", 1024 * 1024 * 256),
-            ("grpc.max_receive_message_length", 1024 * 1024 * 256),
-            # Allow client HTTP/2 keepalive pings every 10s+.
-            # Without this, the gRPC C-core default (300s minimum) causes
-            # GOAWAY when clients send pings more frequently during long
-            # requests (e.g. prefill) where no DATA frames flow.
-            ("grpc.http2.min_ping_interval_without_data_ms", 10000),
-            ("grpc.keepalive_permit_without_calls", True),
-        ],
-    )
+        # Create gRPC server
+        server = grpc.aio.server(
+            futures.ThreadPoolExecutor(max_workers=10),
+            options=[
+                ("grpc.max_send_message_length", 1024 * 1024 * 256),
+                ("grpc.max_receive_message_length", 1024 * 1024 * 256),
+                # Allow client HTTP/2 keepalive pings every 10s+.
+                # Without this, the gRPC C-core default (300s minimum) causes
+                # GOAWAY when clients send pings more frequently during long
+                # requests (e.g. prefill) where no DATA frames flow.
+                ("grpc.http2.min_ping_interval_without_data_ms", 10000),
+                ("grpc.keepalive_permit_without_calls", True),
+            ],
+        )
 
-    # Create standard health service (for Kubernetes probes)
-    health_servicer = SGLangHealthServicer(
-        request_manager=request_manager,
-        scheduler_info=scheduler_info,
-    )
-    health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
+        # Create standard health service (for Kubernetes probes)
+        health_servicer = SGLangHealthServicer(
+            request_manager=request_manager,
+            scheduler_info=scheduler_info,
+        )
+        health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
 
-    # Add SGLang service
-    servicer = SGLangSchedulerServicer(
-        request_manager=request_manager,
-        server_args=server_args,
-        model_config=model_config,
-        model_info=model_info,
-        scheduler_info=scheduler_info,
-        health_servicer=health_servicer,
-    )
-    sglang_scheduler_pb2_grpc.add_SglangSchedulerServicer_to_server(servicer, server)
+        # Add SGLang service
+        servicer = SGLangSchedulerServicer(
+            request_manager=request_manager,
+            server_args=server_args,
+            model_config=model_config,
+            model_info=model_info,
+            scheduler_info=scheduler_info,
+            health_servicer=health_servicer,
+        )
+        sglang_scheduler_pb2_grpc.add_SglangSchedulerServicer_to_server(servicer, server)
 
-    # Enable reflection
-    SERVICE_NAMES = (
-        sglang_scheduler_pb2.DESCRIPTOR.services_by_name["SglangScheduler"].full_name,
-        "grpc.health.v1.Health",
-        reflection.SERVICE_NAME,
-    )
-    reflection.enable_server_reflection(SERVICE_NAMES, server)
+        # Enable reflection
+        SERVICE_NAMES = (
+            sglang_scheduler_pb2.DESCRIPTOR.services_by_name["SglangScheduler"].full_name,
+            "grpc.health.v1.Health",
+            reflection.SERVICE_NAME,
+        )
+        reflection.enable_server_reflection(SERVICE_NAMES, server)
 
-    # Start server
-    listen_addr = f"{server_args.host}:{server_args.port}"
-    if server_args.ssl_certfile and server_args.ssl_keyfile:
-        if server_args.ssl_keyfile_password:
-            raise ValueError(
-                "gRPC mode does not support encrypted SSL key files "
-                "(--ssl-keyfile-password). Please provide an unencrypted key "
-                "file when using --grpc-mode."
-            )
+        # Start server
+        listen_addr = f"{server_args.host}:{server_args.port}"
+        if server_args.ssl_certfile and server_args.ssl_keyfile:
+            if server_args.ssl_keyfile_password:
+                raise ValueError(
+                    "gRPC mode does not support encrypted SSL key files "
+                    "(--ssl-keyfile-password). Please provide an unencrypted key "
+                    "file when using --grpc-mode."
+                )
 
-        def _read_ssl_file(filepath: str, description: str) -> bytes:
-            try:
-                with open(filepath, "rb") as f:
-                    return f.read()
-            except OSError as e:
-                raise ValueError(f"Failed to read {description} '{filepath}': {e}") from e
-
-        private_key = _read_ssl_file(server_args.ssl_keyfile, "SSL key file")
-        certificate_chain = _read_ssl_file(server_args.ssl_certfile, "SSL certificate file")
-        root_certificates = None
-        if server_args.ssl_ca_certs:
-            root_certificates = _read_ssl_file(server_args.ssl_ca_certs, "SSL CA certificates file")
-
-        if server_args.enable_ssl_refresh:
-            # Use dynamic credentials so gRPC re-reads certs on each
-            # new connection via the fetcher callback.
-            _cert_mtime = os.path.getmtime(server_args.ssl_certfile)
-            _key_mtime = os.path.getmtime(server_args.ssl_keyfile)
-            _ca_mtime = (
-                os.path.getmtime(server_args.ssl_ca_certs) if server_args.ssl_ca_certs else None
-            )
-
-            def _cert_config_fetcher():
-                nonlocal _cert_mtime, _key_mtime, _ca_mtime
+            def _read_ssl_file(filepath: str, description: str) -> bytes:
                 try:
-                    new_cert_mt = os.path.getmtime(server_args.ssl_certfile)
-                    new_key_mt = os.path.getmtime(server_args.ssl_keyfile)
-                    new_ca_mt = (
-                        os.path.getmtime(server_args.ssl_ca_certs)
-                        if server_args.ssl_ca_certs
-                        else None
-                    )
+                    with open(filepath, "rb") as f:
+                        return f.read()
+                except OSError as e:
+                    raise ValueError(f"Failed to read {description} '{filepath}': {e}") from e
 
-                    if (
-                        new_cert_mt == _cert_mtime
-                        and new_key_mt == _key_mtime
-                        and new_ca_mt == _ca_mtime
-                    ):
-                        return None  # No change
+            private_key = _read_ssl_file(server_args.ssl_keyfile, "SSL key file")
+            certificate_chain = _read_ssl_file(server_args.ssl_certfile, "SSL certificate file")
+            root_certificates = None
+            if server_args.ssl_ca_certs:
+                root_certificates = _read_ssl_file(
+                    server_args.ssl_ca_certs, "SSL CA certificates file"
+                )
 
-                    new_key = _read_ssl_file(server_args.ssl_keyfile, "SSL key file")
-                    new_cert = _read_ssl_file(server_args.ssl_certfile, "SSL certificate file")
-                    new_root = None
-                    if server_args.ssl_ca_certs:
-                        new_root = _read_ssl_file(
-                            server_args.ssl_ca_certs,
-                            "SSL CA certificates file",
+            if server_args.enable_ssl_refresh:
+                # Use dynamic credentials so gRPC re-reads certs on each
+                # new connection via the fetcher callback.
+                _cert_mtime = os.path.getmtime(server_args.ssl_certfile)
+                _key_mtime = os.path.getmtime(server_args.ssl_keyfile)
+                _ca_mtime = (
+                    os.path.getmtime(server_args.ssl_ca_certs) if server_args.ssl_ca_certs else None
+                )
+
+                def _cert_config_fetcher():
+                    nonlocal _cert_mtime, _key_mtime, _ca_mtime
+                    try:
+                        new_cert_mt = os.path.getmtime(server_args.ssl_certfile)
+                        new_key_mt = os.path.getmtime(server_args.ssl_keyfile)
+                        new_ca_mt = (
+                            os.path.getmtime(server_args.ssl_ca_certs)
+                            if server_args.ssl_ca_certs
+                            else None
                         )
 
-                    logger.info("gRPC SSL certificate change detected, reloading.")
-                    config = grpc.ssl_server_certificate_configuration(
-                        [(new_key, new_cert)],
-                        root_certificates=new_root,
+                        if (
+                            new_cert_mt == _cert_mtime
+                            and new_key_mt == _key_mtime
+                            and new_ca_mt == _ca_mtime
+                        ):
+                            return None  # No change
+
+                        new_key = _read_ssl_file(server_args.ssl_keyfile, "SSL key file")
+                        new_cert = _read_ssl_file(server_args.ssl_certfile, "SSL certificate file")
+                        new_root = None
+                        if server_args.ssl_ca_certs:
+                            new_root = _read_ssl_file(
+                                server_args.ssl_ca_certs,
+                                "SSL CA certificates file",
+                            )
+
+                        logger.info("gRPC SSL certificate change detected, reloading.")
+                        config = grpc.ssl_server_certificate_configuration(
+                            [(new_key, new_cert)],
+                            root_certificates=new_root,
+                        )
+
+                        # Update mtimes only after successful reload
+                        _cert_mtime = new_cert_mt
+                        _key_mtime = new_key_mt
+                        _ca_mtime = new_ca_mt
+
+                        return config
+                    except Exception:
+                        logger.exception(
+                            "Failed to reload gRPC SSL certificates — "
+                            "continuing with previous certificates."
+                        )
+                        return None
+
+                try:
+                    initial_config = grpc.ssl_server_certificate_configuration(
+                        [(private_key, certificate_chain)],
+                        root_certificates=root_certificates,
                     )
-
-                    # Update mtimes only after successful reload
-                    _cert_mtime = new_cert_mt
-                    _key_mtime = new_key_mt
-                    _ca_mtime = new_ca_mt
-
-                    return config
-                except Exception:
-                    logger.exception(
-                        "Failed to reload gRPC SSL certificates — "
-                        "continuing with previous certificates."
+                    credentials = grpc.dynamic_ssl_server_credentials(
+                        initial_config,
+                        _cert_config_fetcher,
                     )
-                    return None
-
-            try:
-                initial_config = grpc.ssl_server_certificate_configuration(
-                    [(private_key, certificate_chain)],
-                    root_certificates=root_certificates,
+                except Exception as e:
+                    raise ValueError(
+                        f"Failed to create gRPC dynamic SSL credentials. "
+                        f"Verify that --ssl-keyfile and --ssl-certfile contain "
+                        f"valid, matching PEM data. Underlying error: {e}"
+                    ) from e
+                logger.info("gRPC SSL certificate auto-refresh enabled.")
+            else:
+                try:
+                    credentials = grpc.ssl_server_credentials(
+                        [(private_key, certificate_chain)],  # pairs: (key, cert)
+                        root_certificates=root_certificates,
+                    )
+                except Exception as e:
+                    raise ValueError(
+                        f"Failed to create gRPC SSL credentials. Verify that "
+                        f"--ssl-keyfile and --ssl-certfile contain valid, matching "
+                        f"PEM data. Underlying error: {e}"
+                    ) from e
+            bound_port = server.add_secure_port(listen_addr, credentials)
+            if bound_port == 0:
+                raise RuntimeError(
+                    f"Failed to bind gRPC TLS server to {listen_addr}. "
+                    f"Check that the port is available and SSL credentials are valid."
                 )
-                credentials = grpc.dynamic_ssl_server_credentials(
-                    initial_config,
-                    _cert_config_fetcher,
-                )
-            except Exception as e:
-                raise ValueError(
-                    f"Failed to create gRPC dynamic SSL credentials. "
-                    f"Verify that --ssl-keyfile and --ssl-certfile contain "
-                    f"valid, matching PEM data. Underlying error: {e}"
-                ) from e
-            logger.info("gRPC SSL certificate auto-refresh enabled.")
+            logger.info(f"gRPC server (TLS) listening on {listen_addr}")
         else:
-            try:
-                credentials = grpc.ssl_server_credentials(
-                    [(private_key, certificate_chain)],  # pairs: (key, cert)
-                    root_certificates=root_certificates,
-                )
-            except Exception as e:
-                raise ValueError(
-                    f"Failed to create gRPC SSL credentials. Verify that "
-                    f"--ssl-keyfile and --ssl-certfile contain valid, matching "
-                    f"PEM data. Underlying error: {e}"
-                ) from e
-        bound_port = server.add_secure_port(listen_addr, credentials)
-        if bound_port == 0:
-            raise RuntimeError(
-                f"Failed to bind gRPC TLS server to {listen_addr}. "
-                f"Check that the port is available and SSL credentials are valid."
-            )
-        logger.info(f"gRPC server (TLS) listening on {listen_addr}")
-    else:
-        server.add_insecure_port(listen_addr)
-        logger.info(f"gRPC server listening on {listen_addr}")
+            server.add_insecure_port(listen_addr)
+            logger.info(f"gRPC server listening on {listen_addr}")
 
-    await server.start()
+        await server.start()
+    except BaseException:
+        logger.exception("gRPC startup failed, releasing scheduler resources")
+        await _cleanup_failed_startup(
+            server,
+            health_servicer,
+            request_manager,
+            scheduler_procs,
+        )
+        raise
 
-    # Start warmup in a separate thread
-    warmup_thread = threading.Thread(
-        target=_wait_and_warmup_grpc,
-        args=(server_args, health_servicer),
-    )
-    warmup_thread.start()
-
-    # Handle shutdown signals
-    loop = asyncio.get_running_loop()
-    stop_event = asyncio.Event()
-
-    def signal_handler():
-        logger.info("Received shutdown signal")
-        stop_event.set()
-
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, signal_handler)
-
+    warmup_thread = None
     try:
+        # Start warmup in a separate thread
+        warmup_thread = threading.Thread(
+            target=_wait_and_warmup_grpc,
+            args=(server_args, health_servicer),
+        )
+        warmup_thread.start()
+
+        # Handle shutdown signals
+        loop = asyncio.get_running_loop()
+        stop_event = asyncio.Event()
+
+        def signal_handler():
+            logger.info("Received shutdown signal")
+            stop_event.set()
+
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, signal_handler)
+
         await stop_event.wait()
     finally:
         logger.info("Shutting down gRPC server")
@@ -363,23 +395,13 @@ async def serve_grpc(
         await servicer.shutdown()
 
         # Wait for warmup thread to finish
-        if warmup_thread.is_alive():
+        if warmup_thread is not None and warmup_thread.is_alive():
             logger.info("Waiting for warmup thread to finish...")
             warmup_thread.join(timeout=5.0)
 
         # Terminate scheduler processes before exiting to avoid atexit hang
         # The scheduler processes have SIGINT ignored, so they won't get KeyboardInterrupt
-        for i, proc in enumerate(scheduler_procs):
-            if proc.is_alive():
-                logger.info(f"Terminating scheduler process {i}...")
-                proc.terminate()
-                proc.join(timeout=2.0)
-                if proc.is_alive():
-                    logger.warning(f"Scheduler process {i} did not terminate, killing...")
-                    proc.kill()
-                    proc.join(timeout=1.0)
-
-        logger.info("All scheduler processes terminated")
+        terminate_scheduler_processes(scheduler_procs)
 
 
 def _execute_grpc_server_warmup(server_args: ServerArgs):

--- a/grpc_servicer/smg_grpc_servicer/sglang/server.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/server.py
@@ -22,7 +22,7 @@ from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
 from sglang.srt.managers.disagg_service import start_disagg_service
 from sglang.srt.runtime_context import publish
-from sglang.srt.server_args import ServerArgs
+from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.utils import kill_process_tree
 from sglang.utils import get_exception_traceback
 from smg_grpc_proto import sglang_scheduler_pb2, sglang_scheduler_pb2_grpc
@@ -33,6 +33,30 @@ from smg_grpc_servicer.sglang.scheduler_launcher import launch_scheduler_process
 from smg_grpc_servicer.sglang.servicer import SGLangSchedulerServicer
 
 logger = logging.getLogger(__name__)
+
+
+async def _launch_scheduler_with_request_manager(
+    server_args: ServerArgs,
+    bootstrap_server=None,
+):
+    """Bind scheduler IPC endpoints before scheduler processes connect."""
+    port_args = PortArgs.init_new(server_args)
+    request_manager = GrpcRequestManager(
+        server_args=server_args,
+        port_args=port_args,
+        bootstrap_server=bootstrap_server,
+    )
+
+    try:
+        scheduler_info, launched_port_args, scheduler_procs = launch_scheduler_process_only(
+            server_args=server_args,
+            port_args=port_args,
+        )
+    except BaseException:
+        await request_manager.shutdown()
+        raise
+
+    return scheduler_info, launched_port_args, scheduler_procs, request_manager
 
 
 async def serve_grpc(
@@ -79,8 +103,14 @@ async def serve_grpc(
 
     # Launch only the scheduler process(es) (no tokenizer/detokenizer needed for gRPC)
     logger.info("Launching scheduler process(es)...")
-    scheduler_info, port_args, scheduler_procs = launch_scheduler_process_only(
+    (
+        scheduler_info,
+        port_args,
+        scheduler_procs,
+        request_manager,
+    ) = await _launch_scheduler_with_request_manager(
         server_args=server_args,
+        bootstrap_server=bootstrap_server,
     )
 
     # Load model config to get HF config info (same as TokenizerManager does)
@@ -121,14 +151,6 @@ async def serve_grpc(
             "id2label_json": id2label_json,
             "num_labels": num_labels or 0,
         }
-
-    # Create request manager with the correct port args
-    # Note: We pass None for bootstrap_server since it's already started above
-    request_manager = GrpcRequestManager(
-        server_args=server_args,
-        port_args=port_args,
-        bootstrap_server=bootstrap_server,
-    )
 
     if on_request_manager_ready is not None:
         try:

--- a/grpc_servicer/tests/test_sglang_scheduler_launcher.py
+++ b/grpc_servicer/tests/test_sglang_scheduler_launcher.py
@@ -1,0 +1,142 @@
+"""Engine-free tests for SGLang scheduler process lifecycle."""
+
+import importlib.util
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def _module(name, **attrs):
+    module = ModuleType(name)
+    for attr, value in attrs.items():
+        setattr(module, attr, value)
+    return module
+
+
+@pytest.fixture
+def scheduler_launcher_mod(monkeypatch):
+    """Load scheduler_launcher.py without importing the SGLang engine."""
+
+    class TorchMemorySaverAdapter:
+        @staticmethod
+        def create(**_kwargs):
+            return SimpleNamespace(configure_subprocess=nullcontext)
+
+    stubs = {
+        "sglang": _module("sglang"),
+        "sglang.srt": _module("sglang.srt"),
+        "sglang.srt.managers": _module("sglang.srt.managers"),
+        "sglang.srt.managers.data_parallel_controller": _module(
+            "sglang.srt.managers.data_parallel_controller",
+            run_data_parallel_controller_process=lambda *_args: None,
+        ),
+        "sglang.srt.managers.scheduler": _module(
+            "sglang.srt.managers.scheduler",
+            run_scheduler_process=lambda *_args, **_kwargs: None,
+        ),
+        "sglang.srt.server_args": _module(
+            "sglang.srt.server_args",
+            PortArgs=object,
+            ServerArgs=object,
+        ),
+        "sglang.srt.utils": _module(
+            "sglang.srt.utils",
+            configure_logger=lambda _args: None,
+            numa_utils=SimpleNamespace(
+                configure_subprocess=lambda *_args: nullcontext(),
+            ),
+        ),
+        "sglang.srt.utils.torch_memory_saver_adapter": _module(
+            "sglang.srt.utils.torch_memory_saver_adapter",
+            TorchMemorySaverAdapter=TorchMemorySaverAdapter,
+        ),
+    }
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_path = (
+        Path(__file__).parents[1] / "smg_grpc_servicer" / "sglang" / "scheduler_launcher.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_sglang_scheduler_launcher", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ready_failure_terminates_every_started_scheduler(monkeypatch, scheduler_launcher_mod):
+    class Reader:
+        def __init__(self, result):
+            self.result = result
+
+        def recv(self):
+            return self.result
+
+    class Process:
+        instances = []
+
+        def __init__(self, **_kwargs):
+            self.alive = False
+            self.terminated = False
+            self.killed = False
+            self.join_timeouts = []
+            self.exitcode = None
+            self.instances.append(self)
+
+        def start(self):
+            self.alive = True
+
+        def is_alive(self):
+            return self.alive
+
+        def terminate(self):
+            self.terminated = True
+            self.alive = False
+
+        def kill(self):
+            self.killed = True
+            self.alive = False
+
+        def join(self, timeout=None):
+            self.join_timeouts.append(timeout)
+
+    readers = iter(
+        [
+            Reader({"status": "ready"}),
+            Reader({"status": "error", "error": "rank failed"}),
+        ]
+    )
+    monkeypatch.setattr(scheduler_launcher_mod.mp, "set_start_method", lambda *_args, **_kw: None)
+    monkeypatch.setattr(
+        scheduler_launcher_mod.mp, "Pipe", lambda **_kwargs: (next(readers), object())
+    )
+    monkeypatch.setattr(scheduler_launcher_mod.mp, "Process", Process)
+
+    server_args = SimpleNamespace(
+        check_server_args=lambda: None,
+        dp_size=1,
+        enable_memory_saver=False,
+        nnodes=1,
+        pp_size=1,
+        tp_size=2,
+        node_rank=0,
+        base_gpu_id=0,
+        gpu_id_step=1,
+        enable_dp_attention=False,
+        attn_cp_size=1,
+        moe_dp_size=1,
+        ep_size=1,
+    )
+
+    with pytest.raises(RuntimeError, match="rank 1 initialization failed: rank failed"):
+        scheduler_launcher_mod.launch_scheduler_process_only(
+            server_args,
+            port_args=object(),
+        )
+
+    assert len(Process.instances) == 2
+    assert all(proc.terminated for proc in Process.instances)
+    assert all(not proc.is_alive() for proc in Process.instances)
+    assert all(proc.join_timeouts == [2.0] for proc in Process.instances)

--- a/grpc_servicer/tests/test_sglang_server_startup.py
+++ b/grpc_servicer/tests/test_sglang_server_startup.py
@@ -92,6 +92,7 @@ def server_mod(monkeypatch):
         "smg_grpc_servicer.sglang.scheduler_launcher": _module(
             "smg_grpc_servicer.sglang.scheduler_launcher",
             launch_scheduler_process_only=lambda **_kwargs: None,
+            terminate_scheduler_processes=lambda _procs: None,
         ),
         "smg_grpc_servicer.sglang.servicer": _module(
             "smg_grpc_servicer.sglang.servicer",
@@ -221,3 +222,70 @@ def test_scheduler_launch_failure_never_starts_serving(monkeypatch, server_mod):
     grpc_server_factory.assert_not_called()
     health_servicer_factory.assert_not_called()
     warmup_thread_factory.assert_not_called()
+
+
+def test_post_launch_startup_failure_releases_owned_resources(monkeypatch, server_mod):
+    request_manager = SimpleNamespace(shutdown=AsyncMock())
+    scheduler_procs = [object(), object()]
+    terminate_scheduler_processes = Mock()
+
+    async def launch(**_kwargs):
+        return {"status": "ready"}, object(), scheduler_procs, request_manager
+
+    model_config_factory = Mock(side_effect=RuntimeError("model config failed"))
+    monkeypatch.setattr(server_mod, "_launch_scheduler_with_request_manager", launch)
+    monkeypatch.setattr(
+        server_mod,
+        "ModelConfig",
+        SimpleNamespace(from_server_args=model_config_factory),
+    )
+    monkeypatch.setattr(
+        server_mod,
+        "terminate_scheduler_processes",
+        terminate_scheduler_processes,
+        raising=False,
+    )
+
+    server_args = SimpleNamespace(disaggregation_mode="null")
+    with pytest.raises(RuntimeError, match="model config failed"):
+        asyncio.run(server_mod.serve_grpc(server_args))
+
+    request_manager.shutdown.assert_awaited_once_with()
+    terminate_scheduler_processes.assert_called_once_with(scheduler_procs)
+
+
+def test_failed_startup_cleanup_runs_in_reverse_ownership_order(monkeypatch, server_mod):
+    events = []
+    scheduler_procs = [object()]
+
+    health_servicer = SimpleNamespace(
+        set_not_serving=Mock(side_effect=lambda: events.append("health"))
+    )
+
+    async def stop_server(grace):
+        assert grace == 0
+        events.append("server")
+
+    async def shutdown_manager():
+        events.append("manager")
+
+    server = SimpleNamespace(stop=AsyncMock(side_effect=stop_server))
+    request_manager = SimpleNamespace(shutdown=AsyncMock(side_effect=shutdown_manager))
+    terminate_scheduler_processes = Mock(side_effect=lambda _procs: events.append("schedulers"))
+    monkeypatch.setattr(
+        server_mod,
+        "terminate_scheduler_processes",
+        terminate_scheduler_processes,
+    )
+
+    asyncio.run(
+        server_mod._cleanup_failed_startup(
+            server,
+            health_servicer,
+            request_manager,
+            scheduler_procs,
+        )
+    )
+
+    assert events == ["health", "server", "schedulers", "manager"]
+    terminate_scheduler_processes.assert_called_once_with(scheduler_procs)

--- a/grpc_servicer/tests/test_sglang_server_startup.py
+++ b/grpc_servicer/tests/test_sglang_server_startup.py
@@ -1,0 +1,223 @@
+"""Engine-free tests for SGLang gRPC server startup ordering."""
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+def _module(name, **attrs):
+    module = ModuleType(name)
+    for attr, value in attrs.items():
+        setattr(module, attr, value)
+    return module
+
+
+@pytest.fixture
+def server_mod(monkeypatch):
+    """Load server.py with lightweight stand-ins for optional runtime deps."""
+
+    class PortArgs:
+        @staticmethod
+        def init_new(_server_args):
+            raise AssertionError("test must replace PortArgs.init_new")
+
+    class ServerArgs:
+        pass
+
+    stubs = {
+        "grpc": _module("grpc", aio=SimpleNamespace()),
+        "grpc_health": _module("grpc_health"),
+        "grpc_health.v1": _module(
+            "grpc_health.v1",
+            health_pb2_grpc=SimpleNamespace(),
+        ),
+        "grpc_reflection": _module("grpc_reflection"),
+        "grpc_reflection.v1alpha": _module(
+            "grpc_reflection.v1alpha",
+            reflection=SimpleNamespace(),
+        ),
+        "sglang": _module("sglang"),
+        "sglang.srt": _module("sglang.srt"),
+        "sglang.srt.configs": _module("sglang.srt.configs"),
+        "sglang.srt.configs.model_config": _module(
+            "sglang.srt.configs.model_config",
+            ModelConfig=object,
+        ),
+        "sglang.srt.disaggregation": _module("sglang.srt.disaggregation"),
+        "sglang.srt.disaggregation.utils": _module(
+            "sglang.srt.disaggregation.utils",
+            FAKE_BOOTSTRAP_HOST="2.2.2.2",
+            DisaggregationMode=object,
+        ),
+        "sglang.srt.managers": _module("sglang.srt.managers"),
+        "sglang.srt.managers.disagg_service": _module(
+            "sglang.srt.managers.disagg_service",
+            start_disagg_service=lambda _args: None,
+        ),
+        "sglang.srt.runtime_context": _module(
+            "sglang.srt.runtime_context",
+            publish=lambda _args, role: None,
+        ),
+        "sglang.srt.server_args": _module(
+            "sglang.srt.server_args",
+            PortArgs=PortArgs,
+            ServerArgs=ServerArgs,
+        ),
+        "sglang.srt.utils": _module(
+            "sglang.srt.utils",
+            kill_process_tree=lambda _pid: None,
+        ),
+        "sglang.utils": _module(
+            "sglang.utils",
+            get_exception_traceback=lambda: "",
+        ),
+        "smg_grpc_proto": _module(
+            "smg_grpc_proto",
+            sglang_scheduler_pb2=SimpleNamespace(),
+            sglang_scheduler_pb2_grpc=SimpleNamespace(),
+        ),
+        "smg_grpc_servicer.sglang.health_servicer": _module(
+            "smg_grpc_servicer.sglang.health_servicer",
+            SGLangHealthServicer=object,
+        ),
+        "smg_grpc_servicer.sglang.request_manager": _module(
+            "smg_grpc_servicer.sglang.request_manager",
+            GrpcRequestManager=object,
+        ),
+        "smg_grpc_servicer.sglang.scheduler_launcher": _module(
+            "smg_grpc_servicer.sglang.scheduler_launcher",
+            launch_scheduler_process_only=lambda **_kwargs: None,
+        ),
+        "smg_grpc_servicer.sglang.servicer": _module(
+            "smg_grpc_servicer.sglang.servicer",
+            SGLangSchedulerServicer=object,
+        ),
+    }
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    module_path = Path(__file__).parents[1] / "smg_grpc_servicer" / "sglang" / "server.py"
+    spec = importlib.util.spec_from_file_location("test_sglang_grpc_server", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_request_manager_binds_before_scheduler_launch(monkeypatch, server_mod):
+    events = []
+    server_args = object()
+    port_args = object()
+    request_manager = SimpleNamespace(shutdown=AsyncMock())
+    scheduler_info = {"status": "ready"}
+    scheduler_procs = [object()]
+
+    def init_ports(args):
+        assert args is server_args
+        events.append("ports")
+        return port_args
+
+    def create_request_manager(**kwargs):
+        assert kwargs == {
+            "server_args": server_args,
+            "port_args": port_args,
+            "bootstrap_server": "bootstrap",
+        }
+        events.append("request-manager")
+        return request_manager
+
+    def launch_scheduler(**kwargs):
+        assert kwargs == {
+            "server_args": server_args,
+            "port_args": port_args,
+        }
+        events.append("scheduler")
+        return scheduler_info, port_args, scheduler_procs
+
+    monkeypatch.setattr(server_mod.PortArgs, "init_new", init_ports)
+    monkeypatch.setattr(server_mod, "GrpcRequestManager", create_request_manager)
+    monkeypatch.setattr(server_mod, "launch_scheduler_process_only", launch_scheduler)
+
+    result = asyncio.run(
+        server_mod._launch_scheduler_with_request_manager(
+            server_args,
+            bootstrap_server="bootstrap",
+        )
+    )
+
+    assert events == ["ports", "request-manager", "scheduler"]
+    assert result == (scheduler_info, port_args, scheduler_procs, request_manager)
+    request_manager.shutdown.assert_not_awaited()
+
+
+def test_scheduler_launch_failure_closes_bound_manager(monkeypatch, server_mod):
+    events = []
+    manager = None
+
+    class BoundSocket:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    class RequestManager:
+        def __init__(self, **_kwargs):
+            nonlocal manager
+            manager = self
+            self.socket = BoundSocket()
+            self.asyncio_tasks = {asyncio.create_task(asyncio.Event().wait())}
+            self.shutdown_called = False
+            events.append("request-manager")
+
+        async def shutdown(self):
+            self.shutdown_called = True
+            events.append("shutdown")
+            for task in self.asyncio_tasks:
+                task.cancel()
+            await asyncio.gather(*self.asyncio_tasks, return_exceptions=True)
+            self.socket.close()
+
+    def fail_launch(**_kwargs):
+        events.append("scheduler")
+        raise RuntimeError("scheduler failed")
+
+    monkeypatch.setattr(server_mod.PortArgs, "init_new", lambda _args: object())
+    monkeypatch.setattr(server_mod, "GrpcRequestManager", RequestManager)
+    monkeypatch.setattr(server_mod, "launch_scheduler_process_only", fail_launch)
+
+    async def launch():
+        with pytest.raises(RuntimeError, match="scheduler failed"):
+            await server_mod._launch_scheduler_with_request_manager(object())
+
+    asyncio.run(launch())
+
+    assert events == ["request-manager", "scheduler", "shutdown"]
+    assert manager.shutdown_called
+    assert manager.socket.closed
+    assert all(task.done() for task in manager.asyncio_tasks)
+
+
+def test_scheduler_launch_failure_never_starts_serving(monkeypatch, server_mod):
+    grpc_server_factory = Mock()
+    health_servicer_factory = Mock()
+    warmup_thread_factory = Mock()
+
+    async def fail_launch(**_kwargs):
+        raise RuntimeError("scheduler failed")
+
+    monkeypatch.setattr(server_mod, "_launch_scheduler_with_request_manager", fail_launch)
+    monkeypatch.setattr(server_mod.grpc.aio, "server", grpc_server_factory, raising=False)
+    monkeypatch.setattr(server_mod, "SGLangHealthServicer", health_servicer_factory)
+    monkeypatch.setattr(server_mod.threading, "Thread", warmup_thread_factory)
+
+    server_args = SimpleNamespace(disaggregation_mode="null")
+    with pytest.raises(RuntimeError, match="scheduler failed"):
+        asyncio.run(server_mod.serve_grpc(server_args))
+
+    grpc_server_factory.assert_not_called()
+    health_servicer_factory.assert_not_called()
+    warmup_thread_factory.assert_not_called()


### PR DESCRIPTION
## Description

### Problem

The SGLang gRPC server launched scheduler processes before constructing the request manager. The request manager owns and binds the parent-side ZMQ IPC endpoints, so scheduler processes could try to connect before those endpoints existed and race during startup.

Startup failure also needs explicit ownership handling. A ready-handshake failure can occur after several scheduler ranks have started, and later failures in model configuration, TLS setup, port binding, or `server.start()` can otherwise retain scheduler processes and bound IPC/gRPC resources.

### Solution

Allocate one `PortArgs` instance, construct the `GrpcRequestManager` so its IPC endpoints bind, and pass the same ports to the scheduler launcher. The launcher owns every process it starts until all ready handshakes succeed and terminates/reaps them on failure.

After scheduler launch, a startup guard owns the partial gRPC server, schedulers, and request manager until `server.start()` succeeds. Failures mark health not serving, stop any partial gRPC server, terminate schedulers, close the request manager, and then propagate the original exception. Only successful startup proceeds to warmup and the existing serving lifecycle.

## Changes

- Bind request-manager ZMQ endpoints before scheduler processes start.
- Reuse the same preallocated `PortArgs` in the scheduler launcher.
- Terminate and reap all partially started scheduler ranks when launch or ready handshake fails.
- Clean up partial gRPC, scheduler, and request-manager state on later startup failures.
- Reuse the scheduler termination helper during normal shutdown.
- Preserve scheduler argument logging when ports are supplied by the caller.
- Add engine-free tests for startup ordering, partial-rank failure, reverse-order cleanup, task completion, and never-serving behavior.

## Test Plan

- Initial regression against `upstream/main` with only the startup tests: `pytest -q grpc_servicer/tests/test_sglang_server_startup.py` — expected red result, 3 failed because the pre-binding helper and `PortArgs` import were absent.
- Review regression against commit `0107b05b`: `pytest -p no:cacheprovider -q grpc_servicer/tests/test_sglang_scheduler_launcher.py::test_ready_failure_terminates_every_started_scheduler grpc_servicer/tests/test_sglang_server_startup.py::test_post_launch_startup_failure_releases_owned_resources` — expected red result, 2 failed because scheduler processes and post-launch resources were retained.
- Focused cleanup regression after the fix: `pytest -p no:cacheprovider -q grpc_servicer/tests/test_sglang_scheduler_launcher.py::test_ready_failure_terminates_every_started_scheduler grpc_servicer/tests/test_sglang_server_startup.py::test_post_launch_startup_failure_releases_owned_resources grpc_servicer/tests/test_sglang_server_startup.py::test_failed_startup_cleanup_runs_in_reverse_ownership_order` — 3 passed.
- `pytest -p no:cacheprovider -q grpc_servicer/tests/test_sglang_server_startup.py grpc_servicer/tests/test_sglang_scheduler_launcher.py` — 6 passed.
- `python -m py_compile grpc_servicer/smg_grpc_servicer/sglang/server.py grpc_servicer/smg_grpc_servicer/sglang/scheduler_launcher.py grpc_servicer/tests/test_sglang_server_startup.py grpc_servicer/tests/test_sglang_scheduler_launcher.py` — passed.
- `ruff format --check grpc_servicer/smg_grpc_servicer/sglang/server.py grpc_servicer/smg_grpc_servicer/sglang/scheduler_launcher.py grpc_servicer/tests/test_sglang_server_startup.py grpc_servicer/tests/test_sglang_scheduler_launcher.py` — 4 files already formatted.
- `ruff check grpc_servicer/smg_grpc_servicer/sglang/server.py grpc_servicer/smg_grpc_servicer/sglang/scheduler_launcher.py grpc_servicer/tests/test_sglang_server_startup.py grpc_servicer/tests/test_sglang_scheduler_launcher.py` — all checks passed.
- `pytest -p no:cacheprovider -q grpc_servicer/tests` — the minimal validation environment lacks `smg_grpc_proto`, so collection cannot complete there. The repository GitHub workflow installs the generated gRPC proto package before running the full Python unit suite.

## Compatibility and Risk

The scheduler launcher still accepts `port_args=None`, so existing callers retain the old allocation behavior. The lifecycle changes are limited to SGLang gRPC startup and shutdown; they do not alter request handling, abort behavior, stream batching, signal semantics, or readiness policy. Health remains `NOT_SERVING` until the existing warmup path marks it serving.

The tests use process and engine stand-ins, so real GPU process startup remains covered by repository CI rather than the local CPU-only lifecycle tests.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes (not run; no Rust files changed)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (not run; no Rust files changed)
- [ ] (Optional) Documentation updated (not required; no user-facing interface change)

</details>
