### PR TITLE
ci: prune superseded TokenSpeed CI images from GHCR

### DIFF
--- a/.github/workflows/ci-tokenspeed-image.yml
+++ b/.github/workflows/ci-tokenspeed-image.yml
@@ -17,6 +17,9 @@ name: CI TokenSpeed Image
 # doesn't exist yet, detect-changes resolves an empty image, and the lanes
 # degrade gracefully. This workflow builds the new tag on merge, and every
 # subsequent run is fast again.
+#
+# Retention: each tag is ~8 GB and nothing can pull a superseded one, so the
+# prune job below keeps the newest few and deletes the rest.
 
 on:
   push:
@@ -122,3 +125,20 @@ jobs:
         run: |
           docker rmi "$IMAGE" || true
           docker rmi "$BASE" || true
+
+  # Superseded tags are unreachable by construction (the tag is a hash of its
+  # own inputs), so this runs whenever the tag resolves — after a fresh push
+  # and after a no-op run that found the tag already present. Split out onto
+  # the CPU pool because that is where the gh CLI is available.
+  prune:
+    needs: [build-and-push]
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Prune superseded images
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci_prune_tokenspeed_images.sh

--- a/scripts/ci_prune_tokenspeed_images.sh
+++ b/scripts/ci_prune_tokenspeed_images.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Delete superseded prebuilt TokenSpeed CI images from GHCR.
+#
+# The tags scripts/ci_tokenspeed_image_tag.sh prints are content-addressed
+# (engine ref + a hash of the image tooling), so every bump strands the
+# previous ~8 GB image under a tag nothing will ever ask for again. Keep the
+# newest few and delete the rest.
+#
+# Keeping more than one is purely about speed. A run that resolved the
+# previous tag before this ran still pulls it instead of falling back to the
+# ~25 minute source build — and even when it can't,
+# ci_fetch_tokenspeed_prebuilt.sh treats a failed pull as a soft fallback, so
+# a deleted tag can never fail a lane.
+#
+# Only versions whose tags ALL carry the ci-tokenspeed- prefix are eligible.
+# The package also holds the nightly and release images, and they are not this
+# script's business.
+#
+# TOLERANT BY DESIGN: cleanup must never fail the publish it follows.
+#
+# Env knobs:
+#   TOKENSPEED_IMAGE_KEEP  how many recent images to keep (default 2)
+#   DRY_RUN=1              list what would be deleted, delete nothing
+
+set -uo pipefail # deliberately NOT -e: every failure is a soft skip
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KEEP="${TOKENSPEED_IMAGE_KEEP:-2}"
+OWNER="${GITHUB_REPOSITORY_OWNER:-smg-project}"
+PACKAGE="${TOKENSPEED_IMAGE_PACKAGE:-smg}"
+PREFIX="ci-tokenspeed-"
+
+log() { echo "[prune-tokenspeed-images] $*"; }
+
+if ! [[ "$KEEP" =~ ^[0-9]+$ ]] || [ "$KEEP" -lt 1 ]; then
+    log "TOKENSPEED_IMAGE_KEEP=${KEEP} is not a positive integer; skipping"
+    exit 0
+fi
+if ! command -v gh &> /dev/null; then
+    log "gh CLI not available; skipping"
+    exit 0
+fi
+
+# Never delete the tag the lanes are resolving right now, whatever its age.
+current="$(bash "${SCRIPT_DIR}/ci_tokenspeed_image_tag.sh" 2> /dev/null)"
+if [ -z "$current" ]; then
+    log "could not resolve the current tag; skipping rather than guessing"
+    exit 0
+fi
+log "current tag: ${current} (keeping newest ${KEEP})"
+
+# Versions tagged exclusively with the ci-tokenspeed- prefix, newest first.
+versions="$(gh api --paginate \
+    "/orgs/${OWNER}/packages/container/${PACKAGE}/versions?per_page=100" \
+    -q ".[]
+        | select(.metadata.container.tags | length > 0)
+        | select([.metadata.container.tags[] | startswith(\"${PREFIX}\")] | all)
+        | [.id, .created_at, (.metadata.container.tags | join(\",\"))]
+        | @tsv" 2>&1)"
+if [ $? -ne 0 ]; then
+    log "listing package versions failed; skipping"
+    log "${versions}"
+    exit 0
+fi
+if [ -z "$versions" ]; then
+    log "no ${PREFIX}* versions found; nothing to do"
+    exit 0
+fi
+
+sorted="$(printf '%s\n' "$versions" | sort -k2,2r)"
+log "found $(printf '%s\n' "$sorted" | wc -l | tr -d ' ') ${PREFIX}* version(s)"
+
+deleted=0
+kept=0
+while IFS=$'\t' read -r id created tags; do
+    [ -n "$id" ] || continue
+    if [ "$kept" -lt "$KEEP" ] || [[ ",${tags}," == *",${current},"* ]]; then
+        kept=$((kept + 1))
+        log "keep   ${tags} (${created})"
+        continue
+    fi
+    if [ "${DRY_RUN:-0}" = "1" ]; then
+        log "would delete ${tags} (${created}, version ${id})"
+        deleted=$((deleted + 1))
+        continue
+    fi
+    if gh api --method DELETE \
+        "/orgs/${OWNER}/packages/container/${PACKAGE}/versions/${id}" > /dev/null 2>&1; then
+        log "delete ${tags} (${created})"
+        deleted=$((deleted + 1))
+    else
+        # Most likely the token lacks package-delete rights. Say so once per
+        # version and carry on; a full image is still cheaper than a red build.
+        log "WARNING: could not delete ${tags} (version ${id})"
+    fi
+done <<< "$sorted"
+
+log "kept ${kept}, deleted ${deleted}"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "**Pruned TokenSpeed images:** kept ${kept}, deleted ${deleted}" >> "$GITHUB_STEP_SUMMARY"
+fi


### PR DESCRIPTION
## Description

### Problem

The prebuilt TokenSpeed CI image is tagged with a hash of its own inputs
(`scripts/ci_tokenspeed_image_tag.sh`: engine ref + Dockerfile + install
scripts). Bumping any of those produces a new tag, and the old one becomes
unreachable — no CI run will ever compute it again.

Nothing deletes it. The only cleanup in the workflow today is:

```yaml
- name: Clean up local images
  run: docker rmi "$IMAGE" || true
```

which frees disk on the build runner and does nothing to the registry. So every
bump strands a full image. Three have piled up so far, all on the same engine
ref, one per tooling change:

```
ci-tokenspeed-7cd7ca0b3028-0d355a7fe763   8.15 GB
ci-tokenspeed-7cd7ca0b3028-ac04a7866b6f   8.15 GB
ci-tokenspeed-7cd7ca0b3028-ac10053bdda6   8.15 GB
```

The current tag makes four. Nothing is billed for this — the package is public
— but it grows by 8 GB every time we touch the image tooling, and it makes the
package listing hard to read.

### Solution

Add a prune job to the image workflow that keeps the newest few
`ci-tokenspeed-*` images and deletes the rest.

Deleting these is safe by construction:

- A superseded tag cannot be computed by any future run, so nothing can ask
  for it.
- A run that resolved a tag before it was deleted degrades rather than breaks.
  `ci_fetch_tokenspeed_prebuilt.sh` is explicitly tolerant — a failed pull logs
  `lane will build from source` and the lane compiles TokenSpeed instead.

So the retention count is a speed knob, not a correctness one. It defaults to
2, which keeps the previous image around until the next bump so in-flight runs
stay on the fast path.

Two guards on what is eligible:

- A version is only touched if **every** one of its tags starts with
  `ci-tokenspeed-`. The `nightly-*` and release images share this package and
  are never candidates.
- The tag the lanes are resolving right now is kept regardless of age.

The job runs on the CPU pool rather than the docker pool, because that is where
the `gh` CLI is already in use. It has no `if:` condition, so it also runs on
the no-op workflow runs that find the tag already present — which is how the
existing backlog gets cleared without waiting for the next engine bump.

Cleanup never fails the publish it follows. A missing `gh`, an unresolvable
tag, a failed listing, a rejected delete: each logs and returns success.

## Changes

- `scripts/ci_prune_tokenspeed_images.sh` (new): lists the container package's
  versions, keeps the newest `TOKENSPEED_IMAGE_KEEP` (default 2) plus the
  current tag, deletes the remaining `ci-tokenspeed-*` versions. `DRY_RUN=1`
  lists without deleting.
- `.github/workflows/ci-tokenspeed-image.yml`: new `prune` job depending on
  `build-and-push`, plus a note about retention in the header.

Not included: the same package holds 192 `nightly-*` tags, which is a much
bigger pile and a separate retention question — those are pullable by people
and by other workflows, so the reasoning that makes this prune safe does not
carry over.

## Test Plan

`bash -n` passes on the new script and `check-yaml` passes on the workflow.

Ran the script against a stubbed `gh` returning a canned package listing (four
`ci-tokenspeed-*` versions, one `nightly-*`, one release version tagged
`1.10.1,latest`, one version tagged both `ci-tokenspeed-*` and something else,
and one untagged version):

| Case | Result |
|---|---|
| default `KEEP=2` | kept the 2 newest, deleted the 2 oldest |
| `KEEP=1` | kept the newest, deleted 3 |
| current tag is the *oldest* version | kept the newest **and** the current, deleted 2 |
| `KEEP=abc`, `KEEP=0` | skipped without deleting anything |
| every DELETE returns 403 | warned per version, exit 0 |
| no `ci-tokenspeed-*` versions | clean no-op |

In every case the `nightly-*`, release, mixed-tag, and untagged versions were
never selected.

Against the real registry with a token lacking `read:packages`, the listing
403s and the script logs `listing package versions failed; skipping` and exits
0 — the tolerant path a restricted workflow token would take.

In CI, this workflow triggers on changes to itself, so merging runs it: the
build is skipped because the tag already exists, and the prune job should
report `kept 2, deleted 2`.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes (n/a, no Rust changes)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (n/a, no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
