### PR TITLE
feat(router): key cache-aware affinity under the request's cache partition

### DIFF
--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -6,10 +6,10 @@ use validator::Validate;
 
 use super::{
     common::{
-        default_true, deserialize_null_as_false, is_false, is_true, validate_stop, ChatLogProbs,
-        ContentPart, Function, FunctionCall, FunctionChoice, GenerationRequest, ResponseFormat,
-        StreamOptions, StringOrArray, Tool, ToolCall, ToolCallDelta, ToolChoice, ToolChoiceValue,
-        ToolReference, Usage,
+        default_true, deserialize_null_as_false, is_false, is_true, validate_stop, CachePartition,
+        ChatLogProbs, ContentPart, Function, FunctionCall, FunctionChoice, GenerationRequest,
+        ResponseFormat, StreamOptions, StringOrArray, Tool, ToolCall, ToolCallDelta, ToolChoice,
+        ToolChoiceValue, ToolReference, Usage,
     },
     sampling_params::{validate_top_k_value, validate_top_p_value},
 };
@@ -639,6 +639,16 @@ impl GenerationRequest for ChatCompletionRequest {
         self.stream
     }
 
+    fn cache_partition(&self) -> CachePartition<'_> {
+        CachePartition {
+            // Engine extensions carried in the passthrough map, not typed
+            // fields: vLLM/SGLang `cache_salt`, SGLang `extra_key`.
+            cache_salt: self.other.get("cache_salt").and_then(Value::as_str),
+            extra_key: self.other.get("extra_key").and_then(Value::as_str),
+            lora_path: self.lora_path.as_deref(),
+        }
+    }
+
     fn get_model(&self) -> Option<&str> {
         Some(&self.model)
     }
@@ -805,7 +815,7 @@ pub struct ChatStreamChoice {
 mod tests {
     use serde_json::{json, Value};
 
-    use super::{thinking_from_reasoning_effort, ChatCompletionRequest};
+    use super::{thinking_from_reasoning_effort, ChatCompletionRequest, GenerationRequest};
 
     fn request_with_output_fields(fields: &[(&str, Value)]) -> ChatCompletionRequest {
         let mut value = json!({
@@ -943,5 +953,28 @@ mod tests {
             serde_json::from_value(value).expect("request must deserialize");
         let tools = request.tools.expect("tools must be present");
         assert_eq!(tools[0].function.parameters, json!({}));
+    }
+
+    #[test]
+    fn cache_partition_reads_passthrough_salt_and_typed_lora() {
+        let request: ChatCompletionRequest = serde_json::from_value(json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "cache_salt": "tenant-a",
+            "extra_key": "k",
+            "lora_path": "adapter"
+        }))
+        .unwrap();
+        let partition = request.cache_partition();
+        assert_eq!(partition.cache_salt, Some("tenant-a"));
+        assert_eq!(partition.extra_key, Some("k"));
+        assert_eq!(partition.lora_path, Some("adapter"));
+
+        let bare: ChatCompletionRequest = serde_json::from_value(json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}]
+        }))
+        .unwrap();
+        assert!(bare.cache_partition().is_empty());
     }
 }

--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -70,9 +70,13 @@ pub struct CachePartition<'a> {
 }
 
 impl CachePartition<'_> {
-    /// True when no partitioning field is set.
+    /// True when no partitioning field is set. An empty string is "unset":
+    /// engines treat an empty salt or adapter as absent, so it must not
+    /// split the request off from the shared unpartitioned cache.
     pub fn is_empty(&self) -> bool {
-        self.cache_salt.is_none() && self.extra_key.is_none() && self.lora_path.is_none()
+        [self.cache_salt, self.extra_key, self.lora_path]
+            .iter()
+            .all(|field| field.is_none_or(str::is_empty))
     }
 }
 

--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -55,6 +55,27 @@ where
 // GenerationRequest Trait
 // ============================================================================
 
+/// The request fields that partition a backend's prefix cache.
+///
+/// Engines namespace their prefix (KV) caches by client-supplied values: a
+/// cache salt, an extra classification key, and the LoRA adapter. Two
+/// requests that share a prompt but differ in any of these can never share
+/// cached blocks on the engine, so routing derives its cache namespace from
+/// this projection. All fields absent means the request is unpartitioned.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CachePartition<'a> {
+    pub cache_salt: Option<&'a str>,
+    pub extra_key: Option<&'a str>,
+    pub lora_path: Option<&'a str>,
+}
+
+impl CachePartition<'_> {
+    /// True when no partitioning field is set.
+    pub fn is_empty(&self) -> bool {
+        self.cache_salt.is_none() && self.extra_key.is_none() && self.lora_path.is_none()
+    }
+}
+
 /// Trait for unified access to generation request properties
 /// Implemented by ChatCompletionRequest, CompletionRequest, GenerateRequest,
 /// EmbeddingRequest, RerankRequest, and ResponsesRequest
@@ -79,6 +100,12 @@ pub trait GenerationRequest: Send + Sync {
     /// derive a session-affinity key from it; a batch reports its first id.
     fn rid(&self) -> Option<&str> {
         None
+    }
+
+    /// The fields that partition the backend's prefix cache for this request.
+    /// Protocols without such fields are unpartitioned.
+    fn cache_partition(&self) -> CachePartition<'_> {
+        CachePartition::default()
     }
 }
 

--- a/crates/protocols/src/completion.rs
+++ b/crates/protocols/src/completion.rs
@@ -220,6 +220,16 @@ impl GenerationRequest for CompletionRequest {
         self.stream
     }
 
+    fn cache_partition(&self) -> CachePartition<'_> {
+        CachePartition {
+            // Engine extensions carried in the passthrough map, not typed
+            // fields: vLLM/SGLang `cache_salt`, SGLang `extra_key`.
+            cache_salt: self.other.get("cache_salt").and_then(Value::as_str),
+            extra_key: self.other.get("extra_key").and_then(Value::as_str),
+            lora_path: self.lora_path.as_deref(),
+        }
+    }
+
     fn get_model(&self) -> Option<&str> {
         Some(&self.model)
     }

--- a/crates/protocols/src/generate.rs
+++ b/crates/protocols/src/generate.rs
@@ -5,7 +5,10 @@ use serde_json::{Map, Value};
 use validator::Validate;
 
 use super::{
-    common::{default_true, deserialize_null_as_false, is_false, GenerationRequest, InputIds},
+    common::{
+        default_true, deserialize_null_as_false, is_false, CachePartition, GenerationRequest,
+        InputIds,
+    },
     sampling_params::SamplingParams,
 };
 use crate::validated::Normalizable;
@@ -211,6 +214,17 @@ impl GenerationRequest for GenerateRequest {
         self.stream
     }
 
+    fn cache_partition(&self) -> CachePartition<'_> {
+        CachePartition {
+            // vLLM's `cache_salt` is a passthrough extension on this
+            // protocol; `extra_key` is SGLang's typed classification key.
+            cache_salt: self.other.get("cache_salt").and_then(Value::as_str),
+            extra_key: self.extra_key.as_deref(),
+            // Either name identifies the adapter the engine namespaces by.
+            lora_path: self.lora_path.as_deref().or(self.lora_id.as_deref()),
+        }
+    }
+
     fn get_model(&self) -> Option<&str> {
         Some(self.model.as_str())
     }
@@ -400,5 +414,29 @@ mod tests {
 
         let r = req();
         assert_eq!(r.routing_tokens(), None);
+    }
+
+    #[test]
+    fn cache_partition_uses_the_typed_extra_key_and_falls_back_to_lora_id() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "text": "hi",
+            "extra_key": "k",
+            "lora_id": "adapter-id",
+            "cache_salt": "tenant-a"
+        }))
+        .unwrap();
+        let partition = request.cache_partition();
+        assert_eq!(partition.cache_salt, Some("tenant-a"));
+        assert_eq!(partition.extra_key, Some("k"));
+        assert_eq!(partition.lora_path, Some("adapter-id"));
+
+        let typed_path: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "text": "hi",
+            "lora_path": "adapter-path",
+            "lora_id": "adapter-id"
+        }))
+        .unwrap();
+        assert_eq!(typed_path.cache_partition().lora_path, Some("adapter-path"));
+        assert!(typed_path.cache_partition().cache_salt.is_none());
     }
 }

--- a/crates/protocols/src/messages.rs
+++ b/crates/protocols/src/messages.rs
@@ -9,7 +9,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use validator::Validate;
 
-use crate::{common::GenerationRequest, validated::Normalizable};
+use crate::{
+    common::{CachePartition, GenerationRequest},
+    validated::Normalizable,
+};
 
 // ============================================================================
 // Request Types
@@ -114,6 +117,16 @@ impl CreateMessageRequest {
 }
 
 impl GenerationRequest for CreateMessageRequest {
+    fn cache_partition(&self) -> CachePartition<'_> {
+        CachePartition {
+            // Engine extensions in the passthrough map, forwarded to the
+            // backend as-is.
+            cache_salt: self.other.get("cache_salt").and_then(Value::as_str),
+            extra_key: self.other.get("extra_key").and_then(Value::as_str),
+            lora_path: self.other.get("lora_path").and_then(Value::as_str),
+        }
+    }
+
     fn rid(&self) -> Option<&str> {
         self.rid.as_deref()
     }
@@ -2462,5 +2475,22 @@ mod tests {
         assert_eq!(req.messages.len(), 2);
         assert_eq!(req.messages[0].role, Role::User);
         assert_eq!(req.messages[1].role, Role::System); // preserved in place
+    }
+
+    #[test]
+    fn cache_partition_reads_passthrough_fields() {
+        use crate::common::GenerationRequest;
+
+        let request: CreateMessageRequest = serde_json::from_value(serde_json::json!({
+            "model": "m",
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hi"}],
+            "cache_salt": "tenant-a"
+        }))
+        .unwrap();
+        let partition = request.cache_partition();
+        assert_eq!(partition.cache_salt, Some("tenant-a"));
+        assert!(partition.extra_key.is_none());
+        assert!(partition.lora_path.is_none());
     }
 }

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -1684,7 +1684,13 @@ impl CacheAwarePolicy {
         let now = Instant::now();
 
         // Hash mode keys on token ids; untokenized requests stay load-balanced.
-        let Some(tokens) = info.tokens.filter(|t| !t.is_empty()) else {
+        // Unpartitioned heads are stripped of marker material like the tree
+        // keys, so the placement key spaces stay disjoint by construction too.
+        let tokens = match info.cache_namespace {
+            Some(_) => info.tokens,
+            None => info.tokens.map(CacheNamespace::unpartitioned_tokens),
+        };
+        let Some(tokens) = tokens.filter(|t| !t.is_empty()) else {
             return self.hash_expected_wait(
                 workers,
                 info,
@@ -5574,5 +5580,29 @@ mod tests {
             text_policy.select_worker(&text_workers, &forged_info),
             Some(0)
         );
+    }
+
+    #[test]
+    fn hash_mode_strips_marker_material_from_unpartitioned_heads() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[4]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        policy.init_workers(&workers);
+        let tokens = [1u32, 2, 3, 4, 5];
+        let tenant_a = salted("tenant-a").unwrap();
+
+        // Tenant A's placement lands on w2 (w1 is busier).
+        workers[0].increment_load();
+        assert_eq!(
+            route_namespaced(&policy, &workers, &tokens, Some(tenant_a)),
+            1
+        );
+        workers[1].increment_load();
+        workers[1].increment_load();
+
+        // An unpartitioned head that spells tenant A's marker keys as the
+        // bare prompt: no holder, so it takes the least-loaded w1.
+        let mut forged = tenant_a.token_marker().to_vec();
+        forged.extend_from_slice(&tokens);
+        assert_eq!(route_namespaced(&policy, &workers, &forged, None), 0);
     }
 }

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -26,6 +26,18 @@
     Same algorithm as (2) but operates on raw text characters instead of
     token IDs, avoiding tokenization overhead.
 
+    Cache Namespaces (cache_salt / extra_key / LoRA)
+    -------------------------------------------
+    A request that carries cache-partition fields keys the approximate trees
+    and the hash index under a namespace marker (see cache_namespace.rs), so
+    requests the engine cannot serve from one cache never match each other.
+    Every live namespace holds its own copy of a shared prefix: max_tree_size
+    bounds the SUM across namespaces, so size it for tenants x working set,
+    and a per-request salt makes every request a unique path. The
+    event-driven mode is unpartitioned (both sides re-hash token ids), and
+    the typed gRPC/ZMQ wires stay unpartitioned until they forward the fields
+    to the engine.
+
     Load Balancing (Expected Wait)
     -------------------------------------------
     When the system is imbalanced, routes to LeastLoad's atomic expected-wait
@@ -774,7 +786,7 @@ impl CacheAwarePolicy {
                     prefixed = namespace.prefixed_tokens(tokens, self.config.block_size.max(1));
                     &prefixed
                 }
-                None => tokens,
+                None => CacheNamespace::unpartitioned_tokens(tokens),
             };
             // gRPC request: update token tree
             let tree = self
