### PR TITLE
refactor(tokenizer): replace the Kimi-K3 prompt-segment API with a deferred encode

### DIFF
--- a/crates/tokenizer/src/cache/mod.rs
+++ b/crates/tokenizer/src/cache/mod.rs
@@ -31,7 +31,9 @@ use crate::{
     chat_template::{
         ChatTemplateContentFormat, ChatTemplateParams, ThinkingKeyName, ThinkingToggle,
     },
-    traits::{Decoder, Encoder, Encoding, PromptSegment, SpecialTokens, TokenIdType, Tokenizer},
+    traits::{
+        ChatTemplateOutput, Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer,
+    },
 };
 
 /// Configuration for the tokenizer cache
@@ -248,15 +250,6 @@ impl Encoder for CachedTokenizer {
             .map(|&input| self.encode(input, add_special_tokens))
             .collect()
     }
-
-    fn encode_segments(&self, segments: &[PromptSegment]) -> Result<Encoding> {
-        // A single control segment is the flat prompt the caches are keyed on.
-        // Mixed segments are encoded piecewise by the inner tokenizer, uncached.
-        match segments {
-            [only] if only.allow_special => self.encode(&only.text, false),
-            _ => self.inner.encode_segments(segments),
-        }
-    }
 }
 
 impl Decoder for CachedTokenizer {
@@ -295,12 +288,20 @@ impl Tokenizer for CachedTokenizer {
         self.inner.apply_chat_template(messages, params)
     }
 
-    fn apply_chat_template_segments(
+    fn apply_chat_template_with_encoding(
         &self,
         messages: &[serde_json::Value],
         params: ChatTemplateParams,
-    ) -> Result<Vec<PromptSegment>> {
-        self.inner.apply_chat_template_segments(messages, params)
+        assistant_prefix: Option<&str>,
+    ) -> Result<ChatTemplateOutput> {
+        // Forward rather than inherit the default: the default would render
+        // through the inner tokenizer's flat template and report `FromText`,
+        // silently dropping a deferred encode. A flat rendering still reaches
+        // the L0/L1 caches because the caller encodes its text through
+        // `self.encode`; a deferred encode never does, since two renderings
+        // can share one text with different ids.
+        self.inner
+            .apply_chat_template_with_encoding(messages, params, assistant_prefix)
     }
 
     fn chat_template_content_format(&self) -> ChatTemplateContentFormat {
@@ -691,5 +692,62 @@ mod tests {
         assert_eq!(cached.vocab_size(), tokenizer.vocab_size());
         assert!(cached.token_to_id("Hello").is_some());
         assert!(cached.id_to_token(1).is_some());
+    }
+
+    #[test]
+    fn forwards_deferred_chat_encodes_from_the_inner_tokenizer() {
+        use crate::{
+            chat_template::ChatTemplateParams,
+            mock::MockTokenizer,
+            traits::{PromptEncoding, Tokenizer as _},
+        };
+
+        let inner = MockTokenizer::new().with_deferred_chat_ids(vec![7, 8, 9]);
+        let cached = CachedTokenizer::new(
+            Arc::new(inner),
+            CacheConfig {
+                enable_l0: true,
+                ..Default::default()
+            },
+        );
+        let messages = vec![serde_json::json!({"role": "user", "content": "Hello"})];
+        let params = ChatTemplateParams {
+            add_generation_prompt: true,
+            ..Default::default()
+        };
+
+        let rendered = cached
+            .apply_chat_template_with_encoding(&messages, params, Some("Sure"))
+            .unwrap();
+        assert!(
+            rendered.text.ends_with("assistant: Sure"),
+            "{}",
+            rendered.text
+        );
+        let PromptEncoding::Deferred(job) = rendered.encoding else {
+            panic!("the wrapper must hand the inner tokenizer's deferred encode through");
+        };
+        assert_eq!(job.run().unwrap().token_ids(), &[7, 8, 9]);
+
+        // A flat inner tokenizer reports `FromText`, and the caller's
+        // `encode(text)` still goes through the wrapper's caches.
+        let flat = CachedTokenizer::new(
+            Arc::new(MockTokenizer::new()),
+            CacheConfig {
+                enable_l0: true,
+                ..Default::default()
+            },
+        );
+        let params = ChatTemplateParams {
+            add_generation_prompt: true,
+            ..Default::default()
+        };
+        let rendered = flat
+            .apply_chat_template_with_encoding(&messages, params, None)
+            .unwrap();
+        assert!(matches!(rendered.encoding, PromptEncoding::FromText));
+        let _ = flat.encode(&rendered.text, false).unwrap();
+        let _ = flat.encode(&rendered.text, false).unwrap();
+        assert_eq!(flat.cache_stats().map(|s| s.hits), Some(1));
     }
 }

--- a/crates/tokenizer/src/encoders/kimi_k3_xtml.rs
+++ b/crates/tokenizer/src/encoders/kimi_k3_xtml.rs
@@ -15,11 +15,15 @@
 //! `<|sep|>`, `<|end_of_msg|>` and media anchors with special tokens allowed,
 //! everything else — tag names, attribute pieces, message text of every role,
 //! reasoning, tool arguments, internal system messages — as ordinary BPE. A
-//! marker string inside message text therefore never becomes a control id, and
+//! marker string inside message text therefore never becomes a control id
+//! (the one exception is the gateway's `<|media_pad|>` anchor, see below), and
 //! attribute pieces (`" role"`, `="`, value, `"`) are separate BPE units.
-//! [`render_kimi_k3_xtml_segments`] reproduces that segmentation piece by
-//! piece; [`apply_kimi_k3_xtml`] is its concatenation for callers that want
-//! the flat prompt string.
+//! `render_kimi_k3_xtml_prompt` reproduces that segmentation piece by piece
+//! for the tiktoken backend, which encodes it and hands the caller a deferred
+//! encode; [`apply_kimi_k3_xtml_with_effort_default`] is that prompt joined
+//! flat (without the prefill), and [`apply_kimi_k3_xtml`] the bare
+//! `build_chat_segments` rendering with no served effort default. The segment
+//! type stays private to this crate.
 //!
 //! # Image prompts are not built here
 //!
@@ -33,10 +37,7 @@
 use anyhow::{anyhow, Result};
 use serde_json::{Map, Value};
 
-use crate::{
-    chat_template::ChatTemplateParams,
-    traits::{join_segments, PromptSegment},
-};
+use crate::chat_template::ChatTemplateParams;
 
 const OPEN_TOKEN: &str = "<|open|>";
 const CLOSE_TOKEN: &str = "<|close|>";
@@ -45,6 +46,38 @@ const END_OF_MSG_TOKEN: &str = "<|end_of_msg|>";
 const IMAGE_PLACEHOLDER: &str = "<|kimi_image_placeholder|>";
 /// The gateway's per-image anchor (`KimiK3VisionSpec::placeholder_token`).
 const MEDIA_ANCHOR: &str = "<|media_pad|>";
+
+/// One piece of a rendered prompt, tagged with how special-token strings in
+/// it must be encoded: the reference's `EncodeSegment { text, allow_special }`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PromptSegment {
+    pub(crate) text: String,
+    /// `true`: special-token strings map to their control ids (structural
+    /// markers emitted by the renderer). `false`: ordinary BPE, so a literal
+    /// marker string inside message text stays text.
+    pub(crate) allow_special: bool,
+}
+
+impl PromptSegment {
+    pub(crate) fn control(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            allow_special: true,
+        }
+    }
+
+    pub(crate) fn text(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            allow_special: false,
+        }
+    }
+}
+
+/// The flat prompt string: segment texts concatenated in order.
+pub(crate) fn join_segments(segments: &[PromptSegment]) -> String {
+    segments.iter().map(|s| s.text.as_str()).collect()
+}
 
 /// The effort the reference applies when a request names none.
 ///
@@ -83,21 +116,25 @@ pub fn apply_kimi_k3_xtml_with_effort_default(
     )?))
 }
 
-/// Segmented form of [`apply_kimi_k3_xtml`]: the reference's `EncodeSegment`
-/// list, structural markers as control segments and everything else as text.
-pub fn render_kimi_k3_xtml_segments(
+/// The served prompt as segments: [`apply_kimi_k3_xtml_with_effort_default`]
+/// plus the caller's `continue_final_message` prefill, appended as one control
+/// piece so marker strings in the prefill keep their control ids. That is
+/// what the flat encode of `rendered + prefill` produced before segments
+/// existed and what SGLang's prefix append does: the rendering always ends in
+/// a control piece (`<|sep|>` after the generation prompt), so no BPE merge
+/// crosses the seam and the prefill's ids equal the flat encode of the same
+/// prefill byte for byte. A prefill of ordinary text encodes the same either
+/// way.
+pub(crate) fn render_kimi_k3_xtml_prompt(
     messages: &[Value],
     params: &ChatTemplateParams,
+    assistant_prefix: Option<&str>,
 ) -> Result<Vec<PromptSegment>> {
-    render_xtml(messages, params, None)
-}
-
-/// Segmented form of [`apply_kimi_k3_xtml_with_effort_default`].
-pub fn render_kimi_k3_xtml_segments_with_effort_default(
-    messages: &[Value],
-    params: &ChatTemplateParams,
-) -> Result<Vec<PromptSegment>> {
-    render_xtml(messages, params, Some(DEFAULT_THINKING_EFFORT))
+    let mut out = render_xtml(messages, params, Some(DEFAULT_THINKING_EFFORT))?;
+    if let Some(prefix) = assistant_prefix {
+        push_control(&mut out, prefix);
+    }
+    Ok(out)
 }
 
 fn render_xtml(
@@ -1006,7 +1043,7 @@ mod tests {
             "function": {"name": "f", "parameters": {"type": "object"}}
         })];
         let params = params(Some(true), Some(&tools));
