### PR TITLE
ci: install the gh CLI before pruning TokenSpeed images

### DIFF
--- a/.github/workflows/ci-tokenspeed-image.yml
+++ b/.github/workflows/ci-tokenspeed-image.yml
@@ -138,6 +138,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Install gh CLI
+        run: |
+          if ! command -v gh &>/dev/null; then
+            mkdir -p "$HOME/.local/bin"
+            GH_VERSION="2.74.0"
+            GH_SHA256="e55c9d49dc49c0b0fef0a9acd3510482fd9e27ff52ae80f8a6e838cd25b4cd89"
+            curl -fsSL --connect-timeout 10 --max-time 120 -o /tmp/gh.tgz \
+              "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz"
+            echo "${GH_SHA256}  /tmp/gh.tgz" | sha256sum --check --quiet
+            tar xzf /tmp/gh.tgz --strip-components=2 -C "$HOME/.local/bin" "gh_${GH_VERSION}_linux_amd64/bin/gh"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
+
       - name: Prune superseded images
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/ci_prune_tokenspeed_images.sh
+++ b/scripts/ci_prune_tokenspeed_images.sh
@@ -84,14 +84,15 @@ while IFS=$'\t' read -r id created tags; do
         deleted=$((deleted + 1))
         continue
     fi
-    if gh api --method DELETE \
-        "/orgs/${OWNER}/packages/container/${PACKAGE}/versions/${id}" > /dev/null 2>&1; then
+    if err="$(gh api --method DELETE \
+        "/orgs/${OWNER}/packages/container/${PACKAGE}/versions/${id}" 2>&1 > /dev/null)"; then
         log "delete ${tags} (${created})"
         deleted=$((deleted + 1))
     else
-        # Most likely the token lacks package-delete rights. Say so once per
-        # version and carry on; a full image is still cheaper than a red build.
-        log "WARNING: could not delete ${tags} (version ${id})"
+        # Most likely the token lacks package-delete rights. Print what the API
+        # actually said so that is diagnosable from the log, then carry on: a
+        # stale image is cheaper than a red build.
+        log "WARNING: could not delete ${tags} (version ${id}): ${err//$'\n'/ }"
     fi
 done <<< "$sorted"
 


### PR DESCRIPTION
## Description

### Problem

The prune job that keeps GHCR from accumulating superseded ~8 GB TokenSpeed CI images shells out to `gh`, but `gh` is not installed on the CPU runner pool. Its first run did nothing:

```
[prune-tokenspeed-images] gh CLI not available; skipping
```

The job was green, because the script is deliberately tolerant — cleanup must never fail the publish it follows. So the miss was silent, and the stale images are still there.

Every other job in this repo that uses `gh` on this pool installs a pinned copy first (`nightly-triage.yml`, `claude-code-review.yml`, `engine-version-watch.yml`). The prune job was the one that didn't.

A second, smaller problem: when a delete is rejected, the script threw the API response away and logged a bare `WARNING: could not delete <tag>`. That is not enough to tell a permissions rejection from anything else.

### Solution

Add the same `Install gh CLI` step the other jobs use — same pinned version, same checksum — and capture the API error so a rejected delete says why.

## Changes

- `.github/workflows/ci-tokenspeed-image.yml`: add the `Install gh CLI` step to the `prune` job, before the prune step.
- `scripts/ci_prune_tokenspeed_images.sh`: on a failed delete, log the API error alongside the tag.

## Test Plan

Ran the script against a stubbed `gh` and a canned versions list (4 `ci-tokenspeed-*` versions, plus a nightly tag and a mixed-tag version that must never be selected):

| Case | Result |
| --- | --- |
| `KEEP=2` | keeps 2, deletes 2 |
| `KEEP=1` | keeps 1, deletes 3 |
| `DRY_RUN=1` | lists the same 2, deletes nothing |
| delete rejected with HTTP 403 | logs the 403 text per version, `deleted 0`, exit 0 |
| `KEEP=abc` | skips, exit 0 |

The nightly tag and the mixed-tag version were excluded from selection in every case ("found 4" out of 6).

Merging this re-triggers the workflow (the workflow file is in its own `paths` filter). The build step is a no-op because the tag already exists, so the prune job runs and its log is the real verification. If the `GITHUB_TOKEN` turns out to lack package-delete rights, that now shows up as the API's own message and I'll follow up.

<details>
<summary>Checklist</summary>

- [x] Pre-commit hooks pass on the changed files
- [ ] `cargo +nightly fmt --all` (n/a, no Rust changes)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` (n/a, no Rust changes)
- [ ] `cargo test` (n/a, no Rust changes)
- [x] Conventional commit with DCO sign-off
- [x] No AI attribution

</details>