@@ -809,7 +821,7 @@ impl CacheAwarePolicy {
                     prefixed = namespace.prefixed_text(text);
                     &prefixed
                 }
-                None => text,
+                None => CacheNamespace::unpartitioned_text(text),
             };
             // HTTP request: update string tree
             let tree = self
@@ -1936,7 +1948,7 @@ impl CacheAwarePolicy {
                 prefixed = namespace.prefixed_tokens(tokens, page_size);
                 (&prefixed, CacheNamespace::token_marker_len(page_size))
             }
-            None => (tokens, 0),
+            None => (CacheNamespace::unpartitioned_tokens(tokens), 0),
         };
 
         // One fused descent: match first, atomically choose+credit the final
@@ -2021,7 +2033,7 @@ impl CacheAwarePolicy {
                 prefixed = namespace.prefixed_text(text);
                 (&prefixed, TEXT_MARKER_LEN)
             }
-            None => (text, 0),
+            None => (CacheNamespace::unpartitioned_text(text), 0),
         };
 
         let mut selected_idx: Option<usize> = None;
@@ -5505,5 +5517,62 @@ mod tests {
         // ...while the namespaced key matches in full.
         let keyed = tenant_a.prefixed_tokens(&prompt, policy.config.block_size);
         assert_eq!(tree.prefix_match_legacy(&keyed).0.len(), keyed.len());
+    }
+
+    #[test]
+    fn an_unpartitioned_request_cannot_forge_its_way_into_a_namespace() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            cache_threshold: 0.5,
+            ..Default::default()
+        });
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        policy.init_workers(&workers);
+        let tenant_a = salted("tenant-a").unwrap();
+        let prompt: Vec<u32> = (100..132).collect();
+
+        // Tenant A's prompt lands on w2 (w1 is busier).
+        workers[0].increment_load();
+        assert_eq!(
+            route_namespaced(&policy, &workers, &prompt, Some(tenant_a)),
+            1
+        );
+        workers[1].increment_load();
+        workers[1].increment_load();
+
+        // An unpartitioned request whose token ids spell tenant A's marker
+        // must not hit tenant A's entry: it misses and takes the least-loaded
+        // w1. Same for text that spells the marker on the string tree.
+        let forged = tenant_a.prefixed_tokens(&prompt, policy.config.block_size);
+        assert_eq!(route_namespaced(&policy, &workers, &forged, None), 0);
+
+        let text_policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            cache_threshold: 0.5,
+            ..Default::default()
+        });
+        let text_workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        text_policy.init_workers(&text_workers);
+        text_workers[0].increment_load();
+        let text_info = SelectWorkerInfo {
+            request_text: Some("shared system prompt"),
+            cache_namespace: Some(tenant_a),
+            ..Default::default()
+        };
+        assert_eq!(
+            text_policy.select_worker(&text_workers, &text_info),
+            Some(1)
+        );
+        text_workers[1].increment_load();
+        text_workers[1].increment_load();
+        let forged_text = tenant_a.prefixed_text("shared system prompt");
+        let forged_info = SelectWorkerInfo {
+            request_text: Some(&forged_text),
+            ..Default::default()
+        };
+        assert_eq!(
+            text_policy.select_worker(&text_workers, &forged_info),
+            Some(0)
+        );
     }
 }

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -71,8 +71,8 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
 use super::{
-    normalize_model_key, utils::PeriodicTask, CacheAwareConfig, LeastLoadPolicy,
-    LoadBalancingPolicy, SelectWorkerInfo,
+    normalize_model_key, utils::PeriodicTask, CacheAwareConfig, CacheNamespace, LeastLoadPolicy,
+    LoadBalancingPolicy, SelectWorkerInfo, TEXT_MARKER_LEN,
 };
 /// Latest per-worker backend load snapshot stream, keyed by worker URL.
 pub(crate) use crate::worker::load_state::{LoadReceiver, LoadSnapshot};
