### PR TITLE
ci: install RDMA runtime libraries on the TokenSpeed prebuilt path

### DIFF
--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -159,6 +159,34 @@ ensure_python_headers() {
     fi
 }
 
+ensure_rdma_libs() {
+    # ── RDMA runtime libraries ─────────────────────────────────────────────
+    # The EPD lane moves embeddings over Mooncake, whose native extension
+    # dlopens libibverbs/libnuma at import time whatever the transport is.
+    # Without them the encode worker dies during startup with
+    # "libibverbs.so.1: cannot open shared object file", which TokenSpeed
+    # reports as a generic "please install mooncake".
+    #
+    # Like the CUDA toolkit and Python headers above, these belong to the
+    # runner and are not part of the prebuilt payload: the source build only
+    # ever pulled them in as a transitive dependency of libopenmpi-dev, so the
+    # prebuilt fast path leaves the runner without them. Install them
+    # explicitly on both paths, same set as ci_install_vllm.sh.
+    if ldconfig -p 2> /dev/null | grep -q 'libibverbs\.so\.1'; then
+        echo "RDMA libraries: libibverbs.so.1 present"
+        return
+    fi
+
+    echo "libibverbs.so.1 not found; installing RDMA runtime libraries"
+    if ! command -v apt-get &> /dev/null; then
+        echo "ERROR: no apt-get to install the RDMA runtime libraries with" >&2
+        exit 1
+    fi
+    export DEBIAN_FRONTEND=noninteractive
+    $RETRY 3 10 $SUDO apt-get update -qq
+    $RETRY 3 10 $SUDO apt-get install -y --no-install-recommends libnuma1 libibverbs1 ibverbs-providers
+}
+
 install_tokenspeed_from_source() {
     # ── Clone TokenSpeed ───────────────────────────────────────────────────
     # ``git clone --branch`` only accepts branch/tag names, not SHAs, so we
@@ -302,6 +330,7 @@ fi
 
 setup_cuda_env
 ensure_python_headers
+ensure_rdma_libs
 
 if [ "$use_prebuilt" = "0" ]; then
     install_tokenspeed_from_source
@@ -341,6 +370,20 @@ python3 -c "from smg_grpc_servicer.tokenspeed.servicer import TokenSpeedSchedule
     print('gRPC servicer: importable')"
 python3 -c "from smg_grpc_servicer.tokenspeed.encoder_servicer import _lazy_encode_request; \
     print('EncodeRequest:', _lazy_encode_request())"
+# Prove Mooncake's native extension loads here rather than 20 minutes later
+# inside the EPD lane, where TokenSpeed reduces the dlopen failure to a
+# generic "please install mooncake". Lanes without the package skip it.
+python3 -c "
+import importlib.util
+
+if importlib.util.find_spec('mooncake') is None:
+    print('mooncake: not installed, skipping')
+else:
+    import torch  # bundled CUDA libraries must load first
+    from mooncake.engine import TransferEngine
+
+    print('mooncake TransferEngine: importable')
+"
 python3 -c "
 import pathlib
 import smg_grpc_proto


### PR DESCRIPTION
## Description

### Problem

`e2e-4gpu-epd (tokenspeed)` fails on every run, including on `main`. The encode
worker dies during startup:

```
File "/opt/tokenspeed-src/python/tokenspeed/runtime/pd/base/mooncake_engine.py", line 29, in __init__
    from mooncake.engine import TransferEngine
ImportError: libibverbs.so.1: cannot open shared object file: No such file or directory

The above exception was the direct cause of the following exception:
ImportError: Please install mooncake by following the instructions at ... to run TokenSpeed with MooncakeTransferEngine.
```

followed by `Worker Qwen/Qwen3.5-9B died during startup` and
`Engine tokenspeed failed to start workers 3 times`.

No PR caused this. The lane flipped the moment `ci-tokenspeed-image.yml`
published the current prebuilt image tag on 2026-09-04. Before that,
`docker manifest inspect` in `pr-test-rust.yml` found no image, so
`TOKENSPEED_PREBUILT_IMAGE` resolved empty and every lane built TokenSpeed from
source. The source build runs:

```
apt-get install -y --no-install-recommends libssl-dev libopenmpi-dev cmake
```

and `libopenmpi-dev` is the only thing that pulls `libibverbs1` onto the runner.
Once the image became resolvable, `ci_install_tokenspeed.sh` started skipping
the source build, so that apt never runs. The image itself has the libraries,
but `ci_fetch_tokenspeed_prebuilt.sh` only copies `/opt/smg-ci` and
`/opt/tokenspeed-src` out of it — the apt layer stays in the container.

Only EPD notices, because only EPD loads Mooncake. The chat and ZMQ TokenSpeed
lanes pass on the same image.

This is the third time a runner dependency has gone missing this way. The CUDA
toolkit and the Python headers had the same problem, and both are already
installed on both paths for exactly this reason. The RDMA libraries were the
one that got left behind.

### Solution

Install the RDMA runtime libraries explicitly, on both paths, next to the CUDA
toolkit and the Python headers. Same package set the vLLM lane already uses for
Mooncake.

Also add a Mooncake import canary to the verification block, so a broken
install fails during setup with the real dlopen error instead of twenty minutes
later behind TokenSpeed's generic "please install mooncake" message. Lanes
without the package installed skip the check.

## Changes

- `scripts/ci_install_tokenspeed.sh`
  - New `ensure_rdma_libs()`: installs `libnuma1 libibverbs1 ibverbs-providers`
    when `libibverbs.so.1` is not on the loader path, and returns early when it
    is, so the source path and repeat runs cost nothing.
  - Called unconditionally alongside `setup_cuda_env` and
    `ensure_python_headers`.
  - Mooncake import canary in the verification block.

`libssl-dev` and `cmake` stay where they are. Those are needed to compile
TokenSpeed, not to run it, so they are correctly scoped to the source build.

## Test Plan

Locally:

- `bash -n scripts/ci_install_tokenspeed.sh` passes.
- Exercised `ensure_rdma_libs()` against stubbed `ldconfig` / `apt-get`:
  returns early when `libibverbs.so.1` is listed, and otherwise issues
  `apt-get install -y --no-install-recommends libnuma1 libibverbs1 ibverbs-providers`
  through the retry wrapper.
- Exercised the canary both ways: prints `mooncake: not installed, skipping`
  when the package is absent, and exits non-zero with the original
  `libibverbs.so.1: cannot open shared object file` when the package is present
  but its extension cannot load. That is the failure this PR fixes, caught at
  setup.

In CI, the check is `e2e-4gpu-epd (tokenspeed)` going green on this PR, and the
setup log printing `mooncake TransferEngine: importable`.

One note on rollout: `ci_install_tokenspeed.sh` is part of the content-addressed
image tag, so this PR's lanes fall back to the ~25 minute source build until
`ci-tokenspeed-image.yml` republishes after merge. That path installs the
libraries too, so EPD is fixed either way — but the green run on this PR
exercises the source path, and the prebuilt path is covered by the first main
run after the image rebuilds.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes (n/a, no Rust changes)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (n/a, no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
