### PR TITLE
fix(grpc): preserve length finish reasons on truncated tool calls

### DIFF
--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -195,12 +195,10 @@ impl ResponseProcessor {
             complete.finish_reason()
         };
 
-        // Override finish reason if we have tool calls
-        let final_finish_reason_str = if tool_calls.is_some() {
-            "tool_calls"
-        } else {
-            finish_reason_str
-        };
+        // Tool calls override a natural stop; a truncated (`length`) or
+        // filtered generation keeps the engine's reason.
+        let final_finish_reason_str =
+            utils::finish_reason_with_tool_calls(finish_reason_str, tool_calls.is_some());
 
         // When the local decoder matched a stop string, surface it (the engine
         // reports no stop_reason over the ZMQ path); otherwise use the engine's.
@@ -759,15 +757,11 @@ impl ResponseProcessor {
                 .and_then(|v| v.as_str().map(String::from))
         });
 
-        let stop_reason = if tool_calls.is_some() || finish_reason_str == "tool_calls" {
-            Some(messages::StopReason::ToolUse)
-        } else if stop_sequence.is_some() {
-            Some(messages::StopReason::StopSequence)
-        } else if finish_reason_str == "length" {
-            Some(messages::StopReason::MaxTokens)
-        } else {
-            Some(messages::StopReason::EndTurn)
-        };
+        let stop_reason = Some(utils::messages_stop_reason(
+            finish_reason_str,
+            tool_calls.is_some(),
+            stop_sequence.is_some(),
+        ));
 
         // Clear stop_sequence when stop_reason is not StopSequence
         let stop_sequence = if matches!(stop_reason, Some(messages::StopReason::StopSequence)) {

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -686,12 +686,11 @@ impl StreamingProcessor {
 
         // Phase 4: Finish reason chunks
         for (index, finish_reason) in &finish_reasons {
-            let final_finish_reason =
-                if has_tool_calls.get(index).copied().unwrap_or(false) && finish_reason == "stop" {
-                    "tool_calls".to_string()
-                } else {
-                    finish_reason.clone()
-                };
+            let final_finish_reason = utils::finish_reason_with_tool_calls(
+                finish_reason,
+                has_tool_calls.get(index).copied().unwrap_or(false),
+            )
+            .to_string();
 
             let matched_stop_value = matched_stops.get(index).and_then(|v| v.clone());
 
@@ -2498,15 +2497,11 @@ impl StreamingProcessor {
         }
 
         // Phase 4: Emit message_delta with stop_reason and usage
-        let stop_reason = if has_tool_calls || finish_reason_str == "tool_calls" {
-            Some(messages::StopReason::ToolUse)
-        } else if matched_stop.is_some() {
-            Some(messages::StopReason::StopSequence)
-        } else if finish_reason_str == "length" {
-            Some(messages::StopReason::MaxTokens)
-        } else {
-            Some(messages::StopReason::EndTurn)
-        };
+        let stop_reason = Some(utils::messages_stop_reason(
+            &finish_reason_str,
+            has_tool_calls,
+            matched_stop.is_some(),
+        ));
 
         let stop_sequence = if matches!(stop_reason, Some(messages::StopReason::StopSequence)) {
             matched_stop.and_then(|v| v.as_str().map(String::from))

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -19,6 +19,7 @@ use openai_protocol::{
     chat::{ChatCompletionRequest, ChatMessage},
     common::{FunctionCallResponse, StringOrArray, Tool, ToolCall, ToolChoice, ToolChoiceValue},
     generate::GenerateFinishReason,
+    messages::StopReason,
 };
 use serde_json::{json, Value};
 use tokio::sync::Semaphore;
@@ -749,6 +750,42 @@ pub(crate) fn generate_tool_call_id(
     } else {
         // Kimi-K2 format: functions.{name}:{global_index}.
         format!("functions.{}:{}", tool_name, history_count + tool_index)
+    }
+}
+
+/// Finish reason for a chat choice after tool-call extraction.
+///
+/// Parsed tool calls turn a natural stop (or a missing reason) into
+/// `tool_calls`. A generation the engine cut short (`length`) or filtered
+/// (`content_filter`) keeps that reason even when the parser recovered tool
+/// calls from the partial text: the client needs the truncation signal more
+/// than the label, and the recovered calls are still returned.
+pub(crate) fn finish_reason_with_tool_calls(engine_reason: &str, has_tool_calls: bool) -> &str {
+    match (has_tool_calls, engine_reason) {
+        (true, "length" | "content_filter") => engine_reason,
+        (true, _) => "tool_calls",
+        (false, _) => engine_reason,
+    }
+}
+
+/// Anthropic `stop_reason` for a finished turn.
+///
+/// Truncation wins: a turn the engine cut at `max_tokens` reports `max_tokens`
+/// even when a tool-use block was recovered from the partial output. Otherwise
+/// tool use outranks a matched stop sequence, which outranks a natural stop.
+pub(crate) fn messages_stop_reason(
+    engine_reason: &str,
+    has_tool_calls: bool,
+    has_stop_sequence: bool,
+) -> StopReason {
+    if engine_reason == "length" {
+        StopReason::MaxTokens
+    } else if has_tool_calls || engine_reason == "tool_calls" {
+        StopReason::ToolUse
+    } else if has_stop_sequence {
+        StopReason::StopSequence
+    } else {
+        StopReason::EndTurn
     }
 }
 
@@ -1530,5 +1567,68 @@ mod tests {
         let id = generate_tool_call_id("gpt-4o", "get_weather", 0, 0);
         assert!(id.starts_with("call_"), "got: {id}");
         assert!(!id.contains("get_weather"), "got: {id}");
+    }
+}
+
+#[cfg(test)]
+mod finish_reason_tests {
+    use openai_protocol::messages::StopReason;
+
+    use super::{finish_reason_with_tool_calls, messages_stop_reason};
+
+    #[test]
+    fn tool_calls_rewrite_only_natural_stops() {
+        assert_eq!(finish_reason_with_tool_calls("stop", true), "tool_calls");
+        assert_eq!(finish_reason_with_tool_calls("", true), "tool_calls");
+        assert_eq!(
+            finish_reason_with_tool_calls("tool_calls", true),
+            "tool_calls"
+        );
+        // A truncated or filtered generation keeps the engine's reason even
+        // when tool calls were recovered from the partial text.
+        assert_eq!(finish_reason_with_tool_calls("length", true), "length");
+        assert_eq!(
+            finish_reason_with_tool_calls("content_filter", true),
+            "content_filter"
+        );
+    }
+
+    #[test]
+    fn without_tool_calls_the_engine_reason_passes_through() {
+        for reason in ["stop", "length", "content_filter", "tool_calls", ""] {
+            assert_eq!(finish_reason_with_tool_calls(reason, false), reason);
+        }
+    }
+
+    #[test]
+    fn messages_truncation_outranks_tool_use() {
+        assert_eq!(
+            messages_stop_reason("length", true, false),
+            StopReason::MaxTokens
+        );
+        assert_eq!(
+            messages_stop_reason("length", false, true),
+            StopReason::MaxTokens
+        );
+    }
+
+    #[test]
+    fn messages_natural_stop_precedence_is_unchanged() {
+        assert_eq!(
+            messages_stop_reason("stop", true, true),
+            StopReason::ToolUse
+        );
+        assert_eq!(
+            messages_stop_reason("tool_calls", false, false),
+            StopReason::ToolUse
+        );
+        assert_eq!(
+            messages_stop_reason("stop", false, true),
+            StopReason::StopSequence
+        );
+        assert_eq!(
+            messages_stop_reason("stop", false, false),
+            StopReason::EndTurn
+        );
     }
 }

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -11,9 +11,9 @@ pub(crate) mod tonic_ext;
 pub use chat_utils::{create_stop_decoder, process_chat_messages};
 pub(crate) use chat_utils::{
     encode_blocking, filter_chat_request_by_tool_choice, filter_tools_by_tool_choice,
-    generate_tool_call_id, get_history_tool_calls_count, parse_finish_reason,
-    parse_json_schema_response, process_chat_messages_with_placeholders, resolve_tokenizer,
-    send_error_sse,
+    finish_reason_with_tool_calls, generate_tool_call_id, get_history_tool_calls_count,
+    messages_stop_reason, parse_finish_reason, parse_json_schema_response,
+    process_chat_messages_with_placeholders, resolve_tokenizer, send_error_sse,
 };
 pub(crate) use logprobs::{
     convert_generate_input_logprobs, convert_generate_output_logprobs, convert_proto_logprobs,


### PR DESCRIPTION
## Description

### Problem

When a generation is cut off by `max_tokens` in the middle of a tool call, the gateway reports the wrong finish reason on two surfaces:

- **Chat completions (non-streaming)** rewrites `finish_reason` to `"tool_calls"` unconditionally whenever the parser extracted tool calls, so a request that hit the length limit mid-arguments is reported as a clean tool-call stop — the client gets a partial `arguments` string with no signal that anything was truncated. The streaming path already preserves `"length"` (it rewrites only a `"stop"`), so the same generation gets different answers depending on `stream`.
- **Messages (`/v1/messages`, both paths)** sets `stop_reason: "tool_use"` whenever a tool-use block exists, even when the engine reported `length`. Anthropic semantics require `max_tokens` when the output was cut, tool-use block or not.

### Solution

One rule, applied on every surface through two small helpers in `routers/grpc/utils`:

- `finish_reason_with_tool_calls(engine_reason, has_tool_calls)` — parsed tool calls turn a natural stop (or a missing reason) into `tool_calls`; `length` and `content_filter` are preserved even when tool calls were recovered from the partial text. The recovered calls are still returned as parsed.
- `messages_stop_reason(engine_reason, has_tool_calls, has_stop_sequence)` — `max_tokens` outranks `tool_use`; otherwise the existing precedence (`tool_use` > `stop_sequence` > `end_turn`) is unchanged.

Non-streaming chat, streaming chat, and both Messages paths now call these instead of their local predicates. A local stop-decoder match still means a natural stop.

## Changes

- `model_gateway/src/routers/grpc/utils/chat_utils.rs`: the two helpers + unit tests (truncation preserved, natural-stop rewrite unchanged, pass-through without tool calls, Messages precedence)
- `model_gateway/src/routers/grpc/utils/mod.rs`: re-exports
- `model_gateway/src/routers/grpc/regular/processor.rs`: chat and Messages non-streaming sites use the helpers
- `model_gateway/src/routers/grpc/regular/streaming.rs`: chat and Messages streaming sites use the helpers

## Test Plan

- [x] `cargo test -p smg --lib` (incl. the new `finish_reason_tests`)
- [x] `cargo test -p smg --test messages_test --test messages_streaming_test --test api_tests`
- [x] `cargo clippy -p smg --all-targets -- -D warnings`
- [x] nightly `cargo fmt`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (run for the touched crate locally: `cargo clippy -p smg --all-targets -- -D warnings`; CI runs the full matrix)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