@@ -172,8 +172,20 @@ struct PlacementHolder {
 /// evicts the stalest.
 const PLACEMENT_HOLDER_CAP: usize = 3;
 
-fn hash_token_head(head: &[u32]) -> u64 {
-    xxhash_rust::xxh3::xxh3_64(bytemuck::cast_slice(head))
+fn hash_token_head(namespace: Option<CacheNamespace>, head: &[u32]) -> u64 {
+    match namespace {
+        // An unpartitioned head hashes exactly as before.
+        None => xxhash_rust::xxh3::xxh3_64(bytemuck::cast_slice(head)),
+        // A partitioned head hashes as marker ‖ head (the placement index has
+        // no pages, so the bare marker suffices): a differing namespace is a
+        // different key, and a same-namespace head keys as before.
+        Some(namespace) => {
+            let mut hasher = xxhash_rust::xxh3::Xxh3::new();
+            hasher.update(bytemuck::cast_slice(&namespace.token_marker()));
+            hasher.update(bytemuck::cast_slice(head));
+            hasher.digest()
+        }
+    }
 }
 
 /// Per-model inner container for [`CacheAwarePolicy::hash_index`].
@@ -751,9 +763,19 @@ impl CacheAwarePolicy {
         let selected = self.select_expected_wait(workers, healthy_indices, info)?;
         let worker_url = workers[selected].url();
 
-        // Even in imbalanced mode, update the appropriate tree to maintain cache state
-        // Prefer token tree for gRPC requests, fall back to string tree for HTTP
+        // Even in imbalanced mode, update the appropriate tree to maintain cache
+        // state, under the request's cache namespace so a partitioned request
+        // never seeds affinity for other partitions. Prefer the token tree for
+        // gRPC requests, fall back to the string tree for HTTP.
         if let Some(tokens) = info.tokens {
+            let prefixed;
+            let tokens: &[u32] = match info.cache_namespace {
+                Some(namespace) => {
+                    prefixed = namespace.prefixed_tokens(tokens, self.config.block_size.max(1));
+                    &prefixed
+                }
+                None => tokens,
+            };
             // gRPC request: update token tree
             let tree = self
                 .token_trees
@@ -781,6 +803,14 @@ impl CacheAwarePolicy {
                 }
             }
         } else if let Some(text) = info.request_text {
+            let prefixed;
+            let text: &str = match info.cache_namespace {
+                Some(namespace) => {
+                    prefixed = namespace.prefixed_text(text);
+                    &prefixed
+                }
+                None => text,
+            };
             // HTTP request: update string tree
             let tree = self
                 .string_trees
@@ -1097,6 +1127,11 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         //   2. Approximate token tree: TokenTree prefix matching (gRPC, no events)
         //   3. Approximate string tree: Tree prefix matching (HTTP)
         if let Some(tokens) = request_tokens {
+            // Event-driven mode re-hashes engine-reported blocks from their
+            // token ids on both sides, so a namespace marker on the request
+            // side alone would break every same-namespace match. It stays
+            // unpartitioned here; the approximate and hash modes below key
+            // under the request's cache namespace.
             if self.has_event_indexer(model_id) {
                 self.select_worker_event_driven(
                     workers,
@@ -1685,7 +1720,10 @@ impl CacheAwarePolicy {
 
         let url_to_idx = Self::healthy_url_index(workers, healthy_indices);
         for &boundary in applicable.iter().rev() {
-            let key = (boundary, hash_token_head(&tokens[..boundary]));
+            let key = (
+                boundary,
+                hash_token_head(info.cache_namespace, &tokens[..boundary]),
+            );
             let holder_candidates = self.live_holder_candidates(&url_to_idx, model_id, key, now);
             if holder_candidates.is_empty() {
                 continue;
@@ -1702,7 +1740,14 @@ impl CacheAwarePolicy {
             } else {
                 "hash_spill"
             };
-            self.record_placement(model_id, tokens, applicable, workers[selected].url(), now);
+            self.record_placement(
+                model_id,
+                info.cache_namespace,
+                tokens,
+                applicable,
+                workers[selected].url(),
+                now,
+            );
             Self::log_hash_decision(branch, boundary, workers[selected].url(), model_id);
             return Some(selected);
         }
@@ -1735,7 +1780,14 @@ impl CacheAwarePolicy {
     ) -> Option<usize> {
         let idx = self.select_expected_wait(workers, healthy_indices, info)?;
         if !applicable.is_empty() {
-            self.record_placement(model_id, tokens, applicable, workers[idx].url(), now);
+            self.record_placement(
+                model_id,
+                info.cache_namespace,
+                tokens,
+                applicable,
+                workers[idx].url(),
+                now,
+            );
         }
         Self::log_hash_decision(branch, 0, workers[idx].url(), model_id);
         Some(idx)
@@ -1790,6 +1842,7 @@ impl CacheAwarePolicy {
     fn record_placement(
         &self,
         model_id: &str,
+        namespace: Option<CacheNamespace>,
         tokens: &[u32],
         boundaries: &[usize],
         worker_url: &str,
@@ -1807,7 +1860,7 @@ impl CacheAwarePolicy {
             )
         };
         for &boundary in boundaries {
-            let key = (boundary, hash_token_head(&tokens[..boundary]));
+            let key = (boundary, hash_token_head(namespace, &tokens[..boundary]));
             let mut holders = model.entry(key).or_default();
             holders.retain(|h| now.duration_since(h.last_touch) <= ttl);
             if let Some(holder) = holders.iter_mut().find(|h| h.worker_url == worker_url) {
@@ -1872,15 +1925,31 @@ impl CacheAwarePolicy {
             .value()
             .clone();
 
+        // A partitioned request keys under its namespace marker: another
+        // namespace diverges at position 0 and can never match, and the
+        // marker never counts toward the match ratio. The marker fills whole
+        // pages, so the prompt's page grid is the unpartitioned one.
+        let page_size = self.config.block_size.max(1);
+        let prefixed;
+        let (keyed, marker_len): (&[u32], usize) = match info.cache_namespace {
+            Some(namespace) => {
+                prefixed = namespace.prefixed_tokens(tokens, page_size);
+                (&prefixed, CacheNamespace::token_marker_len(page_size))
+            }
+            None => (tokens, 0),
+        };
+
         // One fused descent: match first, atomically choose+credit the final
         // worker from the affinity/spill candidate set, then insert only that
         // worker before the closure returns.
         let mut selected_idx: Option<usize> = None;
-        let result = tree.match_and_insert_with(tokens, |result| {
-            let match_rate = if result.input_token_count == 0 {
+        let result = tree.match_and_insert_with(keyed, |result| {
+            let matched = result.matched_token_count.saturating_sub(marker_len);
+            let input = result.input_token_count.saturating_sub(marker_len);
+            let match_rate = if input == 0 {
                 0.0
             } else {
-                result.matched_token_count as f32 / result.input_token_count as f32
+                matched as f32 / input as f32
             };
             selected_idx = if match_rate > self.config.cache_threshold {
                 self.select_matched_candidate(
@@ -1900,16 +1969,16 @@ impl CacheAwarePolicy {
         self.log_tree_decision(
             selected_idx.map(|idx| workers[idx].url()),
             healthy_indices.first().map(|&idx| workers[idx].url()),
-            result.matched_token_count,
-            result.input_token_count,
+            result.matched_token_count.saturating_sub(marker_len),
+            result.input_token_count.saturating_sub(marker_len),
             &result.matched_tenants,
             model_id,
         );
 
         let idx = selected_idx?;
         if self.should_populate_hash_index() {
-            let matched_prefix: Vec<u32> = tokens[..result.matched_token_count].to_vec();
-            let node_hash = kv_index::hash_token_path(tokens);
+            let matched_prefix: Vec<u32> = keyed[..result.matched_token_count].to_vec();
+            let node_hash = kv_index::hash_token_path(keyed);
             self.hash_index
                 .entry(model_id.to_string())
                 .or_default()
@@ -1945,12 +2014,24 @@ impl CacheAwarePolicy {
             .value()
             .clone();
 
+        // Same partition rule as the token tree, in chars.
+        let prefixed;
+        let (keyed, marker_len): (&str, usize) = match info.cache_namespace {
+            Some(namespace) => {
+                prefixed = namespace.prefixed_text(text);
+                (&prefixed, TEXT_MARKER_LEN)
+            }
+            None => (text, 0),
+        };
+
         let mut selected_idx: Option<usize> = None;
-        let result = tree.match_and_insert_with(text, |result| {
-            let match_rate = if result.input_char_count == 0 {
+        let result = tree.match_and_insert_with(keyed, |result| {
+            let matched = result.matched_char_count.saturating_sub(marker_len);
+            let input = result.input_char_count.saturating_sub(marker_len);
+            let match_rate = if input == 0 {
                 0.0
             } else {
-                result.matched_char_count as f32 / result.input_char_count as f32
+                matched as f32 / input as f32
             };
             selected_idx = if match_rate > self.config.cache_threshold {
                 self.select_matched_candidate(
@@ -1970,16 +2051,16 @@ impl CacheAwarePolicy {
         self.log_tree_decision(
             selected_idx.map(|idx| workers[idx].url()),
             healthy_indices.first().map(|&idx| workers[idx].url()),
-            result.matched_char_count,
-            result.input_char_count,
+            result.matched_char_count.saturating_sub(marker_len),
+            result.input_char_count.saturating_sub(marker_len),
             &result.matched_tenants,
             model_id,
         );
 
         let idx = selected_idx?;
         if self.should_populate_hash_index() {
-            let matched_prefix: String = text.chars().take(result.matched_char_count).collect();
-            let path_hash = kv_index::hash_node_path(text);
+            let matched_prefix: String = keyed.chars().take(result.matched_char_count).collect();
+            let path_hash = kv_index::hash_node_path(keyed);
             self.hash_index
                 .entry(model_id.to_string())
                 .or_default()
@@ -3377,7 +3458,7 @@ mod tests {
             token_tree.insert_tokens(&tokens, worker_url);
             policy.token_trees.insert(model_id.to_string(), token_tree);
 
-            policy.record_placement(model_id, &tokens, &[16], worker_url, Instant::now());
+            policy.record_placement(model_id, None, &tokens, &[16], worker_url, Instant::now());
         }
 
         policy.remove_workers_from_model("retired-model", &HashSet::from([worker_url.to_string()]));
@@ -4802,7 +4883,14 @@ mod tests {
         let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
         let model = normalize_model_key(workers[0].model_id());
         let cached: Vec<u32> = (0..16).collect();
-        policy.record_placement(model, &cached, &[16], workers[0].url(), Instant::now());
+        policy.record_placement(
+            model,
+            None,
+            &cached,
+            &[16],
+            workers[0].url(),
+            Instant::now(),
+        );
         workers[1].increment_load();
         update_expected_wait_loads(&policy, &workers, &[10_000, 0]);
 
@@ -4827,7 +4915,7 @@ mod tests {
         let model = normalize_model_key(workers[0].model_id());
         let placements = policy.placement_index.get(model).unwrap();
         let holders = placements
-            .get(&(16, hash_token_head(&tokens)))
+            .get(&(16, hash_token_head(None, &tokens)))
             .expect("final dispatch must be recorded");
         assert_eq!(holders.len(), 1);
         assert_eq!(holders[0].worker_url, workers[1].url());
@@ -4839,7 +4927,14 @@ mod tests {
         let workers = make_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
         let model = normalize_model_key(workers[0].model_id());
         let tokens: Vec<u32> = (0..16).collect();
-        policy.record_placement(model, &tokens, &[16], workers[0].url(), Instant::now());
+        policy.record_placement(
+            model,
+            None,
+            &tokens,
+            &[16],
+            workers[0].url(),
+            Instant::now(),
+        );
         for _ in 0..100 {
             workers[0].increment_load();
         }
@@ -4853,7 +4948,9 @@ mod tests {
         assert_only_final_worker_credited(&policy, &workers, 2, 16);
 
         let placements = policy.placement_index.get(model).unwrap();
-        let holders = placements.get(&(16, hash_token_head(&tokens))).unwrap();
+        let holders = placements
+            .get(&(16, hash_token_head(None, &tokens)))
+            .unwrap();
         let holder_urls: HashSet<&str> = holders
             .iter()
             .map(|holder| holder.worker_url.as_str())
@@ -4887,8 +4984,8 @@ mod tests {
         let model = normalize_model_key(workers[0].model_id());
         let tokens: Vec<u32> = (0..16).collect();
         let now = Instant::now();
-        policy.record_placement(model, &tokens, &[16], workers[0].url(), now);
-        policy.record_placement(model, &tokens, &[16], workers[1].url(), now);
+        policy.record_placement(model, None, &tokens, &[16], workers[0].url(), now);
+        policy.record_placement(model, None, &tokens, &[16], workers[1].url(), now);
         for _ in 0..5 {
             workers[1].increment_load();
         }
@@ -4952,8 +5049,8 @@ mod tests {
         let now = Instant::now();
 
         // w2 holds the 16-token head, w1 the deeper 32-token head.
-        policy.record_placement(model, &tokens, &[16], "http://w2:8000", now);
-        policy.record_placement(model, &tokens, &[32], "http://w1:8000", now);
+        policy.record_placement(model, None, &tokens, &[16], "http://w2:8000", now);
+        policy.record_placement(model, None, &tokens, &[32], "http://w1:8000", now);
         // Even with the shallow holder strictly less loaded, the deeper
         // boundary must win.
         workers[0].increment_load();
@@ -4974,7 +5071,7 @@ mod tests {
         // 64 exceeds the request length: only the two applicable levels.
         assert_eq!(placements.len(), 2);
         for boundary in [16usize, 32] {
-            let key = (boundary, hash_token_head(&tokens[..boundary]));
+            let key = (boundary, hash_token_head(None, &tokens[..boundary]));
             let holders = placements.get(&key).unwrap();
             assert_eq!(holders.len(), 1);
             assert_eq!(holders[0].worker_url, workers[selected].url());
@@ -5022,9 +5119,9 @@ mod tests {
         let model = normalize_model_key(workers[0].model_id());
         let tokens: Vec<u32> = (0..16).collect();
         let t0 = Instant::now();
-        let key = (16usize, hash_token_head(&tokens[..16]));
+        let key = (16usize, hash_token_head(None, &tokens[..16]));
 
-        policy.record_placement(model, &tokens, &[16], "http://w1:8000", t0);
+        policy.record_placement(model, None, &tokens, &[16], "http://w1:8000", t0);
 
         let url_to_idx = CacheAwarePolicy::healthy_url_index(&workers, &[0, 1]);
         // Just inside the 180s default TTL: live.
@@ -5074,7 +5171,7 @@ mod tests {
         let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
         let tokens: Vec<u32> = (0..16).collect();
         let t0 = Instant::now();
-        let key = (16usize, hash_token_head(&tokens[..16]));
+        let key = (16usize, hash_token_head(None, &tokens[..16]));
 
         for (i, url) in [
             "http://w1:8000",
@@ -5085,7 +5182,14 @@ mod tests {
         .iter()
         .enumerate()
         {
-            policy.record_placement("m", &tokens, &[16], url, t0 + Duration::from_secs(i as u64));
+            policy.record_placement(
+                "m",
+                None,
+                &tokens,
+                &[16],
+                url,
+                t0 + Duration::from_secs(i as u64),
+            );
         }
 
         let placements = policy.placement_index.get("m").unwrap();
@@ -5100,9 +5204,16 @@ mod tests {
         let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
         let model = normalize_model_key(workers[0].model_id());
         let tokens: Vec<u32> = (0..16).collect();
-        let key = (16usize, hash_token_head(&tokens[..16]));
+        let key = (16usize, hash_token_head(None, &tokens[..16]));
 
-        policy.record_placement(model, &tokens, &[16], "http://w1:8000", Instant::now());
+        policy.record_placement(
+            model,
+            None,
+            &tokens,
+            &[16],
+            "http://w1:8000",
+            Instant::now(),
+        );
         // Past both gate margins (rel 1.1 of avg 50, abs avg+32): spill.
         for _ in 0..100 {
             workers[0].increment_load();
@@ -5126,7 +5237,14 @@ mod tests {
         let model = normalize_model_key(workers[0].model_id());
         let tokens: Vec<u32> = (0..16).collect();
 
-        policy.record_placement(model, &tokens, &[16], "http://w1:8000", Instant::now());
+        policy.record_placement(
+            model,
+            None,
+            &tokens,
+            &[16],
+            "http://w1:8000",
+            Instant::now(),
+        );
         workers[0].increment_load();
         let _tx = inject_kv(&policy, &workers, &[0.9, 0.1]);
 
@@ -5155,14 +5273,14 @@ mod tests {
         let policy = CacheAwarePolicy::with_config(hash_config(&[16]));
         let tokens: Vec<u32> = (0..16).collect();
         let now = Instant::now();
-        policy.record_placement("m", &tokens, &[16], "http://w1:8000", now);
-        policy.record_placement("m", &tokens, &[16], "http://w2:8000", now);
+        policy.record_placement("m", None, &tokens, &[16], "http://w1:8000", now);
+        policy.record_placement("m", None, &tokens, &[16], "http://w2:8000", now);
 
         policy.remove_worker_by_url("http://w1:8000");
 
         let placements = policy.placement_index.get("m").unwrap();
         let holders = placements
-            .get(&(16usize, hash_token_head(&tokens[..16])))
+            .get(&(16usize, hash_token_head(None, &tokens[..16])))
             .unwrap();
         assert_eq!(holders.len(), 1);
         assert_eq!(holders[0].worker_url, "http://w2:8000");
@@ -5174,9 +5292,10 @@ mod tests {
         let fresh: Vec<u32> = (0..16).collect();
         let stale: Vec<u32> = (500..516).collect();
         let t0 = Instant::now();
-        policy.record_placement("m", &stale, &[16], "http://w1:8000", t0);
+        policy.record_placement("m", None, &stale, &[16], "http://w1:8000", t0);
         policy.record_placement(
             "m",
+            None,
             &fresh,
             &[16],
             "http://w1:8000",
@@ -5192,7 +5311,7 @@ mod tests {
         let placements = policy.placement_index.get("m").unwrap();
         assert_eq!(placements.len(), 1);
         assert!(placements
-            .get(&(16usize, hash_token_head(&fresh[..16])))
+            .get(&(16usize, hash_token_head(None, &fresh[..16])))
             .is_some());
     }
 
@@ -5202,9 +5321,9 @@ mod tests {
         let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
         let tokens: Vec<u32> = (0..16).collect();
         let now = Instant::now();
-        let key = (16usize, hash_token_head(&tokens[..16]));
-        policy.record_placement("m", &tokens, &[16], "http://w1:8000", now);
-        policy.record_placement("m", &tokens, &[16], "http://w2:8000", now);
+        let key = (16usize, hash_token_head(None, &tokens[..16]));
+        policy.record_placement("m", None, &tokens, &[16], "http://w1:8000", now);
+        policy.record_placement("m", None, &tokens, &[16], "http://w2:8000", now);
 
         // w1 unhealthy: its holder entry must not resolve.
         let url_to_idx = CacheAwarePolicy::healthy_url_index(&workers, &[1]);
@@ -5256,7 +5375,7 @@ mod tests {
                     for i in 0..50u32 {
                         let base = t * 1000 + i * 16;
                         let tokens: Vec<u32> = (base..base + 16).collect();
-                        policy.record_placement("m", &tokens, &[16], "http://w1:8000", now);
+                        policy.record_placement("m", None, &tokens, &[16], "http://w1:8000", now);
                         CacheAwarePolicy::sweep_placement_index(&policy.placement_index, ttl, now);
                     }
                 });
@@ -5275,5 +5394,116 @@ mod tests {
     fn with_config_normalizes_boundaries() {
         let policy = CacheAwarePolicy::with_config(hash_config(&[64, 16, 16, 0]));
         assert_eq!(policy.config.cache_boundaries, vec![16, 64]);
+    }
+
+    // ---- cache namespaces (cache_salt / extra_key / LoRA partitioning) ----
+
+    fn salted(salt: &str) -> Option<CacheNamespace> {
+        CacheNamespace::derive(&openai_protocol::common::CachePartition {
+            cache_salt: Some(salt),
+            extra_key: None,
+            lora_path: None,
+        })
+    }
+
+    fn route_namespaced(
+        policy: &CacheAwarePolicy,
+        workers: &[Arc<dyn Worker>],
+        tokens: &[u32],
+        cache_namespace: Option<CacheNamespace>,
+    ) -> usize {
+        policy
+            .select_worker(
+                workers,
+                &SelectWorkerInfo {
+                    tokens: Some(tokens),
+                    cache_namespace,
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn head_hash_is_unchanged_without_a_namespace_and_keys_like_the_tree_with_one() {
+        let head = [5u32, 6, 7, 8];
+        assert_eq!(
+            hash_token_head(None, &head),
+            xxhash_rust::xxh3::xxh3_64(bytemuck::cast_slice(&head))
+        );
+        let tenant_a = salted("tenant-a").unwrap();
+        let tenant_b = salted("tenant-b").unwrap();
+        // A namespaced head hashes marker ‖ head (hash mode has no pages).
+        let mut keyed = tenant_a.token_marker().to_vec();
+        keyed.extend_from_slice(&head);
+        assert_eq!(
+            hash_token_head(Some(tenant_a), &head),
+            xxhash_rust::xxh3::xxh3_64(bytemuck::cast_slice(&keyed))
+        );
+        assert_ne!(
+            hash_token_head(Some(tenant_a), &head),
+            hash_token_head(None, &head)
+        );
+        assert_ne!(
+            hash_token_head(Some(tenant_a), &head),
+            hash_token_head(Some(tenant_b), &head)
+        );
+    }
+
+    #[test]
+    fn hash_mode_keys_placements_under_the_cache_namespace() {
+        let policy = CacheAwarePolicy::with_config(hash_config(&[4]));
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        policy.init_workers(&workers);
+        let tokens = [1u32, 2, 3, 4, 5];
+        let tenant_a = salted("tenant-a");
+        let tenant_b = salted("tenant-b");
+
+        // w1 is busier: tenant A's first request misses onto w2 and is
+        // recorded there under its namespace.
+        workers[0].increment_load();
+        assert_eq!(route_namespaced(&policy, &workers, &tokens, tenant_a), 1);
+        // A hash hit keeps tenant A on w2 once w2 is the busier worker...
+        workers[1].increment_load();
+        workers[1].increment_load();
+        assert_eq!(route_namespaced(&policy, &workers, &tokens, tenant_a), 1);
+        // ...while tenant B and an unpartitioned request key differently,
+        // miss, and take the least-loaded w1.
+        assert_eq!(route_namespaced(&policy, &workers, &tokens, tenant_b), 0);
+        assert_eq!(route_namespaced(&policy, &workers, &tokens, None), 0);
+    }
+
+    #[test]
+    fn imbalance_fallback_inserts_under_the_cache_namespace() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        });
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        policy.init_workers(&workers);
+        // One full page (the tree is page-aligned at the default block size).
+        let prompt: Vec<u32> = (100..116).collect();
+        let tenant_a = salted("tenant-a").unwrap();
+        let model_id = normalize_model_key(workers[0].model_id());
+        // Materialize the model's token tree so the fallback path has one to
+        // update.
+        let seed: Vec<u32> = (1..17).collect();
+        route_namespaced(&policy, &workers, &seed, None);
+
+        let info = SelectWorkerInfo {
+            tokens: Some(&prompt),
+            cache_namespace: Some(tenant_a),
+            ..Default::default()
+        };
+        policy
+            .select_worker_fallback(&workers, &info, &[0, 1], model_id)
+            .unwrap();
+
+        let tree = policy.token_trees.get(model_id).unwrap().value().clone();
+        // The unpartitioned prompt cannot see the namespaced insert...
+        assert!(tree.prefix_match_legacy(&prompt).0.is_empty());
+        // ...while the namespaced key matches in full.
+        let keyed = tenant_a.prefixed_tokens(&prompt, policy.config.block_size);
+        assert_eq!(tree.prefix_match_legacy(&keyed).0.len(), keyed.len());
     }
 }

--- a/model_gateway/src/policies/cache_namespace.rs
+++ b/model_gateway/src/policies/cache_namespace.rs
@@ -19,6 +19,18 @@
 //!
 //! The marker is excluded from the match ratio, so it cannot by itself push
 //! two unrelated prompts of one namespace over the cache threshold.
+//!
+//! Unpartitioned keys never start with marker material: real vocabulary ids
+//! never carry the marker bit and prompt text does not begin with a control
+//! character, and [`CacheNamespace::unpartitioned_tokens`] /
+//! [`CacheNamespace::unpartitioned_text`] strip any that a client does send,
+//! so the two key spaces are disjoint by construction and an unpartitioned
+//! request cannot forge its way into a namespace's subtree.
+//!
+//! Occupancy: every live namespace holds its own copy of a shared prefix, so
+//! the approximate trees' `max_tree_size` bounds the sum across namespaces.
+//! Size it for tenants × working set; a per-request salt makes every request
+//! a unique path.
 
 use openai_protocol::common::CachePartition;
 use xxhash_rust::xxh3::Xxh3;
@@ -52,9 +64,10 @@ pub struct CacheNamespace(u64);
 
 impl CacheNamespace {
     /// Derive the namespace from a request's partition fields; `None` when
-    /// no field is set. Each field is encoded with a presence byte and its
-    /// length, so an absent field, an empty field and adjacent fields with
-    /// shifted boundaries all hash differently.
+    /// no field is set (an empty string counts as unset, as it does on the
+    /// engine). Each field is encoded with a presence byte and its length,
+    /// so an absent field and adjacent fields with shifted boundaries hash
+    /// differently.
     pub fn derive(partition: &CachePartition<'_>) -> Option<Self> {
         if partition.is_empty() {
             return None;
@@ -66,7 +79,7 @@ impl CacheNamespace {
             partition.extra_key,
             partition.lora_path,
         ] {
-            match field {
+            match field.filter(|value| !value.is_empty()) {
                 Some(value) => {
                     hasher.update(&[1u8]);
                     hasher.update(&(value.len() as u64).to_le_bytes());
@@ -118,6 +131,24 @@ impl CacheNamespace {
         keyed.push_str(text);
         keyed
     }
+
+    /// The routing key of an unpartitioned request: leading ids that carry
+    /// the marker bit are dropped so the key can never enter a namespace's
+    /// subtree. A no-op for vocabulary ids.
+    pub fn unpartitioned_tokens(tokens: &[u32]) -> &[u32] {
+        let start = tokens
+            .iter()
+            .position(|&id| id & MARKER_TOKEN_BIT == 0)
+            .unwrap_or(tokens.len());
+        &tokens[start..]
+    }
+
+    /// The routing key of an unpartitioned request: leading marker delimiters
+    /// are dropped so the key can never enter a namespace's subtree. A no-op
+    /// for prompt text.
+    pub fn unpartitioned_text(text: &str) -> &str {
+        text.trim_start_matches(TEXT_MARKER_DELIM)
+    }
 }
 
 #[cfg(test)]
@@ -159,13 +190,40 @@ mod tests {
     }
 
     #[test]
-    fn absent_empty_and_shifted_boundaries_all_differ() {
-        let empty = CacheNamespace::derive(&partition(Some(""), None, None)).unwrap();
-        let absent_with_extra = CacheNamespace::derive(&partition(None, Some(""), None)).unwrap();
-        assert_ne!(empty, absent_with_extra);
+    fn empty_fields_count_as_absent() {
+        // Engines treat an empty salt or adapter as unset; so does routing.
+        assert_eq!(
+            CacheNamespace::derive(&partition(Some(""), None, None)),
+            None
+        );
+        assert_eq!(
+            CacheNamespace::derive(&partition(Some(""), Some("k"), None)),
+            CacheNamespace::derive(&partition(None, Some("k"), None))
+        );
+    }
+
+    #[test]
+    fn shifted_field_boundaries_differ() {
         let ab_c = CacheNamespace::derive(&partition(Some("ab"), Some("c"), None)).unwrap();
         let a_bc = CacheNamespace::derive(&partition(Some("a"), Some("bc"), None)).unwrap();
         assert_ne!(ab_c, a_bc);
+    }
+
+    #[test]
+    fn unpartitioned_keys_never_start_with_marker_material() {
+        let ns = CacheNamespace::derive(&partition(Some("salt"), None, None)).unwrap();
+        // Vocabulary ids and prompt text pass through untouched.
+        assert_eq!(CacheNamespace::unpartitioned_tokens(&[7, 8, 9]), &[7, 8, 9]);
+        assert_eq!(CacheNamespace::unpartitioned_text("hello"), "hello");
+        // A forged marker at the head of an unpartitioned key is dropped.
+        let forged_tokens = ns.prefixed_tokens(&[7, 8, 9], 16);
+        assert_eq!(
+            CacheNamespace::unpartitioned_tokens(&forged_tokens),
+            &[7, 8, 9]
+        );
+        let forged_text = ns.prefixed_text("hello");
+        assert!(!CacheNamespace::unpartitioned_text(&forged_text).starts_with(TEXT_MARKER_DELIM));
+        assert!(CacheNamespace::unpartitioned_tokens(&ns.token_marker()).is_empty());
     }
 
     #[test]

--- a/model_gateway/src/policies/cache_namespace.rs
+++ b/model_gateway/src/policies/cache_namespace.rs
@@ -1,0 +1,210 @@
+//! Cache namespaces: the routing-side mirror of an engine's prefix-cache
+//! partition.
+//!
+//! Engines partition their prefix caches by client-supplied request fields
+//! (a cache salt, an extra classification key, the LoRA adapter). A router
+//! that keys affinity on the prompt alone asserts prefix hits the engine
+//! cannot serve whenever two requests share a prompt but differ in one of
+//! those fields: it pins the request to a worker for a reuse that never
+//! happens, and the operator sees a healthy router-side match rate over a
+//! dead engine-side cache.
+//!
+//! A [`CacheNamespace`] is a fixed-width hash of the partition fields placed
+//! at the head of every routing key, so requests in different namespaces
+//! diverge at the first position and can never match each other, while
+//! requests in the same namespace keep their full affinity. Only the hash
+//! travels: no client value reaches the trees, the hash index or mesh
+//! gossip. Requests without any partition field get no namespace, and their
+//! routing keys are byte-identical to before.
+//!
+//! The marker is excluded from the match ratio, so it cannot by itself push
+//! two unrelated prompts of one namespace over the cache threshold.
+
+use openai_protocol::common::CachePartition;
+use xxhash_rust::xxh3::Xxh3;
+
+/// Domain separator: a change to the encoding changes every namespace.
+const DOMAIN: &[u8] = b"smg/cache-namespace/v1";
+
+/// Distinct token ids in a namespace marker (see
+/// [`CacheNamespace::token_marker`]). The token-tree marker is padded to
+/// the tree's page size ([`CacheNamespace::token_marker_len`]).
+pub const TOKEN_MARKER_LEN: usize = 2;
+
+/// Width in chars of the string-tree marker (see
+/// [`CacheNamespace::text_marker`]).
+pub const TEXT_MARKER_LEN: usize = 18;
+
+/// Set on every marker token id. Vocabularies are orders of magnitude
+/// smaller than 2^31, so a marker can never collide with a prompt token.
+const MARKER_TOKEN_BIT: u32 = 1 << 31;
+
+/// Pads a token-tree marker out to a whole page.
+const MARKER_PAD_TOKEN: u32 = MARKER_TOKEN_BIT;
+
+/// Delimits the string-tree marker; a control character that prompt text
+/// does not begin with.
+const TEXT_MARKER_DELIM: char = '\u{1}';
+
+/// Fixed-width identity of a request's cache partition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CacheNamespace(u64);
+
+impl CacheNamespace {
+    /// Derive the namespace from a request's partition fields; `None` when
+    /// no field is set. Each field is encoded with a presence byte and its
+    /// length, so an absent field, an empty field and adjacent fields with
+    /// shifted boundaries all hash differently.
+    pub fn derive(partition: &CachePartition<'_>) -> Option<Self> {
+        if partition.is_empty() {
+            return None;
+        }
+        let mut hasher = Xxh3::new();
+        hasher.update(DOMAIN);
+        for field in [
+            partition.cache_salt,
+            partition.extra_key,
+            partition.lora_path,
+        ] {
+            match field {
+                Some(value) => {
+                    hasher.update(&[1u8]);
+                    hasher.update(&(value.len() as u64).to_le_bytes());
+                    hasher.update(value.as_bytes());
+                }
+                None => hasher.update(&[0u8]),
+            }
+        }
+        Some(Self(hasher.digest()))
+    }
+
+    /// The namespace as token ids for the token tree and hash mode: two ids
+    /// with the reserved high bit set, so they never match prompt tokens.
+    pub fn token_marker(self) -> [u32; TOKEN_MARKER_LEN] {
+        [
+            (self.0 >> 32) as u32 | MARKER_TOKEN_BIT,
+            self.0 as u32 | MARKER_TOKEN_BIT,
+        ]
+    }
+
+    /// The namespace as a fixed-width text prefix for the string tree.
+    pub fn text_marker(self) -> String {
+        format!("{d}{:016x}{d}", self.0, d = TEXT_MARKER_DELIM)
+    }
+
+    /// Length of the token-tree marker for a tree with `page_size`-token
+    /// pages: the marker fills whole pages, so the prompt's own page grid is
+    /// exactly what it is without a namespace and the match count for a given
+    /// prompt is unchanged.
+    pub fn token_marker_len(page_size: usize) -> usize {
+        let page_size = page_size.max(1);
+        TOKEN_MARKER_LEN.div_ceil(page_size) * page_size
+    }
+
+    /// `tokens` with the marker at its head, padded to whole `page_size` pages.
+    pub fn prefixed_tokens(self, tokens: &[u32], page_size: usize) -> Vec<u32> {
+        let marker_len = Self::token_marker_len(page_size);
+        let mut keyed = Vec::with_capacity(marker_len + tokens.len());
+        keyed.extend_from_slice(&self.token_marker());
+        keyed.resize(marker_len, MARKER_PAD_TOKEN);
+        keyed.extend_from_slice(tokens);
+        keyed
+    }
+
+    /// `text` with the marker at its head.
+    pub fn prefixed_text(self, text: &str) -> String {
+        let mut keyed = String::with_capacity(TEXT_MARKER_LEN + text.len());
+        keyed.push_str(&self.text_marker());
+        keyed.push_str(text);
+        keyed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn partition<'a>(
+        cache_salt: Option<&'a str>,
+        extra_key: Option<&'a str>,
+        lora_path: Option<&'a str>,
+    ) -> CachePartition<'a> {
+        CachePartition {
+            cache_salt,
+            extra_key,
+            lora_path,
+        }
+    }
+
+    #[test]
+    fn unpartitioned_requests_have_no_namespace() {
+        assert_eq!(CacheNamespace::derive(&CachePartition::default()), None);
+    }
+
+    #[test]
+    fn derivation_is_stable_and_field_sensitive() {
+        let a = CacheNamespace::derive(&partition(Some("tenant-a"), None, None)).unwrap();
+        assert_eq!(
+            a,
+            CacheNamespace::derive(&partition(Some("tenant-a"), None, None)).unwrap()
+        );
+        let b = CacheNamespace::derive(&partition(Some("tenant-b"), None, None)).unwrap();
+        assert_ne!(a, b);
+        // The same bytes in a different field are a different partition.
+        let extra = CacheNamespace::derive(&partition(None, Some("tenant-a"), None)).unwrap();
+        let lora = CacheNamespace::derive(&partition(None, None, Some("tenant-a"))).unwrap();
+        assert_ne!(a, extra);
+        assert_ne!(a, lora);
+        assert_ne!(extra, lora);
+    }
+
+    #[test]
+    fn absent_empty_and_shifted_boundaries_all_differ() {
+        let empty = CacheNamespace::derive(&partition(Some(""), None, None)).unwrap();
+        let absent_with_extra = CacheNamespace::derive(&partition(None, Some(""), None)).unwrap();
+        assert_ne!(empty, absent_with_extra);
+        let ab_c = CacheNamespace::derive(&partition(Some("ab"), Some("c"), None)).unwrap();
+        let a_bc = CacheNamespace::derive(&partition(Some("a"), Some("bc"), None)).unwrap();
+        assert_ne!(ab_c, a_bc);
+    }
+
+    #[test]
+    fn token_marker_never_collides_with_vocabulary_ids() {
+        let ns = CacheNamespace::derive(&partition(Some("salt"), None, None)).unwrap();
+        for id in ns.token_marker() {
+            assert!(id & MARKER_TOKEN_BIT != 0);
+        }
+        let keyed = ns.prefixed_tokens(&[7, 8, 9], 1);
+        assert_eq!(keyed.len(), TOKEN_MARKER_LEN + 3);
+        assert_eq!(&keyed[TOKEN_MARKER_LEN..], &[7, 8, 9]);
+        assert_eq!(&keyed[..TOKEN_MARKER_LEN], &ns.token_marker());
+    }
+
+    #[test]
+    fn token_marker_fills_whole_pages() {
+        let ns = CacheNamespace::derive(&partition(Some("salt"), None, None)).unwrap();
+        assert_eq!(CacheNamespace::token_marker_len(16), 16);
+        assert_eq!(CacheNamespace::token_marker_len(1), 2);
+        assert_eq!(CacheNamespace::token_marker_len(0), 2);
+        let keyed = ns.prefixed_tokens(&[7, 8, 9], 16);
+        assert_eq!(keyed.len(), 16 + 3);
+        assert_eq!(&keyed[..TOKEN_MARKER_LEN], &ns.token_marker());
+        assert!(keyed[TOKEN_MARKER_LEN..16]
+            .iter()
+            .all(|&id| id & MARKER_TOKEN_BIT != 0));
+        assert_eq!(&keyed[16..], &[7, 8, 9]);
+    }
+
+    #[test]
+    fn text_marker_is_fixed_width_and_prefixes_the_prompt() {
+        let ns = CacheNamespace::derive(&partition(None, Some("k"), Some("adapter"))).unwrap();
+        let marker = ns.text_marker();
+        assert_eq!(marker.chars().count(), TEXT_MARKER_LEN);
+        assert!(marker.starts_with(TEXT_MARKER_DELIM));
+        assert!(marker.ends_with(TEXT_MARKER_DELIM));
+        let keyed = ns.prefixed_text("hello");
+        assert_eq!(keyed.chars().count(), TEXT_MARKER_LEN + 5);
+        assert!(keyed.ends_with("hello"));
+        assert!(keyed.starts_with(&marker));
+    }
+}

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 
 mod bucket;
 mod cache_aware;
+mod cache_namespace;
 mod consistent_hashing;
 mod dp_min_token;
 mod factory;
@@ -29,6 +30,7 @@ pub(crate) mod utils;
 
 pub use bucket::BucketPolicy;
 pub use cache_aware::{CacheAwarePolicy, TreeHandle, TreeKind};
+pub use cache_namespace::{CacheNamespace, TEXT_MARKER_LEN, TOKEN_MARKER_LEN};
 pub use consistent_hashing::ConsistentHashingPolicy;
 pub use dp_min_token::MinimumTokensPolicy;
 pub use factory::PolicyFactory;
@@ -297,6 +299,10 @@ pub struct SelectWorkerInfo<'a> {
     /// consistent_hashing and prefix_hash prefer it over their other keying
     /// input.
     pub routing_key: Option<&'a str>,
+    /// The request's cache partition (cache salt / extra key / LoRA), when
+    /// set. Cache-aware routing keys its affinity under it so requests the
+    /// engine cannot serve from the same cache never match each other.
+    pub cache_namespace: Option<CacheNamespace>,
     /// Session key derived from the request body's `rid` (routers with typed
     /// body access populate it); consumed by the routing-key override when
     /// its key source includes rid.

--- a/model_gateway/src/routers/common/request_lease.rs
+++ b/model_gateway/src/routers/common/request_lease.rs
@@ -5,7 +5,9 @@ use std::sync::{Mutex, MutexGuard, PoisonError};
 use bytes::Bytes;
 
 use super::trim_serialization_slack;
-use crate::{config::types::RetryConfig, observability::metrics::Metrics};
+use crate::{
+    config::types::RetryConfig, observability::metrics::Metrics, policies::CacheNamespace,
+};
 
 /// When a [`RequestLease`] lets go of the parsed request.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -33,6 +35,7 @@ pub(crate) struct RoutingDerivatives {
     pub tokens: Option<Vec<u32>>,
     pub text: Option<String>,
     pub rid_key: Option<String>,
+    pub cache_namespace: Option<CacheNamespace>,
 }
 
 /// Borrowed view of the leased request and its routing derivatives.
@@ -42,6 +45,7 @@ pub(crate) struct LeaseView<'a, T> {
     pub tokens: Option<&'a [u32]>,
     pub text: Option<&'a str>,
     pub rid_key: Option<&'a str>,
+    pub cache_namespace: Option<CacheNamespace>,
 }
 
 /// Single owner of a request's dispatch-phase memory: the parsed request,
@@ -188,6 +192,7 @@ impl<T> RequestLease<T> {
             tokens: held.routing.tokens.as_deref(),
             text: held.routing.text.as_deref(),
             rid_key: held.routing.rid_key.as_deref(),
+            cache_namespace: held.routing.cache_namespace,
         }
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -113,7 +113,14 @@ impl PipelineStage for WorkerSelectionStage {
         // would actually read it (tokens win otherwise).
         let keep_text =
             tokens.is_none() || self.policy_registry.any_policy_needs_request_text(headers);
-        let cache_namespace = CacheNamespace::derive(&ctx.input.request_type.cache_partition());
+        // The typed engine wires (gRPC servicers, direct ZMQ) do not carry the
+        // request's cache-partition fields yet, so the engine's prefix cache
+        // is unpartitioned on this path and the router must not split
+        // affinity for it: a namespace here would cost cache hits for every
+        // request that sets a salt today. The snapshot carries the field so
+        // the forwarding change can derive it (as the HTTP proxy path does via
+        // `GenerationRequest::cache_partition`) without touching selection.
+        let cache_namespace: Option<CacheNamespace> = None;
         ctx.state.routing_snapshot = Some(RoutingSnapshot {
             routing_text: keep_text.then(|| text.map(str::to_string)).flatten(),
             token_ids: ids.to_vec(),
@@ -1542,5 +1549,91 @@ mod tests {
             StatusCode::SERVICE_UNAVAILABLE,
             "verdict must reflect the pinned pool, not every runtime"
         );
+    }
+
+    /// The namespace lives on the routing snapshot so a retry re-selects in
+    /// the same cache partition: the retained snapshot, not a re-derivation
+    /// from a request that may already be released, decides the key.
+    #[test]
+    fn reselect_keys_affinity_under_the_retained_cache_namespace() {
+        use openai_protocol::common::CachePartition;
+
+        let model_id = "namespace-retry-model";
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let workers: Vec<Arc<dyn Worker>> = ["grpc://127.0.0.1:9401", "grpc://127.0.0.1:9402"]
+            .iter()
+            .map(|url| {
+                Arc::new(
+                    BasicWorkerBuilder::new(*url)
+                        .model(ModelCard::new(model_id))
+                        .worker_type(WorkerType::Regular)
+                        .connection_mode(ConnectionMode::Grpc)
+                        .runtime_type(RuntimeType::Vllm)
+                        .health_config(no_health_check())
+                        .build(),
+                ) as Arc<dyn Worker>
+            })
+            .collect();
+        for worker in &workers {
+            worker_registry.register(Arc::clone(worker)).unwrap();
+        }
+        let stage = WorkerSelectionStage::new(
+            worker_registry,
+            Arc::new(PolicyRegistry::new(PolicyConfig::CacheAware {
+                cache_threshold: 0.5,
+                balance_abs_threshold: 32,
+                balance_rel_threshold: 1.1,
+                eviction_interval_secs: 0,
+                max_tree_size: 4096,
+                block_size: 16,
+                balance_token_usage_threshold: 1.0,
+                overload_token_usage_threshold: 1.0,
+                overlap_decay: 0.0,
+                selection_temperature: 0.0,
+                cache_index: Default::default(),
+                cache_ttl_secs: 180,
+                cache_boundaries: Vec::new(),
+            })),
+            WorkerSelectionMode::Regular,
+        );
+        let wire = WireConstraint {
+            runtime: RuntimeType::Vllm,
+            connection: ConnectionMode::Grpc,
+        };
+        let namespace = |salt: &str| {
+            CacheNamespace::derive(&CachePartition {
+                cache_salt: Some(salt),
+                extra_key: None,
+                lora_path: None,
+            })
+        };
+        let selected = |ctx: &DispatchContext| match ctx.workers.as_ref().unwrap() {
+            WorkerSelection::Single { worker } => worker.url().to_string(),
+            WorkerSelection::Disaggregated { .. } => panic!("expected single selection"),
+        };
+        let prompt: Vec<u32> = (1..33).collect();
+
+        // Worker 1 is busier, so tenant A's first selection lands on worker 2.
+        workers[0].increment_load();
+        let mut ctx = dispatch_ctx(model_id, wire);
+        ctx.routing.token_ids = prompt.clone();
+        ctx.routing.cache_namespace = namespace("tenant-a");
+        stage.reselect(&mut ctx).unwrap();
+        assert_eq!(selected(&ctx), "grpc://127.0.0.1:9402");
+
+        // A retry from the retained snapshot stays in tenant A's partition
+        // even once worker 2 is the busier one...
+        workers[1].increment_load();
+        workers[1].increment_load();
+        stage.reselect(&mut ctx).unwrap();
+        assert_eq!(selected(&ctx), "grpc://127.0.0.1:9402");
+
+        // ...while a retained snapshot for tenant B misses and takes the
+        // least-loaded worker 1.
+        let mut other = dispatch_ctx(model_id, wire);
+        other.routing.token_ids = prompt;
+        other.routing.cache_namespace = namespace("tenant-b");
+        stage.reselect(&mut other).unwrap();
+        assert_eq!(selected(&other), "grpc://127.0.0.1:9401");
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -13,8 +13,8 @@ use super::PipelineStage;
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     policies::{
-        policy_filters_unavailable_workers, LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo,
-        WorkerLeg,
+        policy_filters_unavailable_workers, CacheNamespace, LoadBalancingPolicy, PolicyRegistry,
+        SelectWorkerInfo, WorkerLeg,
     },
     routers::{
         common::overload,
@@ -113,17 +113,27 @@ impl PipelineStage for WorkerSelectionStage {
         // would actually read it (tokens win otherwise).
         let keep_text =
             tokens.is_none() || self.policy_registry.any_policy_needs_request_text(headers);
+        let cache_namespace = CacheNamespace::derive(&ctx.input.request_type.cache_partition());
         ctx.state.routing_snapshot = Some(RoutingSnapshot {
             routing_text: keep_text.then(|| text.map(str::to_string)).flatten(),
             token_ids: ids.to_vec(),
             rid_key: rid_key.clone(),
+            cache_namespace,
         });
         let rid_key = rid_key.as_deref();
 
         let model_id = ctx.input.model_id.as_str();
         let workers = match self.mode {
             WorkerSelectionMode::Regular => {
-                match self.select_single_worker(model_id, text, tokens, headers, rid_key, None) {
+                match self.select_single_worker(
+                    model_id,
+                    text,
+                    tokens,
+                    headers,
+                    rid_key,
+                    cache_namespace,
+                    None,
+                ) {
                     Some(w) => WorkerSelection::Single { worker: w },
                     None => {
                         return Err(self.selection_failure(model_id, &[WorkerType::Regular], None))
@@ -131,7 +141,15 @@ impl PipelineStage for WorkerSelectionStage {
                 }
             }
             WorkerSelectionMode::PrefillDecode => {
-                match self.select_pd_pair(model_id, text, tokens, headers, rid_key, None) {
+                match self.select_pd_pair(
+                    model_id,
+                    text,
+                    tokens,
+                    headers,
+                    rid_key,
+                    cache_namespace,
+                    None,
+                ) {
                     Some((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
                         encode_assignments: None,
                         prefill,
@@ -168,6 +186,7 @@ impl PipelineStage for WorkerSelectionStage {
                     tokens,
                     headers,
                     rid_key,
+                    cache_namespace,
                     &encode_item_hashes,
                 ) {
                     Some((encode_assignments, prefill, decode, runtime_type)) => {
@@ -243,13 +262,22 @@ impl WorkerSelectionStage {
             Some(ctx.routing.token_ids.as_slice())
         };
         let rid_key = ctx.routing.rid_key.as_deref();
+        let cache_namespace = ctx.routing.cache_namespace;
         let headers = ctx.headers.as_ref();
         let model_id = ctx.model_id.as_str();
         let wire = Some(ctx.wire);
 
         let workers = match self.mode {
             WorkerSelectionMode::Regular => {
-                match self.select_single_worker(model_id, text, tokens, headers, rid_key, wire) {
+                match self.select_single_worker(
+                    model_id,
+                    text,
+                    tokens,
+                    headers,
+                    rid_key,
+                    cache_namespace,
+                    wire,
+                ) {
                     Some(w) => WorkerSelection::Single { worker: w },
                     None => {
                         return Err(self.selection_failure(model_id, &[WorkerType::Regular], wire))
@@ -257,7 +285,15 @@ impl WorkerSelectionStage {
                 }
             }
             WorkerSelectionMode::PrefillDecode | WorkerSelectionMode::EncodePrefillDecode => {
-                match self.select_pd_pair(model_id, text, tokens, headers, rid_key, wire) {
+                match self.select_pd_pair(
+                    model_id,
+                    text,
+                    tokens,
+                    headers,
+                    rid_key,
+                    cache_namespace,
+                    wire,
+                ) {
                     Some((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
                         encode_assignments: None,
                         prefill,
@@ -359,6 +395,10 @@ impl WorkerSelectionStage {
             .collect()
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "selection threads every routing input the policy consumes"
+    )]
     fn select_single_worker(
         &self,
         model_id: &str,
@@ -366,6 +406,7 @@ impl WorkerSelectionStage {
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
+        cache_namespace: Option<CacheNamespace>,
         wire: Option<WireConstraint>,
     ) -> Option<Arc<dyn Worker>> {
         // Get workers for the specified model. The gRPC router serves both gRPC
@@ -422,6 +463,7 @@ impl WorkerSelectionStage {
                 headers,
                 routing_key: self.policy_registry.resolve_routing_key(headers),
                 rid_key,
+                cache_namespace,
                 hash_ring,
                 leg: WorkerLeg::Single,
             },
@@ -453,6 +495,10 @@ impl WorkerSelectionStage {
             .collect()
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "selection threads every routing input the policy consumes"
+    )]
     fn select_pd_pair(
         &self,
         model_id: &str,
@@ -460,6 +506,7 @@ impl WorkerSelectionStage {
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
+        cache_namespace: Option<CacheNamespace>,
         wire: Option<WireConstraint>,
     ) -> Option<PdWorkerPair> {
         // Both legs derive from ONE membership snapshot: separate pool
@@ -551,6 +598,7 @@ impl WorkerSelectionStage {
             headers,
             routing_key: self.policy_registry.resolve_routing_key(headers),
             rid_key,
+            cache_namespace,
             hash_ring,
             leg: WorkerLeg::Prefill,
         };
@@ -595,6 +643,10 @@ impl WorkerSelectionStage {
     /// encode worker. prefill+decode are selected as a normal PD pair. All pools
     /// are filtered to a runtime shared by the selected encode/prefill/decode
     /// legs.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "selection threads every routing input the policy consumes"
+    )]
     fn select_encode_prefill_decode_workers(
         &self,
         model_id: &str,
@@ -602,6 +654,7 @@ impl WorkerSelectionStage {
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
+        cache_namespace: Option<CacheNamespace>,
         encode_item_hashes: &[Vec<u8>],
     ) -> Option<EncodePrefillDecodeWorkerSelection> {
         // All three legs derive from ONE membership snapshot (see
@@ -709,6 +762,7 @@ impl WorkerSelectionStage {
             headers,
             routing_key: self.policy_registry.resolve_routing_key(headers),
             rid_key,
+            cache_namespace,
             hash_ring: hash_ring.clone(),
             leg: WorkerLeg::Prefill,
         };
@@ -790,6 +844,7 @@ fn assign_encode_workers(
                 // Encode items key by media-content hash; a conversation key
                 // here would defeat per-item encode reuse.
                 rid_key: None,
+                cache_namespace: None,
                 hash_ring: hash_ring.clone(),
                 leg: WorkerLeg::Single,
             };
@@ -925,7 +980,7 @@ mod tests {
         let mut decode_hits = HashMap::new();
         for _ in 0..iterations {
             let (prefill, decode, _) = stage
-                .select_pd_pair(model_id, None, None, None, None, None)
+                .select_pd_pair(model_id, None, None, None, None, None, None)
                 .expect("select_pd_pair should return a pair");
             *prefill_hits.entry(prefill.url().to_string()).or_default() += 1;
             *decode_hits.entry(decode.url().to_string()).or_default() += 1;
@@ -951,7 +1006,7 @@ mod tests {
             WorkerSelectionMode::PrefillDecode,
         );
         assert!(stage
-            .select_pd_pair(model_id, None, None, None, None, None)
+            .select_pd_pair(model_id, None, None, None, None, None, None)
             .is_some());
 
         for url in &prefill_urls {
@@ -961,7 +1016,7 @@ mod tests {
 
         assert!(
             stage
-                .select_pd_pair(model_id, None, None, None, None, None)
+                .select_pd_pair(model_id, None, None, None, None, None, None)
                 .is_none(),
             "the veto empties the prefill pool"
         );
@@ -1131,7 +1186,7 @@ mod tests {
 
         assert!(
             stage
-                .select_pd_pair(model_id, None, None, None, None, None)
+                .select_pd_pair(model_id, None, None, None, None, None, None)
                 .is_none(),
             "ZMQ-only PD pools must not yield a pair"
         );
@@ -1139,7 +1194,7 @@ mod tests {
         // Adding gRPC legs makes selection succeed, and it never picks the ZMQ ones.
         let (prefill_urls, decode_urls) = register_pd_workers(&worker_registry, model_id, 4);
         let (prefill, decode, _) = stage
-            .select_pd_pair(model_id, None, None, None, None, None)
+            .select_pd_pair(model_id, None, None, None, None, None, None)
             .expect("gRPC PD pair should be selected");
         assert!(prefill_urls.contains(&prefill.url().to_string()));
         assert!(decode_urls.contains(&decode.url().to_string()));
@@ -1186,7 +1241,7 @@ mod tests {
         let mut poison = HeaderMap::new();
         poison.insert("x-smg-routing-key", "req-unique-1".parse().unwrap());
         let first = stage
-            .select_single_worker(model_id, None, None, Some(&poison), rid_key, None)
+            .select_single_worker(model_id, None, None, Some(&poison), rid_key, None, None)
             .unwrap();
         for (i, rid) in ["conv7_t2", "conv7_t2_r1", "conv7_t3"].iter().enumerate() {
             let mut rotated = HeaderMap::new();
@@ -1201,6 +1256,7 @@ mod tests {
                     None,
                     Some(&rotated),
                     policy_registry.derive_rid_key(Some(rid)),
+                    None,
                     None,
                 )
                 .unwrap();
@@ -1239,13 +1295,13 @@ mod tests {
         );
 
         assert!(stage
-            .select_single_worker(model_id, None, None, None, None, None)
+            .select_single_worker(model_id, None, None, None, None, None, None)
             .is_some());
 
         worker_registry.set_worker_overloaded(&workers[0], true);
         assert!(
             stage
-                .select_single_worker(model_id, None, None, None, None, None)
+                .select_single_worker(model_id, None, None, None, None, None, None)
                 .is_some(),
             "one eligible worker left still serves"
         );
@@ -1253,7 +1309,7 @@ mod tests {
         worker_registry.set_worker_overloaded(&workers[1], true);
         assert!(
             stage
-                .select_single_worker(model_id, None, None, None, None, None)
+                .select_single_worker(model_id, None, None, None, None, None, None)
                 .is_none(),
             "the veto empties the candidate pool"
         );
@@ -1269,7 +1325,7 @@ mod tests {
         // genuinely absent model.
         worker_registry.set_worker_overloaded(&workers[0], false);
         assert!(stage
-            .select_single_worker(model_id, None, None, None, None, None)
+            .select_single_worker(model_id, None, None, None, None, None, None)
             .is_some());
         assert_eq!(
             stage
@@ -1290,6 +1346,7 @@ mod tests {
                 routing_text: None,
                 token_ids: vec![1, 2, 3],
                 rid_key: None,
+                cache_namespace: None,
             },
             wire,
             tokenizer: None,

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -12,7 +12,6 @@ use llm_tokenizer::{stop::StopSequenceDecoder, traits::Tokenizer, TokenizerRegis
 use openai_protocol::{
     chat::{ChatCompletionRequest, ChatCompletionResponse},
     classify::{ClassifyRequest, ClassifyResponse},
-    common::{CachePartition, GenerationRequest},
     completion::{CompletionRequest, CompletionResponse},
     embedding::{EmbeddingRequest, EmbeddingResponse},
     generate::{GenerateRequest, GenerateResponse},
@@ -130,21 +129,6 @@ impl RequestType {
             Self::Classify(r) => r.rid.as_deref(),
             Self::Messages(r) => r.rid.as_deref(),
             Self::Responses(_) | Self::Transcription { .. } => None,
-        }
-    }
-
-    /// The request's cache-partition fields (cache salt / extra key / LoRA).
-    /// Protocols without such fields are unpartitioned.
-    pub fn cache_partition(&self) -> CachePartition<'_> {
-        match self {
-            Self::Chat(r) => r.cache_partition(),
-            Self::Generate(r) => r.cache_partition(),
-            Self::Completion(r) => r.cache_partition(),
-            Self::Responses(_)
-            | Self::Embedding(_)
-            | Self::Classify(_)
-            | Self::Messages(_)
-            | Self::Transcription { .. } => CachePartition::default(),
         }
     }
 }

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -12,6 +12,7 @@ use llm_tokenizer::{stop::StopSequenceDecoder, traits::Tokenizer, TokenizerRegis
 use openai_protocol::{
     chat::{ChatCompletionRequest, ChatCompletionResponse},
     classify::{ClassifyRequest, ClassifyResponse},
+    common::{CachePartition, GenerationRequest},
     completion::{CompletionRequest, CompletionResponse},
     embedding::{EmbeddingRequest, EmbeddingResponse},
     generate::{GenerateRequest, GenerateResponse},
@@ -40,6 +41,7 @@ use super::{
 };
 use crate::{
     middleware::TenantRequestMeta,
+    policies::CacheNamespace,
     routers::error::internal_error,
     worker::{ConnectionMode, RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry},
 };
@@ -128,6 +130,21 @@ impl RequestType {
             Self::Classify(r) => r.rid.as_deref(),
             Self::Messages(r) => r.rid.as_deref(),
             Self::Responses(_) | Self::Transcription { .. } => None,
+        }
+    }
+
+    /// The request's cache-partition fields (cache salt / extra key / LoRA).
+    /// Protocols without such fields are unpartitioned.
+    pub fn cache_partition(&self) -> CachePartition<'_> {
+        match self {
+            Self::Chat(r) => r.cache_partition(),
+            Self::Generate(r) => r.cache_partition(),
+            Self::Completion(r) => r.cache_partition(),
+            Self::Responses(_)
+            | Self::Embedding(_)
+            | Self::Classify(_)
+            | Self::Messages(_)
+            | Self::Transcription { .. } => CachePartition::default(),
         }
     }
 }
@@ -223,6 +240,8 @@ pub(crate) struct RoutingSnapshot {
     pub token_ids: Vec<u32>,
     /// rid-derived sticky key, derived once at first selection.
     pub rid_key: Option<String>,
+    /// The request's cache namespace, derived once at first selection.
+    pub cache_namespace: Option<CacheNamespace>,
 }
 
 /// The wire the retained plan was built for. Retry re-selection filters

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -33,7 +33,7 @@ use crate::{
         metrics::{bool_to_static_str, metrics_labels, Metrics},
         otel_trace::inject_trace_context_http,
     },
-    policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
+    policies::{CacheNamespace, LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
     routers::{
         common::{
             attach_sized_body, header_utils,
@@ -466,6 +466,7 @@ impl PDRouter {
                 view.text,
                 view.tokens,
                 view.rid_key,
+                view.cache_namespace,
                 context.model_id,
                 context.headers.as_ref(),
             )
@@ -1310,6 +1311,7 @@ impl PDRouter {
         request_text: Option<&str>,
         tokens: Option<&[u32]>,
         rid_key: Option<&str>,
+        cache_namespace: Option<CacheNamespace>,
         model_id: &str,
         headers: Option<&HeaderMap>,
     ) -> Result<PdPair, Box<PdSelectionFailure>> {
@@ -1364,6 +1366,7 @@ impl PDRouter {
                 request_text,
                 tokens,
                 rid_key,
+                cache_namespace,
                 headers,
                 hash_ring.clone(),
                 "prefill",
@@ -1378,6 +1381,7 @@ impl PDRouter {
                 request_text,
                 tokens,
                 rid_key,
+                cache_namespace,
                 headers,
                 hash_ring,
                 "decode",
@@ -1414,6 +1418,7 @@ impl PDRouter {
         request_text: Option<&str>,
         tokens: Option<&[u32]>,
         rid_key: Option<&str>,
+        cache_namespace: Option<CacheNamespace>,
         headers: Option<&HeaderMap>,
         hash_ring: Option<Arc<HashRing>>,
         worker_type: &str,
@@ -1448,6 +1453,7 @@ impl PDRouter {
                     headers,
                     routing_key: self.policy_registry.resolve_routing_key(headers),
                     rid_key,
+                    cache_namespace,
                     hash_ring,
                     leg,
                 },
@@ -1846,22 +1852,22 @@ impl RouterTrait for PDRouter {
         // Note: This endpoint actually causes the model to generate tokens, so we only test one pair
 
         // Select a random worker pair using the policy
-        let (prefill, decode) = match self.select_pd_pair(None, None, None, UNKNOWN_MODEL_ID, None)
-        {
-            Ok(pair) => pair,
-            // A deep probe that generates gets the same answer routing does:
-            // an all-vetoed fleet fails the probe, exactly as an all-circuit-
-            // broken one already did.
-            Err(failure) => match *failure {
-                PdSelectionFailure::Shed(shed) => return shed,
-                PdSelectionFailure::Unavailable(e) => {
-                    return error::service_unavailable(
-                        "no_healthy_worker_pair",
-                        format!("No healthy worker pair available: {e}"),
-                    );
-                }
-            },
-        };
+        let (prefill, decode) =
+            match self.select_pd_pair(None, None, None, None, UNKNOWN_MODEL_ID, None) {
+                Ok(pair) => pair,
+                // A deep probe that generates gets the same answer routing does:
+                // an all-vetoed fleet fails the probe, exactly as an all-circuit-
+                // broken one already did.
+                Err(failure) => match *failure {
+                    PdSelectionFailure::Shed(shed) => return shed,
+                    PdSelectionFailure::Unavailable(e) => {
+                        return error::service_unavailable(
+                            "no_healthy_worker_pair",
+                            format!("No healthy worker pair available: {e}"),
+                        );
+                    }
+                },
+            };
 
         let prefill_url = format!("{}/health_generate", prefill.url());
         let (prefill_result, decode_result) = tokio::join!(
@@ -1970,6 +1976,7 @@ impl RouterTrait for PDRouter {
                 .policy_registry
                 .derive_rid_key(body.rid())
                 .map(str::to_string),
+            cache_namespace: CacheNamespace::derive(&body.cache_partition()),
         };
         let context = PDRequestContext {
             route: "/generate",
@@ -2010,6 +2017,7 @@ impl RouterTrait for PDRouter {
                 .policy_registry
                 .derive_rid_key(body.rid())
                 .map(str::to_string),
+            cache_namespace: CacheNamespace::derive(&body.cache_partition()),
         };
         let context = PDRequestContext {
             route: "/v1/chat/completions",
@@ -2046,6 +2054,7 @@ impl RouterTrait for PDRouter {
                 .policy_registry
                 .derive_rid_key(body.rid())
                 .map(str::to_string),
+            cache_namespace: CacheNamespace::derive(&body.cache_partition()),
         };
         let context = PDRequestContext {
             route: "/v1/messages",
@@ -2082,6 +2091,7 @@ impl RouterTrait for PDRouter {
                 .policy_registry
                 .derive_rid_key(body.rid())
                 .map(str::to_string),
+            cache_namespace: CacheNamespace::derive(&body.cache_partition()),
         };
         let context = PDRequestContext {
             route: "/v1/responses",
@@ -2125,6 +2135,7 @@ impl RouterTrait for PDRouter {
                 .policy_registry
                 .derive_rid_key(body.rid())
                 .map(str::to_string),
+            cache_namespace: CacheNamespace::derive(&body.cache_partition()),
         };
         let context = PDRequestContext {
             route: "/v1/completions",
@@ -2160,6 +2171,7 @@ impl RouterTrait for PDRouter {
                 .policy_registry
                 .derive_rid_key(body.rid())
                 .map(str::to_string),
+            cache_namespace: CacheNamespace::derive(&body.cache_partition()),
         };
         let context = PDRequestContext {
             route: "/v1/rerank",
@@ -2387,7 +2399,7 @@ mod tests {
             .worker_registry
             .register_or_replace(Arc::from(decode_worker));
 
-        let result = router.select_pd_pair(None, None, None, UNKNOWN_MODEL_ID, None);
+        let result = router.select_pd_pair(None, None, None, None, UNKNOWN_MODEL_ID, None);
 
         assert!(result.is_ok());
         let (prefill, _decode) = result.unwrap();
@@ -2412,13 +2424,13 @@ mod tests {
         }
 
         let (prefill, decode) = router
-            .select_pd_pair(None, None, None, "GLM-5.2-Coding", None)
+            .select_pd_pair(None, None, None, None, "GLM-5.2-Coding", None)
             .expect("alias should select a PD pair");
         assert_eq!(prefill.url(), "http://prefill");
         assert_eq!(decode.url(), "http://decode");
 
         assert!(router
-            .select_pd_pair(None, None, None, "GLM-5.2-Unknown", None)
+            .select_pd_pair(None, None, None, None, "GLM-5.2-Unknown", None)
             .is_err());
     }
 
@@ -2426,7 +2438,7 @@ mod tests {
     async fn test_empty_worker_lists() {
         let router = create_test_pd_router();
 
-        let result = router.select_pd_pair(None, None, None, UNKNOWN_MODEL_ID, None);
+        let result = router.select_pd_pair(None, None, None, None, UNKNOWN_MODEL_ID, None);
 
         assert!(result.is_err());
         // No workers at all is the pre-existing unavailable string, not a shed:

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -1700,8 +1700,10 @@ impl Router {
         let model_id = crate::worker::UNKNOWN_MODEL_ID;
         // Buffered-path parity: a valid tokens hint is exactly what selection
         // would have received there (text is never extracted alongside it).
-        // Streamed requests have no readable body, hence no rid key;
-        // routing-key override is excluded by the body-path gate above.
+        // Streamed requests have no readable body, hence no rid key and no
+        // cache namespace: selection keys unpartitioned here, so a request
+        // that needs partitioned affinity must take the buffered path.
+        // Routing-key override is excluded by the body-path gate above.
         let hinted_tokens = header_utils::parse_routing_tokens_hint(Some(req.headers()));
         let Some(worker) = self.select_worker_for_model(
             model_id,

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -44,7 +44,9 @@ use crate::{
         metrics::{bool_to_static_str, metrics_labels, Metrics},
         otel_trace::inject_trace_context_http,
     },
-    policies::{policy_filters_unavailable_workers, PolicyRegistry, SelectWorkerInfo},
+    policies::{
+        policy_filters_unavailable_workers, CacheNamespace, PolicyRegistry, SelectWorkerInfo,
+    },
     routers::{
         common::{
             attach_sized_body,
@@ -241,6 +243,7 @@ impl Router {
         tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
         rid_key: Option<&str>,
+        cache_namespace: Option<CacheNamespace>,
     ) -> Option<Arc<dyn Worker>> {
         let candidates = self
             .worker_registry
@@ -280,6 +283,7 @@ impl Router {
                 headers,
                 routing_key: self.policy_registry.resolve_routing_key(headers),
                 rid_key,
+                cache_namespace,
                 hash_ring,
                 leg: crate::policies::WorkerLeg::Single,
             },
@@ -382,6 +386,7 @@ impl Router {
             .policy_registry
             .derive_rid_key(typed_req.rid())
             .map(str::to_string);
+        let cache_namespace = CacheNamespace::derive(&typed_req.cache_partition());
         // Resolve once, here, so every registry, policy and metrics lookup
         // below is keyed by the canonical model ID. Only `get_by_model`
         // understands aliases; retry configs, hash rings and policies do not,
@@ -415,6 +420,7 @@ impl Router {
                 tokens: routing_tokens,
                 text,
                 rid_key,
+                cache_namespace,
             },
             ReleasePoint::from_retry_config(retry_config),
         );
@@ -523,7 +529,14 @@ impl Router {
         is_stream: bool,
     ) -> Response {
         let worker = match lease.with_view(|view| {
-            self.select_worker_for_model(model_id, view.text, view.tokens, headers, view.rid_key)
+            self.select_worker_for_model(
+                model_id,
+                view.text,
+                view.tokens,
+                headers,
+                view.rid_key,
+                view.cache_namespace,
+            )
         }) {
             Some(w) => w,
             None => {
@@ -859,6 +872,7 @@ impl Router {
                 headers,
                 routing_key: self.policy_registry.resolve_routing_key(headers),
                 rid_key: None,
+                cache_namespace: None,
                 hash_ring,
                 leg: crate::policies::WorkerLeg::Single,
             },
@@ -1695,6 +1709,7 @@ impl Router {
             hinted_tokens.as_deref(),
             Some(req.headers()),
             None,
+            None,
         ) else {
             Metrics::record_request_body_path(BODY_PATH_BUFFERED, REASON_NO_AVAILABLE_WORKER);
             return Err(req);
@@ -2353,7 +2368,14 @@ mod tests {
         let router = create_test_unhealthy_router();
 
         let selected = router
-            .select_worker_for_model(crate::worker::UNKNOWN_MODEL_ID, None, None, None, None)
+            .select_worker_for_model(
+                crate::worker::UNKNOWN_MODEL_ID,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
         assert!(selected.is_available());
 
@@ -2361,7 +2383,14 @@ mod tests {
             worker.set_status(openai_protocol::worker::WorkerStatus::NotReady);
         }
         assert!(router
-            .select_worker_for_model(crate::worker::UNKNOWN_MODEL_ID, None, None, None, None)
+            .select_worker_for_model(
+                crate::worker::UNKNOWN_MODEL_ID,
+                None,
+                None,
+                None,
+                None,
+                None
+            )
             .is_none());
     }
 

--- a/model_gateway/tests/routing/cache_namespace_routing_test.rs
+++ b/model_gateway/tests/routing/cache_namespace_routing_test.rs
@@ -1,0 +1,197 @@
+//! Cache-aware routing under cache namespaces.
+//!
+//! Engines partition their prefix caches by `cache_salt` / `extra_key` /
+//! the LoRA adapter. Requests that differ in any of those can never share
+//! engine cache, so the router must not assert prefix affinity between them,
+//! while requests inside one partition keep full affinity and unpartitioned
+//! requests behave exactly as before.
+
+use std::sync::Arc;
+
+use openai_protocol::{common::CachePartition, worker::HealthCheckConfig};
+use smg::{
+    policies::{
+        CacheAwareConfig, CacheAwarePolicy, CacheNamespace, LoadBalancingPolicy, SelectWorkerInfo,
+    },
+    worker::{BasicWorkerBuilder, Worker, WorkerType},
+};
+
+fn workers() -> Vec<Arc<dyn Worker>> {
+    ["http://w1:8000", "http://w2:8000"]
+        .iter()
+        .map(|url| {
+            Arc::new(
+                BasicWorkerBuilder::new(*url)
+                    .worker_type(WorkerType::Regular)
+                    .health_config(HealthCheckConfig {
+                        disable_health_check: true,
+                        ..Default::default()
+                    })
+                    .build(),
+            ) as Arc<dyn Worker>
+        })
+        .collect()
+}
+
+fn policy() -> CacheAwarePolicy {
+    CacheAwarePolicy::with_config(CacheAwareConfig {
+        eviction_interval_secs: 0,
+        cache_threshold: 0.5,
+        ..Default::default()
+    })
+}
+
+fn salted(salt: &str) -> Option<CacheNamespace> {
+    CacheNamespace::derive(&CachePartition {
+        cache_salt: Some(salt),
+        extra_key: None,
+        lora_path: None,
+    })
+}
+
+fn route_text(
+    policy: &CacheAwarePolicy,
+    workers: &[Arc<dyn Worker>],
+    text: &str,
+    cache_namespace: Option<CacheNamespace>,
+) -> Option<usize> {
+    policy.select_worker(
+        workers,
+        &SelectWorkerInfo {
+            request_text: Some(text),
+            cache_namespace,
+            ..Default::default()
+        },
+    )
+}
+
+fn route_tokens(
+    policy: &CacheAwarePolicy,
+    workers: &[Arc<dyn Worker>],
+    tokens: &[u32],
+    cache_namespace: Option<CacheNamespace>,
+) -> Option<usize> {
+    policy.select_worker(
+        workers,
+        &SelectWorkerInfo {
+            tokens: Some(tokens),
+            cache_namespace,
+            ..Default::default()
+        },
+    )
+}
+
+/// HTTP path (string tree): a shared prompt under two salts is two affinities.
+#[test]
+fn salted_prompts_do_not_share_affinity_on_the_string_tree() {
+    let policy = policy();
+    let workers = workers();
+    policy.init_workers(&workers);
+    let prompt = "You are a helpful assistant. Summarize the quarterly report.";
+
+    // w1 is busier, so tenant A's first request misses onto w2.
+    workers[0].increment_load();
+    assert_eq!(
+        route_text(&policy, &workers, prompt, salted("tenant-a")),
+        Some(1)
+    );
+
+    // Tenant A keeps its affinity once w2 is the busier worker...
+    workers[1].increment_load();
+    workers[1].increment_load();
+    assert_eq!(
+        route_text(&policy, &workers, prompt, salted("tenant-a")),
+        Some(1)
+    );
+
+    // ...but tenant B shares only the prompt bytes, never the engine cache:
+    // its request is a miss and goes to the least-loaded worker.
+    assert_eq!(
+        route_text(&policy, &workers, prompt, salted("tenant-b")),
+        Some(0)
+    );
+
+    // An unpartitioned request does not see tenant entries either.
+    assert_eq!(route_text(&policy, &workers, prompt, None), Some(0));
+}
+
+/// gRPC path (token tree): same contract on token ids.
+#[test]
+fn salted_prompts_do_not_share_affinity_on_the_token_tree() {
+    let policy = policy();
+    let workers = workers();
+    policy.init_workers(&workers);
+    // Two full pages: the token tree is page-aligned (16 tokens by default).
+    let prompt: Vec<u32> = (101..133).collect();
+
+    workers[0].increment_load();
+    assert_eq!(
+        route_tokens(&policy, &workers, &prompt, salted("tenant-a")),
+        Some(1)
+    );
+
+    workers[1].increment_load();
+    workers[1].increment_load();
+    assert_eq!(
+        route_tokens(&policy, &workers, &prompt, salted("tenant-a")),
+        Some(1)
+    );
+    assert_eq!(
+        route_tokens(&policy, &workers, &prompt, salted("tenant-b")),
+        Some(0)
+    );
+    assert_eq!(route_tokens(&policy, &workers, &prompt, None), Some(0));
+}
+
+/// The namespace marker never counts toward the match ratio: a prompt that
+/// shares nothing but the marker with a tenant's entries is a miss.
+#[test]
+fn the_namespace_marker_alone_is_not_a_prefix_hit() {
+    let policy = policy();
+    let workers = workers();
+    policy.init_workers(&workers);
+
+    let seed: Vec<u32> = (1..33).collect();
+    workers[0].increment_load();
+    assert_eq!(
+        route_tokens(&policy, &workers, &seed, salted("tenant-a")),
+        Some(1)
+    );
+    assert_eq!(
+        route_text(
+            &policy,
+            &workers,
+            "a long enough prompt",
+            salted("tenant-a")
+        ),
+        Some(1)
+    );
+    workers[1].increment_load();
+    workers[1].increment_load();
+    // One unrelated token (or char): were the marker counted, this would be
+    // a near-total match and stick to w2; it must miss and take the
+    // least-loaded w1.
+    assert_eq!(
+        route_tokens(&policy, &workers, &[999], salted("tenant-a")),
+        Some(0)
+    );
+    assert_eq!(
+        route_text(&policy, &workers, "z", salted("tenant-a")),
+        Some(0)
+    );
+}
+
+/// Unpartitioned requests behave exactly as before the namespace existed.
+#[test]
+fn unpartitioned_requests_keep_plain_affinity() {
+    let policy = policy();
+    let workers = workers();
+    policy.init_workers(&workers);
+
+    workers[0].increment_load();
+    assert_eq!(route_text(&policy, &workers, "hello world", None), Some(1));
+    workers[1].increment_load();
+    workers[1].increment_load();
+    assert_eq!(route_text(&policy, &workers, "hello world", None), Some(1));
+    assert_eq!(route_text(&policy, &workers, "hello", None), Some(1));
+}

--- a/model_gateway/tests/routing/mod.rs
+++ b/model_gateway/tests/routing/mod.rs
@@ -1,6 +1,7 @@
 //! Routing integration tests
 
 pub mod cache_aware_backward_compat_test;
+pub mod cache_namespace_routing_test;
 pub mod grpc_completion_batch_test;
 pub mod header_forwarding_test;
 pub mod header_routing_hints_test;


### PR DESCRIPTION
## Description

### Problem

`cache_aware` keys worker affinity on the prompt alone. Engines partition their prefix caches by client-supplied request fields (SGLang: `cache_salt` and `extra_key`, with the LoRA adapter folded in; vLLM: `cache_salt`, LoRA and multimodal keys), so two requests that share a prompt but differ in any of those fields can never share cached blocks on the engine. The router nevertheless saw a prefix hit and pinned the request to a worker for a reuse that could not happen. This is the multi-tenant shape cache-aware routing is deployed for (shared system prompt, per-tenant salt), and there was no signal that the router-side match rate had become noise. Reported in #2420.

### Solution

Derive a **cache namespace** from the request's partition fields and key every routing structure under it.

- `CachePartition` (protocols): the projection of `cache_salt` / `extra_key` / `lora_path` from a request. Chat, completions, generate and Messages implement it; `cache_salt` and `extra_key` are read from the passthrough map on the OpenAI- and Anthropic-shaped bodies (the same map the HTTP proxy forwards to the engine), `extra_key` is typed on generate. An empty string counts as unset, as it does on the engine. Protocols without such fields are unpartitioned.
- `CacheNamespace` (policies): a domain-separated, length-prefixed hash of the partition fields. `None` when no field is set, so unpartitioned requests produce byte-identical routing keys to today.
- `SelectWorkerInfo.cache_namespace`: carried on the HTTP `LeaseView` and on the gRPC `RoutingSnapshot` (retry re-selection keys under the same namespace, covered by a retained-snapshot test).
- **Where it is derived.** Only on the HTTP proxy path, where the body reaches the engine as-is and the engine therefore partitions its cache. The typed gRPC/ZMQ wires do not carry the partition fields yet (the SGLang gRPC proto has no salt/extra-key field, the vLLM ZMQ request's `cache_salt` is never set, TRT-LLM's `cache_salt_id` is never set), so the engine's cache is *unpartitioned* there and a router-side namespace would only cost hits for requests that already send a salt. The gRPC stage keeps the snapshot field but sets it to `None`, with the reason in code; the forwarding change flips it on.
- `cache_aware`:
  - token tree: the marker is two reserved token ids (high bit set, so they can never collide with vocabulary ids) padded to a whole page, so the prompt's page grid is exactly the unpartitioned one and match counts are unchanged;
  - string tree: a fixed-width control-character prefix;
  - placement-index (hash) mode: the marker seeds the head hash, and placements are recorded under the same key;
  - the imbalance fallback inserts under the namespace too, so a partitioned request never seeds affinity for other partitions;
  - the marker is excluded from the match ratio on both trees, so it cannot by itself push two unrelated prompts of one tenant over `cache_threshold`;
  - unpartitioned keys are stripped of any leading marker material (marker-bit token ids, leading delimiter characters) on the trees and in placement-index mode, so the key spaces are disjoint by construction and an unpartitioned request cannot forge its way into a tenant's subtree or placement.
- Only the hash travels: no client value reaches the trees, the hash index or mesh gossip.
- The event-driven (KV-event) mode is deliberately left unpartitioned: it re-hashes engine-reported blocks from token ids on both sides, so a request-side marker alone would break every same-namespace match. Partitioning it needs per-block namespace material on the event side and is a separate change.
- Occupancy: every live namespace holds its own copy of a shared prefix, so `max_tree_size` bounds the sum across namespaces (documented in the policy header and the module docs).
- The streamed request-body path never reads the body, so it keys unpartitioned there, like the rid key. A streamed request that carries partition fields therefore reuses unpartitioned affinity; closing that needs either a namespace header hint or a buffering gate, tracked as a follow-up below.

Not in this PR, tracked as follow-ups: forwarding the partition fields on the typed engine wires and enabling the gRPC-side namespace with it; a namespace header hint (or buffering gate) for the streamed request-body path; multimodal identity in the same namespace; promoting `cache_salt`/`extra_key` to typed protocol fields; a metric for namespaced selections and namespace cardinality.

## Changes

- `crates/protocols/src/common.rs`: `CachePartition` + `GenerationRequest::cache_partition` (default unpartitioned)
- `crates/protocols/src/{chat,completion,generate,messages}.rs`: per-request projections + tests
- `model_gateway/src/policies/cache_namespace.rs` (new): `CacheNamespace` derivation, token/text markers, page-padded token marker, unpartitioned-key hardening + tests
- `model_gateway/src/policies/mod.rs`: `SelectWorkerInfo.cache_namespace`, re-exports
- `model_gateway/src/policies/cache_aware.rs`: namespace-keyed token tree, string tree, placement index and fallback insert; ratio exclusion; event-driven mode documented as unpartitioned; unit tests
- `model_gateway/src/routers/grpc/{context.rs, common/stages/worker_selection.rs}`: `RoutingSnapshot.cache_namespace` threaded through single/PD/EPD selection and retry re-selection (kept `None` on the typed wires until they forward the fields) + retained-snapshot retry test
- `model_gateway/src/routers/common/request_lease.rs`, `routers/http/{router,pd_router}.rs`: `RoutingDerivatives`/`LeaseView.cache_namespace`, threaded through HTTP and PD selection
- `model_gateway/tests/routing/cache_namespace_routing_test.rs` (new): string-tree and token-tree affinity under salts, marker exclusion, unpartitioned behavior unchanged

## Test Plan

- [x] `cargo test -p openai-protocol`
- [x] `cargo test -p smg --lib` (incl. `cache_namespace` unit tests, the `cache_aware` namespace tests: head-hash invariants, placement-index keys, fallback insert, forged-marker rejection, and the worker-selection retained-snapshot retry test)
- [x] `cargo test -p smg --test routing_tests` (incl. the new `cache_namespace_routing_test`)
- [x] `cargo test -p smg --test api_tests`
- [x] `cargo clippy -p openai-protocol -p smg --all-targets -- -D warnings`
- [x] `cargo check -p smg-golang -p smg-python`
- [x] nightly `cargo fmt`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (run for the touched crates locally: `cargo clippy -p openai-protocol -p smg --all-targets -- -D warnings`; CI runs the full matrix)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