-        let segments = render_kimi_k3_xtml_segments(&messages, &params).unwrap();
+        let segments = render_xtml(&messages, &params, None).unwrap();
         assert_eq!(
             join_segments(&segments),
             apply_kimi_k3_xtml(&messages, &params).unwrap()
@@ -1020,7 +1057,7 @@ mod tests {
             json!({"role": "user", "content": "Hi"}),
             json!({"role": "assistant", "content": "ok"}),
         ];
-        let segments = render_kimi_k3_xtml_segments(&messages, &params(Some(true), None)).unwrap();
+        let segments = render_xtml(&messages, &params(Some(true), None), None).unwrap();
         let markers = [OPEN_TOKEN, CLOSE_TOKEN, SEP_TOKEN, END_OF_MSG_TOKEN];
         for text in control_texts(&segments) {
             assert!(
@@ -1047,8 +1084,8 @@ mod tests {
             json!({"role": "user", "content": "Bye"}),
         ];
         let params = params(Some(true), None);
-        let segments = render_kimi_k3_xtml_segments(&messages, &params).unwrap();
-        let plain_segments = render_kimi_k3_xtml_segments(&plain, &params).unwrap();
+        let segments = render_xtml(&messages, &params, None).unwrap();
+        let plain_segments = render_xtml(&plain, &params, None).unwrap();
 
         let injected_segments: Vec<&PromptSegment> =
             segments.iter().filter(|s| s.text == injected).collect();
@@ -1061,7 +1098,7 @@ mod tests {
     #[test]
     fn attribute_pieces_are_separate_text_segments() {
         let messages = vec![json!({"role": "user", "content": "Hi"})];
-        let segments = render_kimi_k3_xtml_segments(&messages, &params(Some(true), None)).unwrap();
+        let segments = render_xtml(&messages, &params(Some(true), None), None).unwrap();
         let expected = [
             PromptSegment::control(OPEN_TOKEN),
             PromptSegment::text("message"),
@@ -1082,7 +1119,7 @@ mod tests {
     #[test]
     fn media_anchors_in_message_text_are_control_segments() {
         let messages = vec![json!({"role": "user", "content": "see <|media_pad|> here"})];
-        let segments = render_kimi_k3_xtml_segments(&messages, &params(Some(true), None)).unwrap();
+        let segments = render_xtml(&messages, &params(Some(true), None), None).unwrap();
         assert_eq!(
             segments[7..10].to_vec(),
             vec![
@@ -1090,6 +1127,117 @@ mod tests {
                 PromptSegment::control(MEDIA_ANCHOR),
                 PromptSegment::text(" here"),
             ]
+        );
+    }
+
+    #[test]
+    fn prefill_is_appended_as_one_control_piece() {
+        let messages = vec![json!({"role": "user", "content": "Hi"})];
+        let params = params(Some(true), None);
+        let base = render_kimi_k3_xtml_prompt(&messages, &params, None).unwrap();
+        let prefix = "<|close|>think<|sep|>Sure";
+        let with = render_kimi_k3_xtml_prompt(&messages, &params, Some(prefix)).unwrap();
+        assert_eq!(&with[..base.len()], &base[..]);
+        assert_eq!(&with[base.len()..], &[PromptSegment::control(prefix)]);
+        assert_eq!(join_segments(&with), join_segments(&base) + prefix);
+        // An empty prefill adds nothing.
+        assert_eq!(
+            render_kimi_k3_xtml_prompt(&messages, &params, Some("")).unwrap(),
+            base
+        );
+    }
+
+    /// The reference `build_chat_segments` lists recorded in
+    /// `tests/fixtures/kimi_k3/k3_render_fixtures.json`, compared piece by
+    /// piece (text and `allow_special`), so the split is checked without a
+    /// checkpoint.
+    #[test]
+    fn segments_match_reference_fixture_lists() {
+        let raw = std::fs::read_to_string(
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/kimi_k3/k3_render_fixtures.json"),
+        )
+        .unwrap();
+        let fixtures: Value = serde_json::from_str(&raw).unwrap();
+        let expected = |case: &str| -> Vec<PromptSegment> {
+            fixtures[case]["segments"]
+                .as_array()
+                .unwrap_or_else(|| panic!("fixture `{case}` has no segments"))
+                .iter()
+                .map(|s| PromptSegment {
+                    text: s["text"].as_str().unwrap().to_string(),
+                    allow_special: s["allow_special"].as_bool().unwrap(),
+                })
+                .collect()
+        };
+        let tools = vec![json!({
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}
+            }
+        })];
+        let hi = vec![json!({"role": "user", "content": "Hi"})];
+
+        // (fixture name, messages, tools, thinking)
+        type Case<'a> = (&'a str, Vec<Value>, Option<&'a [Value]>, Option<bool>);
+        let cases: Vec<Case> = vec![
+            ("plain_user_thinking", hi.clone(), None, Some(true)),
+            (
+                "system_user_thinking",
+                vec![
+                    json!({"role": "system", "content": "You are helpful"}),
+                    json!({"role": "user", "content": "Hi"}),
+                ],
+                None,
+                Some(true),
+            ),
+            ("plain_user_no_thinking", hi.clone(), None, Some(false)),
+            (
+                "assistant_prior_turn",
+                vec![
+                    json!({"role": "user", "content": "Hi"}),
+                    json!({"role": "assistant", "content": "Hello!"}),
+                    json!({"role": "user", "content": "Bye"}),
+                ],
+                None,
+                Some(true),
+            ),
+            (
+                "with_tools",
+                vec![json!({"role": "user", "content": "weather in Paris?"})],
+                Some(&tools),
+                Some(true),
+            ),
+            (
+                "assistant_tool_call_then_result",
+                vec![
+                    json!({"role": "user", "content": "weather?"}),
+                    json!({
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [{
+                            "function": {"name": "get_weather", "arguments": {"city": "Paris"}}
+                        }]
+                    }),
+                    json!({"role": "tool", "tool": "get_weather", "content": "sunny"}),
+                ],
+                Some(&tools),
+                Some(true),
+            ),
+        ];
+        for (case, messages, tools, thinking) in cases {
+            let got = render_xtml(&messages, &params(thinking, tools), None).unwrap();
+            assert_eq!(got, expected(case), "case {case}");
+        }
+
+        let kwargs: HashMap<String, Value> =
+            HashMap::from([("thinking_effort".to_string(), json!("low"))]);
+        let got = render_xtml(&hi, &params_kw(Some(true), &kwargs, true), None).unwrap();
+        assert_eq!(
+            got,
+            expected("thinking_effort_low"),
+            "case thinking_effort_low"
         );
     }
 

--- a/crates/tokenizer/src/lib.rs
+++ b/crates/tokenizer/src/lib.rs
@@ -38,8 +38,8 @@ pub use stop::{SequenceDecoderOutput, StopSequenceConfig, StopSequenceDecoder};
 pub use stream::DecodeStream;
 pub use tiktoken::{TiktokenModel, TiktokenTokenizer};
 pub use traits::{
-    join_segments, Decoder, Encoder, Encoding, PromptSegment, SpecialTokens, TokenIdType,
-    Tokenizer as TokenizerTrait,
+    ChatTemplateOutput, Decoder, EncodeJob, Encoder, Encoding, PromptEncoding, SpecialTokens,
+    TokenIdType, Tokenizer as TokenizerTrait,
 };
 
 /// Main tokenizer wrapper that provides a unified interface for different tokenizer implementations

--- a/crates/tokenizer/src/mock.rs
+++ b/crates/tokenizer/src/mock.rs
@@ -1,16 +1,27 @@
 //! Mock tokenizer implementation for testing
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
 
-use crate::traits::{Decoder, Encoder, Encoding, SpecialTokens, Tokenizer as TokenizerTrait};
+use crate::{
+    chat_template::ChatTemplateParams,
+    traits::{
+        ChatTemplateOutput, Decoder, EncodeJob, Encoder, Encoding, PromptEncoding, SpecialTokens,
+        Tokenizer as TokenizerTrait,
+    },
+};
 
 /// Mock tokenizer for testing purposes
 pub struct MockTokenizer {
     vocab: HashMap<String, u32>,
     reverse_vocab: HashMap<u32, String>,
     special_tokens: SpecialTokens,
+    /// When set, `apply_chat_template_with_encoding` hands back these ids as
+    /// a deferred encode, standing in for a renderer that encodes itself.
+    deferred_chat_ids: Option<Vec<u32>>,
+    /// Runs inside the deferred job, on whatever thread the caller runs it.
+    deferred_chat_probe: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 
 impl Default for MockTokenizer {
@@ -62,7 +73,24 @@ impl MockTokenizer {
             vocab,
             reverse_vocab,
             special_tokens,
+            deferred_chat_ids: None,
+            deferred_chat_probe: None,
         }
+    }
+
+    /// Make `apply_chat_template_with_encoding` return `ids` as a deferred
+    /// encode, the way a renderer whose ids are not a function of its text
+    /// does. The rendered text is unchanged.
+    pub fn with_deferred_chat_ids(mut self, ids: Vec<u32>) -> Self {
+        self.deferred_chat_ids = Some(ids);
+        self
+    }
+
+    /// Run `probe` inside the deferred job, so a test can observe where the
+    /// caller ran it.
+    pub fn with_deferred_chat_probe(mut self, probe: impl Fn() + Send + Sync + 'static) -> Self {
+        self.deferred_chat_probe = Some(Arc::new(probe));
+        self
     }
 }
 
@@ -125,6 +153,57 @@ impl TokenizerTrait for MockTokenizer {
     fn eos_token_ids(&self) -> &[u32] {
         // `<eos>` in the mock vocab.
         &[999]
+    }
+
+    /// One `role: content` line per message, plus an `assistant:` tail when a
+    /// generation prompt is requested.
+    fn apply_chat_template(
+        &self,
+        messages: &[serde_json::Value],
+        params: ChatTemplateParams,
+    ) -> Result<String> {
+        let mut text = String::new();
+        for message in messages {
+            let role = message.get("role").and_then(|v| v.as_str()).unwrap_or("");
+            let content = message
+                .get("content")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            text.push_str(role);
+            text.push_str(": ");
+            text.push_str(content);
+            text.push('\n');
+        }
+        if params.add_generation_prompt {
+            text.push_str("assistant: ");
+        }
+        Ok(text)
+    }
+
+    fn apply_chat_template_with_encoding(
+        &self,
+        messages: &[serde_json::Value],
+        params: ChatTemplateParams,
+        assistant_prefix: Option<&str>,
+    ) -> Result<ChatTemplateOutput> {
+        let mut text = self.apply_chat_template(messages, params)?;
+        if let Some(prefix) = assistant_prefix {
+            text.push_str(prefix);
+        }
+        let encoding = match &self.deferred_chat_ids {
+            Some(ids) => {
+                let ids = ids.clone();
+                let probe = self.deferred_chat_probe.clone();
+                PromptEncoding::Deferred(EncodeJob::new(move || {
+                    if let Some(probe) = &probe {
+                        probe();
+                    }
+                    Ok(Encoding::Plain(ids))
+                }))
+            }
+            None => PromptEncoding::FromText,
+        };
+        Ok(ChatTemplateOutput { text, encoding })
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use anyhow::{Error, Result};
@@ -20,15 +21,15 @@ use crate::{
     encoders::{
         kimi_k25_tools::apply_kimi_k25_tools,
         kimi_k3_xtml::{
-            apply_kimi_k3_xtml_with_effort_default,
-            render_kimi_k3_xtml_segments_with_effort_default,
+            apply_kimi_k3_xtml_with_effort_default, join_segments, render_kimi_k3_xtml_prompt,
+            PromptSegment,
         },
     },
     factory::discover_chat_template_in_dir,
     kimi_k2_tokenizer,
     traits::{
-        Decoder, Encoder, Encoding, PromptSegment, SpecialTokens, TokenIdType,
-        Tokenizer as TokenizerTrait,
+        ChatTemplateOutput, Decoder, EncodeJob, Encoder, Encoding, PromptEncoding, SpecialTokens,
+        TokenIdType, Tokenizer as TokenizerTrait,
     },
 };
 
@@ -178,7 +179,9 @@ fn parse_special_tokens(config: &serde_json::Value) -> SpecialTokens {
 
 /// Tiktoken tokenizer wrapper — supports both built-in OpenAI encodings and hub-loaded models.
 pub struct TiktokenTokenizer {
-    tokenizer: CoreBPE,
+    /// Shared so a deferred chat encode can own a handle and run on another
+    /// thread after the render call returned.
+    tokenizer: Arc<CoreBPE>,
     special_tokens: SpecialTokens,
     vocab: HashMap<String, TokenIdType>,
     reverse_vocab: HashMap<TokenIdType, String>,
@@ -208,7 +211,7 @@ impl TiktokenTokenizer {
     /// Create a new Tiktoken tokenizer for the specified built-in model
     pub fn new(model: TiktokenModel) -> Result<Self> {
         let tokenizer =
-            match model {
+            Arc::new(match model {
                 TiktokenModel::O200kBase => o200k_base()
                     .map_err(|e| Error::msg(format!("Failed to load o200k_base: {e}")))?,
                 TiktokenModel::Cl100kBase => cl100k_base()
@@ -222,7 +225,7 @@ impl TiktokenTokenizer {
                 TiktokenModel::R50kBase => {
                     r50k_base().map_err(|e| Error::msg(format!("Failed to load r50k_base: {e}")))?
                 }
-            };
+            });
 
         let special_tokens = Self::get_special_tokens_for_model(model);
         // Built-in encodings have no tokenizer_config.json; every token the
@@ -327,7 +330,7 @@ impl TiktokenTokenizer {
             .map(|id| id as usize + 1)
             .unwrap_or(0);
         let (vocab, reverse_vocab) = build_vocab_maps(&encoder, &config.added_tokens);
-        let tokenizer = CoreBPE::new(encoder, special_tokens_encoder, pattern)?;
+        let tokenizer = Arc::new(CoreBPE::new(encoder, special_tokens_encoder, pattern)?);
 
         // 5. Load chat template — propagate errors for explicit paths,
         //    silently fall back for auto-discovery
@@ -508,6 +511,26 @@ pub fn is_tiktoken_file(path: &Path) -> bool {
         .is_some_and(|name| name == "tiktoken.model" || name.ends_with(".tiktoken"))
 }
 
+/// Piecewise encode for a segmented prompt: control pieces with special
+/// tokens recognized, text pieces as ordinary BPE. The allowed-special set is
+/// built once per prompt; `encode_with_special_tokens` would rebuild it for
+/// every piece, and a Kimi prompt has hundreds of control pieces.
+fn encode_segments(bpe: &CoreBPE, segments: &[PromptSegment]) -> Result<Vec<TokenIdType>> {
+    let allowed = bpe.special_tokens();
+    let mut ids = Vec::new();
+    for segment in segments {
+        if segment.allow_special {
+            let (piece, _) = bpe
+                .encode(&segment.text, &allowed)
+                .map_err(|e| Error::msg(format!("tiktoken encode failed: {e}")))?;
+            ids.extend(piece);
+        } else {
+            ids.extend(bpe.encode_ordinary(&segment.text));
+        }
+    }
+    Ok(ids)
+}
+
 impl Encoder for TiktokenTokenizer {
     fn encode(&self, input: &str, _add_special_tokens: bool) -> Result<Encoding> {
         // tiktoken ignores `add_special_tokens` (it means BOS/EOS prepend on HF
@@ -523,18 +546,6 @@ impl Encoder for TiktokenTokenizer {
             .iter()
             .map(|input| self.encode(input, add_special_tokens))
             .collect()
-    }
-
-    fn encode_segments(&self, segments: &[PromptSegment]) -> Result<Encoding> {
-        let mut ids = Vec::new();
-        for segment in segments {
-            if segment.allow_special {
-                ids.extend(self.tokenizer.encode_with_special_tokens(&segment.text));
-            } else {
-                ids.extend(self.tokenizer.encode_ordinary(&segment.text));
-            }
-        }
-        Ok(Encoding::Tiktoken(ids))
     }
 }
 
@@ -628,19 +639,35 @@ impl TokenizerTrait for TiktokenTokenizer {
         }
     }
 
-    fn apply_chat_template_segments(
+    fn apply_chat_template_with_encoding(
         &self,
         messages: &[serde_json::Value],
         params: ChatTemplateParams,
-    ) -> Result<Vec<PromptSegment>> {
-        match self.renderer {
-            Renderer::KimiK3Xtml => {
-                render_kimi_k3_xtml_segments_with_effort_default(messages, &params)
+        assistant_prefix: Option<&str>,
+    ) -> Result<ChatTemplateOutput> {
+        if !matches!(self.renderer, Renderer::KimiK3Xtml) {
+            let mut text = self.apply_chat_template(messages, params)?;
+            if let Some(prefix) = assistant_prefix {
+                text.push_str(prefix);
             }
-            _ => Ok(vec![PromptSegment::control(
-                self.apply_chat_template(messages, params)?,
-            )]),
+            return Ok(ChatTemplateOutput {
+                text,
+                encoding: PromptEncoding::FromText,
+            });
         }
+        // K3's ids are not a function of the flat text: render the reference's
+        // segments and hand the caller the piecewise encode to run where it
+        // would have encoded the text. The renderer reads none of
+        // `params.special_tokens`, so the injection `apply_chat_template`
+        // performs is a no-op here.
+        let segments = render_kimi_k3_xtml_prompt(messages, &params, assistant_prefix)?;
+        let text = join_segments(&segments);
+        let bpe = Arc::clone(&self.tokenizer);
+        let job = EncodeJob::new(move || encode_segments(&bpe, &segments).map(Encoding::Tiktoken));
+        Ok(ChatTemplateOutput {
+            text,
+            encoding: PromptEncoding::Deferred(job),
+        })
     }
 
     fn chat_template_content_format(&self) -> ChatTemplateContentFormat {
@@ -1043,8 +1070,9 @@ mod tests {
             .collect()
     }
 
-    #[test]
-    fn test_encode_segments_keeps_control_tokens_out_of_text_segments() {
+    /// A tiktoken directory whose `config.json` selects the K3 renderer and
+    /// whose vocabulary is every byte plus the four structural markers.
+    fn k3_byte_dir() -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("tiktoken.model"),
@@ -1053,45 +1081,143 @@ mod tests {
         .unwrap();
         std::fs::write(
             dir.path().join("tokenizer_config.json"),
-            r#"{"added_tokens_decoder": {"300": {"content": "<|open|>", "special": false}}}"#,
+            r#"{"added_tokens_decoder": {
+                "300": {"content": "<|open|>", "special": false},
+                "301": {"content": "<|close|>", "special": false},
+                "302": {"content": "<|sep|>", "special": false},
+                "303": {"content": "<|end_of_msg|>", "special": true}
+            }}"#,
         )
         .unwrap();
-        let tokenizer = TiktokenTokenizer::from_dir(dir.path()).unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{"architectures": ["KimiK3ForConditionalGeneration"]}"#,
+        )
+        .unwrap();
+        dir
+    }
 
-        let control = tokenizer
-            .encode_segments(&[PromptSegment::control("<|open|>")])
-            .unwrap();
-        assert_eq!(control.token_ids(), &[300]);
+    #[test]
+    fn test_encode_segments_keeps_control_tokens_out_of_text_segments() {
+        let tokenizer = TiktokenTokenizer::from_dir(k3_byte_dir().path()).unwrap();
+        let bpe = &tokenizer.tokenizer;
 
-        let text = tokenizer
-            .encode_segments(&[PromptSegment::text("<|open|>")])
-            .unwrap();
+        let control = encode_segments(bpe, &[PromptSegment::control("<|open|>")]).unwrap();
+        assert_eq!(control, vec![300]);
+
+        let text = encode_segments(bpe, &[PromptSegment::text("<|open|>")]).unwrap();
         assert!(
-            !text.token_ids().contains(&300),
-            "marker in a text segment must not become a control id: {:?}",
-            text.token_ids()
+            !text.contains(&300),
+            "marker in a text segment must not become a control id: {text:?}"
         );
-        assert_eq!(
-            tokenizer.decode(text.token_ids(), false).unwrap(),
-            "<|open|>"
-        );
+        assert_eq!(tokenizer.decode(&text, false).unwrap(), "<|open|>");
 
-        let mixed = tokenizer
-            .encode_segments(&[
+        let mixed = encode_segments(
+            bpe,
+            &[
                 PromptSegment::control("<|open|>"),
                 PromptSegment::text("message"),
                 PromptSegment::text("<|open|>"),
-            ])
-            .unwrap();
-        assert_eq!(mixed.token_ids().iter().filter(|&&id| id == 300).count(), 1);
+            ],
+        )
+        .unwrap();
+        assert_eq!(mixed.iter().filter(|&&id| id == 300).count(), 1);
         assert_eq!(
-            tokenizer.decode(mixed.token_ids(), false).unwrap(),
+            tokenizer.decode(&mixed, false).unwrap(),
             "<|open|>message<|open|>"
         );
 
         // The flat encode still maps every marker string to its control id.
         let flat = tokenizer.encode("<|open|>message<|open|>", false).unwrap();
         assert_eq!(flat.token_ids().iter().filter(|&&id| id == 300).count(), 2);
+    }
+
+    #[test]
+    fn test_k3_chat_template_defers_its_encode() {
+        let tokenizer = TiktokenTokenizer::from_dir(k3_byte_dir().path()).unwrap();
+        let messages = vec![serde_json::json!({"role": "user", "content": "<|open|>x"})];
+        let params = || ChatTemplateParams {
+            add_generation_prompt: true,
+            ..Default::default()
+        };
+
+        let rendered = tokenizer
+            .apply_chat_template_with_encoding(&messages, params(), None)
+            .unwrap();
+        assert_eq!(
+            rendered.text,
+            tokenizer.apply_chat_template(&messages, params()).unwrap(),
+            "the flat text is the served rendering"
+        );
+        let PromptEncoding::Deferred(job) = rendered.encoding else {
+            panic!("K3 must defer its encode");
+        };
+        let ids = job.run().unwrap();
+        let expected = encode_segments(
+            &tokenizer.tokenizer,
+            &render_kimi_k3_xtml_prompt(&messages, &params(), None).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(ids.token_ids(), &expected[..]);
+        // The user-typed marker is text (four structural <|open|> per prompt:
+        // thinking-effort message, user message, assistant tail, think tail).
+        assert_eq!(ids.token_ids().iter().filter(|&&id| id == 300).count(), 4);
+        let flat = tokenizer.encode(&rendered.text, false).unwrap();
+        assert_eq!(flat.token_ids().iter().filter(|&&id| id == 300).count(), 5);
+    }
+
+    #[test]
+    fn test_k3_prefill_keeps_its_control_tokens() {
+        let tokenizer = TiktokenTokenizer::from_dir(k3_byte_dir().path()).unwrap();
+        let messages = vec![serde_json::json!({"role": "user", "content": "Hi"})];
+        let params = ChatTemplateParams {
+            add_generation_prompt: true,
+            ..Default::default()
+        };
+        let prefix = "<|close|>think<|sep|>Sure";
+        let rendered = tokenizer
+            .apply_chat_template_with_encoding(&messages, params, Some(prefix))
+            .unwrap();
+        assert!(rendered.text.ends_with(prefix));
+        let PromptEncoding::Deferred(job) = rendered.encoding else {
+            panic!("K3 must defer its encode");
+        };
+        let ids = job.run().unwrap();
+        let tail: Vec<u32> = std::iter::once(301)
+            .chain("think".bytes().map(u32::from))
+            .chain(std::iter::once(302))
+            .chain("Sure".bytes().map(u32::from))
+            .collect();
+        assert!(
+            ids.token_ids().ends_with(&tail),
+            "prefill markers must stay control ids: {:?}",
+            ids.token_ids()
+        );
+    }
+
+    #[test]
+    fn test_flat_renderer_reports_from_text_with_prefill_joined() {
+        let dir = write_minimal_tiktoken_dir("{}", None);
+        let mut tokenizer = TiktokenTokenizer::from_dir(dir.path()).unwrap();
+        tokenizer
+            .set_chat_template(
+                "{% for m in messages %}{{ m.content }}{% endfor %}{% if add_generation_prompt %}A:{% endif %}"
+                    .to_string(),
+            )
+            .unwrap();
+        let messages = vec![serde_json::json!({"role": "user", "content": "hello"})];
+        let params = || ChatTemplateParams {
+            add_generation_prompt: true,
+            ..Default::default()
+        };
+        let rendered = tokenizer
+            .apply_chat_template_with_encoding(&messages, params(), Some(" there"))
+            .unwrap();
+        assert_eq!(
+            rendered.text,
+            tokenizer.apply_chat_template(&messages, params()).unwrap() + " there"
+        );
+        assert!(matches!(rendered.encoding, PromptEncoding::FromText));
     }
 
     #[test]

--- a/crates/tokenizer/src/traits.rs
+++ b/crates/tokenizer/src/traits.rs
@@ -12,49 +12,56 @@ use crate::chat_template::{
 /// Type alias for token IDs
 pub type TokenIdType = u32;
 
-/// One piece of a rendered prompt, tagged with how special-token strings in
-/// it must be encoded.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PromptSegment {
+/// An encode a renderer prepared while applying the chat template but left
+/// for the caller to run. Built only inside this crate.
+///
+/// Run it exactly where `encode(&text, false)` would otherwise run: the caller
+/// picks the thread, so the work goes through the same offload as a flat
+/// encode. A flat encode of the prompt text does not reproduce these ids.
+/// Wrappers that implement `Tokenizer` over another tokenizer must forward
+/// `apply_chat_template_with_encoding` so the job survives.
+#[must_use = "run it where you would encode the prompt text; a flat encode yields different ids"]
+pub struct EncodeJob(Box<dyn FnOnce() -> Result<Encoding> + Send + 'static>);
+
+impl EncodeJob {
+    pub(crate) fn new(f: impl FnOnce() -> Result<Encoding> + Send + 'static) -> Self {
+        Self(Box::new(f))
+    }
+
+    /// Perform the encode.
+    pub fn run(self) -> Result<Encoding> {
+        (self.0)()
+    }
+}
+
+impl std::fmt::Debug for EncodeJob {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("EncodeJob")
+    }
+}
+
+/// How the `text` of a [`ChatTemplateOutput`] becomes token ids.
+#[derive(Debug)]
+pub enum PromptEncoding {
+    /// `encode(&text, false)` is the prompt's encoding (every flat renderer).
+    FromText,
+    /// The renderer prepared the encode itself: run the job instead of
+    /// encoding `text` (renderers whose ids are not a function of the text).
+    Deferred(EncodeJob),
+}
+
+/// The applied chat template: the flat prompt string plus how to encode it.
+#[derive(Debug)]
+pub struct ChatTemplateOutput {
+    /// The flat prompt, for logs, routing, and `original_text`.
     pub text: String,
-    /// `true`: special-token strings map to their control ids (structural
-    /// markers emitted by the renderer). `false`: ordinary BPE, so a literal
-    /// marker string inside message text stays text.
-    pub allow_special: bool,
-}
-
-impl PromptSegment {
-    pub fn control(text: impl Into<String>) -> Self {
-        Self {
-            text: text.into(),
-            allow_special: true,
-        }
-    }
-
-    pub fn text(text: impl Into<String>) -> Self {
-        Self {
-            text: text.into(),
-            allow_special: false,
-        }
-    }
-}
-
-/// The flat prompt string: segment texts concatenated in order.
-pub fn join_segments(segments: &[PromptSegment]) -> String {
-    segments.iter().map(|s| s.text.as_str()).collect()
+    pub encoding: PromptEncoding,
 }
 
 /// Core encoding trait - separate from decoding for modularity
 pub trait Encoder: Send + Sync {
     fn encode(&self, input: &str, add_special_tokens: bool) -> Result<Encoding>;
     fn encode_batch(&self, inputs: &[&str], add_special_tokens: bool) -> Result<Vec<Encoding>>;
-
-    /// Encode a segmented prompt. The default joins the segments and encodes
-    /// the flat string; backends that can keep control tokens out of ordinary
-    /// text override it.
-    fn encode_segments(&self, segments: &[PromptSegment]) -> Result<Encoding> {
-        self.encode(&join_segments(segments), false)
-    }
 }
 
 /// Core decoding trait - can be implemented independently
@@ -133,17 +140,25 @@ pub trait Tokenizer: Encoder + Decoder {
         ))
     }
 
-    /// Segmented form of `apply_chat_template`. Renderers that separate
-    /// structural markers from message text override this; the default wraps
-    /// the flat rendering in a single control segment.
-    fn apply_chat_template_segments(
+    /// `apply_chat_template` plus how to encode the result, with the optional
+    /// `continue_final_message` prefill applied. The default appends the
+    /// prefill to the flat rendering and reports [`PromptEncoding::FromText`];
+    /// renderers whose ids are not a function of the text override it and
+    /// hand back a deferred encode instead.
+    fn apply_chat_template_with_encoding(
         &self,
         messages: &[serde_json::Value],
         params: ChatTemplateParams,
-    ) -> Result<Vec<PromptSegment>> {
-        Ok(vec![PromptSegment::control(
-            self.apply_chat_template(messages, params)?,
-        )])
+        assistant_prefix: Option<&str>,
+    ) -> Result<ChatTemplateOutput> {
+        let mut text = self.apply_chat_template(messages, params)?;
+        if let Some(prefix) = assistant_prefix {
+            text.push_str(prefix);
+        }
+        Ok(ChatTemplateOutput {
+            text,
+            encoding: PromptEncoding::FromText,
+        })
     }
 
     /// Get the content format expected by the chat template.

--- a/crates/tokenizer/tests/common/mod.rs
+++ b/crates/tokenizer/tests/common/mod.rs
@@ -1,4 +1,5 @@
 //! Common test utilities for tokenizer tests
+#![allow(dead_code)] // each integration test binary uses a subset of these helpers
 
 use std::{
     fs,
@@ -88,3 +89,76 @@ pub const EXPECTED_HASHES: [u64; 4] = [
     6245658446118930933,
     5097285695902185237,
 ];
+
+const KIMI_K3_REPO: &str = "https://huggingface.co/moonshotai/Kimi-K3/resolve/main";
+const KIMI_K3_CACHE_DIR: &str = ".tokenizer_cache/kimi_k3";
+
+/// A directory holding the Kimi-K3 tokenizer files (`tiktoken.model`,
+/// `tokenizer_config.json`) plus a minimal `config.json` naming the K3
+/// architecture so the tiktoken backend selects the XTML renderer.
+///
+/// `KIMI_K3_MODEL_DIR` points at a full checkpoint directory and skips the
+/// download; otherwise the two tokenizer files are fetched once from the
+/// public repository into `.tokenizer_cache/kimi_k3/`.
+#[expect(clippy::unwrap_used, reason = "test helper — panics are intentional")]
+#[expect(clippy::expect_used, reason = "test helper — panics are intentional")]
+#[expect(clippy::print_stdout, reason = "test diagnostic output")]
+#[expect(clippy::panic, reason = "test helper — panics are intentional")]
+pub fn ensure_kimi_k3_cached() -> PathBuf {
+    if let Some(dir) = std::env::var_os("KIMI_K3_MODEL_DIR") {
+        return PathBuf::from(dir);
+    }
+
+    let mutex = DOWNLOAD_MUTEX.get_or_init(|| Mutex::new(()));
+    let _guard = mutex.lock().unwrap();
+
+    let cache_dir = PathBuf::from(KIMI_K3_CACHE_DIR);
+    if !cache_dir.exists() {
+        fs::create_dir_all(&cache_dir).expect("Failed to create cache directory");
+    }
+
+    for (file, min_bytes) in [
+        ("tiktoken.model", 1_000_000),
+        ("tokenizer_config.json", 500),
+    ] {
+        let path = cache_dir.join(file);
+        if path.exists() {
+            continue;
+        }
+        println!("Downloading Kimi-K3 {file} from HuggingFace...");
+        let client = reqwest::blocking::Client::new();
+        let response = client
+            .get(format!("{KIMI_K3_REPO}/{file}"))
+            .send()
+            .unwrap_or_else(|e| panic!("Failed to download {file}: {e}"));
+        assert!(
+            response.status().is_success(),
+            "Failed to download {file}: HTTP {}",
+            response.status()
+        );
+        let content = response.bytes().expect("Failed to read download");
+        assert!(
+            content.len() >= min_bytes,
+            "Downloaded {file} too small: {} bytes",
+            content.len()
+        );
+        // Rename into place so a failed write never leaves a short file that
+        // the next run would trust.
+        let part = cache_dir.join(format!("{file}.part"));
+        fs::write(&part, content).expect("Failed to write to cache");
+        fs::rename(&part, &path).expect("Failed to move download into place");
+    }
+
+    // Renderer detection reads `config.json::architectures`; the tokenizer
+    // needs nothing else from the checkpoint's 500 KB config.
+    let config_path = cache_dir.join("config.json");
+    if !config_path.exists() {
+        fs::write(
+            &config_path,
+            r#"{"architectures": ["KimiK3ForConditionalGeneration"], "model_type": "kimi_k3"}"#,
+        )
+        .expect("Failed to write config.json");
+    }
+
+    cache_dir
+}

--- a/crates/tokenizer/tests/kimi_k3_renderer.rs
+++ b/crates/tokenizer/tests/kimi_k3_renderer.rs
@@ -8,16 +8,18 @@
 
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 
-use std::{collections::HashMap, fs, path::Path};
+use std::{collections::HashMap, fs};
 
 use llm_tokenizer::{
     chat_template::ChatTemplateParams,
     encoders::kimi_k3_xtml::apply_kimi_k3_xtml,
-    traits::{Encoder, Tokenizer as TokenizerTrait},
+    traits::{Encoder, PromptEncoding, Tokenizer as TokenizerTrait},
     TiktokenTokenizer,
 };
 use serde_json::{json, Value};
 use tempfile::TempDir;
+
+mod common;
 
 const MIN_TIKTOKEN_MODEL: &str = "aGVsbG8= 0\n";
 
@@ -223,15 +225,17 @@ fn tokenizer_loads_and_renders_k3_without_chat_template() {
 
 /// Token-id parity with the checkpoint's own `apply_chat_template(tokenize=True)`
 /// (`build_chat_segments` + `_encode_chat_segments`), recorded in
-/// `tests/fixtures/kimi_k3/k3_render_ids_fixtures.json`. Needs the real
-/// tokenizer files: point `KIMI_K3_MODEL_DIR` at a Kimi-K3 checkpoint directory
-/// and run with `cargo test -- --ignored`.
+/// `tests/fixtures/kimi_k3/k3_render_ids_fixtures.json` from
+/// `nvidia/Kimi-K3-NVFP4` (the same tokenizer files as `moonshotai/Kimi-K3`)
+/// and reproduced under transformers 4.57.6 and 5.16.1.
+///
+/// The real `tiktoken.model` and `tokenizer_config.json` are fetched once
+/// into `.tokenizer_cache/kimi_k3/`; `KIMI_K3_MODEL_DIR` points at a local
+/// checkpoint directory instead.
 #[test]
-#[ignore = "requires a Kimi-K3 checkpoint directory in KIMI_K3_MODEL_DIR"]
 fn segment_encoding_matches_vendor_token_ids() {
-    let model_dir = std::env::var_os("KIMI_K3_MODEL_DIR")
-        .expect("set KIMI_K3_MODEL_DIR to a Kimi-K3 checkpoint directory");
-    let tok = TiktokenTokenizer::from_dir(Path::new(&model_dir)).expect("K3 tokenizer should load");
+    let model_dir = common::ensure_kimi_k3_cached();
+    let tok = TiktokenTokenizer::from_dir(&model_dir).expect("K3 tokenizer should load");
 
     let raw = fs::read_to_string(
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -239,6 +243,15 @@ fn segment_encoding_matches_vendor_token_ids() {
     )
     .expect("k3 id fixtures must exist");
     let cases: Value = serde_json::from_str(&raw).expect("fixtures must be valid JSON");
+
+    // Cases where a flat encode of the rendered text cannot reproduce the
+    // reference ids: marker strings inside message text become control ids,
+    // and BPE merges across attribute-piece boundaries (`=".hidden`).
+    const FLAT_DIFFERS: &[&str] = &[
+        "injected_markers",
+        "tool_call_round_trip",
+        "punctuation_attribute_value",
+    ];
 
     for (name, case) in cases.as_object().expect("fixture root is an object") {
         let messages = case["messages"].as_array().expect("messages").clone();
@@ -255,30 +268,35 @@ fn segment_encoding_matches_vendor_token_ids() {
             ..Default::default()
         };
 
-        let segments = tok
-            .apply_chat_template_segments(&messages, params())
-            .expect("segment render should succeed");
-        let ids = tok
-            .encode_segments(&segments)
-            .expect("segment encode should succeed");
-        assert_eq!(
-            ids.token_ids(),
-            &expected[..],
-            "case {name}: segment encoding differs"
-        );
-
-        // The flat path maps marker strings inside message text to control ids
-        // and lets BPE merge across attribute-piece boundaries (`=".hidden`), so
-        // it must disagree with the reference exactly in those cases.
         let flat = tok
             .apply_chat_template(&messages, params())
             .expect("flat render");
+        let rendered = tok
+            .apply_chat_template_with_encoding(&messages, params(), None)
+            .expect("render should succeed");
+        assert_eq!(
+            rendered.text, flat,
+            "case {name}: text is the flat rendering"
+        );
+        assert_eq!(
+            rendered.text,
+            case["text"].as_str().expect("text"),
+            "case {name}: text differs from the reference"
+        );
+        let PromptEncoding::Deferred(job) = rendered.encoding else {
+            panic!("case {name}: K3 must defer its encode");
+        };
+        let ids = job.run().expect("deferred encode should succeed");
+        assert_eq!(
+            ids.token_ids(),
+            &expected[..],
+            "case {name}: deferred encoding differs from the reference"
+        );
+
         let flat_ids = tok.encode(&flat, false).expect("flat encode");
-        let flat_must_differ = messages.iter().any(|m| m.to_string().contains("<|"))
-            || name == "punctuation_attribute_value";
         assert_eq!(
             flat_ids.token_ids() != &expected[..],
-            flat_must_differ,
+            FLAT_DIFFERS.contains(&name.as_str()),
             "case {name}: flat encoding parity unexpected"
         );
     }

--- a/model_gateway/src/routers/grpc/mod.rs
+++ b/model_gateway/src/routers/grpc/mod.rs
@@ -1,7 +1,6 @@
 //! gRPC router implementations
 
 use axum::response::Response;
-use llm_tokenizer::traits::PromptSegment;
 use openai_protocol::{chat::ChatCompletionRequest, common::StringOrArray};
 
 use crate::routers::error;
@@ -54,10 +53,7 @@ fn validate_text_only_output(request: &ChatCompletionRequest) -> Result<(), Box<
 /// The multimodal intermediate lives on `ProcessingState`, not here.
 #[derive(Debug)]
 pub struct ProcessedMessages {
-    /// The flat prompt, `segments` concatenated; kept for logs and `original_text`.
     pub text: String,
-    /// What gets encoded: the renderer's control/text split of the same prompt.
-    pub segments: Vec<PromptSegment>,
     pub stop_sequences: Option<StringOrArray>,
 }
 

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -162,24 +162,26 @@ pub(crate) async fn prepare_chat_like(
         };
 
         // Step 2: Process messages and apply chat template
-        let mut processed_messages = match utils::process_chat_messages_with_placeholders(
-            &body_ref,
-            &*tokenizer,
-            placeholder_tokens.as_ref(),
-            media_order,
-        ) {
-            Ok(msgs) => msgs,
-            Err(e) => {
-                error!(function = "ChatPreparationStage::execute", error = %e, "Failed to process chat messages");
-                return Err(error::bad_request("process_messages_failed", e));
-            }
-        };
+        let (processed_messages, prompt_encoding) =
+            match utils::process_chat_messages_with_placeholders(
+                &body_ref,
+                &*tokenizer,
+                placeholder_tokens.as_ref(),
+                media_order,
+            ) {
+                Ok(msgs) => msgs,
+                Err(e) => {
+                    error!(function = "ChatPreparationStage::execute", error = %e, "Failed to process chat messages");
+                    return Err(error::bad_request("process_messages_failed", e));
+                }
+            };
 
-        // Step 3: Tokenize the rendered segments (the renderer decides which
-        // pieces may carry special tokens)
-        let encoding = match utils::encode_segments_blocking(
+        // Step 3: Tokenize the prompt the way its renderer said to (a flat
+        // encode of the text, or the encode the renderer prepared)
+        let encoding = match utils::encode_prompt_blocking(
             tokenizer.clone(),
-            std::mem::take(&mut processed_messages.segments),
+            &processed_messages.text,
+            prompt_encoding,
         )
         .await
         {

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -167,7 +167,7 @@ impl MessagePreparationStage {
         };
 
         // Step 2: Process messages and apply chat template
-        let mut processed_messages = match message_utils::process_messages(
+        let (processed_messages, prompt_encoding) = match message_utils::process_messages(
             request,
             &*tokenizer,
             tools_for_template,
@@ -181,10 +181,11 @@ impl MessagePreparationStage {
             }
         };
 
-        // Step 3: Tokenize the rendered segments
-        let encoding = match utils::encode_segments_blocking(
+        // Step 3: Tokenize the prompt the way its renderer said to
+        let encoding = match utils::encode_prompt_blocking(
             tokenizer.clone(),
-            std::mem::take(&mut processed_messages.segments),
+            &processed_messages.text,
+            prompt_encoding,
         )
         .await
         {

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -12,7 +12,7 @@ use llm_multimodal::{MediaPartOrder, Modality};
 use llm_tokenizer::{
     chat_template::{ChatTemplateContentFormat, ChatTemplateParams},
     stop::StopSequenceDecoderBuilder,
-    traits::{join_segments, Encoding, PromptSegment, Tokenizer},
+    traits::{Encoding, PromptEncoding, Tokenizer},
     StopSequenceDecoder,
 };
 use openai_protocol::{
@@ -114,43 +114,50 @@ fn encode_permits() -> &'static Semaphore {
     })
 }
 
-/// Tokenize off the async worker threads so CPU-bound `encode` cannot stall the
-/// runtime, bounded by [`encode_permits`] so concurrent offloaded encodes cannot
-/// oversubscribe the CPU. Small inputs are encoded inline to avoid the offload
-/// round-trip dominating.
+/// Run CPU-bound tokenization off the async worker threads so it cannot stall
+/// the runtime, bounded by [`encode_permits`] so concurrent offloaded encodes
+/// cannot oversubscribe the CPU. Inputs below the threshold run inline to avoid
+/// the offload round-trip dominating.
+async fn offload<F>(len: usize, encode: F) -> anyhow::Result<Encoding>
+where
+    F: FnOnce() -> anyhow::Result<Encoding> + Send + 'static,
+{
+    if len < ENCODE_OFFLOAD_MIN_BYTES {
+        return encode();
+    }
+    let _permit = encode_permits()
+        .acquire()
+        .await
+        .map_err(|e| anyhow!("encode semaphore closed: {e}"))?;
+    tokio::task::spawn_blocking(encode)
+        .await
+        .map_err(|e| anyhow!("tokenization task failed: {e}"))?
+}
+
+/// Tokenize `text` through the offload policy of [`offload`].
 pub(crate) async fn encode_blocking(
     tokenizer: Arc<dyn Tokenizer>,
     text: String,
     add_special_tokens: bool,
 ) -> anyhow::Result<Encoding> {
-    if text.len() < ENCODE_OFFLOAD_MIN_BYTES {
-        return tokenizer.encode(&text, add_special_tokens);
-    }
-    let _permit = encode_permits()
-        .acquire()
-        .await
-        .map_err(|e| anyhow!("encode semaphore closed: {e}"))?;
-    tokio::task::spawn_blocking(move || tokenizer.encode(&text, add_special_tokens))
-        .await
-        .map_err(|e| anyhow!("tokenization task failed: {e}"))?
+    offload(text.len(), move || {
+        tokenizer.encode(&text, add_special_tokens)
+    })
+    .await
 }
 
-/// Segmented counterpart of [`encode_blocking`] with the same offload policy.
-pub(crate) async fn encode_segments_blocking(
+/// Tokenize a rendered chat prompt the way its renderer said to: a deferred
+/// encode runs as the job the renderer prepared, anything else encodes `text`.
+/// Both take the same offload policy as [`encode_blocking`].
+pub(crate) async fn encode_prompt_blocking(
     tokenizer: Arc<dyn Tokenizer>,
-    segments: Vec<PromptSegment>,
+    text: &str,
+    encoding: PromptEncoding,
 ) -> anyhow::Result<Encoding> {
-    let bytes: usize = segments.iter().map(|s| s.text.len()).sum();
-    if bytes < ENCODE_OFFLOAD_MIN_BYTES {
-        return tokenizer.encode_segments(&segments);
+    match encoding {
+        PromptEncoding::FromText => encode_blocking(tokenizer, text.to_string(), false).await,
+        PromptEncoding::Deferred(job) => offload(text.len(), move || job.run()).await,
     }
-    let _permit = encode_permits()
-        .acquire()
-        .await
-        .map_err(|e| anyhow!("encode semaphore closed: {e}"))?;
-    tokio::task::spawn_blocking(move || tokenizer.encode_segments(&segments))
-        .await
-        .map_err(|e| anyhow!("tokenization task failed: {e}"))?
 }
 
 /// Process tool call arguments in messages
@@ -459,6 +466,11 @@ pub(crate) fn filter_chat_request_by_tool_choice(
 
 /// Process chat messages and apply template (shared by both routers)
 /// Requires HuggingFace tokenizer with chat template support
+///
+/// Returns the flat prompt only. A renderer that must encode the prompt itself
+/// (Kimi-K3) cannot be honored through this entry point; the gRPC pipeline
+/// uses [`process_chat_messages_with_placeholders`] and encodes what it
+/// returns.
 pub fn process_chat_messages(
     request: &ChatCompletionRequest,
     tokenizer: &dyn Tokenizer,
@@ -469,21 +481,35 @@ pub fn process_chat_messages(
         placeholders.insert(Modality::Image, token.to_string());
         placeholders
     });
-    process_chat_messages_with_placeholders(
+    let (processed, encoding) = process_chat_messages_with_placeholders(
         request,
         tokenizer,
         placeholder_tokens.as_ref(),
         MediaPartOrder::MediaFirst,
-    )
+    )?;
+    if matches!(encoding, PromptEncoding::Deferred(_)) {
+        static WARNED: OnceLock<()> = OnceLock::new();
+        WARNED.get_or_init(|| {
+            tracing::warn!(
+                "the tokenizer's renderer encodes prompts itself; a flat encode of \
+                 ProcessedMessages.text may not reproduce its token ids (marker strings \
+                 in message text, BPE merges across attribute-piece boundaries)"
+            );
+        });
+    }
+    Ok(processed)
 }
 
+/// Render the chat prompt. The second element says how the tokenize step must
+/// encode it: [`PromptEncoding::FromText`] for every flat renderer, or the
+/// deferred encode a segment-aware renderer prepared.
 pub(crate) fn process_chat_messages_with_placeholders(
     request: &ChatCompletionRequest,
     tokenizer: &dyn Tokenizer,
     placeholder_tokens: Option<&PlaceholderTokens>,
     media_order: MediaPartOrder,
-) -> Result<ProcessedMessages, String> {
-    let segments = {
+) -> Result<(ProcessedMessages, PromptEncoding), String> {
+    let rendered = {
         // Get content format and transform messages accordingly
         let content_format = tokenizer.chat_template_content_format();
         let mut transformed_messages = process_content_format_with_order(
@@ -541,11 +567,13 @@ pub(crate) fn process_chat_messages_with_placeholders(
         {
             // Pop the last message to handle it separately — guarded by !is_empty() check above
             let Some(last_msg) = transformed_messages.pop() else {
-                return Ok(ProcessedMessages {
-                    text: String::new(),
-                    segments: Vec::new(),
-                    stop_sequences: request.stop.clone(),
-                });
+                return Ok((
+                    ProcessedMessages {
+                        text: String::new(),
+                        stop_sequences: request.stop.clone(),
+                    },
+                    PromptEncoding::FromText,
+                ));
             };
             last_msg
                 .get("content")
@@ -555,28 +583,25 @@ pub(crate) fn process_chat_messages_with_placeholders(
             None
         };
 
-        // Apply chat template with the (now possibly shorter) list of messages
-        let mut segments = tokenizer
-            .apply_chat_template_segments(&transformed_messages, params)
-            .map_err(|e| format!("Failed to apply chat template: {e}"))?;
-
-        // Append assistant prefix if we have one. A flat renderer hands back a
-        // single control segment and the prefix joins it, so the prompt stays
-        // one encoding unit; segment-aware renderers take it as message text.
-        if let Some(prefix) = assistant_prefix {
-            match segments.as_mut_slice() {
-                [only] if only.allow_special => only.text.push_str(&prefix),
-                _ => segments.push(PromptSegment::text(prefix)),
-            }
-        }
-        segments
+        // Apply chat template with the (now possibly shorter) list of messages.
+        // The prefill goes into the same call so the text and its encoding are
+        // produced together and cannot drift apart.
+        tokenizer
+            .apply_chat_template_with_encoding(
+                &transformed_messages,
+                params,
+                assistant_prefix.as_deref(),
+            )
+            .map_err(|e| format!("Failed to apply chat template: {e}"))?
     };
 
-    Ok(ProcessedMessages {
-        text: join_segments(&segments),
-        segments,
-        stop_sequences: request.stop.clone(),
-    })
+    Ok((
+        ProcessedMessages {
+            text: rendered.text,
+            stop_sequences: request.stop.clone(),
+        },
+        rendered.encoding,
+    ))
 }
 
 /// Create a StopSequenceDecoder from stop parameters
@@ -1554,5 +1579,142 @@ mod tests {
         let id = generate_tool_call_id("gpt-4o", "get_weather", 0, 0);
         assert!(id.starts_with("call_"), "got: {id}");
         assert!(!id.contains("get_weather"), "got: {id}");
+    }
+
+    // --- render -> encode contract -------------------------------------------
+
+    fn prefill_request() -> ChatCompletionRequest {
+        serde_json::from_value(json!({
+            "model": "m",
+            "continue_final_message": true,
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Sure"}
+            ]
+        }))
+        .unwrap()
+    }
+
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    #[test]
+    fn flat_renderer_joins_the_prefill_and_reports_from_text() {
+        let tokenizer = llm_tokenizer::MockTokenizer::new();
+        let (processed, encoding) = process_chat_messages_with_placeholders(
+            &prefill_request(),
+            &tokenizer,
+            None,
+            MediaPartOrder::MediaFirst,
+        )
+        .unwrap();
+        assert_eq!(processed.text, "user: Hello\nassistant: Sure");
+        assert!(matches!(encoding, PromptEncoding::FromText));
+
+        // The tokenize step encodes the text exactly as before.
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(tokenizer);
+        let ids = block_on(encode_prompt_blocking(
+            tokenizer.clone(),
+            &processed.text,
+            encoding,
+        ))
+        .unwrap();
+        assert_eq!(
+            ids.token_ids(),
+            tokenizer
+                .encode(&processed.text, false)
+                .unwrap()
+                .token_ids()
+        );
+    }
+
+    #[test]
+    fn deferred_renderer_gets_the_prefill_and_its_job_runs_in_the_tokenize_step() {
+        let tokenizer = llm_tokenizer::MockTokenizer::new().with_deferred_chat_ids(vec![7, 8, 9]);
+        let (processed, encoding) = process_chat_messages_with_placeholders(
+            &prefill_request(),
+            &tokenizer,
+            None,
+            MediaPartOrder::MediaFirst,
+        )
+        .unwrap();
+        assert_eq!(
+            processed.text, "user: Hello\nassistant: Sure",
+            "the prefill is passed into the render call"
+        );
+        assert!(matches!(encoding, PromptEncoding::Deferred(_)));
+
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(tokenizer);
+        let ids = block_on(encode_prompt_blocking(tokenizer, &processed.text, encoding)).unwrap();
+        assert_eq!(ids.token_ids(), &[7, 8, 9]);
+    }
+
+    #[test]
+    fn deferred_encode_takes_the_offload_path_for_large_prompts() {
+        use std::{
+            sync::Mutex,
+            thread::{self, ThreadId},
+        };
+        // The job records the thread it ran on. `block_on` polls on this
+        // thread, so an offloaded job runs somewhere else.
+        let ran_on: Arc<Mutex<Option<ThreadId>>> = Arc::new(Mutex::new(None));
+        let probe = {
+            let ran_on = ran_on.clone();
+            move || *ran_on.lock().unwrap() = Some(thread::current().id())
+        };
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+            llm_tokenizer::MockTokenizer::new()
+                .with_deferred_chat_ids(vec![1, 2])
+                .with_deferred_chat_probe(probe),
+        );
+        let render = |content: &str| {
+            let request: ChatCompletionRequest = serde_json::from_value(json!({
+                "model": "m",
+                "messages": [{"role": "user", "content": content}]
+            }))
+            .unwrap();
+            process_chat_messages_with_placeholders(
+                &request,
+                &*tokenizer,
+                None,
+                MediaPartOrder::MediaFirst,
+            )
+            .unwrap()
+        };
+        let encode = |text: &str, encoding: PromptEncoding| {
+            block_on(encode_prompt_blocking(tokenizer.clone(), text, encoding)).unwrap()
+        };
+
+        let (processed, encoding) = render(&"x".repeat(ENCODE_OFFLOAD_MIN_BYTES * 4));
+        assert!(processed.text.len() >= ENCODE_OFFLOAD_MIN_BYTES);
+        assert_eq!(encode(&processed.text, encoding).token_ids(), &[1, 2]);
+        let offloaded = ran_on.lock().unwrap().take().expect("the job ran");
+        assert_ne!(
+            offloaded,
+            thread::current().id(),
+            "a large deferred encode is offloaded"
+        );
+
+        let (processed, encoding) = render("hi");
+        assert!(processed.text.len() < ENCODE_OFFLOAD_MIN_BYTES);
+        encode(&processed.text, encoding);
+        let inline = ran_on.lock().unwrap().take().expect("the job ran");
+        assert_eq!(
+            inline,
+            thread::current().id(),
+            "a small deferred encode runs inline"
+        );
+    }
+
+    #[test]
+    fn public_entry_point_keeps_the_flat_text_for_a_deferred_renderer() {
+        let tokenizer = llm_tokenizer::MockTokenizer::new().with_deferred_chat_ids(vec![7]);
+        let processed = process_chat_messages(&prefill_request(), &tokenizer, None).unwrap();
+        assert_eq!(processed.text, "user: Hello\nassistant: Sure");
     }
 }

--- a/model_gateway/src/routers/grpc/utils/message_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/message_utils.rs
@@ -8,7 +8,7 @@
 use llm_multimodal::{MediaPartOrder, Modality};
 use llm_tokenizer::{
     chat_template::{ChatTemplateContentFormat, ChatTemplateParams},
-    traits::{join_segments, Tokenizer},
+    traits::{PromptEncoding, Tokenizer},
 };
 use openai_protocol::{
     common::{self, StringOrArray, Tool as ChatTool, ToolChoice as ChatToolChoice},
@@ -30,14 +30,15 @@ use crate::routers::grpc::{multimodal::PlaceholderTokens, ProcessedMessages};
 ///
 /// Parallel to `process_chat_messages()` in chat_utils, but works with
 /// Anthropic Messages API types. Converts InputMessages to JSON values
-/// that the chat template expects, then applies the template.
+/// that the chat template expects, then applies the template. The second
+/// element says how the tokenize step must encode the prompt.
 pub fn process_messages(
     request: &CreateMessageRequest,
     tokenizer: &dyn Tokenizer,
     chat_tools: Option<&[ChatTool]>,
     placeholder_tokens: Option<&PlaceholderTokens>,
     media_order: MediaPartOrder,
-) -> Result<ProcessedMessages, String> {
+) -> Result<(ProcessedMessages, PromptEncoding), String> {
     let content_format = tokenizer.chat_template_content_format();
 
     // Step 1: Convert InputMessages to chat template JSON values
@@ -96,8 +97,8 @@ pub fn process_messages(
         ..Default::default()
     };
 
-    let segments = tokenizer
-        .apply_chat_template_segments(&transformed_messages, params)
+    let rendered = tokenizer
+        .apply_chat_template_with_encoding(&transformed_messages, params, None)
         .map_err(|e| format!("Failed to apply chat template: {e}"))?;
 
     // Step 7: Build ProcessedMessages
@@ -106,11 +107,13 @@ pub fn process_messages(
         .as_ref()
         .map(|seqs| StringOrArray::Array(seqs.clone()));
 
-    Ok(ProcessedMessages {
-        text: join_segments(&segments),
-        segments,
-        stop_sequences,
-    })
+    Ok((
+        ProcessedMessages {
+            text: rendered.text,
+            stop_sequences,
+        },
+        rendered.encoding,
+    ))
 }
 
 // ============================================================================

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod tonic_ext;
 // Re-export all public items so consumer imports stay unchanged.
 pub use chat_utils::{create_stop_decoder, process_chat_messages};
 pub(crate) use chat_utils::{
-    encode_blocking, encode_segments_blocking, filter_chat_request_by_tool_choice,
+    encode_blocking, encode_prompt_blocking, filter_chat_request_by_tool_choice,
     filter_tools_by_tool_choice, generate_tool_call_id, get_history_tool_calls_count,
     parse_finish_reason, parse_json_schema_response, process_chat_messages_with_placeholders,
     resolve_tokenizer, send_error_sse,

--- a/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
+++ b/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
@@ -312,16 +312,11 @@ async fn feature_disabled_is_a_no_op() {
 /// the stage is actually live on a second wired pipeline too, not just
 /// constructed and never reached.
 ///
-/// Chat and Messages are deliberately not covered the same way here: both
-/// need `apply_chat_template` to turn their `messages` array into a prompt
-/// before preparation ever reaches the reserve stage, and `MockTokenizer`
-/// (`crates/tokenizer/src/mock.rs`) doesn't implement it -- confirmed by
-/// running this exact test against `route_chat`, which fails earlier with
-/// `process_messages_failed: Chat template not supported by this
-/// tokenizer`, a 400 from the Chat preparation stage, not a 429 from rate
-/// limiting. That's a pre-existing gap in the shared mock tokenizer,
-/// unrelated to this PR; extending it (or swapping in a template-capable
-/// fake) is out of scope here. Harmony and PD dispatch are also not covered:
+/// Chat and Messages are not covered the same way here. `MockTokenizer`
+/// (`crates/tokenizer/src/mock.rs`) renders a minimal `role: content`
+/// template, so a `route_chat` mirror of this case would reach the reserve
+/// stage; the mechanics it would exercise are the ones Completion already
+/// proves. Harmony and PD dispatch are also not covered:
 /// Harmony needs a harmony-flavored model registered so `HarmonyDetector`
 /// routes into it, and PD needs a distinct prefill+decode worker pair --
 /// both larger harness investments than this suite carries for its other


### PR DESCRIPTION
## Description

### Problem

#2421 fixed Kimi-K3 tokenization by rendering the prompt as the checkpoint's segment list and encoding it piecewise, which is the only correct way: a user-typed `<|open|>` must stay text, and attribute pieces such as `=".hidden"` must not BPE-merge across their boundary. To get that split from the render step to the tokenize step it made the mechanism public, and every pipeline learned a K3 concept:

- `PromptSegment` and `join_segments` re-exported from the tokenizer crate root, plus two provided trait methods (`Encoder::encode_segments`, `Tokenizer::apply_chat_template_segments`);
- a `pub segments: Vec<PromptSegment>` field on `ProcessedMessages`, taken by `std::mem::take` in step 3 and empty afterwards;
- `encode_segments_blocking` and a branch on `allow_special` in the gateway's `continue_final_message` placement.

Three smaller problems came with it: the K3 prefill was appended as ordinary text, so `<|close|>think<|sep|><|open|>response<|sep|>…` could no longer close the think block and a prefilled `<|media_pad|>` failed anchor validation; `encode_with_special_tokens` rebuilt the 256-entry allowed-special set for every control segment (a 41-message tool conversation renders to 539 of them, about 1.5 ms of rebuilds per encode); and the vendor-id parity test was `#[ignore]`d behind an env var no workflow sets.

### Solution

Keep the segment split inside the tokenizer crate and hand the gateway something it can run later. One provided method replaces the two:

```rust
fn apply_chat_template_with_encoding(&self, messages, params, assistant_prefix: Option<&str>)
    -> Result<ChatTemplateOutput>;                 // { text, encoding: PromptEncoding }
enum PromptEncoding { FromText, Deferred(EncodeJob) }   // EncodeJob::run(self) -> Result<Encoding>
```

The default renders through `apply_chat_template`, appends the prefill, and reports `FromText`; every Jinja, DeepSeek and Kimi-K2.5 backend is byte-identical to before. The K3 tiktoken backend overrides it and returns the flat text plus an `EncodeJob`, a closure over an `Arc<CoreBPE>` and the crate-private segments that performs the piecewise encode when run. The gateway's step 3 runs the job exactly where it would have called `encode(text)`, through the same 512-byte threshold, permit semaphore and `spawn_blocking`, so K3's encode stays off the async runtime and render errors stay 400 while encode errors stay 500.

`ProcessedMessages` returns to `{ text, stop_sequences }`, the public `process_chat_messages` keeps its signature, and no segment type or `allow_special` flag appears in `model_gateway`. The prefill is a parameter of the render call so text and encoding cannot drift apart; K3 appends it as one control piece, which I verified on the checkpoint tokenizer gives the prefill the same ids as the flat encode of `rendered + prefill` main produced before #2421 and as SGLang's prefix append. The allowed-special set is built once per prompt.

## Changes

- `crates/tokenizer/src/traits.rs`: `EncodeJob`, `PromptEncoding`, `ChatTemplateOutput`, provided `Tokenizer::apply_chat_template_with_encoding`; `PromptSegment`, `join_segments`, `Encoder::encode_segments`, `Tokenizer::apply_chat_template_segments` removed.
- `crates/tokenizer/src/encoders/kimi_k3_xtml.rs`: `PromptSegment`/`join_segments` move in as `pub(crate)`; `render_kimi_k3_xtml_prompt(messages, params, assistant_prefix)` appends the prefill as a control piece; module docs.
- `crates/tokenizer/src/tiktoken.rs`: `tokenizer: Arc<CoreBPE>`; private `encode_segments` with the hoisted allowed set; `apply_chat_template_with_encoding` override for K3.
- `crates/tokenizer/src/cache/mod.rs`: forwards the new method (load-bearing) instead of the two segment hooks; `mock.rs`: trivial template plus `with_deferred_chat_ids` for tests; `lib.rs`: re-exports.
- `model_gateway/src/routers/grpc/mod.rs`: `ProcessedMessages` back to main. `utils/chat_utils.rs`: private `offload` helper shared by `encode_blocking` and the new `encode_prompt_blocking`; `process_chat_messages_with_placeholders` and `message_utils::process_messages` return the `PromptEncoding` alongside; the public entry point warns once if it drops a deferred encode. Both preparation stages: two-line change in steps 2 and 3.
- Tests: K3 override defers and matches the piecewise encode; marker-bearing prefill keeps control ids; flat backend reports `FromText` with the prefill joined; cache wrapper forwards; a checkpoint-free golden against the reference `build_chat_segments` lists in `k3_render_fixtures.json`; gateway tests for both prefill arms, the job in the tokenize step below and above the offload threshold, and the public entry point. The vendor parity test runs by default, fetching the two tokenizer files into `.tokenizer_cache/kimi_k3/` (`KIMI_K3_MODEL_DIR` still overrides).

Follow-ups, not in this PR: an ids-returning helper for the Go bindings (they keep main's flat-text behaviour; the once-per-process warning is visible only if the host installs a tracing subscriber); neutralizing user-typed `<|media_pad|>` in the content-format step; the reference's 400k/25k chunking.

## Test Plan

- `cargo test -p llm-tokenizer` with `KIMI_K3_MODEL_DIR` pointing at the checkpoint's `tiktoken.model` + `tokenizer_config.json`: 194 unit tests pass; `kimi_k3_renderer` 11/11 including `segment_encoding_matches_vendor_token_ids`, which is no longer ignored (the fixture ids reproduce under transformers 4.57.6 and 5.16.1). The remaining integration binaries pass; `tokenizer_integration` needs network for its TinyLlama download, unchanged.
- `cargo test -p smg --lib --features vendored-openssl`: 1932 passed, 0 failed. The four new `chat_utils` tests cover both prefill arms, the deferred job running in the tokenize step, and the offload branch (the job records the thread it ran on: a prompt above `ENCODE_OFFLOAD_MIN_BYTES` runs off the runtime thread, a small one inline).
- `cargo test -p smg --test tenant_rate_limiting_grpc_test --features vendored-openssl`: 14 passed (its doc comment about the mock tokenizer is updated, since the mock now renders a minimal template).
- `cargo clippy -p llm-tokenizer -p smg -p smg-golang --features smg/vendored-openssl --all-targets -- -D warnings`: clean. `cargo +nightly fmt --all --check`: clean.
- Prefill policy checked on the checkpoint tokenizer for plain, marker-bearing, `<|media_pad|>`, leading-space, newline and empty prefills: `encode(tail + prefill)` equals `encode(tail) ++ encode(prefill, specials allowed)`, so the control-piece append gives the prefill the same ids as the pre-#2421 flat encode and as SGLang's prefix append.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (run per crate with `--features smg/vendored-openssl`: the build host has no system OpenCV)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
