### PR TITLE
fix(grpc): report vLLM loads per DP rank

### DIFF
--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -1384,6 +1384,26 @@ pub struct WorkerLoadResponse {
 }
 
 impl WorkerLoadResponse {
+    /// Scope a backend response to one virtual DP worker. A missing rank is
+    /// unavailable; it must never inherit another rank or an aggregate. A
+    /// gateway fleet rollup cannot be projected because its rank IDs repeat
+    /// independently under each annotated worker.
+    pub fn for_dp_rank(mut self, rank: Option<usize>) -> Option<Self> {
+        if rank.is_some() && !self.ranks_are_dp_ranks() {
+            return None;
+        }
+        if let Some(rank) = rank {
+            let rank = i32::try_from(rank).ok()?;
+            self.loads.retain(|load| load.dp_rank == rank);
+            self.aggregate = None;
+        }
+        if self.loads.is_empty() {
+            return None;
+        }
+        self.dp_rank_count = i32::try_from(self.loads.len()).ok()?;
+        Some(self)
+    }
+
     /// Average token usage ratio across DP ranks. Returns 0.0 if empty.
     pub fn effective_token_usage(&self) -> f64 {
         if self.loads.is_empty() {

--- a/crates/protocols/tests/dp_load_projection.rs
+++ b/crates/protocols/tests/dp_load_projection.rs
@@ -1,0 +1,69 @@
+use openai_protocol::worker::{
+    EngineAggregateMetricsSnapshot, SchedulerLoadSnapshot, WorkerLoadResponse,
+};
+
+fn dp4() -> WorkerLoadResponse {
+    WorkerLoadResponse {
+        dp_rank_count: 4,
+        loads: (0..4)
+            .map(|rank| SchedulerLoadSnapshot {
+                dp_rank: rank,
+                num_running_reqs: rank + 1,
+                num_used_tokens: (rank + 1) * 125,
+                max_total_num_tokens: 1000,
+                token_usage: f64::from(rank + 1) / 8.0,
+                ..Default::default()
+            })
+            .collect(),
+        aggregate: Some(EngineAggregateMetricsSnapshot::default()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn virtual_workers_only_receive_their_global_rank() {
+    for rank in 0..4 {
+        let load = dp4().for_dp_rank(Some(rank)).unwrap();
+        assert_eq!(load.dp_rank_count, 1);
+        assert_eq!(load.loads[0].dp_rank, rank as i32);
+        assert_eq!(load.loads[0].num_running_reqs, rank as i32 + 1);
+        assert_eq!(load.effective_token_usage(), (rank + 1) as f64 / 8.0);
+        assert_eq!(load.total_used_tokens(), (rank as i64 + 1) * 125);
+        assert!(load.has_absolute_token_data());
+        assert!(load.aggregate.is_none());
+    }
+}
+
+#[test]
+fn non_virtual_worker_keeps_all_ranks() {
+    let load = dp4().for_dp_rank(None).unwrap();
+    assert_eq!(load.dp_rank_count, 4);
+    assert_eq!(load.dp_rank_loads().len(), 4);
+    assert!(load.aggregate.is_some());
+}
+
+#[test]
+fn missing_rank_never_falls_back_to_rank_zero() {
+    let mut partial = dp4();
+    partial.loads.truncate(1);
+    assert!(partial.for_dp_rank(Some(1)).is_none());
+    assert!(dp4().for_dp_rank(Some(4)).is_none());
+    assert!(dp4().for_dp_rank(Some(usize::MAX)).is_none());
+}
+
+#[test]
+fn empty_response_is_unavailable_not_idle() {
+    assert!(WorkerLoadResponse::default().for_dp_rank(None).is_none());
+    assert!(WorkerLoadResponse::default().for_dp_rank(Some(0)).is_none());
+}
+
+#[test]
+fn fleet_rollup_is_not_mistaken_for_engine_dp_ranks() {
+    let mut fleet = dp4();
+    for (index, load) in fleet.loads.iter_mut().enumerate() {
+        load.worker = Some(format!("http://worker-{index}"));
+    }
+
+    assert!(fleet.clone().for_dp_rank(Some(1)).is_none());
+    assert_eq!(fleet.for_dp_rank(None).unwrap().loads.len(), 4);
+}

--- a/grpc_servicer/README.md
+++ b/grpc_servicer/README.md
@@ -36,6 +36,27 @@ pip install smg-grpc-servicer[sglang]
 vllm serve meta-llama/Llama-2-7b-hf --grpc
 ```
 
+#### DP load reporting
+
+`GetLoads` reports cached scheduler statistics for each managed global DP rank;
+the optional `dp_rank` filter includes rank zero. Keep vLLM stats logging enabled:
+missing snapshots are omitted rather than reported as idle. The gateway scopes
+each virtual DP worker's load to its own rank, not the backend-wide average.
+
+`max_total_num_tokens` uses vLLM's profiled **per-engine**
+`kv_cache_size_tokens`. `num_used_tokens` is the rounded-up occupied KV-token
+equivalent (`token_usage * capacity`), not pending prompt tokens. Older vLLM
+versions without this capacity field retain ratio-only reporting (absolute
+fields remain zero). Deferred/skipped waiting requests are included in queue
+depth. Optional sections other than core are still best-effort; no extra
+scheduler RPC is issued.
+
+Rollout requires updating both the gateway binary and `smg-grpc-servicer`
+inside the vLLM image. With DP4, verify four distinct ranks in unfiltered
+`GetLoads` and one matching rank per `@0`–`@3` worker in the gateway's
+`/get_loads`. This fixes telemetry attribution; throughput/latency improvements
+require workload testing.
+
 ### MLX
 
 ```bash

--- a/grpc_servicer/smg_grpc_servicer/vllm/loads.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/loads.py
@@ -1,0 +1,131 @@
+"""Read cached vLLM scheduler loads without dispatching engine work."""
+
+import math
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+from smg_grpc_proto import vllm_engine_pb2 as pb
+
+_MAX_INT32 = 2**31 - 1
+
+
+def _managed_ranks(engine):
+    """Return the global ranks managed by this vLLM frontend."""
+    manager = getattr(engine, "logger_manager", None)
+    ranks = getattr(manager, "engine_indexes", None)
+    if ranks is None:
+        engine_core = getattr(engine, "engine_core", None)
+        ranks = getattr(engine_core, "engine_ranks_managed", None)
+    if ranks is None:
+        config = getattr(engine, "vllm_config", None)
+        parallel = getattr(config, "parallel_config", None)
+        size = getattr(parallel, "data_parallel_size", 1)
+        ranks = (
+            range(size)
+            if isinstance(size, int) and not isinstance(size, bool) and 0 < size <= _MAX_INT32
+            else ()
+        )
+    return sorted(
+        {
+            rank
+            for rank in ranks
+            if isinstance(rank, int) and not isinstance(rank, bool) and 0 <= rank <= _MAX_INT32
+        }
+    )
+
+
+def _scheduler_stats_by_rank(engine, ranks):
+    """Collect only rank-addressable snapshots from compatible logger shapes."""
+    manager = getattr(engine, "logger_manager", None)
+    snapshots = {}
+    for logger in getattr(manager, "stat_loggers", None) or []:
+        per_rank = getattr(logger, "last_scheduler_stats_dict", None)
+        if isinstance(per_rank, Mapping):
+            candidates = per_rank
+        else:
+            per_engine = getattr(logger, "per_engine_stat_loggers", None)
+            if isinstance(per_engine, Mapping):
+                candidates = {
+                    rank: getattr(nested, "last_scheduler_stats", None)
+                    for rank, nested in per_engine.items()
+                }
+            elif len(ranks) == 1 and not getattr(logger, "aggregated", False):
+                candidates = {ranks[0]: getattr(logger, "last_scheduler_stats", None)}
+            else:
+                continue
+
+        for rank in ranks:
+            stats = candidates.get(rank)
+            if stats is not None:
+                snapshots.setdefault(rank, stats)
+    return snapshots
+
+
+def _is_nonnegative_int32(value):
+    return isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= _MAX_INT32
+
+
+def build_loads_response(engine, request, version=""):
+    """Build cached per-rank loads; omit missing or invalid telemetry."""
+    ranks = _managed_ranks(engine)
+    requested_rank = request.dp_rank if request.HasField("dp_rank") else None
+    if requested_rank is not None and requested_rank not in ranks:
+        raise ValueError(f"DP rank {requested_rank} is not managed by this engine: {ranks}")
+
+    snapshots = _scheduler_stats_by_rank(engine, ranks)
+    if requested_rank is not None:
+        snapshots = (
+            {requested_rank: snapshots[requested_rank]} if requested_rank in snapshots else {}
+        )
+
+    config = getattr(engine, "vllm_config", None)
+    cache = getattr(config, "cache_config", None)
+    # This is profiled per DP engine and accounts for hybrid KV-cache groups.
+    # num_gpu_blocks can be DP-summed and block multiplication is not group-aware.
+    capacity = getattr(cache, "kv_cache_size_tokens", None)
+    if not _is_nonnegative_int32(capacity) or capacity == 0:
+        capacity = 0
+    scheduler = getattr(config, "scheduler_config", None)
+    max_running = getattr(scheduler, "max_num_seqs", 0)
+    if not _is_nonnegative_int32(max_running):
+        max_running = 0
+
+    loads = []
+    for rank, stats in sorted(snapshots.items()):
+        running = getattr(stats, "num_running_reqs", None)
+        waiting = getattr(stats, "num_waiting_reqs", None)
+        skipped = getattr(stats, "num_skipped_waiting_reqs", 0)
+        try:
+            usage = float(getattr(stats, "kv_cache_usage", None))
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if (
+            not all(_is_nonnegative_int32(value) for value in (running, waiting, skipped))
+            or not math.isfinite(usage)
+            or not 0.0 <= usage <= 1.0
+        ):
+            continue
+        waiting += skipped
+        total = running + waiting
+        if waiting > _MAX_INT32 or total > _MAX_INT32:
+            continue
+
+        loads.append(
+            pb.SchedulerLoad(
+                dp_rank=rank,
+                num_running_reqs=running,
+                num_waiting_reqs=waiting,
+                num_total_reqs=total,
+                token_usage=usage,
+                num_used_tokens=math.ceil(usage * capacity),
+                max_total_num_tokens=capacity,
+                max_running_requests=max_running,
+            )
+        )
+
+    return pb.GetLoadsResponse(
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        version=version,
+        dp_rank_count=len(loads),
+        loads=loads,
+    )

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -11,7 +11,6 @@ import itertools
 import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
-from datetime import datetime, timezone
 from pathlib import Path
 
 import grpc
@@ -49,6 +48,7 @@ from smg_grpc_servicer.vllm.kv_transfer import (
     params_to_response_fields,
     resolve_pd_connector,
 )
+from smg_grpc_servicer.vllm.loads import build_loads_response
 from smg_grpc_servicer.vllm.mm_salt import has_preprocessed_mm_payload, mm_identity_cache_salt
 
 logger = init_logger(__name__)
@@ -92,40 +92,6 @@ try:
     from vllm.version import __version__ as VLLM_VERSION
 except Exception:  # pragma: no cover - version lookup is best-effort
     VLLM_VERSION = ""
-
-
-def _latest_scheduler_stats(engine, engine_idx: int = 0):
-    """Best-effort read of the most recent ``SchedulerStats`` snapshot.
-
-    vLLM has no synchronous "current stats" accessor on ``AsyncLLM``/``EngineClient``;
-    ``SchedulerStats`` arrive asynchronously and are cached on the stat loggers. This
-    reaches into ``engine.logger_manager.stat_loggers`` and returns the freshest
-    snapshot, handling the logger-shape variants:
-
-    - ``LoggingStatLogger``                  -> ``.last_scheduler_stats``
-    - ``AggregatedLoggingStatLogger`` (DP)   -> ``.last_scheduler_stats_dict[idx]``
-    - ``PerEngineStatLoggerAdapter``         -> ``.per_engine_stat_loggers[idx]``
-    - ``PrometheusStatLogger``               -> skipped (no cached snapshot)
-
-    Returns ``None`` when stats logging is disabled (``--disable-log-stats``) or no
-    engine step has produced outputs yet.
-    """
-    logger_manager = getattr(engine, "logger_manager", None)
-    if logger_manager is None:
-        return None
-    for sl in getattr(logger_manager, "stat_loggers", None) or []:
-        per = getattr(sl, "last_scheduler_stats_dict", None)
-        if isinstance(per, dict) and engine_idx in per:
-            return per[engine_idx]
-        stats = getattr(sl, "last_scheduler_stats", None)
-        if stats is not None:
-            return stats
-        per_engine = getattr(sl, "per_engine_stat_loggers", None)
-        if isinstance(per_engine, dict) and engine_idx in per_engine:
-            nested = getattr(per_engine[engine_idx], "last_scheduler_stats", None)
-            if nested is not None:
-                return nested
-    return None
 
 
 class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
@@ -531,55 +497,11 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         request: vllm_engine_pb2.GetLoadsRequest,
         context: grpc.aio.ServicerContext,
     ) -> vllm_engine_pb2.GetLoadsResponse:
-        """
-        Handle load-metric requests.
-
-        Reads the latest SchedulerStats snapshot cached on the engine's stat
-        loggers and maps it onto a single-DP-rank SchedulerLoad: ``token_usage``
-        carries KV-cache utilization ([0,1)) and ``num_running_reqs`` /
-        ``num_waiting_reqs`` report queue depth.
-
-        Always returns exactly one SchedulerLoad entry (zero-filled when no
-        snapshot is available yet, e.g. with --disable-log-stats or before the
-        first engine step) so callers treat the worker as responsive rather than
-        dropping the poll.
-
-        Note: ``request.dp_rank`` and ``request.include`` are accepted but not yet
-        applied — vLLM reports a single DP rank (``dp_rank_count=1``) with only
-        core metrics, so there is nothing to filter. They are reserved for future
-        multi-DP / sectioned-metrics support.
-
-        Args:
-            request: The GetLoadsRequest protobuf
-            context: gRPC context
-
-        Returns:
-            GetLoadsResponse protobuf
-        """
-        stats = _latest_scheduler_stats(self.engine)
-        if stats is not None:
-            num_running = int(getattr(stats, "num_running_reqs", 0) or 0)
-            num_waiting = int(getattr(stats, "num_waiting_reqs", 0) or 0)
-            kv_usage = float(getattr(stats, "kv_cache_usage", 0.0) or 0.0)
-        else:
-            num_running = 0
-            num_waiting = 0
-            kv_usage = 0.0
-
-        load = vllm_engine_pb2.SchedulerLoad(
-            dp_rank=0,
-            num_running_reqs=num_running,
-            num_waiting_reqs=num_waiting,
-            num_total_reqs=num_running + num_waiting,
-            token_usage=max(0.0, kv_usage),
-        )
-
-        return vllm_engine_pb2.GetLoadsResponse(
-            timestamp=datetime.now(timezone.utc).isoformat(),
-            version=VLLM_VERSION,
-            dp_rank_count=1,
-            loads=[load],
-        )
+        """Report cached per-rank core loads; unavailable ranks are omitted."""
+        try:
+            return build_loads_response(self.engine, request, VLLM_VERSION)
+        except ValueError as exc:
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(exc))
 
     async def GetTokenizer(
         self,

--- a/grpc_servicer/tests/test_vllm_loads.py
+++ b/grpc_servicer/tests/test_vllm_loads.py
@@ -1,0 +1,164 @@
+"""Engine-free regression coverage for vLLM per-DP GetLoads."""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace as NS
+
+import pytest
+from smg_grpc_proto import vllm_engine_pb2 as pb
+
+_PATH = Path(__file__).parents[1] / "smg_grpc_servicer" / "vllm" / "loads.py"
+_SPEC = importlib.util.spec_from_file_location("vllm_loads", _PATH)
+loads = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(loads)
+
+
+def stats(running=0, waiting=0, usage=0.0, skipped=0):
+    return NS(
+        num_running_reqs=running,
+        num_waiting_reqs=waiting,
+        num_skipped_waiting_reqs=skipped,
+        kv_cache_usage=usage,
+    )
+
+
+def engine(loggers, ranks=(0, 1, 2, 3), capacity=1000):
+    cache = NS(kv_cache_size_tokens=capacity, num_gpu_blocks=99999, block_size=128)
+    return NS(
+        logger_manager=NS(stat_loggers=loggers, engine_indexes=list(ranks)),
+        vllm_config=NS(
+            parallel_config=NS(data_parallel_size=4),
+            cache_config=cache,
+            scheduler_config=NS(max_num_seqs=256),
+        ),
+    )
+
+
+@pytest.fixture
+def dp4():
+    per_rank = {rank: stats(rank + 1, rank, (rank + 1) / 8, skipped=rank) for rank in range(4)}
+    aggregate = NS(
+        last_scheduler_stats_dict=per_rank,
+        last_scheduler_stats=stats(999, 999, 0.99),
+        aggregated=True,
+    )
+    return engine([NS(), aggregate])
+
+
+def test_distinct_dp4_loads_with_per_engine_capacity(dp4):
+    result = loads.build_loads_response(dp4, pb.GetLoadsRequest(), "test-version")
+    assert result.version == "test-version"
+    assert result.timestamp
+    assert result.dp_rank_count == 4
+    assert [item.dp_rank for item in result.loads] == [0, 1, 2, 3]
+    assert [item.num_running_reqs for item in result.loads] == [1, 2, 3, 4]
+    assert [item.num_waiting_reqs for item in result.loads] == [0, 2, 4, 6]
+    assert [item.num_total_reqs for item in result.loads] == [1, 4, 7, 10]
+    assert [item.num_used_tokens for item in result.loads] == [125, 250, 375, 500]
+    assert all(item.max_total_num_tokens == 1000 for item in result.loads)
+    assert all(item.max_running_requests == 256 for item in result.loads)
+
+
+@pytest.mark.parametrize("rank", range(4))
+def test_rank_filter_including_explicit_zero(dp4, rank):
+    result = loads.build_loads_response(dp4, pb.GetLoadsRequest(dp_rank=rank))
+    assert [(item.dp_rank, item.num_running_reqs) for item in result.loads] == [(rank, rank + 1)]
+
+
+@pytest.mark.parametrize("rank", [-1, 4, 100])
+def test_unmanaged_rank_is_rejected(dp4, rank):
+    with pytest.raises(ValueError, match="not managed"):
+        loads.build_loads_response(dp4, pb.GetLoadsRequest(dp_rank=rank))
+
+
+def test_aggregate_disabled_loggers_preserve_nonzero_global_ranks():
+    nested = NS(
+        per_engine_stat_loggers={
+            4: NS(last_scheduler_stats=stats(7, usage=0.25)),
+            5: NS(last_scheduler_stats=None),
+        }
+    )
+    e = engine([nested], (4, 5))
+    del e.logger_manager.engine_indexes
+    e.engine_core = NS(engine_ranks_managed=[4, 5])
+
+    result = loads.build_loads_response(e, pb.GetLoadsRequest())
+    assert [(item.dp_rank, item.num_running_reqs) for item in result.loads] == [(4, 7)]
+    assert not loads.build_loads_response(e, pb.GetLoadsRequest(dp_rank=5)).loads
+
+
+@pytest.mark.parametrize("ranks", [(0,), (0, 1, 2, 3)])
+def test_rank_dictionary_never_falls_back_to_aggregate(ranks):
+    aggregate = NS(
+        last_scheduler_stats_dict={},
+        last_scheduler_stats=stats(999, usage=0.99),
+        aggregated=True,
+    )
+    assert not loads.build_loads_response(engine([aggregate], ranks), pb.GetLoadsRequest()).loads
+
+
+def test_scalar_snapshot_only_for_single_nonaggregate_rank():
+    logger = NS(last_scheduler_stats=stats(7, usage=0.25), aggregated=False)
+    assert not loads.build_loads_response(engine([logger]), pb.GetLoadsRequest()).loads
+    result = loads.build_loads_response(engine([logger], (5,)), pb.GetLoadsRequest())
+    assert [(item.dp_rank, item.num_running_reqs) for item in result.loads] == [(5, 7)]
+    logger.aggregated = True
+    assert not loads.build_loads_response(engine([logger], (5,)), pb.GetLoadsRequest()).loads
+
+
+def test_missing_logger_is_not_reported_as_idle(dp4):
+    dp4.logger_manager = None
+    assert not loads.build_loads_response(dp4, pb.GetLoadsRequest()).loads
+
+
+def test_idle_snapshot_is_reported():
+    logger = NS(last_scheduler_stats=stats(), aggregated=False)
+    result = loads.build_loads_response(engine([logger], (0,)), pb.GetLoadsRequest())
+    assert result.dp_rank_count == 1
+    assert result.loads[0].num_used_tokens == 0
+
+
+@pytest.mark.parametrize("capacity", [None, False, True, 0, -1, 2**31])
+def test_unknown_capacity_never_uses_dp_summed_gpu_blocks(dp4, capacity):
+    dp4.vllm_config.cache_config.kv_cache_size_tokens = capacity
+    result = loads.build_loads_response(dp4, pb.GetLoadsRequest())
+    assert all(item.max_total_num_tokens == item.num_used_tokens == 0 for item in result.loads)
+    assert result.loads[3].token_usage == 0.5
+
+
+def test_capacity_int32_boundary_is_representable():
+    logger = NS(last_scheduler_stats=stats(usage=1.0), aggregated=False)
+    result = loads.build_loads_response(engine([logger], (0,), 2**31 - 1), pb.GetLoadsRequest())
+    assert result.loads[0].max_total_num_tokens == 2**31 - 1
+    assert result.loads[0].num_used_tokens == 2**31 - 1
+
+
+@pytest.mark.parametrize("usage", [None, float("nan"), float("inf"), -0.1, 1.1])
+def test_invalid_usage_is_omitted(usage):
+    logger = NS(last_scheduler_stats=stats(usage=usage), aggregated=False)
+    assert not loads.build_loads_response(engine([logger], (0,)), pb.GetLoadsRequest()).loads
+
+
+@pytest.mark.parametrize(
+    ("running", "waiting", "skipped"),
+    [
+        (-1, 0, 0),
+        (0, -1, 0),
+        (0, 0, -1),
+        (True, 0, 0),
+        (2**31, 0, 0),
+        (2**31 - 1, 1, 0),
+        (0, 2**31 - 1, 1),
+    ],
+)
+def test_invalid_or_overflowing_request_counts_are_omitted(running, waiting, skipped):
+    logger = NS(
+        last_scheduler_stats=stats(running, waiting, usage=0.25, skipped=skipped),
+        aggregated=False,
+    )
+    assert not loads.build_loads_response(engine([logger], (0,)), pb.GetLoadsRequest()).loads
+
+
+def test_optional_sections_do_not_hide_core_metrics(dp4):
+    request = pb.GetLoadsRequest(include=["core", "disagg", "queues", "memory"])
+    assert loads.build_loads_response(dp4, request).dp_rank_count == 4

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -242,11 +242,12 @@ impl NativeLoadsPath {
 
     /// Where to probe this route on `worker`.
     fn probe_url(self, worker: &Arc<dyn Worker>) -> String {
-        let base = worker.url();
         match self {
             // Sections beyond `core` degrade gracefully: an engine that does
             // not report them omits the fields, which deserialize to `None`.
-            Self::Engine => format!("{base}/v1/loads?include=core,disagg,queues,memory"),
+            Self::Engine => {
+                worker.endpoint_url("/v1/loads?include=core,disagg,queues,memory")
+            }
             // A gateway serves a whole fleet, so an unscoped `/loads` blends
             // every model it fronts. A worker registered for exactly one
             // model must be asked about that model alone.
@@ -254,9 +255,9 @@ impl NativeLoadsPath {
                 [card] => {
                     let model: String =
                         url::form_urlencoded::byte_serialize(card.id.as_bytes()).collect();
-                    format!("{base}/loads?model={model}")
+                    worker.endpoint_url(&format!("/loads?model={model}"))
                 }
-                _ => format!("{base}/loads"),
+                _ => worker.endpoint_url("/loads"),
             },
         }
     }
@@ -656,9 +657,10 @@ impl WorkerMonitor {
     /// a worker, and `/v1/loads` on an engine. Which one a worker answered on
     /// is memoized, so the extra attempt costs one 404 per worker, once.
     ///
-    /// Every backend is normalized into a single-rank [`WorkerLoadResponse`]
-    /// whose `token_usage` field drives the load-aware policies. Returns
-    /// `None` on failure so the caller records the load as unavailable (`-1`).
+    /// Engine responses are projected to a virtual worker's configured DP
+    /// rank. Gateway responses retain their fleet shape because their rank
+    /// IDs are only unique within each annotated worker. Returns `None` on
+    /// failure so the caller records the load as unavailable (`-1`).
     ///
     /// `native_loads_memo` is the shared probe memo, or `None` for callers
     /// with no monitor to borrow it from (they simply always discover).
@@ -673,12 +675,21 @@ impl WorkerMonitor {
             .unwrap_or_default();
         let mut memo = known;
 
-        let mut response = None;
+        // The outer option means a native route answered. The inner option
+        // can still be `None` when an engine omitted this virtual worker's
+        // configured DP rank; that is terminal and must not fall back to an
+        // aggregate Prometheus snapshot.
+        let mut native_result = None;
         for path in known.candidates() {
             match Self::probe_native_loads(worker, path).await {
                 NativeLoads::Available(load) => {
                     memo.record_answered(path);
-                    response = Some(load);
+                    native_result = Some(match path {
+                        NativeLoadsPath::Engine => {
+                            Self::project_backend_load(worker.as_ref(), load)
+                        }
+                        NativeLoadsPath::Gateway => Some(load),
+                    });
                     break;
                 }
                 NativeLoads::Absent => memo.record_absent(path),
@@ -692,8 +703,8 @@ impl WorkerMonitor {
                 store.insert(worker.url().to_string(), memo);
             }
         }
-        if response.is_some() {
-            return response;
+        if let Some(result) = native_result {
+            return result;
         }
 
         match worker.metadata().spec.runtime_type {
@@ -746,7 +757,7 @@ impl WorkerMonitor {
     /// exposed as `vllm:gpu_cache_usage_perc` in vLLM v0 and renamed to
     /// `vllm:kv_cache_usage_perc` in vLLM v1, so accept either.
     async fn fetch_http_load_vllm(worker: &Arc<dyn Worker>) -> Option<WorkerLoadResponse> {
-        let url = format!("{}/metrics", worker.url());
+        let url = worker.endpoint_url("/metrics");
         let body = Self::authed_get(worker, &url).await?.text().await.ok()?;
         let m = PromScrape::parse(&body);
 
@@ -772,7 +783,7 @@ impl WorkerMonitor {
     /// the `sglang:` metric prefix through v0.5.3 and switched to `sglang_`
     /// in v0.5.4+, so detect whichever is present and use it throughout.
     async fn fetch_http_load_sglang(worker: &Arc<dyn Worker>) -> Option<WorkerLoadResponse> {
-        let url = format!("{}/metrics", worker.url());
+        let url = worker.endpoint_url("/metrics");
         let body = Self::authed_get(worker, &url).await?.text().await.ok()?;
         let m = PromScrape::parse(&body);
 
@@ -828,6 +839,13 @@ impl WorkerMonitor {
         }
     }
 
+    fn project_backend_load(
+        worker: &dyn Worker,
+        load: WorkerLoadResponse,
+    ) -> Option<WorkerLoadResponse> {
+        load.for_dp_rank(worker.dp_rank())
+    }
+
     /// Fetch load via the backend client's `GetLoads` (gRPC RPC or the ZMQ
     /// engine's pushed scheduler stats). Returns `None` on missing client,
     /// error, or empty `loads` array.
@@ -845,8 +863,7 @@ impl WorkerMonitor {
         };
 
         match backend_client.get_loads().await {
-            Ok(load) if !load.loads.is_empty() => Some(load),
-            Ok(_) => None,
+            Ok(load) => Self::project_backend_load(worker.as_ref(), load),
             Err(e) => {
                 debug!("backend GetLoads failed for {}: {e}", worker.url());
                 None
@@ -1305,6 +1322,39 @@ mod worker_monitor_tests {
         (registry, monitor)
     }
 
+    fn dp4_load() -> WorkerLoadResponse {
+        WorkerLoadResponse {
+            dp_rank_count: 4,
+            loads: (0..4)
+                .map(|rank| SchedulerLoadSnapshot {
+                    dp_rank: rank,
+                    num_running_reqs: rank + 1,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn backend_load_is_projected_to_virtual_worker_rank() {
+        let worker = BasicWorkerBuilder::new("grpc://vllm:8000")
+            .connection_mode(ConnectionMode::Grpc)
+            .dp_config(2, 4)
+            .build();
+
+        let load = WorkerMonitor::project_backend_load(&worker, dp4_load()).unwrap();
+        assert_eq!(load.dp_rank_count, 1);
+        assert_eq!(load.loads[0].dp_rank, 2);
+        assert_eq!(load.loads[0].num_running_reqs, 3);
+
+        let missing_worker = BasicWorkerBuilder::new("grpc://vllm:8000")
+            .connection_mode(ConnectionMode::Grpc)
+            .dp_config(4, 5)
+            .build();
+        assert!(WorkerMonitor::project_backend_load(&missing_worker, dp4_load()).is_none());
+    }
+
     #[tokio::test]
     async fn bootstrap_reconcile_starts_loops_for_existing_workers() {
         let (registry, monitor) = build_monitor();
@@ -1739,6 +1789,14 @@ mod native_loads_tests {
     const NATIVE_BODY: &str = r#"{"loads":[{"dp_rank":0,"num_running_reqs":3,
         "num_waiting_reqs":4,"num_waiting_uncached_tokens":900,"token_usage":0.25}]}"#;
 
+    const NATIVE_DP_BODY: &str = r#"{"dp_rank_count":2,"loads":[
+        {"dp_rank":0,"num_running_reqs":3,"token_usage":0.25},
+        {"dp_rank":1,"num_running_reqs":9,"token_usage":0.75}]}"#;
+
+    const GATEWAY_FLEET_BODY: &str = r#"{"dp_rank_count":2,"loads":[
+        {"worker":"http://engine-a","dp_rank":0,"num_running_reqs":3},
+        {"worker":"http://engine-b","dp_rank":0,"num_running_reqs":9}]}"#;
+
     struct Stub {
         url: String,
         /// `/v1/loads` hits.
@@ -1817,6 +1875,22 @@ mod native_loads_tests {
 
     fn vllm_worker(url: &str) -> Arc<dyn Worker> {
         vllm_worker_with_overload(url, OverloadUpdate::default())
+    }
+
+    fn vllm_dp_worker(url: &str, rank: usize, size: usize) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Http)
+                .runtime_type(RuntimeType::Vllm)
+                .model(ModelCard::new("a"))
+                .dp_config(rank, size)
+                .health_config(HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        )
     }
 
     /// Worker carrying a per-worker overload block — protection for it is
@@ -2143,6 +2217,36 @@ mod native_loads_tests {
             memo.get(worker.url()).and_then(|hit| hit.answered()),
             Some(NativeLoadsPath::Engine)
         );
+    }
+
+    #[tokio::test]
+    async fn native_loads_are_projected_to_the_virtual_worker_rank() {
+        let stub = spawn_engine(StatusCode::OK, NATIVE_DP_BODY).await;
+        let worker = vllm_dp_worker(&stub.url, 1, 2);
+
+        let resp = WorkerMonitor::fetch_http_load(&worker, None)
+            .await
+            .expect("rank 1 load response");
+
+        assert_eq!(resp.dp_rank_count, 1);
+        assert_eq!(resp.loads.len(), 1);
+        assert_eq!(resp.loads[0].dp_rank, 1);
+        assert_eq!(resp.loads[0].num_running_reqs, 9);
+    }
+
+    #[tokio::test]
+    async fn gateway_fleet_loads_are_not_projected_as_engine_dp_ranks() {
+        let stub = spawn_gateway(GATEWAY_FLEET_BODY).await;
+        let worker = vllm_dp_worker(&stub.url, 1, 2);
+
+        let resp = WorkerMonitor::fetch_http_load(&worker, None)
+            .await
+            .expect("gateway fleet load response");
+
+        assert_eq!(resp.loads.len(), 2);
+        assert!(resp.loads.iter().all(|load| load.worker.is_some()));
+        assert_eq!(stub.gateway_probes.load(Ordering::SeqCst), 1);
+        assert_eq!(stub.probes.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

### Problem

The vLLM gRPC `GetLoads` implementation reads a scalar scheduler snapshot and labels it as DP rank 0. For data-parallel engines this can make every virtual gateway worker inherit rank 0 or backend-average telemetry. Missing stats are also reported as an idle rank, which can attract traffic to a rank whose load is actually unknown.

### Solution

Read only rank-addressable snapshots from vLLM's logger manager, preserve global DP rank IDs, and use vLLM's profiled per-engine `kv_cache_size_tokens` for absolute capacity. Missing or invalid telemetry is omitted instead of synthesized as idle. On the gateway side, scope each engine-native load response to the virtual worker's configured DP rank and never fall back to another rank or an aggregate. Fleet rollups returned by an upstream gateway's `/loads` endpoint retain their worker annotations and are not mistaken for one engine's DP ranks. HTTP probes use the worker's base endpoint, without its virtual `@rank` identity suffix; Prometheus fallback remains aggregate when native per-rank telemetry is unavailable.

This adapts the original change by haoxli (`haoxli0412@gmail.com`) and was rebased onto upstream `main` at `de5ff2ce`; the commit preserves the original author and DCO sign-off.

## Changes

- expose cached vLLM scheduler loads per managed global DP rank
- support the optional `dp_rank` filter, including explicit rank zero
- reject unmanaged rank filters with `INVALID_ARGUMENT`
- keep aggregate/scalar stats from leaking into per-rank telemetry
- report profiled per-engine KV capacity and include skipped waiting requests
- project native backend load responses to gateway virtual DP workers
- preserve cached gateway `/loads` fleet rollups introduced by #2418
- build native and Prometheus probe URLs from the base worker endpoint
- document rollout and load-field semantics
- add engine-free Python and Rust regression coverage

## Test Plan

Executed on `ci:~/work/smg` before the latest-main rebase; the post-rebase GitHub PR workflow re-runs the complete gate:

- `.venv/bin/python -m pytest -q grpc_servicer/tests/test_vllm_loads.py` — 34 passed
- `.venv/bin/python -m pytest -q -rs grpc_servicer/tests/test_vllm*.py` — 70 passed, 0 skipped, using the repository CI environment's pinned vLLM 0.27.1, ZMQ, and msgspec dependencies
- supplemental base-environment `pytest -q -rs grpc_servicer/tests` — 142 passed; its 5 repository-declared optional-engine skips were not used as vLLM validation
- Python `ruff check`, `ruff format --check`, and `py_compile` on changed Python files
- `cargo test -p openai-protocol --test dp_load_projection` — 4 passed
- `cargo test -p openai-protocol --lib` — 111 passed
- `cargo test -p smg --lib worker_monitor_tests::backend_load_is_projected_to_virtual_worker_rank` — 1 passed
- `cargo test -p smg --lib native_loads_tests::native_loads_are_projected_to_the_virtual_worker_rank` — 1 passed
- `cargo test -q -p smg --lib` — 1929 passed, 5 existing ignored tests
- `cargo clippy -p openai-protocol -p smg --lib --tests -- -D warnings`
- `cargo +nightly fmt -p openai-protocol -p smg -- --check`
- `cargo +nightly fmt --all -- --check`

The latest-main conflict resolution adds focused regression cases proving that engine-native responses select one virtual DP rank while annotated gateway fleet rollups are preserved rather than filtered by a non-global rank ID.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] Scoped production and test targets pass strict Clippy
- [x] Python lint, formatting, focused tests, and complete unit-test suite pass
- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
