### PR TITLE
feat(radix-tree): chain-native prefix-membership index

### DIFF
--- a/.github/workflows/radix-tree-fuzz.yml
+++ b/.github/workflows/radix-tree-fuzz.yml
@@ -1,0 +1,44 @@
+name: radix-tree fuzz campaign
+
+# The always-on `fuzz_quick` in the unit-test lane is a triage gate (8+3
+# seeds, debug build). The differential campaign — seeded runs against
+# the reference model, every 4th at the wide H<=64 sharing width, plus
+# the out-of-contract chaos runs — is release-only and runs here nightly
+# so the data structure's correctness gate does not depend on someone
+# remembering to run it by hand. Budget: 1000 seeds took 52 min in
+# release on an M-series laptop; 600 fits a 2x slower hosted runner
+# inside the 120-minute job limit with headroom. Dispatch for more.
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      seeds:
+        description: "RADIX_FUZZ_SEEDS"
+        default: "600"
+      start:
+        description: "RADIX_FUZZ_START"
+        default: "1000"
+
+concurrency:
+  group: radix-tree-fuzz
+  cancel-in-progress: true
+
+jobs:
+  campaign:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: radix-tree-fuzz
+      - name: Run the differential campaign (release)
+        env:
+          RADIX_FUZZ_SEEDS: ${{ github.event.inputs.seeds || '600' }}
+          RADIX_FUZZ_START: ${{ github.event.inputs.start || '1000' }}
+        run: |
+          cargo test -p smg-radix-tree --release --test fuzz_differential \
+            -- --ignored --nocapture fuzz_campaign

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -41,6 +41,8 @@ jobs:
             path: crates/mm_rdma
           - crate: engine-zmq-client
             path: crates/engine_zmq_client
+          - crate: smg-radix-tree
+            path: crates/radix_tree
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/publish-crate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7718,6 +7718,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "smg-radix-tree"
+version = "0.1.0"
+dependencies = [
+ "kv-index",
+ "rustc-hash 2.1.3",
+]
+
+[[package]]
 name = "smg-rl"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp",
-    "crates/external_router", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/mm_rdma", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/engine_zmq_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "crates/mock_worker", "crates/rl"]
+    "crates/external_router", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/mm_rdma", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/engine_zmq_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "crates/mock_worker", "crates/rl", "crates/radix_tree"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -15,6 +15,7 @@ smg-auth = { version = "1.2.3", path = "crates/auth" }
 smg-mcp = { version = "2.3.3", path = "crates/mcp" }
 smg-external-router = { version = "0.1.0", path = "crates/external_router" }
 kv-index = { version = "1.4.0", path = "crates/kv_index" }
+smg-radix-tree = { version = "0.1.0", path = "crates/radix_tree" }
 smg-data-connector = { version = "2.3.4", path = "crates/data_connector", package = "data-connector" }
 llm-multimodal = { version = "1.11.0", path = "crates/multimodal" }
 smg-wasm = { version = "1.1.4", path = "crates/wasm", package = "smg-wasm" }

--- a/crates/kv_index/src/event_tree.rs
+++ b/crates/kv_index/src/event_tree.rs
@@ -165,6 +165,34 @@ pub fn compute_content_hash(token_ids: &[u32]) -> ContentHash {
     ContentHash(hasher.finish())
 }
 
+/// Rolling prefix hash over content hashes: `XXH3(prev || current)`, the
+/// same chaining `PositionalIndexer` computes internally. Exported so
+/// out-of-process publishers (the radix index service's placement feed)
+/// can synthesize byte-identical position chains for identical prefixes.
+///
+/// Note the base case: position 0's `SequenceHash` is the bare
+/// `ContentHash` value (`SequenceHash(c0.0)`), NOT
+/// `chain_prefix_hash(SequenceHash(0), c0)`. Callers must seed with the
+/// first content hash and chain from position 1, or the whole chain
+/// silently diverges from the indexer's (zero prefix matches, no error):
+///
+/// ```
+/// use kv_index::{chain_prefix_hash, ContentHash, SequenceHash};
+/// let contents = [ContentHash(11), ContentHash(22), ContentHash(33)];
+/// let mut chain = vec![SequenceHash(contents[0].0)];
+/// for &c in &contents[1..] {
+///     let prev = *chain.last().unwrap();
+///     chain.push(chain_prefix_hash(prev, c));
+/// }
+/// assert_eq!(chain.len(), 3);
+/// ```
+pub fn chain_prefix_hash(prev: SequenceHash, current: ContentHash) -> SequenceHash {
+    let mut bytes = [0u8; 16];
+    bytes[..8].copy_from_slice(&prev.0.to_le_bytes());
+    bytes[8..].copy_from_slice(&current.0.to_le_bytes());
+    SequenceHash(xxhash_rust::xxh3::xxh3_64_with_seed(&bytes, XXH3_SEED))
+}
+
 /// Chunk request tokens by block size and compute a [`ContentHash`] per full block.
 ///
 /// This is the entry point for the **query path**: given a request's token IDs and

--- a/crates/kv_index/src/lib.rs
+++ b/crates/kv_index/src/lib.rs
@@ -20,9 +20,9 @@ mod token_tree;
 
 pub use common::{MatchResult, TenantId};
 pub use event_tree::{
-    compute_content_hash, compute_request_content_hashes, ApplyError, ContentHash, OverlapScores,
-    PositionalIndexer, PruneStats, SequenceHash, StoredBlock, WorkerBlockMap, WorkerId,
-    WorkerIdExhausted,
+    chain_prefix_hash, compute_content_hash, compute_request_content_hashes, ApplyError,
+    ContentHash, OverlapScores, PositionalIndexer, PruneStats, SequenceHash, StoredBlock,
+    WorkerBlockMap, WorkerId, WorkerIdExhausted, XXH3_SEED,
 };
 pub use path_hash::{hash_node_path, hash_token_path, GLOBAL_EVICTION_HASH};
 // Re-export under names matching old tree.rs API for easier migration

--- a/crates/radix_tree/Cargo.toml
+++ b/crates/radix_tree/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "smg-radix-tree"
+version = "0.1.0"
+edition = "2021"
+description = "Generic prefix-membership index: chain-native radix tree answering which holders share the longest prefix of a block chain, and how deep"
+license = "Apache-2.0"
+repository = "https://github.com/smg-project/smg"
+readme = "README.md"
+authors = ["Simo Lin <linsimo.mark@gmail.com>"]
+keywords = ["radix-tree", "prefix-matching", "cache-routing", "kv-cache", "llm"]
+categories = ["data-structures", "caching"]
+
+# The Rust import path stays `radix_tree`; only the crates.io package name
+# carries the `smg-` prefix (the bare `radix-tree` name is taken).
+[lib]
+name = "radix_tree"
+path = "src/lib.rs"
+
+[dependencies]
+# Zero SMG dependencies. External utility crates only.
+rustc-hash = "2"
+
+
+[dev-dependencies]
+# The differential oracle. Dev-only AND path-only (no version): cargo
+# drops a version-less path dev-dependency from the published manifest,
+# so the crate on crates.io carries no SMG dependency at all and can be
+# published in tier 1 without waiting on a kv-index release (a
+# versioned dev-dep would have to exist on the registry first — a race
+# whenever both crates bump in one release).
+kv-index = { path = "../kv_index" }

--- a/crates/radix_tree/README.md
+++ b/crates/radix_tree/README.md
@@ -1,0 +1,98 @@
+# radix-tree
+
+Published on crates.io as **`smg-radix-tree`** (the bare `radix-tree` name
+belongs to an unrelated router crate); the Rust import path is `radix_tree`.
+No SMG dependencies — it is a tier-1 crate in the release workflow.
+
+A generic prefix-membership index: given per-holder chains of
+content-addressed blocks, answer *"which holders already hold the
+longest prefix of this chain, and how deep?"* — plus the write and
+lifecycle operations a long-lived, multi-tenant index service needs
+as first-class API. Zero SMG dependencies; everything it sees is a
+hash.
+
+Built as the ground-up replacement for the gateway's
+`kv_index::PositionalIndexer` as a fleet-wide index core; the shared
+radix-index service (`smg-radix-index`, a separate crate) is built on
+it.
+
+## API in one glance
+
+```rust
+let mut tree = RadixTree::new(Config::default());
+let w = tree.create_holder("worker-7");            // generational id
+tree.store(w, None, &[(key, content), ...])?;      // anchor a chain
+tree.store(w, Some(parent_key), &more)?;           // extend it
+tree.remove(w, &[key]);                            // event-feed eviction
+tree.truncate_tail(w, keep);                       // prefix-closed capacity cut
+tree.clear(w);                                     // epoch bump
+tree.retire_holder(w);                             // frees everything, id recycled
+
+let mut scratch = OverlapScratch::default();
+let mut out = Vec::new();
+tree.overlap(&chain_hashes, &mut scratch, &mut out);
+// out: [{ holder, depth, total_blocks }]
+tree.enumerate(w);                                 // (pos, key, content) for snapshots
+```
+
+The contract — exact matching semantics, convergence scope, and the
+§4 alias rules — is what `tests/differential.rs` enforces: every core
+must equal the reference model on every run.
+
+## Structure
+
+Prefixes form a trie of **chains**. A chain's contents are one
+contiguous array, stored once no matter how many holders cover it;
+membership is a short list of maximal runs pointing at interned
+(hash-consed) holder sets; a query is one hash probe to the root
+chain, a linear scan of contiguous contents to the divergence point,
+a child-fork hop if needed, and a handful of span reads. Matching is
+exact and content-verified — fingerprint collisions cannot
+cross-credit.
+
+`FlatTree` is the first-generation flat layout, kept as a second,
+independently verified implementation: the test harness asserts BOTH
+cores equal the reference model on every run.
+
+## Verification
+
+The crate was built harness-first:
+
+- `tests/differential.rs` — both cores vs a representationally
+  complete reference model AND the production `kv_index` oracle
+  (dev-dependency), with full-state `audit()` at every checkpoint.
+- `tests/fuzz_differential.rs` — wide-config fuzz plus a CHAOS mode
+  that violates every contract precondition under a no-panic,
+  audit-green, model-equal, deterministic-replay contract.
+  `RADIX_FUZZ_SEEDS=10000` ran green.
+- `tests/api.rs` — lifecycle, boundary, and exactness cases the model
+  deliberately doesn't express.
+- `tests/alloc_gate.rs` — counting-allocator gate: single-holder
+  stores amortize to zero allocations.
+- `tests/pinned_bench.rs` — the normative performance workload
+  (`RADIX_BENCH_SIDE=oracle|r1|r3`, `RADIX_BENCH_SCALE=large`,
+  `RADIX_BENCH_SOAK_SECS=n`; `RADIX_BENCH_PROFILE=agentic|churn|fleet|
+  fragmented` are diagnostics, not gates).
+
+## Measured (pinned workload: 12.8M holder-blocks, 256 holders)
+
+| | old `PositionalIndexer` + glue | `RadixTree` |
+|---|---|---|
+| bytes / holder-block | 166.7 | **26.9** |
+| worst cell (d78, 64 holders) cold p99 | 6.0 µs (unsound skip) | **7.6 µs exact** |
+| single-holder query p50 | 917 ns | **292 ns** |
+| writes, mixed stream | 5.5M blocks/s | 4.6M blocks/s |
+| at 128M blocks: worst-cell p99 | 29 µs | **8.0 µs** |
+
+Known sensitivity: interior holes fragment a holder's chain into
+segments, and the query walk pays per segment where the positional
+map does not. On the `fragmented` profile (the pinned shape with 2%
+of every instance's interior blocks evicted at random, ~10 holes in a
+512-block prefix) the worst cell's p99 is 18.5 µs against the
+incumbent's 8.3 µs, at the same 27.5 B/block. Production eviction is
+tail-heavy (the pinned shape); a workload with dense interior holes
+should be measured on this profile before the tree is adopted for it.
+
+No timestamps live in the tree: freshness policy (idle TTL per
+holder) belongs to the consumer; chain data is freed by reference
+counting.

--- a/crates/radix_tree/src/chain.rs
+++ b/crates/radix_tree/src/chain.rs
@@ -1,0 +1,1419 @@
+//! The chain-native core: chains as contiguous data, canonical
+//! maximal-run membership spans, one entry probe per query. Same
+//! public API and matching/convergence contract as the flat core;
+//! the differential referee proves equality.
+
+use rustc_hash::FxHashMap;
+
+use crate::{
+    lineage_root, lineage_step, BlockKey, Config, ContentHash, HolderId, Overlap, OverlapScratch,
+    SetInterner, SetRef, Stats, StoreError, StoreOutcome,
+};
+
+/// One trie chain: contiguous contents/keys stored ONCE, shared by
+/// every holder covering any span of it.
+#[derive(Debug, Default)]
+struct ChainData {
+    /// Trie edge: (parent chain, absolute position of the parent
+    /// block). `None` = a root chain (base_pos == 0).
+    parent: Option<(u32, u32)>,
+    /// Absolute position of contents[0].
+    base_pos: u32,
+    contents: Vec<ContentHash>,
+    /// Lineage fingerprint at contents[0] (audit + canonical iden).
+    start_lineage: u64,
+    /// Lineage at the last position (extension cache).
+    end_lineage: u64,
+    /// Canonical maximal-run membership: sorted, non-overlapping,
+    /// non-adjacent-equal, non-empty sets, within [base_pos,
+    /// base_pos + len).
+    spans: Vec<Span>,
+    /// Child forks: (fork position ON THIS CHAIN, first child
+    /// content, child chain), sorted.
+    children: Vec<(u32, ContentHash, u32)>,
+}
+
+#[derive(Debug, Clone)]
+struct Span {
+    start: u32,
+    len: u32,
+    holders: SetRef,
+}
+
+impl ChainData {
+    fn end_pos(&self) -> u32 {
+        self.base_pos + self.contents.len() as u32
+    }
+    fn content_at(&self, pos: u32) -> ContentHash {
+        self.contents[(pos - self.base_pos) as usize]
+    }
+    fn child_at(&self, fork_pos: u32, content: ContentHash) -> Option<u32> {
+        self.children
+            .binary_search_by_key(&(fork_pos, content), |&(p, c, _)| (p, c))
+            .ok()
+            .map(|i| self.children[i].2)
+    }
+    /// Is `holder` in the span covering `pos` (if any)?
+    fn covered(&self, pos: u32, holder: u32) -> bool {
+        self.span_index(pos)
+            .is_some_and(|i| self.spans[i].holders.binary_search(&holder).is_ok())
+    }
+    fn span_index(&self, pos: u32) -> Option<usize> {
+        let i = self.spans.partition_point(|s| s.start + s.len <= pos);
+        (i < self.spans.len() && self.spans[i].start <= pos).then_some(i)
+    }
+}
+
+#[derive(Debug, Default)]
+struct HolderState3 {
+    name: String,
+    /// key -> (chain, absolute pos). Per-holder (out-of-contract
+    /// inputs can register one key differently across holders).
+    keys: FxHashMap<BlockKey, (u32, u32)>,
+    /// Chains this holder covers (maintenance index).
+    chains: rustc_hash::FxHashSet<u32>,
+}
+
+#[derive(Debug)]
+struct Slot3 {
+    generation: u64,
+    state: Option<HolderState3>,
+}
+
+pub struct RadixTree {
+    cfg: Config,
+    chains: Vec<ChainData>,
+    free_chains: Vec<u32>,
+    /// Root chains by their start lineage. The value is a collision
+    /// list (essentially always length 1): entries are CONTENT-
+    /// verified on every resolution, which makes R3 immune to
+    /// fingerprint collisions — the flat core cannot verify (it
+    /// stores no contents), R3 always can.
+    roots: FxHashMap<u64, Vec<u32>>,
+    slots: Vec<Slot3>,
+    by_name: FxHashMap<String, u32>,
+    free: Vec<u32>,
+    interner: SetInterner,
+    holder_blocks_total: u64,
+    /// Distinct covered (position, content, lineage) = chain
+    /// positions with a non-empty holder set.
+    distinct_entries: u64,
+}
+
+impl RadixTree {
+    pub fn new(cfg: Config) -> Self {
+        Self {
+            cfg,
+            chains: Vec::new(),
+            free_chains: Vec::new(),
+            roots: FxHashMap::default(),
+            slots: Vec::new(),
+            by_name: FxHashMap::default(),
+            free: Vec::new(),
+            interner: SetInterner::default(),
+            holder_blocks_total: 0,
+            distinct_entries: 0,
+        }
+    }
+
+    // ---- holder lifecycle (mirrors the flat core exactly) ----
+
+    pub fn create_holder(&mut self, name: &str) -> HolderId {
+        if let Some(&index) = self.by_name.get(name) {
+            return HolderId::assemble(index, self.slots[index as usize].generation);
+        }
+        let state = HolderState3 {
+            name: name.to_string(),
+            ..HolderState3::default()
+        };
+        let index = if let Some(index) = self.free.pop() {
+            self.slots[index as usize].state = Some(state);
+            index
+        } else {
+            assert!(
+                self.slots.len() < u32::MAX as usize,
+                "holder slot space exhausted (u32 indices)"
+            );
+            self.slots.push(Slot3 {
+                generation: 0,
+                state: Some(state),
+            });
+            (self.slots.len() - 1) as u32
+        };
+        self.by_name.insert(name.to_string(), index);
+        HolderId::assemble(index, self.slots[index as usize].generation)
+    }
+
+    pub fn holder_name(&self, id: HolderId) -> Option<&str> {
+        self.live(id).map(|s| s.name.as_str())
+    }
+
+    pub fn retire_holder(&mut self, id: HolderId) {
+        if self.live(id).is_none() {
+            return;
+        }
+        self.clear(id);
+        let slot = &mut self.slots[id.parts().0 as usize];
+        let state = slot.state.take().expect("checked live");
+        self.by_name.remove(&state.name);
+        slot.generation = slot.generation.wrapping_add(1);
+        self.free.push(id.parts().0);
+    }
+
+    pub fn holder_blocks(&self, id: HolderId) -> u64 {
+        self.live(id).map_or(0, |s| s.keys.len() as u64)
+    }
+
+    fn live(&self, id: HolderId) -> Option<&HolderState3> {
+        let (index, generation) = id.parts();
+        let slot = self.slots.get(index as usize)?;
+        if slot.generation != generation {
+            return None;
+        }
+        slot.state.as_ref()
+    }
+
+    // ---- writes ----
+
+    pub fn store(
+        &mut self,
+        id: HolderId,
+        parent: Option<BlockKey>,
+        blocks: &[(BlockKey, ContentHash)],
+    ) -> Result<StoreOutcome, StoreError> {
+        if self.live(id).is_none() {
+            return Err(StoreError::UnknownHolder);
+        }
+        let holder = id.parts().0;
+        if blocks.is_empty() {
+            return Ok(StoreOutcome {
+                applied: 0,
+                duplicates: 0,
+            });
+        }
+        // Resolve the anchor BEFORE any mutation.
+        let anchor: Option<(u32, u32)> = match parent {
+            Some(parent_key) => {
+                let state = self.state_of(holder);
+                match state.keys.get(&parent_key) {
+                    None => return Err(StoreError::ParentNotFound),
+                    Some(&at) => Some(at),
+                }
+            }
+            None => None,
+        };
+        let start_pos = anchor.map_or(0, |(_, p)| p + 1);
+        if start_pos as u64 + blocks.len() as u64 > self.cfg.max_chain_len as u64 {
+            return Err(StoreError::ChainTooLong);
+        }
+
+        // Walk-insert: follow the trie from the anchor, consuming
+        // blocks; matching content = membership add (or §4 alias
+        // duplicate), mismatch or chain end = fork/extend.
+        let mut applied = 0u32;
+        let mut duplicates = 0u32;
+        // Current walk point: chain + next absolute position to fill,
+        // or None before the first block when anchoring a root.
+        let mut cursor: Option<(u32, u32)> = anchor.map(|(c, p)| (c, p + 1));
+        let mut lineage = anchor.map(|(c, p)| self.lineage_at(c, p));
+        for &(key, content) in blocks {
+            let next_lineage = match lineage {
+                None => lineage_root(content),
+                Some(prev) => lineage_step(prev, content),
+            };
+            let landed = self.place_block(holder, key, content, next_lineage, &mut cursor)?;
+            match landed {
+                Placed::Applied => applied += 1,
+                Placed::Duplicate => duplicates += 1,
+            }
+            lineage = Some(next_lineage);
+        }
+        Ok(StoreOutcome {
+            applied,
+            duplicates,
+        })
+    }
+
+    /// Place one block at the cursor. Advances the cursor to the
+    /// placed position.
+    fn place_block(
+        &mut self,
+        holder: u32,
+        key: BlockKey,
+        content: ContentHash,
+        lineage: u64,
+        cursor: &mut Option<(u32, u32)>,
+    ) -> Result<Placed, StoreError> {
+        // Resolve the target (chain, pos) for this block canonically.
+        let target: (u32, u32) = match *cursor {
+            None => {
+                // Root anchor: canonical root chain by root lineage,
+                // CONTENT-verified (a colliding lineage with a
+                // different first content gets its own chain).
+                let existing = self.roots.get(&lineage).and_then(|list| {
+                    list.iter()
+                        .copied()
+                        .find(|&c| self.chains[c as usize].contents[0] == content)
+                });
+                match existing {
+                    Some(c) => (c, 0),
+                    None => {
+                        let c = self.alloc_chain(ChainData {
+                            parent: None,
+                            base_pos: 0,
+                            contents: vec![content],
+                            start_lineage: lineage,
+                            end_lineage: lineage,
+                            spans: Vec::new(),
+                            children: Vec::new(),
+                        });
+                        self.roots.entry(lineage).or_default().push(c);
+                        (c, 0)
+                    }
+                }
+            }
+            Some((chain, pos)) => {
+                let cd = &self.chains[chain as usize];
+                if pos < cd.end_pos() {
+                    if cd.content_at(pos) == content {
+                        (chain, pos)
+                    } else {
+                        // Fork at pos-1 (or a new root when pos==0 is
+                        // impossible here: cursor mid-chain implies
+                        // pos > base 0 path came through parent).
+                        match cd.child_at(pos - 1, content) {
+                            Some(child) => {
+                                let base = self.chains[child as usize].base_pos;
+                                (child, base)
+                            }
+                            None => {
+                                let c = self.new_child(chain, pos - 1, content, lineage);
+                                (c, pos)
+                            }
+                        }
+                    }
+                } else {
+                    // Past the tip: extend in place, or descend into
+                    // an existing child continuation.
+                    match cd.child_at(pos - 1, content) {
+                        Some(child) => {
+                            let base = self.chains[child as usize].base_pos;
+                            (child, base)
+                        }
+                        None => {
+                            let has_children_at_tip =
+                                cd.children.iter().any(|&(p, _, _)| p + 1 == pos);
+                            if has_children_at_tip {
+                                // The tip already forks; a new
+                                // continuation is another child (in-
+                                // place extension would change the
+                                // fork point's shape non-canonically).
+                                let c = self.new_child(chain, pos - 1, content, lineage);
+                                (c, pos)
+                            } else {
+                                let cd = &mut self.chains[chain as usize];
+                                cd.contents.push(content);
+                                cd.end_lineage = lineage;
+                                (chain, pos)
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        let (chain, pos) = target;
+        *cursor = Some((chain, pos + 1));
+
+        // §4 semantics at the resolved position, PER HOLDER (chaos
+        // finding: chain-global key canonicity diverged from the
+        // model — aliasing is a per-holder concept, so the chain
+        // stores no keys at all; per-holder key maps carry them).
+        // Covered ⇒ this holder already holds the exact triple: a
+        // plain duplicate, an alias (their other key), or a refused
+        // move — all observably identical, all non-destructive.
+        if self.chains[chain as usize].covered(pos, holder) {
+            return Ok(Placed::Duplicate);
+        }
+        // Not covered: a move relocates the key first, then join.
+        // Key BEFORE membership: the invariant every key map entry is
+        // covered by a span (audit rule) must hold at every GC point,
+        // and the old key's coverage is what the removal below drops.
+        // The CURSOR chain is pinned against GC for the gap between
+        // this removal and the add just below: an in-batch move can
+        // otherwise free the chain the batch is standing on, and the
+        // next block would write into a freed slot (found by the
+        // chaos fuzz).
+        if let Some(old) = self.state_of(holder).keys.get(&key).copied() {
+            self.state_of_mut(holder).keys.remove(&key);
+            self.remove_membership_pinned(holder, old, Some(chain));
+        }
+        self.add_membership(holder, chain, pos);
+        self.state_of_mut(holder).keys.insert(key, (chain, pos));
+        Ok(Placed::Applied)
+    }
+
+    /// Read-only no-op predicate: true iff `store(id, parent, blocks)`
+    /// would apply NOTHING — every block already sits at its resolved
+    /// (position, content, lineage) for this holder (plain duplicate,
+    /// §4 alias, or refused move: all observably identical no-ops).
+    /// Exactly `store(..) == Ok(StoreOutcome { applied: 0, .. })`,
+    /// and false wherever store would error — the caller falls through
+    /// to the mutating path, which surfaces the error itself. This is
+    /// the shared-lock fast path for duplicate-dominated multi-writer
+    /// placement streams: the walk mirrors `place_block`'s resolution,
+    /// and any step that would create, extend, or fork a chain is by
+    /// definition not covered.
+    pub fn covered(
+        &self,
+        id: HolderId,
+        parent: Option<BlockKey>,
+        blocks: &[(BlockKey, ContentHash)],
+    ) -> bool {
+        self.dup_prefix(id, parent, blocks).1
+    }
+
+    /// One read-only walk answering two questions for the shared-lock
+    /// apply paths: `(plain_dup_run, fully_covered)`.
+    ///
+    /// - `plain_dup_run`: length of the LEADING run of blocks that are
+    ///   plain same-key duplicates — the holder's key map holds each
+    ///   block's own key at exactly the resolved placement. A caller
+    ///   may re-anchor a store at `blocks[run - 1].0` and apply only
+    ///   the suffix: the skipped prefix is bit-for-bit already there,
+    ///   key included, so the split store lands the identical state
+    ///   (aliases deliberately do NOT extend the run — their key may
+    ///   not be an anchor).
+    /// - `fully_covered`: the [`Self::covered`] predicate — every
+    ///   block (aliases included) is a no-op, i.e. `store` would
+    ///   return `applied == 0`.
+    pub fn dup_prefix(
+        &self,
+        id: HolderId,
+        parent: Option<BlockKey>,
+        blocks: &[(BlockKey, ContentHash)],
+    ) -> (u32, bool) {
+        if self.live(id).is_none() {
+            return (0, false);
+        }
+        let holder = id.parts().0;
+        if blocks.is_empty() {
+            return (0, true);
+        }
+        let anchor: Option<(u32, u32)> = match parent {
+            Some(parent_key) => match self.state_of(holder).keys.get(&parent_key) {
+                None => return (0, false),
+                Some(&at) => Some(at),
+            },
+            None => None,
+        };
+        let start_pos = anchor.map_or(0, |(_, p)| p + 1);
+        if start_pos as u64 + blocks.len() as u64 > self.cfg.max_chain_len as u64 {
+            return (0, false);
+        }
+        // Read-only walk: the trie's own contents resolve every step
+        // after the first, so no lineage is rolled — `store` needs
+        // lineages to CREATE chains, this path never does. (An anchored
+        // walk once rolled `lineage_at` over the whole anchor chain for
+        // a value it never read: O(chain length) on the shared-lock
+        // fast path, per duplicate.)
+        let mut cursor: Option<(u32, u32)> = anchor.map(|(c, p)| (c, p + 1));
+        let mut run = 0u32;
+        let mut run_live = true;
+        for &(key, content) in blocks {
+            let target: (u32, u32) = match cursor {
+                None => {
+                    // Only the first block of a parent-None walk: the root
+                    // lineage is a pure function of that block's content.
+                    match self.roots.get(&lineage_root(content)).and_then(|list| {
+                        list.iter()
+                            .copied()
+                            .find(|&c| self.chains[c as usize].contents[0] == content)
+                    }) {
+                        Some(c) => (c, 0),
+                        None => return (run, false),
+                    }
+                }
+                Some((chain, pos)) => {
+                    let cd = &self.chains[chain as usize];
+                    if pos < cd.end_pos() && cd.content_at(pos) == content {
+                        (chain, pos)
+                    } else {
+                        match cd.child_at(pos - 1, content) {
+                            Some(child) => {
+                                let base = self.chains[child as usize].base_pos;
+                                (child, base)
+                            }
+                            None => return (run, false),
+                        }
+                    }
+                }
+            };
+            let (chain, pos) = target;
+            if !self.chains[chain as usize].covered(pos, holder) {
+                return (run, false);
+            }
+            if run_live {
+                if self.state_of(holder).keys.get(&key) == Some(&(chain, pos)) {
+                    run += 1;
+                } else {
+                    run_live = false;
+                }
+            }
+            cursor = Some((chain, pos + 1));
+        }
+        (run, true)
+    }
+
+    /// Read-only: the absolute position at which `holder` holds `key`,
+    /// or None. The digest fast path uses this to confirm a placement
+    /// chain is fully present without receiving its contents. Two facts
+    /// make that sound:
+    /// - Contiguity: an inferred (placement-fed) holder's held
+    ///   positions are a contiguous prefix per chain (stores add
+    ///   contiguously, truncate cuts the tail, and mid-chain removes
+    ///   only arrive via `Removed`, which pins the holder event-fed —
+    ///   and event-fed holders reject every digest). A tip key at
+    ///   position p therefore proves p+1 blocks are held.
+    /// - Identity: the tip key is a chained seq hash, so it encodes the
+    ///   ENTIRE prefix lineage — a key found at the expected position
+    ///   cannot belong to a different chain that coincidentally aligns
+    ///   (modulo 64-bit hash collision, the same assumption every seq
+    ///   lookup makes). The parent/tip positions need no common-chain
+    ///   check for this reason.
+    pub fn position_of(&self, id: HolderId, key: BlockKey) -> Option<u32> {
+        self.live(id)?;
+        let holder = id.parts().0;
+        self.state_of(holder).keys.get(&key).map(|&(_, pos)| pos)
+    }
+
+    pub fn remove(&mut self, id: HolderId, keys: &[BlockKey]) -> u32 {
+        if self.live(id).is_none() {
+            return 0;
+        }
+        let holder = id.parts().0;
+        let mut removed = 0u32;
+        for &key in keys {
+            let Some(&(chain, pos)) = self.state_of(holder).keys.get(&key) else {
+                continue;
+            };
+            self.state_of_mut(holder).keys.remove(&key);
+            self.remove_membership(holder, (chain, pos));
+            removed += 1;
+        }
+        removed
+    }
+
+    pub fn truncate_tail(&mut self, id: HolderId, keep: u64) -> u64 {
+        if self.live(id).is_none() {
+            return 0;
+        }
+        let holder = id.parts().0;
+        let state = self.state_of(holder);
+        if state.keys.len() as u64 <= keep {
+            return 0;
+        }
+        let mut ordered: Vec<(u32, BlockKey)> =
+            state.keys.iter().map(|(&k, &(_, p))| (p, k)).collect();
+        ordered.sort_unstable();
+        let mut dropped = 0u64;
+        while self.state_of(holder).keys.len() as u64 > keep {
+            let (_, key) = ordered.pop().expect("non-empty");
+            let (chain, pos) = self.state_of(holder).keys[&key];
+            self.state_of_mut(holder).keys.remove(&key);
+            self.remove_membership(holder, (chain, pos));
+            dropped += 1;
+        }
+        dropped
+    }
+
+    pub fn clear(&mut self, id: HolderId) {
+        if self.live(id).is_none() {
+            return;
+        }
+        let holder = id.parts().0;
+        // Wipe the key map FIRST so the "every key is covered by a
+        // span" invariant holds at each chain GC point below (the
+        // debug guard in `maybe_gc_chain_pinned` checks exactly that).
+        // `chains` is exact, not a superset: `remove_membership_pinned`
+        // prunes a chain from it the moment the holder's last span
+        // there goes, so this walk touches only live coverage.
+        let state = self.state_of_mut(holder);
+        let key_count = state.keys.len() as u64;
+        state.keys = FxHashMap::default();
+        let chains: Vec<u32> = std::mem::take(&mut state.chains).into_iter().collect();
+        self.holder_blocks_total -= key_count;
+        for chain in chains {
+            self.drop_holder_from_chain(holder, chain);
+        }
+    }
+
+    // ---- reads ----
+
+    pub fn overlap(
+        &self,
+        chain_query: &[ContentHash],
+        scratch: &mut OverlapScratch,
+        out: &mut Vec<Overlap>,
+    ) {
+        out.clear();
+        if chain_query.is_empty() {
+            return;
+        }
+        let root_lineage = lineage_root(chain_query[0]);
+        let Some(root) = self.roots.get(&root_lineage).and_then(|list| {
+            list.iter()
+                .copied()
+                .find(|&c| self.chains[c as usize].contents[0] == chain_query[0])
+        }) else {
+            return;
+        };
+        // Walk the trie along the query, collecting the matched path
+        // as (chain, from, to) segments into the caller-owned scratch
+        // (no per-query heap once warm — the alloc gate holds this).
+        let segments = &mut scratch.segments;
+        segments.clear();
+        let mut chain = root;
+        let mut pos = 0u32;
+        let limit = chain_query.len().min(u32::MAX as usize) as u32;
+        'walk: while pos < limit {
+            let cd = &self.chains[chain as usize];
+            let seg_from = pos;
+            while pos < limit && pos < cd.end_pos() {
+                if cd.content_at(pos) != chain_query[pos as usize] {
+                    if pos > seg_from {
+                        segments.push((chain, seg_from, pos));
+                    }
+                    // Divergence: a sibling fork may continue.
+                    if pos == seg_from {
+                        // Diverged immediately at segment start:
+                        // fork search happens at pos-1 on the SAME
+                        // parent chain — handled below via child_at
+                        // when entering; nothing matched here.
+                    }
+                    match (pos > 0)
+                        .then(|| self.fork_of(chain, pos - 1, chain_query[pos as usize]))
+                        .flatten()
+                    {
+                        Some(child) => {
+                            chain = child;
+                            continue 'walk;
+                        }
+                        None => break 'walk,
+                    }
+                }
+                pos += 1;
+            }
+            if pos > seg_from {
+                segments.push((chain, seg_from, pos));
+            }
+            if pos >= limit {
+                break;
+            }
+            // Chain exhausted: follow the child fork at the tip.
+            match self.fork_of(chain, pos - 1, chain_query[pos as usize]) {
+                Some(child) => chain = child,
+                None => break,
+            }
+        }
+        if segments.is_empty() {
+            return;
+        }
+        // Merge holder runs along the matched path (same active-set
+        // logic as the flat walk, but over spans — few per segment).
+        let active = &mut scratch.active;
+        let next = &mut scratch.next;
+        active.clear();
+        next.clear();
+        let mut depth = 0u32;
+        let mut first = true;
+        // Data pointer of the interned set the `active` buffer was copied
+        // from, for the O(1) identity run-skip. Comparing against
+        // `active.as_ptr()` (a distinct scratch allocation) can never
+        // match, so the skip only works against the SOURCE set's pointer —
+        // mirrors FlatTree's `active_src`.
+        let mut active_src: Option<*const u32> = None;
+        'runs: for &(c, from, to) in segments.iter() {
+            let cd = &self.chains[c as usize];
+            let mut p = from;
+            while p < to {
+                // `span_index` answers only for a span that COVERS `p`
+                // (it applies the `start <= p` test itself), so an
+                // uncovered position ends the consecutive-depth walk
+                // here — there is no "skip the gap to the next span"
+                // case under the §6 contract.
+                let (run_holders, run_end) = match cd.span_index(p) {
+                    Some(i) => {
+                        let s = &cd.spans[i];
+                        (Some(&s.holders), (s.start + s.len).min(to))
+                    }
+                    None => (None, to),
+                };
+                match run_holders {
+                    None => {
+                        // Uncovered positions: everyone drops here.
+                        for &h in active.iter() {
+                            push_answer3(&self.slots, h, depth, out);
+                        }
+                        active.clear();
+                        break 'runs;
+                    }
+                    Some(set) => {
+                        if first {
+                            active.extend_from_slice(set);
+                            active_src = Some(set.as_ptr());
+                            first = false;
+                        } else if active_src.is_some_and(|src| std::ptr::eq(src, set.as_ptr())) {
+                            // O(1) identity skip: the same interned set, so
+                            // every active holder continues unchanged.
+                        } else if set.as_ref() == active.as_slice() {
+                            // Content-equal after a hand-built subset:
+                            // resync to the interned identity.
+                            active_src = Some(set.as_ptr());
+                        } else {
+                            next.clear();
+                            let mut ai = 0usize;
+                            for &h in set.iter() {
+                                while ai < active.len() && active[ai] < h {
+                                    push_answer3(&self.slots, active[ai], depth, out);
+                                    ai += 1;
+                                }
+                                if ai < active.len() && active[ai] == h {
+                                    next.push(h);
+                                    ai += 1;
+                                }
+                            }
+                            while ai < active.len() {
+                                push_answer3(&self.slots, active[ai], depth, out);
+                                ai += 1;
+                            }
+                            std::mem::swap(active, next);
+                            // next ⊆ set; equal lengths ⟹ equal sets.
+                            active_src = (active.len() == set.len()).then(|| set.as_ptr());
+                        }
+                        if active.is_empty() {
+                            break 'runs;
+                        }
+                        depth = run_end;
+                    }
+                }
+                p = run_end;
+            }
+        }
+        for &h in active.iter() {
+            push_answer3(&self.slots, h, depth, out);
+        }
+    }
+
+    pub fn enumerate(
+        &self,
+        id: HolderId,
+    ) -> impl Iterator<Item = (u32, BlockKey, ContentHash)> + '_ {
+        let rows = self.live(id).map(|state| {
+            let mut v: Vec<(u32, BlockKey, ContentHash)> = state
+                .keys
+                .iter()
+                .map(|(&k, &(c, p))| (p, k, self.chains[c as usize].content_at(p)))
+                .collect();
+            v.sort_unstable();
+            v
+        });
+        rows.unwrap_or_default().into_iter()
+    }
+
+    pub fn stats(&self) -> Stats {
+        let holders = self.slots.iter().filter(|s| s.state.is_some()).count() as u64;
+        let chain_bytes: u64 = self
+            .chains
+            .iter()
+            .map(|c| {
+                16 * c.contents.len() as u64
+                    + 24 * c.spans.len() as u64
+                    + 16 * c.children.len() as u64
+            })
+            .sum();
+        // Interned holder sets: the `Arc<[u32]>` data plus per-bucket
+        // bookkeeping. Omitting this hid an interner leak from the
+        // retire-churn memory gate (audit finding).
+        let interner_bytes: u64 = self
+            .interner
+            .table
+            .values()
+            .map(|bucket| bucket.iter().map(|s| 16 + 4 * s.len() as u64).sum::<u64>() + 24)
+            .sum();
+        Stats {
+            holders,
+            holder_blocks: self.holder_blocks_total,
+            distinct_entries: self.distinct_entries,
+            bytes_estimate: chain_bytes
+                + interner_bytes
+                + self.holder_blocks_total * 24
+                + holders * 128,
+        }
+    }
+
+    // ---- internals ----
+
+    fn state_of(&self, holder: u32) -> &HolderState3 {
+        self.slots[holder as usize].state.as_ref().expect("live")
+    }
+    fn state_of_mut(&mut self, holder: u32) -> &mut HolderState3 {
+        self.slots[holder as usize].state.as_mut().expect("live")
+    }
+
+    fn lineage_at(&self, chain: u32, pos: u32) -> u64 {
+        // Roll from the chain's start (parents cached via
+        // start_lineage; positions within a chain need a walk —
+        // used on the STORE path only for the anchor, so bounded by
+        // one chain's length).
+        let cd = &self.chains[chain as usize];
+        let mut l = cd.start_lineage;
+        for p in (cd.base_pos + 1)..=pos {
+            l = lineage_step(l, cd.content_at(p));
+        }
+        l
+    }
+
+    fn fork_of(&self, chain: u32, fork_pos: u32, content: ContentHash) -> Option<u32> {
+        self.chains[chain as usize].child_at(fork_pos, content)
+    }
+
+    fn alloc_chain(&mut self, data: ChainData) -> u32 {
+        if let Some(c) = self.free_chains.pop() {
+            self.chains[c as usize] = data;
+            c
+        } else {
+            self.chains.push(data);
+            (self.chains.len() - 1) as u32
+        }
+    }
+
+    fn new_child(&mut self, parent: u32, fork_pos: u32, content: ContentHash, lineage: u64) -> u32 {
+        let c = self.alloc_chain(ChainData {
+            parent: Some((parent, fork_pos)),
+            base_pos: fork_pos + 1,
+            contents: vec![content],
+            start_lineage: lineage,
+            end_lineage: lineage,
+            spans: Vec::new(),
+            children: Vec::new(),
+        });
+        let pd = &mut self.chains[parent as usize];
+        let at = pd
+            .children
+            .binary_search_by_key(&(fork_pos, content), |&(p, cc, _)| (p, cc))
+            .unwrap_err();
+        pd.children.insert(at, (fork_pos, content, c));
+        c
+    }
+
+    /// Add `holder` to the membership at (chain, pos), renormalizing
+    /// runs canonically.
+    fn add_membership(&mut self, holder: u32, chain: u32, pos: u32) {
+        let mut m = self.take_position_membership(chain, pos);
+        let was_empty = matches!(m, PosSet::Empty);
+        match &mut m {
+            PosSet::Empty => m = PosSet::Set(self.interner.intern(&[holder])),
+            PosSet::Set(set) => {
+                if let Err(at) = set.binary_search(&holder) {
+                    let mut grown = Vec::with_capacity(set.len() + 1);
+                    grown.extend_from_slice(&set[..at]);
+                    grown.push(holder);
+                    grown.extend_from_slice(&set[at..]);
+                    let new = self.interner.intern(&grown);
+                    let old = std::mem::replace(set, new);
+                    self.interner.release(old);
+                }
+            }
+        }
+        self.put_position_membership(chain, pos, m);
+        if was_empty {
+            self.distinct_entries += 1;
+        }
+        self.holder_blocks_total += 1;
+        self.state_of_mut(holder).chains.insert(chain);
+    }
+
+    fn remove_membership(&mut self, holder: u32, at: (u32, u32)) {
+        self.remove_membership_pinned(holder, at, None);
+    }
+
+    fn remove_membership_pinned(&mut self, holder: u32, at: (u32, u32), pinned: Option<u32>) {
+        let (chain, pos) = at;
+        let mut m = self.take_position_membership(chain, pos);
+        let mut now_empty = false;
+        match &mut m {
+            PosSet::Empty => {}
+            PosSet::Set(set) => {
+                if let Ok(idx) = set.binary_search(&holder) {
+                    if set.len() == 1 {
+                        let old = std::mem::replace(set, self.interner.intern(&[]));
+                        self.interner.release(old);
+                        now_empty = true;
+                        m = PosSet::Empty;
+                    } else {
+                        let mut shrunk = Vec::with_capacity(set.len() - 1);
+                        shrunk.extend_from_slice(&set[..idx]);
+                        shrunk.extend_from_slice(&set[idx + 1..]);
+                        let new = self.interner.intern(&shrunk);
+                        let old = std::mem::replace(set, new);
+                        self.interner.release(old);
+                    }
+                }
+            }
+        }
+        self.put_position_membership(chain, pos, m);
+        // Keep the holder->chains maintenance index EXACT: once the
+        // holder covers no span on this chain, drop the entry. Left
+        // append-only, the set grows to every chain slot the holder
+        // ever touched and `clear`/`retire_holder` then walk (and GC)
+        // dead entries — a standing memory and teardown cost under
+        // eviction churn. The check is O(spans on this chain), a
+        // handful in practice.
+        let still_covers = self.chains[chain as usize]
+            .spans
+            .iter()
+            .any(|s| s.holders.binary_search(&holder).is_ok());
+        if !still_covers {
+            self.state_of_mut(holder).chains.remove(&chain);
+        }
+        if now_empty {
+            self.distinct_entries -= 1;
+            self.maybe_gc_chain_pinned(chain, pinned);
+        }
+        self.holder_blocks_total -= 1;
+    }
+
+    /// Remove the holder from every span of one chain (clear path).
+    fn drop_holder_from_chain(&mut self, holder: u32, chain: u32) {
+        let cd = &self.chains[chain as usize];
+        let positions: Vec<u32> = cd
+            .spans
+            .iter()
+            .filter(|s| s.holders.binary_search(&holder).is_ok())
+            .flat_map(|s| s.start..s.start + s.len)
+            .collect();
+        for pos in positions {
+            let mut m = self.take_position_membership(chain, pos);
+            if let PosSet::Set(set) = &mut m {
+                if let Ok(idx) = set.binary_search(&holder) {
+                    if set.len() == 1 {
+                        let old = std::mem::replace(set, self.interner.intern(&[]));
+                        self.interner.release(old);
+                        m = PosSet::Empty;
+                        self.distinct_entries -= 1;
+                    } else {
+                        let mut shrunk = Vec::with_capacity(set.len() - 1);
+                        shrunk.extend_from_slice(&set[..idx]);
+                        shrunk.extend_from_slice(&set[idx + 1..]);
+                        let new = self.interner.intern(&shrunk);
+                        let old = std::mem::replace(set, new);
+                        self.interner.release(old);
+                    }
+                }
+            }
+            self.put_position_membership(chain, pos, m);
+        }
+        self.maybe_gc_chain(chain);
+    }
+
+    /// Extract the membership at one position, splitting its span so
+    /// the position stands alone; `put` re-normalizes neighbors.
+    fn take_position_membership(&mut self, chain: u32, pos: u32) -> PosSet {
+        let cd = &mut self.chains[chain as usize];
+        let Some(i) = cd.span_index(pos) else {
+            return PosSet::Empty;
+        };
+        let s = cd.spans[i].clone();
+        // Split into [start, pos), [pos, pos+1), (pos+1, end)
+        let mut replacement = Vec::with_capacity(3);
+        if pos > s.start {
+            replacement.push(Span {
+                start: s.start,
+                len: pos - s.start,
+                holders: s.holders.clone(),
+            });
+        }
+        let taken = s.holders.clone();
+        if s.start + s.len > pos + 1 {
+            replacement.push(Span {
+                start: pos + 1,
+                len: s.start + s.len - pos - 1,
+                holders: s.holders.clone(),
+            });
+        }
+        // Replace the original span with its fragments; the original
+        // ref is released (fragments and `taken` hold clones).
+        let original = cd.spans[i].clone();
+        cd.spans.splice(i..=i, replacement);
+        self.interner.release(original.holders);
+        PosSet::Set(taken)
+    }
+
+    /// Re-insert the membership at one position and renormalize with
+    /// neighbors (canonical maximal runs).
+    fn put_position_membership(&mut self, chain: u32, pos: u32, m: PosSet) {
+        let cd = &mut self.chains[chain as usize];
+        if let PosSet::Set(set) = m {
+            if !set.is_empty() {
+                let at = cd.spans.partition_point(|s| s.start < pos);
+                cd.spans.insert(
+                    at,
+                    Span {
+                        start: pos,
+                        len: 1,
+                        holders: set,
+                    },
+                );
+            } else {
+                self.interner.release(set);
+            }
+        }
+        // Renormalize around pos: merge adjacent spans with identical
+        // (pointer-equal) sets.
+        let cd = &mut self.chains[chain as usize];
+        let mut i = cd.spans.partition_point(|s| s.start + s.len < pos);
+        i = i.saturating_sub(1);
+        while i + 1 < cd.spans.len() {
+            let (a, b) = (&cd.spans[i], &cd.spans[i + 1]);
+            if a.start + a.len == b.start && std::sync::Arc::ptr_eq(&a.holders, &b.holders) {
+                let merged_len = a.len + b.len;
+                let dropped = cd.spans.remove(i + 1);
+                cd.spans[i].len = merged_len;
+                self.interner.release(dropped.holders);
+            } else if b.start <= pos + 1 {
+                i += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Free a chain when nothing references it.
+    fn maybe_gc_chain(&mut self, chain: u32) {
+        self.maybe_gc_chain_pinned(chain, None);
+    }
+
+    /// Free `chain` if nothing references it, then walk UP: an ancestor
+    /// left with no spans and no children is freed too. Iterative, not
+    /// recursive — `max_chain_len` admits a trie 65 536 positions deep
+    /// with a fork at every position, and freeing its leaf would
+    /// otherwise recurse through every parent on the call stack.
+    fn maybe_gc_chain_pinned(&mut self, chain: u32, pinned: Option<u32>) {
+        let mut chain = chain;
+        loop {
+            if pinned == Some(chain) {
+                return;
+            }
+            let cd = &self.chains[chain as usize];
+            // Already freed (double-GC guard: reachable via a remove on
+            // one path racing a parent-walk free on another).
+            if cd.contents.is_empty() {
+                return;
+            }
+            if !cd.spans.is_empty() || !cd.children.is_empty() {
+                return;
+            }
+            // In-contract this chain has no key-map references either:
+            // `audit()` enforces that every key map entry is covered by
+            // a span, so no spans => no keys. A release-build scan of
+            // every holder's key map here would be O(total keys) on
+            // EVERY chain free (eviction and retire both free chains
+            // in bulk), so the check is debug-only.
+            debug_assert!(
+                !self.slots.iter().any(|slot| slot
+                    .state
+                    .as_ref()
+                    .is_some_and(|state| state.keys.values().any(|&(c, _)| c == chain))),
+                "chain {chain} has no spans/children but a key map still points at it"
+            );
+            let parent = cd.parent;
+            let start_lineage = cd.start_lineage;
+            let first_content = cd.contents.first().copied();
+            self.chains[chain as usize] = ChainData::default();
+            self.free_chains.push(chain);
+            match parent {
+                None => {
+                    if let Some(list) = self.roots.get_mut(&start_lineage) {
+                        list.retain(|&c| c != chain);
+                        if list.is_empty() {
+                            self.roots.remove(&start_lineage);
+                        }
+                    }
+                    return;
+                }
+                Some((p, fork_pos)) => {
+                    let content = first_content.expect("chains are non-empty");
+                    let pd = &mut self.chains[p as usize];
+                    if let Ok(idx) = pd
+                        .children
+                        .binary_search_by_key(&(fork_pos, content), |&(fp, c, _)| (fp, c))
+                    {
+                        pd.children.remove(idx);
+                    }
+                    chain = p;
+                }
+            }
+        }
+    }
+
+    /// Internal structure sizes for leak hunting (soak diagnostics).
+    pub fn debug_footprint(&self) -> String {
+        let live_chains = self
+            .chains
+            .iter()
+            .filter(|c| !c.contents.is_empty())
+            .count();
+        let span_total: usize = self.chains.iter().map(|c| c.spans.len()).sum();
+        let span_cap: usize = self.chains.iter().map(|c| c.spans.capacity()).sum();
+        let content_cap: usize = self.chains.iter().map(|c| c.contents.capacity()).sum();
+        let child_total: usize = self.chains.iter().map(|c| c.children.len()).sum();
+        let intern_sets: usize = self.interner.table.values().map(|v| v.len()).sum();
+        let key_total: usize = self
+            .slots
+            .iter()
+            .filter_map(|s| s.state.as_ref())
+            .map(|s| s.keys.len())
+            .sum();
+        let key_cap: usize = self
+            .slots
+            .iter()
+            .filter_map(|s| s.state.as_ref())
+            .map(|s| s.keys.capacity())
+            .sum();
+        format!(
+            "chains {} (vec {}, free {}) contents_cap {} spans {} (cap {}) children {} roots {} intern {} ({} sets) slots {} keys {} (cap {})",
+            live_chains,
+            self.chains.len(),
+            self.free_chains.len(),
+            content_cap,
+            span_total,
+            span_cap,
+            child_total,
+            self.roots.len(),
+            self.interner.table.len(),
+            intern_sets,
+            self.slots.len(),
+            key_total,
+            key_cap,
+        )
+    }
+
+    // ---- verification ----
+
+    pub fn audit(&self) -> Result<(), String> {
+        use std::collections::HashSet;
+        // Slot/name/free coherence (same rules as the flat core).
+        let mut live = 0u64;
+        for (idx, slot) in self.slots.iter().enumerate() {
+            if let Some(state) = &slot.state {
+                live += 1;
+                if self.by_name.get(&state.name) != Some(&(idx as u32)) {
+                    return Err(format!("by_name incoherent for {}", state.name));
+                }
+            }
+        }
+        if self.by_name.len() as u64 != live {
+            return Err("by_name size mismatch".into());
+        }
+        let mut freed = HashSet::new();
+        for &f in &self.free {
+            if self.slots[f as usize].state.is_some() || !freed.insert(f) {
+                return Err(format!("free-list bad entry {f}"));
+            }
+        }
+        // Chains: shape, spans normalized, children sorted+linked.
+        let mut live_chains = HashSet::new();
+        // Reject a double-freed chain index (mirrors the `free` list
+        // check above): a duplicate would let two logical chains later
+        // alias one physical `ChainData` -> silently wrong overlaps.
+        let mut freed_chains = HashSet::new();
+        for &fc in &self.free_chains {
+            if !freed_chains.insert(fc) {
+                return Err(format!("free-chains duplicate entry {fc} (double free)"));
+            }
+        }
+        for (ci, cd) in self.chains.iter().enumerate() {
+            let ci = ci as u32;
+            if freed_chains.contains(&ci) {
+                if !cd.contents.is_empty() {
+                    return Err(format!("freed chain {ci} not empty"));
+                }
+                continue;
+            }
+            if cd.contents.is_empty() {
+                // Never-allocated default slots only exist as freed.
+                return Err(format!("live chain {ci} is empty"));
+            }
+            live_chains.insert(ci);
+            let mut prev_end = cd.base_pos;
+            let mut prev_set: Option<&SetRef> = None;
+            for s in &cd.spans {
+                if s.len == 0 || s.holders.is_empty() {
+                    return Err(format!("chain {ci} empty span"));
+                }
+                if s.start < prev_end && prev_set.is_some() {
+                    return Err(format!("chain {ci} overlapping spans"));
+                }
+                if s.start < cd.base_pos || s.start + s.len > cd.end_pos() {
+                    return Err(format!("chain {ci} span out of bounds"));
+                }
+                if let Some(ps) = prev_set {
+                    if s.start == prev_end && std::sync::Arc::ptr_eq(ps, &s.holders) {
+                        return Err(format!("chain {ci} non-maximal adjacent spans"));
+                    }
+                }
+                let mut ph = None;
+                for &h in s.holders.iter() {
+                    if ph.is_some_and(|p: u32| p >= h) {
+                        return Err(format!("chain {ci} unsorted span holders"));
+                    }
+                    ph = Some(h);
+                    if self
+                        .slots
+                        .get(h as usize)
+                        .and_then(|s| s.state.as_ref())
+                        .is_none()
+                    {
+                        return Err(format!("chain {ci} span holds retired holder {h}"));
+                    }
+                }
+                prev_end = s.start + s.len;
+                prev_set = Some(&s.holders);
+            }
+            let mut prev_child = None;
+            for &(fp, c, child) in &cd.children {
+                if prev_child.is_some_and(|p| p >= (fp, c)) {
+                    return Err(format!("chain {ci} unsorted children"));
+                }
+                prev_child = Some((fp, c));
+                if fp < cd.base_pos || fp >= cd.end_pos() {
+                    return Err(format!("chain {ci} child fork out of bounds"));
+                }
+                let ch = &self.chains[child as usize];
+                if ch.parent != Some((ci, fp)) || ch.base_pos != fp + 1 {
+                    return Err(format!("chain {ci} child {child} link broken"));
+                }
+            }
+            match cd.parent {
+                None => {
+                    let listed = self
+                        .roots
+                        .get(&cd.start_lineage)
+                        .is_some_and(|l| l.contains(&ci));
+                    if cd.base_pos != 0 || !listed {
+                        return Err(format!("root chain {ci} unindexed"));
+                    }
+                }
+                Some((p, fp)) => {
+                    let pd = &self.chains[p as usize];
+                    if pd.child_at(fp, cd.contents[0]) != Some(ci) {
+                        return Err(format!("chain {ci} not in parent's children"));
+                    }
+                }
+            }
+            // start/end lineage coherence.
+            let mut l = cd.start_lineage;
+            for i in 1..cd.contents.len() {
+                l = lineage_step(l, cd.contents[i]);
+            }
+            if l != cd.end_lineage {
+                return Err(format!("chain {ci} end_lineage stale"));
+            }
+        }
+        for (&l, list) in &self.roots {
+            if list.is_empty() {
+                return Err(format!("roots entry {l:#x} empty list"));
+            }
+            let mut contents_seen = HashSet::new();
+            for &c in list {
+                let cd = &self.chains[c as usize];
+                if cd.parent.is_some() || cd.start_lineage != l || freed_chains.contains(&c) {
+                    return Err(format!("roots entry {l:#x} bad chain {c}"));
+                }
+                if !contents_seen.insert(cd.contents[0]) {
+                    return Err(format!("roots entry {l:#x} duplicate first content"));
+                }
+            }
+        }
+        // Key maps <-> coverage; counters. The holder->chains index is
+        // EXACT: it lists a chain iff the holder covers a span there.
+        let mut blocks = 0u64;
+        // One reusable scratch set for the whole audit: `audit()` runs
+        // per op under the fuzz, so per-holder set construction would
+        // dominate its debug-build cost.
+        let mut seen_chains: HashSet<u32> = HashSet::new();
+        for (idx, slot) in self.slots.iter().enumerate() {
+            let Some(state) = &slot.state else { continue };
+            blocks += state.keys.len() as u64;
+            // `chains ⊇ covered` plus equal cardinality is set equality.
+            seen_chains.clear();
+            for &(c, _) in state.keys.values() {
+                if !state.chains.contains(&c) {
+                    return Err(format!(
+                        "holder {idx} covers chain {c} but its chains index does not list it"
+                    ));
+                }
+                seen_chains.insert(c);
+            }
+            if state.chains.len() != seen_chains.len() {
+                return Err(format!(
+                    "holder {idx} chains index lists {} chains but the holder covers {}",
+                    state.chains.len(),
+                    seen_chains.len()
+                ));
+            }
+            for (&k, &(c, p)) in &state.keys {
+                if !live_chains.contains(&c) {
+                    return Err(format!("holder {idx} key {k:#x} points at dead chain {c}"));
+                }
+                let cd = &self.chains[c as usize];
+                if p < cd.base_pos || p >= cd.end_pos() {
+                    return Err(format!("holder {idx} key {k:#x} position out of bounds"));
+                }
+                if !cd.covered(p, idx as u32) {
+                    return Err(format!("holder {idx} key {k:#x} not covered by spans"));
+                }
+            }
+        }
+        if blocks != self.holder_blocks_total {
+            return Err(format!(
+                "holder_blocks_total {} != recount {blocks}",
+                self.holder_blocks_total
+            ));
+        }
+        // Reverse: every covered (position, holder) is backed by at
+        // least one key in that holder's map (keys are per-holder;
+        // build the reverse view once).
+        let mut reverse: HashSet<(u32, u32, u32)> = HashSet::new();
+        for (idx, slot) in self.slots.iter().enumerate() {
+            if let Some(state) = &slot.state {
+                for &(c, p) in state.keys.values() {
+                    reverse.insert((idx as u32, c, p));
+                }
+            }
+        }
+        for &ci in &live_chains {
+            let cd = &self.chains[ci as usize];
+            for s in &cd.spans {
+                for pos in s.start..s.start + s.len {
+                    for &h in s.holders.iter() {
+                        if !reverse.contains(&(h, ci, pos)) {
+                            return Err(format!(
+                                "span coverage (chain {ci}, pos {pos}, holder {h}) has no key map entry"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        // GC coherence: a live chain must be referenced by spans,
+        // children, or at least one key map (otherwise the GC missed
+        // it — the leak class the churn gate caught).
+        let mut key_ref_chains: HashSet<u32> = HashSet::new();
+        for slot in &self.slots {
+            if let Some(state) = &slot.state {
+                for &(c, _) in state.keys.values() {
+                    key_ref_chains.insert(c);
+                }
+            }
+        }
+        for &ci in &live_chains {
+            let cd = &self.chains[ci as usize];
+            if cd.spans.is_empty() && cd.children.is_empty() && !key_ref_chains.contains(&ci) {
+                return Err(format!("live chain {ci} is orphaned (GC leak)"));
+            }
+        }
+        let mut distinct = 0u64;
+        for &ci in &live_chains {
+            for s in &self.chains[ci as usize].spans {
+                distinct += s.len as u64;
+            }
+        }
+        if distinct != self.distinct_entries {
+            return Err(format!(
+                "distinct_entries {} != recount {distinct}",
+                self.distinct_entries
+            ));
+        }
+        // Interner: no orphaned sets. A set the table still holds but no
+        // live span references (strong_count == 1 — only the table) is a
+        // leak; the release path is meant to drop it once the last
+        // membership reference goes (mirrors FlatTree::audit's detector).
+        for bucket in self.interner.table.values() {
+            for set in bucket {
+                if std::sync::Arc::strong_count(set) == 1 {
+                    return Err(format!(
+                        "interner orphan: set {:?} held only by the table (leak)",
+                        set.as_ref()
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+enum PosSet {
+    Empty,
+    Set(SetRef),
+}
+
+enum Placed {
+    Applied,
+    Duplicate,
+}
+
+fn push_answer3(slots: &[Slot3], holder: u32, depth: u32, out: &mut Vec<Overlap>) {
+    if depth == 0 {
+        return;
+    }
+    let slot = &slots[holder as usize];
+    let Some(state) = slot.state.as_ref() else {
+        return;
+    };
+    out.push(Overlap {
+        holder: HolderId::assemble(holder, slot.generation),
+        depth,
+        total_blocks: state.keys.len() as u64,
+    });
+}
+
+#[cfg(test)]
+mod audit_tests {
+    use super::*;
+    use crate::Config;
+
+    /// The strengthened audit must reject a double-freed chain index — a
+    /// duplicate in `free_chains` would let two logical chains later alias
+    /// one physical `ChainData`, silently corrupting overlap answers.
+    #[test]
+    fn audit_rejects_a_double_freed_chain() {
+        let mut t = RadixTree::new(Config::default());
+        let h = t.create_holder("w1");
+        t.store(h, None, &[(1, 10), (2, 20)]).expect("store");
+        t.clear(h); // frees the chain(s)
+        t.audit().expect("a cleared tree is valid");
+        assert!(!t.free_chains.is_empty(), "clear frees the chain");
+
+        let dup = t.free_chains[0];
+        t.free_chains.push(dup);
+        let err = t.audit().expect_err("a double free must be caught");
+        assert!(err.contains("double free"), "unexpected audit error: {err}");
+    }
+
+    /// The strengthened audit must reject an interner set held only by the
+    /// table (strong_count 1) — the leak class the release path can strand.
+    #[test]
+    fn audit_rejects_an_interner_orphan() {
+        let mut t = RadixTree::new(Config::default());
+        let h = t.create_holder("w1");
+        t.store(h, None, &[(1, 10)]).expect("store");
+        t.audit().expect("a fresh tree is valid");
+
+        // An Arc no live span references — only the table holds it.
+        let orphan: std::sync::Arc<[u32]> = std::sync::Arc::from([99u32].as_slice());
+        t.interner.table.entry(0xDEAD).or_default().push(orphan);
+        let err = t.audit().expect_err("an interner orphan must be caught");
+        assert!(err.contains("orphan"), "unexpected audit error: {err}");
+    }
+}

--- a/crates/radix_tree/src/lib.rs
+++ b/crates/radix_tree/src/lib.rs
@@ -1,0 +1,1247 @@
+//! Generic prefix-membership index.
+//!
+//! The referee lives in `tests/differential.rs` (every
+//! implementation must equal the reference model there, always). Two
+//! cores share the contract:
+//! [`RadixTree`] (the chain-native primary, `chain.rs`) and
+//! [`FlatTree`] (below in this file) — a flat positional entry map
+//! keyed by `(position, content)` with lineage-disambiguated
+//! membership and an internal per-holder registry;
+//! order-insensitive set semantics make convergence hold by
+//! construction. Both are single-writer: no locks, no atomics, no
+//! shards (§8).
+
+#![forbid(unsafe_code)]
+
+mod chain;
+/// The chain-native core is the crate's primary type: chains stored
+/// as contiguous data shared by every holder, membership as maximal
+/// runs over interned holder sets, one entry probe per query. The
+/// flat core remains as [`FlatTree`] — a second, independently
+/// verified implementation the dual-core harness keeps asserting
+/// against the model.
+pub use chain::RadixTree;
+use rustc_hash::FxHashMap;
+
+/// Position-independent content identity (the matching currency).
+pub type ContentHash = u64;
+/// The publisher's removal key (backend block hash / placement chain
+/// hash). Opaque to matching.
+pub type BlockKey = u64;
+
+/// Generational holder id (§5): operations through a retired id fail
+/// loudly, never alias a recycled slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HolderId {
+    index: u32,
+    generation: u64,
+}
+
+impl HolderId {
+    /// Raw (index, generation) — for callers keeping side tables
+    /// keyed by holder. Stale ids stay detectable through the
+    /// generation.
+    pub fn parts(self) -> (u32, u64) {
+        (self.index, self.generation)
+    }
+
+    pub(crate) fn assemble(index: u32, generation: u64) -> Self {
+        Self { index, generation }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Hard bound on chain length; a store extending past it is
+    /// rejected whole (`StoreError::ChainTooLong`).
+    pub max_chain_len: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            max_chain_len: 65_536,
+        }
+    }
+}
+
+/// Advisory (§4): outside the convergence contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StoreOutcome {
+    pub applied: u32,
+    pub duplicates: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreError {
+    /// Unknown or stale-generation holder id.
+    UnknownHolder,
+    /// Parent key not registered; the ONLY error whose sanctioned
+    /// recovery is re-anchoring at position 0 (§4).
+    ParentNotFound,
+    /// Batch would extend past `max_chain_len`; terminal, do not
+    /// re-anchor.
+    ChainTooLong,
+}
+
+/// One query answer row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Overlap {
+    pub holder: HolderId,
+    pub depth: u32,
+    pub total_blocks: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Stats {
+    pub holders: u64,
+    /// Sum of per-holder block counts (capacity arithmetic).
+    pub holder_blocks: u64,
+    /// Unique (position, content, lineage) memberships-bearing
+    /// entries — the oracle-parity metric (§4).
+    pub distinct_entries: u64,
+    /// Rough resident estimate; drift-tolerant, monotone with state.
+    pub bytes_estimate: u64,
+}
+
+/// A block's placement inside its holder: position, content, and the
+/// lineage fingerprint of the chain prefix it was stored under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BlockInfo {
+    pos: u32,
+    content: ContentHash,
+    lineage: u64,
+}
+
+#[derive(Debug, Default)]
+struct HolderState {
+    name: String,
+    /// BlockKey -> placement. Internal — never caller-owned (§4).
+    /// Deliberately the ONLY per-block holder structure: position
+    /// order (truncate_tail/enumerate — cold capacity/snapshot
+    /// paths) is derived from it on demand, costing those calls an
+    /// O(n log n) scan instead of costing every block 16 resident
+    /// bytes of standing order log.
+    registry: FxHashMap<BlockKey, BlockInfo>,
+}
+
+impl HolderState {
+    /// (position, key) pairs in ascending order, derived on demand.
+    fn ordered(&self) -> Vec<(u32, BlockKey)> {
+        let mut v: Vec<(u32, BlockKey)> = self.registry.iter().map(|(&k, i)| (i.pos, k)).collect();
+        v.sort_unstable();
+        v
+    }
+}
+
+#[derive(Debug)]
+struct HolderSlot {
+    generation: u64,
+    /// `None` = retired slot awaiting reuse.
+    state: Option<HolderState>,
+}
+
+/// Lineage fingerprint chain: an INTERNAL rolling 64-bit mix — not
+/// the wire hash scheme (the crate is hash-agnostic, §2).
+#[inline]
+fn lineage_root(content: ContentHash) -> u64 {
+    splitmix(0xA0761D6478BD642F ^ content)
+}
+
+#[inline]
+fn lineage_step(prev: u64, content: ContentHash) -> u64 {
+    splitmix(prev.rotate_left(23) ^ content.wrapping_mul(0x9E3779B97F4A7C15))
+}
+
+#[inline]
+fn splitmix(mut z: u64) -> u64 {
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+    z ^ (z >> 31)
+}
+
+/// Interned, immutable, sorted holder set. Consecutive positions of a
+/// shared chain hold IDENTICAL sets; hash-consing them means (a) the
+/// query walk proves "membership unchanged since the previous
+/// position" by POINTER EQUALITY — a sound O(1) run-skip, unlike the
+/// oracle's count heuristic — and (b) the per-position duplication of
+/// holder arrays collapses to one allocation per distinct set (the
+/// run-compression memory win, without a linked tree).
+type SetRef = std::sync::Arc<[u32]>;
+
+#[derive(Debug, Default)]
+struct SetInterner {
+    /// set-content hash -> interned sets with that hash.
+    table: FxHashMap<u64, Vec<SetRef>>,
+}
+
+impl SetInterner {
+    fn hash_of(set: &[u32]) -> u64 {
+        let mut h = 0x51_7C_C1_B7_27_22_0A_95u64 ^ (set.len() as u64);
+        for &x in set {
+            h = splitmix(h ^ (x as u64).wrapping_mul(0x9E3779B97F4A7C15));
+        }
+        h
+    }
+
+    /// Intern a sorted holder array (consumes the scratch build).
+    fn intern(&mut self, set: &[u32]) -> SetRef {
+        // Empty sets are transient placeholders — a caller shrinking a
+        // span to zero holders immediately converts it to `PosSet::Empty`
+        // and drops this ref without `release`. Tabling it would strand
+        // it there forever (strong_count 1), so keep empties out of the
+        // table; no live span ever holds one.
+        if set.is_empty() {
+            return set.into();
+        }
+        let h = Self::hash_of(set);
+        let bucket = self.table.entry(h).or_default();
+        for existing in bucket.iter() {
+            if existing.as_ref() == set {
+                return existing.clone();
+            }
+        }
+        let arc: SetRef = set.into();
+        bucket.push(arc.clone());
+        arc
+    }
+
+    /// Release a reference that a membership is dropping. When only
+    /// the table still holds the set, it is removed (single-writer,
+    /// so the count is exact here).
+    fn release(&mut self, set: SetRef) {
+        let h = Self::hash_of(&set);
+        // The caller's clone + the table's = 2 when orphaned.
+        if std::sync::Arc::strong_count(&set) == 2 {
+            if let Some(bucket) = self.table.get_mut(&h) {
+                bucket.retain(|s| !std::sync::Arc::ptr_eq(s, &set));
+                if bucket.is_empty() {
+                    self.table.remove(&h);
+                }
+            }
+        }
+    }
+}
+
+/// Membership at one (position, content) entry, lineage-disambiguated.
+/// The common case — one holder, one lineage — is inline and
+/// allocation-free (§9). Shared entries hold one dense sorted holder
+/// array per lineage: 4 B/holder, slice-comparable, streamed by the
+/// query merge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Membership {
+    One {
+        lineage: u64,
+        holder: u32,
+    },
+    /// Buckets sorted by lineage; holders are interned sorted sets.
+    Many(Vec<(u64, SetRef)>),
+}
+
+/// What [`Membership::insert`] did — drives both counter maintenance
+/// and the out-of-contract same-triple dedup in `store`.
+#[derive(PartialEq, Eq)]
+enum Inserted {
+    /// The (lineage, holder) pair was already present: the holder
+    /// already holds a block at this exact (position, content,
+    /// lineage) under a DIFFERENT key. Out-of-contract; the caller
+    /// treats it as a duplicate and does not register the new key.
+    Existing,
+    AddedToExistingLineage,
+    AddedNewLineage,
+}
+
+impl Membership {
+    fn insert(&mut self, lineage: u64, holder: u32, interner: &mut SetInterner) -> Inserted {
+        match self {
+            Membership::One {
+                lineage: l,
+                holder: h,
+            } => {
+                if *l == lineage && *h == holder {
+                    Inserted::Existing
+                } else if *l == lineage {
+                    let set = if *h < holder {
+                        [*h, holder]
+                    } else {
+                        [holder, *h]
+                    };
+                    *self = Membership::Many(vec![(lineage, interner.intern(&set))]);
+                    Inserted::AddedToExistingLineage
+                } else {
+                    let mut buckets = vec![(*l, interner.intern(&[*h]))];
+                    let pos = usize::from(*l < lineage);
+                    buckets.insert(pos, (lineage, interner.intern(&[holder])));
+                    *self = Membership::Many(buckets);
+                    Inserted::AddedNewLineage
+                }
+            }
+            Membership::Many(buckets) => {
+                match buckets.binary_search_by_key(&lineage, |&(l, _)| l) {
+                    Ok(bi) => {
+                        let set = &buckets[bi].1;
+                        match set.binary_search(&holder) {
+                            Ok(_) => Inserted::Existing,
+                            Err(at) => {
+                                let mut grown = Vec::with_capacity(set.len() + 1);
+                                grown.extend_from_slice(&set[..at]);
+                                grown.push(holder);
+                                grown.extend_from_slice(&set[at..]);
+                                let old =
+                                    std::mem::replace(&mut buckets[bi].1, interner.intern(&grown));
+                                interner.release(old);
+                                Inserted::AddedToExistingLineage
+                            }
+                        }
+                    }
+                    Err(bi) => {
+                        buckets.insert(bi, (lineage, interner.intern(&[holder])));
+                        Inserted::AddedNewLineage
+                    }
+                }
+            }
+        }
+    }
+
+    /// Remove; true when the whole membership is now empty.
+    fn remove(&mut self, lineage: u64, holder: u32, interner: &mut SetInterner) -> bool {
+        match self {
+            Membership::One {
+                lineage: l,
+                holder: h,
+            } => *l == lineage && *h == holder,
+            Membership::Many(buckets) => {
+                if let Ok(bi) = buckets.binary_search_by_key(&lineage, |&(l, _)| l) {
+                    let set = &buckets[bi].1;
+                    if let Ok(at) = set.binary_search(&holder) {
+                        if set.len() == 1 {
+                            let (_, old) = buckets.remove(bi);
+                            interner.release(old);
+                        } else {
+                            let mut shrunk = Vec::with_capacity(set.len() - 1);
+                            shrunk.extend_from_slice(&set[..at]);
+                            shrunk.extend_from_slice(&set[at + 1..]);
+                            let old =
+                                std::mem::replace(&mut buckets[bi].1, interner.intern(&shrunk));
+                            interner.release(old);
+                        }
+                    }
+                }
+                if buckets.is_empty() {
+                    return true;
+                }
+                // Collapse back to the inline variant once a single
+                // (lineage, holder) survives: shared prefixes decay to one
+                // holder as workers evict, and leaving the entry `Many`
+                // would keep a bucket Vec plus an interned length-1 set
+                // alive per decayed entry — the B/block figure would then
+                // drift upward over a long-lived index instead of
+                // tracking live sharing.
+                if buckets.len() == 1 && buckets[0].1.len() == 1 {
+                    let (lineage, set) = buckets.pop().expect("one bucket");
+                    let holder = set[0];
+                    interner.release(set);
+                    *self = Membership::One { lineage, holder };
+                }
+                false
+            }
+        }
+    }
+
+    /// Is this exact (lineage, holder) pair present?
+    fn contains(&self, lineage: u64, holder: u32) -> bool {
+        match self {
+            Membership::One {
+                lineage: l,
+                holder: h,
+            } => *l == lineage && *h == holder,
+            Membership::Many(buckets) => buckets
+                .binary_search_by_key(&lineage, |&(l, _)| l)
+                .is_ok_and(|bi| buckets[bi].1.binary_search(&holder).is_ok()),
+        }
+    }
+
+    /// Does any OTHER holder share (lineage) here?
+    fn lineage_shared_beyond(&self, lineage: u64, holder: u32) -> bool {
+        match self {
+            Membership::One {
+                lineage: l,
+                holder: h,
+            } => *l == lineage && *h != holder,
+            Membership::Many(buckets) => {
+                match buckets.binary_search_by_key(&lineage, |&(l, _)| l) {
+                    Ok(bi) => buckets[bi].1.iter().any(|&h| h != holder),
+                    Err(_) => false,
+                }
+            }
+        }
+    }
+}
+
+/// Caller-owned query scratch: keeps [`RadixTree::overlap`]
+/// allocation-free once warm while the tree itself stays `&self` on
+/// the read path (§8). ([`FlatTree::overlap`] reuses the holder
+/// buffers but still allocates its probe list per query — its probes
+/// borrow the tree's interned runs, which no plain scratch can hold;
+/// the flat core is the reference, not the service's hot path.)
+#[derive(Debug, Default)]
+pub struct OverlapScratch {
+    active: Vec<u32>,
+    next: Vec<u32>,
+    lineages: Vec<u64>,
+    /// Chain core: the matched path as (chain, from, to) segments.
+    segments: Vec<(u32, u32, u32)>,
+}
+
+pub struct FlatTree {
+    cfg: Config,
+    entries: FxHashMap<(u32, ContentHash), Membership>,
+    slots: Vec<HolderSlot>,
+    by_name: FxHashMap<String, u32>,
+    free: Vec<u32>,
+    holder_blocks_total: u64,
+    distinct_lineage_entries: u64,
+    interner: SetInterner,
+}
+
+impl FlatTree {
+    pub fn new(cfg: Config) -> Self {
+        Self {
+            cfg,
+            entries: FxHashMap::default(),
+            slots: Vec::new(),
+            by_name: FxHashMap::default(),
+            free: Vec::new(),
+            holder_blocks_total: 0,
+            distinct_lineage_entries: 0,
+            interner: SetInterner::default(),
+        }
+    }
+
+    // ---- holder lifecycle (§5) ----
+
+    /// Create (or return the live holder of this name). Recycles
+    /// retired slots; the returned id's generation detects staleness.
+    pub fn create_holder(&mut self, name: &str) -> HolderId {
+        if let Some(&index) = self.by_name.get(name) {
+            return HolderId {
+                index,
+                generation: self.slots[index as usize].generation,
+            };
+        }
+        let state = HolderState {
+            name: name.to_string(),
+            ..HolderState::default()
+        };
+        let index = if let Some(index) = self.free.pop() {
+            let slot = &mut self.slots[index as usize];
+            slot.state = Some(state);
+            index
+        } else {
+            assert!(
+                self.slots.len() < u32::MAX as usize,
+                "holder slot space exhausted (u32 indices)"
+            );
+            self.slots.push(HolderSlot {
+                generation: 0,
+                state: Some(state),
+            });
+            (self.slots.len() - 1) as u32
+        };
+        self.by_name.insert(name.to_string(), index);
+        HolderId {
+            index,
+            generation: self.slots[index as usize].generation,
+        }
+    }
+
+    pub fn holder_name(&self, id: HolderId) -> Option<&str> {
+        self.live(id).map(|s| s.name.as_str())
+    }
+
+    /// Release every byte attributable to the holder; the id becomes
+    /// stale (generation bumped) and the slot reusable.
+    pub fn retire_holder(&mut self, id: HolderId) {
+        if self.live(id).is_none() {
+            return;
+        }
+        self.clear(id);
+        let slot = &mut self.slots[id.index as usize];
+        let state = slot.state.take().expect("checked live");
+        self.by_name.remove(&state.name);
+        slot.generation = slot.generation.wrapping_add(1);
+        self.free.push(id.index);
+    }
+
+    /// O(1).
+    pub fn holder_blocks(&self, id: HolderId) -> u64 {
+        self.live(id).map_or(0, |s| s.registry.len() as u64)
+    }
+
+    /// Read-only: the position at which `holder` holds `key` (see
+    /// `RadixTree::position_of`).
+    pub fn position_of(&self, id: HolderId, key: BlockKey) -> Option<u32> {
+        self.live(id)?.registry.get(&key).map(|info| info.pos)
+    }
+
+    // ---- writes (§4) ----
+
+    /// All-or-nothing on error; see `StoreError` for the recovery
+    /// contract per variant.
+    pub fn store(
+        &mut self,
+        id: HolderId,
+        parent: Option<BlockKey>,
+        blocks: &[(BlockKey, ContentHash)],
+    ) -> Result<StoreOutcome, StoreError> {
+        if self.live(id).is_none() {
+            return Err(StoreError::UnknownHolder);
+        }
+        if blocks.is_empty() {
+            return Ok(StoreOutcome {
+                applied: 0,
+                duplicates: 0,
+            });
+        }
+        let state = self.slots[id.index as usize]
+            .state
+            .as_ref()
+            .expect("checked live");
+        // Resolve the anchor BEFORE any mutation (all-or-nothing).
+        let (start_pos, mut lineage_prev) = match parent {
+            Some(parent_key) => match state.registry.get(&parent_key) {
+                None => return Err(StoreError::ParentNotFound),
+                Some(info) => (info.pos + 1, Some(info.lineage)),
+            },
+            None => {
+                // Re-publish dedup: a parent-None batch whose first
+                // key already anchors a chain at position 0 extends
+                // that chain (the model's rule; in-contract the fresh
+                // lineage recomputation matches the stored one).
+                (0, None)
+            }
+        };
+        if start_pos as u64 + blocks.len() as u64 > self.cfg.max_chain_len as u64 {
+            return Err(StoreError::ChainTooLong);
+        }
+
+        let mut applied = 0u32;
+        let mut duplicates = 0u32;
+        for (i, &(key, content)) in blocks.iter().enumerate() {
+            let pos = start_pos + i as u32;
+            let lineage = match lineage_prev {
+                None => lineage_root(content),
+                Some(prev) => lineage_step(prev, content),
+            };
+            lineage_prev = Some(lineage);
+            let info = BlockInfo {
+                pos,
+                content,
+                lineage,
+            };
+            let state = self.slots[id.index as usize]
+                .state
+                .as_mut()
+                .expect("checked live");
+            match state.registry.get(&key) {
+                Some(existing) if *existing == info => {
+                    duplicates += 1;
+                    continue;
+                }
+                _ => {}
+            }
+            // §4 alias pre-check, BEFORE any mutation: if the holder
+            // already holds this exact (position, content, lineage)
+            // under another key, the store is a duplicate — and a
+            // would-be MOVE is refused NON-destructively (the old
+            // placement stays; review finding: the earlier order
+            // unindexed first and destroyed a block while reporting
+            // a no-op).
+            let dest_taken = self
+                .entries
+                .get(&(info.pos, info.content))
+                .is_some_and(|m| m.contains(info.lineage, id.index));
+            if dest_taken {
+                duplicates += 1;
+                continue;
+            }
+            if let Some(&existing) = self.slots[id.index as usize]
+                .state
+                .as_ref()
+                .expect("checked live")
+                .registry
+                .get(&key)
+            {
+                // §4: re-registration MOVES the block.
+                Self::unindex(
+                    &mut self.entries,
+                    &mut self.interner,
+                    &mut self.distinct_lineage_entries,
+                    id.index,
+                    existing,
+                );
+                self.slots[id.index as usize]
+                    .state
+                    .as_mut()
+                    .expect("checked live")
+                    .registry
+                    .remove(&key);
+                self.holder_blocks_total -= 1;
+            }
+            let inserted = self.index_block(id.index, info);
+            debug_assert!(inserted, "alias pre-check guarantees insertion");
+            let state = self.slots[id.index as usize]
+                .state
+                .as_mut()
+                .expect("checked live");
+            state.registry.insert(key, info);
+            self.holder_blocks_total += 1;
+            applied += 1;
+        }
+        Ok(StoreOutcome {
+            applied,
+            duplicates,
+        })
+    }
+
+    /// Read-only no-op predicate: true iff `store(id, parent, blocks)`
+    /// would apply nothing (see `RadixTree::covered` — same contract,
+    /// gated against the model by the same fuzz assertions).
+    pub fn covered(
+        &self,
+        id: HolderId,
+        parent: Option<BlockKey>,
+        blocks: &[(BlockKey, ContentHash)],
+    ) -> bool {
+        self.dup_prefix(id, parent, blocks).1
+    }
+
+    /// See `RadixTree::dup_prefix` — same contract, gated against the
+    /// model by the same fuzz assertions.
+    pub fn dup_prefix(
+        &self,
+        id: HolderId,
+        parent: Option<BlockKey>,
+        blocks: &[(BlockKey, ContentHash)],
+    ) -> (u32, bool) {
+        if self.live(id).is_none() {
+            return (0, false);
+        }
+        if blocks.is_empty() {
+            return (0, true);
+        }
+        let state = self.slots[id.index as usize]
+            .state
+            .as_ref()
+            .expect("checked live");
+        let (start_pos, mut lineage_prev) = match parent {
+            Some(parent_key) => match state.registry.get(&parent_key) {
+                None => return (0, false),
+                Some(info) => (info.pos + 1, Some(info.lineage)),
+            },
+            None => (0, None),
+        };
+        if start_pos as u64 + blocks.len() as u64 > self.cfg.max_chain_len as u64 {
+            return (0, false);
+        }
+        let mut run = 0u32;
+        let mut run_live = true;
+        for (i, &(key, content)) in blocks.iter().enumerate() {
+            let pos = start_pos + i as u32;
+            let lineage = match lineage_prev {
+                None => lineage_root(content),
+                Some(prev) => lineage_step(prev, content),
+            };
+            lineage_prev = Some(lineage);
+            let info = BlockInfo {
+                pos,
+                content,
+                lineage,
+            };
+            let plain = state.registry.get(&key) == Some(&info);
+            let held = plain
+                || self
+                    .entries
+                    .get(&(info.pos, info.content))
+                    .is_some_and(|m| m.contains(info.lineage, id.index));
+            if !held {
+                return (run, false);
+            }
+            if run_live {
+                if plain {
+                    run += 1;
+                } else {
+                    run_live = false;
+                }
+            }
+        }
+        (run, true)
+    }
+
+    /// Idempotent; returns blocks actually removed (advisory).
+    pub fn remove(&mut self, id: HolderId, keys: &[BlockKey]) -> u32 {
+        if self.live(id).is_none() {
+            return 0;
+        }
+        let mut removed = 0u32;
+        for &key in keys {
+            let state = self.slots[id.index as usize]
+                .state
+                .as_mut()
+                .expect("checked live");
+            let Some(info) = state.registry.remove(&key) else {
+                continue;
+            };
+            self.holder_blocks_total -= 1;
+            Self::unindex(
+                &mut self.entries,
+                &mut self.interner,
+                &mut self.distinct_lineage_entries,
+                id.index,
+                info,
+            );
+            removed += 1;
+        }
+        removed
+    }
+
+    /// Forest-wide prefix-closed eviction (§4): drop blocks in
+    /// strictly decreasing position order, ties by key, until `keep`
+    /// remain. Returns dropped count.
+    pub fn truncate_tail(&mut self, id: HolderId, keep: u64) -> u64 {
+        if self.live(id).is_none() {
+            return 0;
+        }
+        let state = self.slots[id.index as usize]
+            .state
+            .as_mut()
+            .expect("checked live");
+        if state.registry.len() as u64 <= keep {
+            return 0;
+        }
+        let mut ordered = state.ordered();
+        let mut dropped = 0u64;
+        while ordered.len() as u64 > keep {
+            let (pos, key) = ordered.pop().expect("non-empty");
+            let state = self.slots[id.index as usize]
+                .state
+                .as_mut()
+                .expect("checked live");
+            let info = state.registry.remove(&key).expect("derived from registry");
+            debug_assert_eq!(info.pos, pos);
+            self.holder_blocks_total -= 1;
+            Self::unindex(
+                &mut self.entries,
+                &mut self.interner,
+                &mut self.distinct_lineage_entries,
+                id.index,
+                info,
+            );
+            dropped += 1;
+        }
+        dropped
+    }
+
+    /// Drop all blocks; the holder (id, name, epoch posture at the
+    /// caller) survives — this is the epoch-bump primitive (§2).
+    pub fn clear(&mut self, id: HolderId) {
+        if self.live(id).is_none() {
+            return;
+        }
+        let state = self.slots[id.index as usize]
+            .state
+            .as_mut()
+            .expect("checked live");
+        let registry = std::mem::take(&mut state.registry);
+        self.holder_blocks_total -= registry.len() as u64;
+        for (_, info) in registry {
+            Self::unindex(
+                &mut self.entries,
+                &mut self.interner,
+                &mut self.distinct_lineage_entries,
+                id.index,
+                info,
+            );
+        }
+    }
+
+    // ---- reads ----
+
+    /// §6 exact overlap: lineage-true consecutive depth per holder.
+    /// `out` is cleared and filled (holders at depth 0 absent).
+    ///
+    /// Two-phase walk: probing each position's entry has no data
+    /// dependency on its neighbors (lineages are a pure rolling
+    /// function of the QUERY), so phase 1 issues all map probes
+    /// back-to-back — the CPU overlaps their cache misses — and only
+    /// phase 2's cheap merge is sequential. This is what makes exact
+    /// matching latency-competitive without the oracle's unsound
+    /// skip heuristics.
+    pub fn overlap(
+        &self,
+        chain: &[ContentHash],
+        scratch: &mut OverlapScratch,
+        out: &mut Vec<Overlap>,
+    ) {
+        out.clear();
+        if chain.is_empty() {
+            return;
+        }
+        // Phase 0: lineages up front.
+        let lineages = &mut scratch.lineages;
+        lineages.clear();
+        let mut lineage = 0u64;
+        for (p, &content) in chain.iter().enumerate() {
+            lineage = if p == 0 {
+                lineage_root(content)
+            } else {
+                lineage_step(lineage, content)
+            };
+            lineages.push(lineage);
+        }
+        // Phase 1: independent probes resolving each position's
+        // dense holder run, endpoints touched so the run data rides
+        // the same overlapped misses. Stops at the first absent
+        // entry (no deeper position can matter).
+        enum RunProbe<'a> {
+            One(u32),
+            Slice(&'a [u32]),
+            Miss,
+        }
+        // The probe list borrows the tree's interned runs, so it cannot
+        // live in the caller's `OverlapScratch`; this is the flat core's
+        // one per-query allocation (see `OverlapScratch`). Capped: the
+        // walk breaks at the first miss, so a full-length hint would
+        // charge every miss query for a depth it never reaches, while
+        // a deep match regrows geometrically a couple of times at most.
+        let mut probes: Vec<RunProbe> = Vec::with_capacity(chain.len().min(1024));
+        for (p, &content) in chain.iter().enumerate() {
+            match self.entries.get(&(p as u32, content)) {
+                Some(Membership::One { lineage, holder }) => {
+                    probes.push(if *lineage == lineages[p] {
+                        RunProbe::One(*holder)
+                    } else {
+                        RunProbe::Miss
+                    })
+                }
+                Some(Membership::Many(buckets)) => {
+                    let run = if buckets.len() == 1 {
+                        (buckets[0].0 == lineages[p]).then(|| &*buckets[0].1)
+                    } else {
+                        buckets
+                            .binary_search_by_key(&lineages[p], |&(l, _)| l)
+                            .ok()
+                            .map(|bi| &*buckets[bi].1)
+                    };
+                    match run {
+                        Some(run) => {
+                            // Endpoint touches: pull the run's first
+                            // and last cache lines now, overlapped.
+                            std::hint::black_box(run[0]);
+                            std::hint::black_box(run[run.len() - 1]);
+                            probes.push(RunProbe::Slice(run));
+                        }
+                        None => probes.push(RunProbe::Miss),
+                    }
+                }
+                None => break,
+            }
+            if matches!(probes.last(), Some(RunProbe::Miss)) {
+                break;
+            }
+        }
+        // Phase 2: sequential merge over dense holder runs.
+        let mut active = std::mem::take(&mut scratch.active);
+        let mut next = std::mem::take(&mut scratch.next);
+        active.clear();
+        next.clear();
+        let mut survivors_depth = 0u32;
+        let mut one_hold = [0u32; 1];
+        // The interned-set identity `active` currently equals, when it
+        // exactly equals one: pointer equality against a position's
+        // run then proves "membership unchanged" in O(1), soundly
+        // (interning guarantees identical sets share one allocation).
+        let mut active_src: Option<*const u32> = None;
+        for (p, probe) in probes.iter().enumerate() {
+            let run: &[u32] = match probe {
+                RunProbe::One(h) => {
+                    one_hold[0] = *h;
+                    &one_hold[..]
+                }
+                RunProbe::Slice(r) => r,
+                RunProbe::Miss => &[],
+            };
+            if p == 0 {
+                if run.is_empty() {
+                    break;
+                }
+                active.extend_from_slice(run);
+                if matches!(probe, RunProbe::Slice(_)) {
+                    active_src = Some(run.as_ptr());
+                }
+            } else {
+                if active_src.is_some_and(|src| std::ptr::eq(src, run.as_ptr())) {
+                    // O(1) sound run-skip: same interned set object.
+                } else if run == active.as_slice() {
+                    // Content-equal after a hand-built subset: resync
+                    // to the interned identity.
+                    if matches!(probe, RunProbe::Slice(_)) {
+                        active_src = Some(run.as_ptr());
+                    }
+                } else {
+                    // Merge-intersect two sorted runs; dropped
+                    // holders get depth p in the same pass.
+                    next.clear();
+                    let mut ai = 0usize;
+                    for &h in run {
+                        while ai < active.len() && active[ai] < h {
+                            self.push_answer(active[ai], p as u32, out);
+                            ai += 1;
+                        }
+                        if ai < active.len() && active[ai] == h {
+                            next.push(h);
+                            ai += 1;
+                        }
+                    }
+                    while ai < active.len() {
+                        self.push_answer(active[ai], p as u32, out);
+                        ai += 1;
+                    }
+                    std::mem::swap(&mut active, &mut next);
+                    // next ⊆ run; equal lengths ⟹ equal sets.
+                    active_src = if active.len() == run.len() && matches!(probe, RunProbe::Slice(_))
+                    {
+                        Some(run.as_ptr())
+                    } else {
+                        None
+                    };
+                }
+            }
+            if active.is_empty() {
+                break;
+            }
+            survivors_depth = p as u32 + 1;
+        }
+        // Holders still active survived every visited position.
+        for &h in active.iter() {
+            self.push_answer(h, survivors_depth, out);
+        }
+        drop(probes);
+        scratch.active = active;
+        scratch.next = next;
+    }
+
+    /// Position-ordered enumeration (snapshot/Pull; §4). Order is
+    /// derived on demand — snapshot is a cold path.
+    pub fn enumerate(
+        &self,
+        id: HolderId,
+    ) -> impl Iterator<Item = (u32, BlockKey, ContentHash)> + '_ {
+        let state = self.live(id);
+        let ordered = state.map(|s| s.ordered()).unwrap_or_default();
+        ordered.into_iter().map(move |(pos, key)| {
+            let info = state
+                .expect("ordered non-empty implies live")
+                .registry
+                .get(&key)
+                .expect("derived from registry");
+            (pos, key, info.content)
+        })
+    }
+
+    pub fn stats(&self) -> Stats {
+        let holders = self.slots.iter().filter(|s| s.state.is_some()).count() as u64;
+        // Rough model: entry map + memberships + registries, PLUS the
+        // interned holder sets — the same term `RadixTree::stats` counts
+        // (omitting it hid an interner leak from the retire-churn gate,
+        // which `tests/api.rs` now runs against both cores).
+        let interner_bytes: u64 = self
+            .interner
+            .table
+            .values()
+            .map(|bucket| bucket.iter().map(|s| 16 + 4 * s.len() as u64).sum::<u64>() + 24)
+            .sum();
+        let bytes = self.entries.len() as u64 * 48
+            + self.holder_blocks_total * 72
+            + holders * 128
+            + interner_bytes;
+        Stats {
+            holders,
+            holder_blocks: self.holder_blocks_total,
+            distinct_entries: self.distinct_lineage_entries,
+            bytes_estimate: bytes,
+        }
+    }
+
+    // ---- verification ----
+
+    /// Full-state consistency audit: recomputes every counter and
+    /// cross-checks every structure from first principles. O(state);
+    /// meant for the fuzz harness and debug assertions, not the hot
+    /// path. Returns the first violation found.
+    pub fn audit(&self) -> Result<(), String> {
+        use std::collections::HashSet;
+        // Slot / name / free-list coherence.
+        let mut live = 0u64;
+        for (idx, slot) in self.slots.iter().enumerate() {
+            if let Some(state) = &slot.state {
+                live += 1;
+                match self.by_name.get(&state.name) {
+                    Some(&i) if i as usize == idx => {}
+                    other => {
+                        return Err(format!(
+                            "by_name[{}] = {:?}, expected {}",
+                            state.name, other, idx
+                        ))
+                    }
+                }
+            }
+        }
+        if self.by_name.len() as u64 != live {
+            return Err(format!(
+                "by_name has {} entries, {} live slots",
+                self.by_name.len(),
+                live
+            ));
+        }
+        let mut seen_free = HashSet::new();
+        for &f in &self.free {
+            if f as usize >= self.slots.len() {
+                return Err(format!("free-list index {f} out of range"));
+            }
+            if self.slots[f as usize].state.is_some() {
+                return Err(format!("free-list index {f} is live"));
+            }
+            if !seen_free.insert(f) {
+                return Err(format!("free-list duplicate {f}"));
+            }
+        }
+        // Counters + forward containment (registry -> entries).
+        let mut blocks = 0u64;
+        for (idx, slot) in self.slots.iter().enumerate() {
+            let Some(state) = &slot.state else { continue };
+            blocks += state.registry.len() as u64;
+            for (&key, info) in &state.registry {
+                let Some(m) = self.entries.get(&(info.pos, info.content)) else {
+                    return Err(format!(
+                        "registry block {key:#x} of holder {idx} at ({},{:#x}) has no entry",
+                        info.pos, info.content
+                    ));
+                };
+                let mut found = false;
+                match m {
+                    Membership::One { lineage, holder } => {
+                        found = *lineage == info.lineage && *holder as usize == idx;
+                    }
+                    Membership::Many(buckets) => {
+                        if let Ok(bi) = buckets.binary_search_by_key(&info.lineage, |&(l, _)| l) {
+                            found = buckets[bi].1.binary_search(&(idx as u32)).is_ok();
+                        }
+                    }
+                }
+                if !found {
+                    return Err(format!(
+                        "membership missing for holder {idx} block {key:#x} at ({},{:#x}) lineage {:#x}",
+                        info.pos, info.content, info.lineage
+                    ));
+                }
+            }
+        }
+        if blocks != self.holder_blocks_total {
+            return Err(format!(
+                "holder_blocks_total {} != recount {}",
+                self.holder_blocks_total, blocks
+            ));
+        }
+        // Reverse containment (entries -> registries) + shape + distinct.
+        let mut holder_triples: Vec<HashSet<(u32, u64, u64)>> =
+            vec![HashSet::new(); self.slots.len()];
+        for (idx, slot) in self.slots.iter().enumerate() {
+            if let Some(state) = &slot.state {
+                for info in state.registry.values() {
+                    holder_triples[idx].insert((info.pos, info.content, info.lineage));
+                }
+            }
+        }
+        let mut distinct = 0u64;
+        for (&(pos, content), m) in &self.entries {
+            match m {
+                Membership::One { lineage, holder } => {
+                    distinct += 1;
+                    if self
+                        .slots
+                        .get(*holder as usize)
+                        .and_then(|s| s.state.as_ref())
+                        .is_none()
+                    {
+                        return Err(format!(
+                            "entry ({pos},{content:#x}) holds retired holder {holder}"
+                        ));
+                    }
+                    if !holder_triples[*holder as usize].contains(&(pos, content, *lineage)) {
+                        return Err(format!(
+                            "entry ({pos},{content:#x}) lineage {lineage:#x} not in holder {holder}'s registry"
+                        ));
+                    }
+                }
+                Membership::Many(buckets) => {
+                    if buckets.is_empty() {
+                        return Err(format!("empty Many at ({pos},{content:#x})"));
+                    }
+                    // Canonical form: a single (lineage, holder) is the
+                    // inline `One` variant (`remove` collapses back to it).
+                    // Enforced here because nothing else observes it —
+                    // every op stays correct and the model still agrees
+                    // if the collapse is lost, only the B/block drifts.
+                    if buckets.len() == 1 && buckets[0].1.len() == 1 {
+                        return Err(format!("non-collapsed Many at ({pos},{content:#x})"));
+                    }
+                    let mut prev_l = None;
+                    for (l, holders) in buckets {
+                        distinct += 1;
+                        if holders.is_empty() {
+                            return Err(format!("empty bucket at ({pos},{content:#x})"));
+                        }
+                        if prev_l.is_some_and(|p: u64| p >= *l) {
+                            return Err(format!("unsorted buckets at ({pos},{content:#x})"));
+                        }
+                        prev_l = Some(*l);
+                        let mut prev_h = None;
+                        for &h in holders.iter() {
+                            if prev_h.is_some_and(|p: u32| p >= h) {
+                                return Err(format!("unsorted holders at ({pos},{content:#x})"));
+                            }
+                            prev_h = Some(h);
+                            if self
+                                .slots
+                                .get(h as usize)
+                                .and_then(|s| s.state.as_ref())
+                                .is_none()
+                            {
+                                return Err(format!(
+                                    "entry ({pos},{content:#x}) holds retired holder {h}"
+                                ));
+                            }
+                            if !holder_triples[h as usize].contains(&(pos, content, *l)) {
+                                return Err(format!(
+                                    "entry ({pos},{content:#x}) lineage {l:#x} not in holder {h}'s registry"
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if distinct != self.distinct_lineage_entries {
+            return Err(format!(
+                "distinct_lineage_entries {} != recount {}",
+                self.distinct_lineage_entries, distinct
+            ));
+        }
+        // Interner coherence: every bucket's set is findable in the
+        // table under its content hash, and the table holds no orphan
+        // sets (kept alive by nothing but the table = a leak).
+        for m in self.entries.values() {
+            if let Membership::Many(buckets) = m {
+                for (_, set) in buckets {
+                    let h = SetInterner::hash_of(set);
+                    let found = self
+                        .interner
+                        .table
+                        .get(&h)
+                        .is_some_and(|v| v.iter().any(|s| std::sync::Arc::ptr_eq(s, set)));
+                    if !found {
+                        return Err(format!("interned set {:?} missing from table", &set[..]));
+                    }
+                }
+            }
+        }
+        for (h, sets) in &self.interner.table {
+            for set in sets {
+                if std::sync::Arc::strong_count(set) == 1 {
+                    return Err(format!(
+                        "orphan interned set under hash {h:#x}: {:?}",
+                        &set[..]
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // ---- internals ----
+
+    fn live(&self, id: HolderId) -> Option<&HolderState> {
+        let slot = self.slots.get(id.index as usize)?;
+        if slot.generation != id.generation {
+            return None;
+        }
+        slot.state.as_ref()
+    }
+
+    fn push_answer(&self, holder: u32, depth: u32, out: &mut Vec<Overlap>) {
+        if depth == 0 {
+            return;
+        }
+        let slot = &self.slots[holder as usize];
+        let Some(state) = slot.state.as_ref() else {
+            return;
+        };
+        out.push(Overlap {
+            holder: HolderId {
+                index: holder,
+                generation: slot.generation,
+            },
+            depth,
+            total_blocks: state.registry.len() as u64,
+        });
+    }
+
+    /// Add the (lineage, holder) membership for a block. Returns
+    /// false for the out-of-contract case where the holder ALREADY
+    /// holds this exact (position, content, lineage) under another
+    /// key — the caller then treats the store as a duplicate and the
+    /// new key is never registered (deterministic; audited).
+    fn index_block(&mut self, holder: u32, info: BlockInfo) -> bool {
+        let interner = &mut self.interner;
+        match self.entries.entry((info.pos, info.content)) {
+            std::collections::hash_map::Entry::Vacant(vacant) => {
+                vacant.insert(Membership::One {
+                    lineage: info.lineage,
+                    holder,
+                });
+                self.distinct_lineage_entries += 1;
+                true
+            }
+            std::collections::hash_map::Entry::Occupied(mut occupied) => {
+                match occupied.get_mut().insert(info.lineage, holder, interner) {
+                    Inserted::Existing => false,
+                    Inserted::AddedToExistingLineage => true,
+                    Inserted::AddedNewLineage => {
+                        self.distinct_lineage_entries += 1;
+                        true
+                    }
+                }
+            }
+        }
+    }
+
+    fn unindex(
+        entries: &mut FxHashMap<(u32, ContentHash), Membership>,
+        interner: &mut SetInterner,
+        distinct: &mut u64,
+        holder: u32,
+        info: BlockInfo,
+    ) {
+        let Some(membership) = entries.get_mut(&(info.pos, info.content)) else {
+            return;
+        };
+        let shared = membership.lineage_shared_beyond(info.lineage, holder);
+        if membership.remove(info.lineage, holder, interner) {
+            entries.remove(&(info.pos, info.content));
+        }
+        if !shared {
+            *distinct -= 1;
+        }
+    }
+}

--- a/crates/radix_tree/tests/alloc_gate.rs
+++ b/crates/radix_tree/tests/alloc_gate.rs
@@ -1,0 +1,188 @@
+//! §11 allocation gate: storing fresh single-holder blocks performs
+//! zero heap allocations amortized beyond map growth. The relative
+//! RSS gate cannot catch a regression to per-block heap sets (the
+//! §13.4 risk), so this counts allocations directly.
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use radix_tree::{Config, FlatTree, Overlap, OverlapScratch, RadixTree};
+
+struct Counting;
+
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        System.alloc(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static A: Counting = Counting;
+
+/// `ALLOCS` is process-global and libtest runs the `#[test]`s in this
+/// binary on parallel threads, so every measured window takes this
+/// lock: without it the store test's ~100k allocations would land in
+/// the overlap test's delta (or vice versa) and the gates would flake.
+static GATE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn measured() -> std::sync::MutexGuard<'static, ()> {
+    GATE.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+#[test]
+fn fresh_single_holder_stores_amortize_to_map_growth() {
+    let _window = measured();
+    run_flat();
+    run_chain();
+}
+
+fn run_flat() {
+    let mut tree = FlatTree::new(Config::default());
+    let h = tree.create_holder("h");
+    // Warm: one chain so first-touch allocations (scratch, maps) are
+    // out of the measured window.
+    let warm: Vec<(u64, u64)> = (1..=64u64).map(|i| (i, i ^ 0xABCD)).collect();
+    tree.store(h, None, &warm).expect("warm");
+
+    // Many realistic-length chains (512 blocks), fresh single-holder
+    // blocks throughout — never near max_chain_len.
+    const BLOCKS: u64 = 100_000;
+    const CHAIN_LEN: u64 = 512;
+    let mut batch = Vec::with_capacity(8);
+    let before = ALLOCS.load(Ordering::Relaxed);
+    let mut key = 1000u64;
+    let mut stored = 0u64;
+    'outer: loop {
+        let mut parent = None;
+        let mut in_chain = 0u64;
+        while in_chain < CHAIN_LEN {
+            batch.clear();
+            for _ in 0..8 {
+                key += 1;
+                batch.push((key, key.wrapping_mul(0x9E3779B97F4A7C15) | 1));
+            }
+            tree.store(h, parent, &batch).expect("store");
+            parent = Some(key);
+            stored += 8;
+            in_chain += 8;
+            if stored >= BLOCKS {
+                break 'outer;
+            }
+        }
+    }
+    let allocs = ALLOCS.load(Ordering::Relaxed) - before;
+    let per_block = allocs as f64 / stored as f64;
+    println!("{allocs} allocations for {stored} single-holder blocks = {per_block:.4}/block");
+    // Membership::One is inline (zero per-block); what remains is
+    // amortized structure growth: BTreeSet nodes (~1 per 11 inserts)
+    // and hash-map doublings. 0.5/block is generous headroom over
+    // that floor while still failing any per-block heap regression
+    // (a heap set per block would cost >= 1.0).
+    assert!(
+        per_block < 0.5,
+        "flat allocation regression: {per_block:.4} allocs/block (gate: < 0.5)"
+    );
+}
+
+/// Same gate for the chain-native core: contents-Vec growth and span
+/// bookkeeping must amortize, never per-block allocate.
+fn run_chain() {
+    let mut tree = RadixTree::new(Config::default());
+    let h = tree.create_holder("h");
+    let warm: Vec<(u64, u64)> = (1..=64u64).map(|i| (i, i ^ 0xABCD)).collect();
+    tree.store(h, None, &warm).expect("warm");
+    const BLOCKS: u64 = 100_000;
+    const CHAIN_LEN: u64 = 512;
+    let mut batch = Vec::with_capacity(8);
+    let before = ALLOCS.load(Ordering::Relaxed);
+    let mut key = 10_000_000u64;
+    let mut stored = 0u64;
+    'outer: loop {
+        let mut parent = None;
+        let mut in_chain = 0u64;
+        while in_chain < CHAIN_LEN {
+            batch.clear();
+            for _ in 0..8 {
+                key += 1;
+                batch.push((key, key.wrapping_mul(0x9E3779B97F4A7C15) | 1));
+            }
+            tree.store(h, parent, &batch).expect("store");
+            parent = Some(key);
+            stored += 8;
+            in_chain += 8;
+            if stored >= BLOCKS {
+                break 'outer;
+            }
+        }
+    }
+    let allocs = ALLOCS.load(Ordering::Relaxed) - before;
+    let per_block = allocs as f64 / stored as f64;
+    println!("chain core: {allocs} allocations for {stored} blocks = {per_block:.4}/block");
+    assert!(
+        per_block < 0.5,
+        "chain allocation regression: {per_block:.4} allocs/block (gate: < 0.5)"
+    );
+}
+
+/// Read-path gate: with a caller-owned scratch reused across queries, an
+/// overlap query over a warm forest must not allocate per query beyond a
+/// tiny constant. The write path had a gate; the hot read path did not, so
+/// a per-query heap regression on overlap was invisible.
+#[test]
+fn overlap_queries_do_not_allocate_per_query() {
+    let _window = measured();
+    let mut tree = RadixTree::new(Config::default());
+    // Warm forest: several holders share a 256-block prefix then diverge,
+    // so a query crosses many span boundaries (the merge path under test).
+    let base: Vec<(u64, u64)> = (1..=256u64)
+        .map(|i| (i, i.wrapping_mul(0x9E3779B97F4A7C15) | 1))
+        .collect();
+    for hi in 0..8u64 {
+        let h = tree.create_holder(&format!("h{hi}"));
+        tree.store(h, None, &base).expect("prefix");
+        let tail: Vec<(u64, u64)> = (0..64u64)
+            .map(|j| {
+                let k = 1_000_000 * (hi + 1) + j;
+                (k, k | 1)
+            })
+            .collect();
+        tree.store(h, Some(256), &tail).expect("tail");
+    }
+    let query: Vec<u64> = base.iter().map(|&(_, c)| c).collect();
+
+    // Warm the scratch/out buffers so their first-touch growth is excluded.
+    let mut qscratch = OverlapScratch::default();
+    let mut out: Vec<Overlap> = Vec::new();
+    for _ in 0..4 {
+        tree.overlap(&query, &mut qscratch, &mut out);
+    }
+    assert_eq!(out.len(), 8, "all eight holders match the shared prefix");
+
+    const QUERIES: u64 = 10_000;
+    let before = ALLOCS.load(Ordering::Relaxed);
+    for _ in 0..QUERIES {
+        tree.overlap(&query, &mut qscratch, &mut out);
+    }
+    let allocs = ALLOCS.load(Ordering::Relaxed) - before;
+    let per_query = allocs as f64 / QUERIES as f64;
+    println!("{allocs} allocations for {QUERIES} overlap queries = {per_query:.4}/query");
+    // Every working buffer (holder sets, path segments) lives in the
+    // caller's scratch, so a warm query performs NO heap allocation at
+    // all; gate at < 0.01 so any new per-query heap fails loudly.
+    assert!(
+        per_query < 0.01,
+        "overlap read-path allocation regression: {per_query:.4}/query (gate: < 0.01)"
+    );
+}

--- a/crates/radix_tree/tests/api.rs
+++ b/crates/radix_tree/tests/api.rs
@@ -1,0 +1,228 @@
+//! Targeted API contract tests: the behaviors the differential harness
+//! can't reach because the model deliberately has no ids, config
+//! bounds, or lifecycle. Every case runs against BOTH cores — the two
+//! implement one contract, and the chaos fuzz does not cover live-name
+//! idempotency, retirement accounting, stale-id semantics, exact
+//! truncation order, or `ChainTooLong` atomicity.
+
+use radix_tree::{
+    Config, FlatTree, HolderId, Overlap, OverlapScratch, RadixTree, Stats, StoreError, StoreOutcome,
+};
+
+/// The public surface both cores share, so each case is written once.
+trait Core {
+    fn with_config(cfg: Config) -> Self;
+    fn create_holder(&mut self, name: &str) -> HolderId;
+    fn retire_holder(&mut self, id: HolderId);
+    fn holder_name(&self, id: HolderId) -> Option<&str>;
+    fn holder_blocks(&self, id: HolderId) -> u64;
+    fn store(
+        &mut self,
+        id: HolderId,
+        parent: Option<u64>,
+        blocks: &[(u64, u64)],
+    ) -> Result<StoreOutcome, StoreError>;
+    fn remove(&mut self, id: HolderId, keys: &[u64]) -> u32;
+    fn truncate_tail(&mut self, id: HolderId, keep: u64) -> u64;
+    fn enumerate(&self, id: HolderId) -> Vec<(u32, u64, u64)>;
+    fn overlap(&self, chain: &[u64], scratch: &mut OverlapScratch, out: &mut Vec<Overlap>);
+    fn stats(&self) -> Stats;
+}
+
+macro_rules! impl_core {
+    ($t:ty) => {
+        impl Core for $t {
+            fn with_config(cfg: Config) -> Self {
+                <$t>::new(cfg)
+            }
+            fn create_holder(&mut self, name: &str) -> HolderId {
+                <$t>::create_holder(self, name)
+            }
+            fn retire_holder(&mut self, id: HolderId) {
+                <$t>::retire_holder(self, id)
+            }
+            fn holder_name(&self, id: HolderId) -> Option<&str> {
+                <$t>::holder_name(self, id)
+            }
+            fn holder_blocks(&self, id: HolderId) -> u64 {
+                <$t>::holder_blocks(self, id)
+            }
+            fn store(
+                &mut self,
+                id: HolderId,
+                parent: Option<u64>,
+                blocks: &[(u64, u64)],
+            ) -> Result<StoreOutcome, StoreError> {
+                <$t>::store(self, id, parent, blocks)
+            }
+            fn remove(&mut self, id: HolderId, keys: &[u64]) -> u32 {
+                <$t>::remove(self, id, keys)
+            }
+            fn truncate_tail(&mut self, id: HolderId, keep: u64) -> u64 {
+                <$t>::truncate_tail(self, id, keep)
+            }
+            fn enumerate(&self, id: HolderId) -> Vec<(u32, u64, u64)> {
+                <$t>::enumerate(self, id).collect()
+            }
+            fn overlap(&self, chain: &[u64], scratch: &mut OverlapScratch, out: &mut Vec<Overlap>) {
+                <$t>::overlap(self, chain, scratch, out)
+            }
+            fn stats(&self) -> Stats {
+                <$t>::stats(self)
+            }
+        }
+    };
+}
+
+impl_core!(FlatTree);
+impl_core!(RadixTree);
+
+/// One `#[test]` per core for each generic case below.
+macro_rules! both_cores {
+    ($($case:ident),* $(,)?) => {
+        $(
+            mod $case {
+                #[test]
+                fn flat() {
+                    super::$case::<super::FlatTree>();
+                }
+                #[test]
+                fn chain() {
+                    super::$case::<super::RadixTree>();
+                }
+            }
+        )*
+    };
+}
+
+both_cores!(
+    stale_id_fails_loudly_never_aliases,
+    retire_releases_everything_bounded_under_churn,
+    truncate_tail_is_forest_wide_prefix_closed_and_deterministic,
+    chain_too_long_is_terminal_and_atomic,
+    create_holder_is_idempotent_per_live_name,
+    lineage_exactness_content_coincidence_never_over_matches,
+);
+
+fn tree<C: Core>() -> C {
+    C::with_config(Config::default())
+}
+
+fn stale_id_fails_loudly_never_aliases<C: Core>() {
+    let mut t = tree::<C>();
+    let a = t.create_holder("a");
+    t.store(a, None, &[(1, 10), (2, 20)]).expect("store");
+    t.retire_holder(a);
+    // Slot recycled by a different holder.
+    let b = t.create_holder("b");
+    t.store(b, None, &[(3, 30)]).expect("store");
+    assert_eq!(a.parts().0, b.parts().0, "test premise: slot reused");
+    // Every operation through the stale id is a loud no-op.
+    assert_eq!(t.store(a, None, &[(4, 40)]), Err(StoreError::UnknownHolder));
+    assert_eq!(t.remove(a, &[3]), 0);
+    assert_eq!(t.holder_blocks(a), 0);
+    assert_eq!(t.holder_name(a), None);
+    assert_eq!(t.enumerate(a).len(), 0);
+    assert_eq!(t.truncate_tail(a, 0), 0);
+    // The recycled holder was never touched.
+    assert_eq!(t.holder_blocks(b), 1);
+    assert_eq!(t.holder_name(b), Some("b"));
+}
+
+fn retire_releases_everything_bounded_under_churn<C: Core>() {
+    let mut t = tree::<C>();
+    let mut baseline = None;
+    for cycle in 0..200u64 {
+        let h = t.create_holder(&format!("pod-{cycle}"));
+        let blocks: Vec<(u64, u64)> = (0..64)
+            .map(|i| (cycle * 1000 + i + 1, cycle * 2000 + i + 1))
+            .collect();
+        t.store(h, None, &blocks).expect("store");
+        t.retire_holder(h);
+        let est = t.stats().bytes_estimate;
+        match baseline {
+            None => baseline = Some(est),
+            Some(b) => assert!(
+                est <= b,
+                "state grew under churn: cycle {cycle}, {est} > {b}"
+            ),
+        }
+        assert_eq!(t.stats().holders, 0);
+        assert_eq!(t.stats().holder_blocks, 0);
+        assert_eq!(t.stats().distinct_entries, 0);
+    }
+}
+
+fn truncate_tail_is_forest_wide_prefix_closed_and_deterministic<C: Core>() {
+    let mut t = tree::<C>();
+    let h = t.create_holder("h");
+    // Two chains: positions 0..4 and 0..2.
+    t.store(h, None, &[(10, 1), (11, 2), (12, 3), (13, 4)])
+        .expect("chain A");
+    t.store(h, None, &[(20, 5), (21, 6)]).expect("chain B");
+    assert_eq!(t.holder_blocks(h), 6);
+    // keep=3: drops A@3, A@2, then the position-1 tie (A@1 key 11 vs
+    // B@1 key 21) resolved by HIGHEST key first per the (pos, key)
+    // order -> 21 goes first.
+    let dropped = t.truncate_tail(h, 3);
+    assert_eq!(dropped, 3);
+    assert_eq!(t.enumerate(h), vec![(0, 10, 1), (0, 20, 5), (1, 11, 2)]);
+    // Prefix-closed: every remaining position p>0 has its position
+    // p-1 present on the same chain (A kept 0,1; B kept 0).
+    // Queries still answer the kept prefixes exactly.
+    let mut out = Vec::new();
+    let mut sc = OverlapScratch::default();
+    t.overlap(&[1, 2, 3], &mut sc, &mut out);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].depth, 2);
+    t.overlap(&[5, 6], &mut sc, &mut out);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].depth, 1);
+}
+
+fn chain_too_long_is_terminal_and_atomic<C: Core>() {
+    let mut t = C::with_config(Config { max_chain_len: 4 });
+    let h = t.create_holder("h");
+    t.store(h, None, &[(1, 1), (2, 2), (3, 3)]).expect("fits");
+    // Extending 3 + 2 > 4: rejected whole.
+    assert_eq!(
+        t.store(h, Some(3), &[(4, 4), (5, 5)]),
+        Err(StoreError::ChainTooLong)
+    );
+    assert_eq!(t.holder_blocks(h), 3);
+    // Exactly at the bound is fine.
+    t.store(h, Some(3), &[(4, 4)]).expect("at bound");
+    assert_eq!(t.holder_blocks(h), 4);
+}
+
+fn create_holder_is_idempotent_per_live_name<C: Core>() {
+    let mut t = tree::<C>();
+    let a1 = t.create_holder("a");
+    let a2 = t.create_holder("a");
+    assert_eq!(a1, a2);
+    t.retire_holder(a1);
+    let a3 = t.create_holder("a");
+    assert_ne!(a1, a3, "new generation after retire");
+    assert_eq!(t.holder_blocks(a3), 0);
+}
+
+fn lineage_exactness_content_coincidence_never_over_matches<C: Core>() {
+    let mut t = tree::<C>();
+    let h = t.create_holder("h");
+    // Chain X: contents [7, 8]; chain Y: contents [9, 8] — content 8
+    // appears at position 1 under BOTH lineages.
+    t.store(h, None, &[(1, 7), (2, 8)]).expect("X");
+    t.store(h, None, &[(3, 9), (4, 8)]).expect("Y");
+    let mut out = Vec::new();
+    let mut sc = OverlapScratch::default();
+    // Query [7, 8]: depth 2 via X only.
+    t.overlap(&[7, 8], &mut sc, &mut out);
+    assert_eq!((out[0].holder, out[0].depth), (h, 2));
+    // Query [9, 8]: depth 2 via Y only.
+    t.overlap(&[9, 8], &mut sc, &mut out);
+    assert_eq!((out[0].holder, out[0].depth), (h, 2));
+    // Query [5, 8]: content 8 exists at position 1 (twice!) but no
+    // chain has lineage [5] -> depth 0, no answer at all.
+    t.overlap(&[5, 8], &mut sc, &mut out);
+    assert!(out.is_empty(), "lineage-blind positional match leaked");
+}

--- a/crates/radix_tree/tests/common/mod.rs
+++ b/crates/radix_tree/tests/common/mod.rs
@@ -1,0 +1,112 @@
+//! The model-referee harness.
+//!
+//! Three pieces:
+//! - [`model`]: a trivially-correct implementation of the §6/§7
+//!   contract — per-holder chain forests with literal lineage
+//!   vectors. Slow, obvious, and the referee for everything else.
+//! - [`oracle`]: `kv_index::PositionalIndexer` behind the engine's
+//!   replicated glue (per-holder reverse maps, interning), applied
+//!   through the same operation stream.
+//! - [`workload`]: a seeded deterministic generator producing
+//!   §7-scoped operation streams with shared prefixes, divergent
+//!   tails, duplicates, gaps, and content coincidence.
+
+// Each integration-test binary compiles this module independently and
+// uses a different slice of it; unused-in-this-binary is expected.
+#![allow(dead_code)]
+
+pub mod model;
+pub mod oracle;
+pub mod workload;
+
+/// One operation in a workload stream. Holder identity is a dense
+/// index (the harness maps it to names/ids per implementation).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Op {
+    Store {
+        holder: usize,
+        /// `None` anchors a new chain at position 0.
+        parent: Option<u64>,
+        /// (BlockKey, ContentHash) pairs, consecutive positions.
+        blocks: Vec<(u64, u64)>,
+    },
+    Remove {
+        holder: usize,
+        keys: Vec<u64>,
+    },
+    Clear {
+        holder: usize,
+    },
+}
+
+impl Op {
+    pub fn holder(&self) -> usize {
+        match self {
+            Op::Store { holder, .. } | Op::Remove { holder, .. } | Op::Clear { holder } => *holder,
+        }
+    }
+
+    /// Whether reordering this op against its holder's stores is
+    /// outside the §7 convergence scope. (Used by the R1 convergence
+    /// suite; the R0 reinterleaver conservatively keeps all order.)
+    #[allow(dead_code)]
+    pub fn orders_holder(&self) -> bool {
+        matches!(self, Op::Remove { .. } | Op::Clear { .. })
+    }
+}
+
+/// SplitMix64: tiny deterministic RNG so the harness has zero deps
+/// and identical streams on every platform.
+#[derive(Debug, Clone)]
+pub struct Rng(pub u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+    /// Next raw 64-bit output. (Not named `next`: an inherent `next`
+    /// on a public type trips `clippy::should_implement_trait`.)
+    pub fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+    /// Uniform in [0, n).
+    pub fn below(&mut self, n: usize) -> usize {
+        (self.next_u64() % n as u64) as usize
+    }
+    /// Bernoulli with probability pct/100.
+    pub fn chance(&mut self, pct: u64) -> bool {
+        self.next_u64() % 100 < pct
+    }
+}
+
+/// A present-but-malformed campaign/bench variable is an operator error,
+/// never a silent fall-through to the default (a `10_000` typo would
+/// otherwise run the default and report success for a run nobody asked
+/// for). Absent => default. One parse contract for every test binary.
+pub fn env_u64(name: &str, default: u64) -> u64 {
+    match std::env::var(name) {
+        Ok(v) => v
+            .parse()
+            .unwrap_or_else(|e| panic!("{name}={v:?} is not a u64: {e}")),
+        Err(_) => default,
+    }
+}
+
+/// Resident set size of this process in KiB, from `ps`. Shared by the
+/// two RSS-measuring benchmarks so the parse contract cannot drift: an
+/// unparsable `ps` line is a failed measurement, never a silent zero
+/// (which would wrap the `after - before` delta in release builds).
+pub fn rss_kib() -> u64 {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &std::process::id().to_string()])
+        .output()
+        .expect("ps");
+    let text = String::from_utf8_lossy(&out.stdout);
+    text.trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("cannot parse ps rss output {text:?}: {e}"))
+}

--- a/crates/radix_tree/tests/common/model.rs
+++ b/crates/radix_tree/tests/common/model.rs
@@ -1,0 +1,321 @@
+//! The trivially-correct model of the matching/convergence contract.
+//!
+//! Representationally complete: every block carries its OWN literal
+//! lineage (the content prefix it was stored under, including
+//! itself), exactly mirroring the subject's registry of
+//! (position, content, lineage-fingerprint) — with the fingerprint
+//! replaced by the literal vector, so no hashing and no collisions.
+//! This makes the model defined on ARBITRARY inputs (aliases, moves,
+//! twin keys), which lets the chaos fuzz use it as referee too.
+//!
+//! §4 alias semantics, mirrored exactly:
+//! - same key, same (pos, content, lineage): duplicate;
+//! - different key, same (pos, content, lineage) already held: the
+//!   new key is a duplicate and is NEVER registered — and when that
+//!   key was previously registered elsewhere (a refused MOVE), its
+//!   old placement stays intact;
+//! - same key, different placement: MOVE (old placement removed).
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    rc::Rc,
+};
+
+use super::Op;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BlockRec {
+    pos: u32,
+    content: u64,
+    /// Literal lineage: contents at positions 0..=pos as stored.
+    lineage: Rc<Vec<u64>>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct Holder {
+    registry: HashMap<u64, BlockRec>,
+}
+
+/// Model-level store outcome, mirroring the §4 error surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreResult {
+    Applied { applied: u32, duplicates: u32 },
+    ParentNotFound,
+    ChainTooLong,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Model {
+    holders: Vec<Holder>,
+    max_chain_len: u32,
+}
+
+impl Model {
+    pub fn new(holder_count: usize) -> Self {
+        Self::with_max(holder_count, 65_536)
+    }
+
+    /// Mirror a subject configured with a specific max_chain_len.
+    pub fn with_max(holder_count: usize, max_chain_len: u32) -> Self {
+        Self {
+            holders: vec![Holder::default(); holder_count],
+            max_chain_len,
+        }
+    }
+
+    pub fn apply(&mut self, op: &Op) -> Option<StoreResult> {
+        match op {
+            Op::Store {
+                holder,
+                parent,
+                blocks,
+            } => Some(self.store(*holder, *parent, blocks)),
+            Op::Remove { holder, keys } => {
+                self.remove(*holder, keys);
+                None
+            }
+            Op::Clear { holder } => {
+                self.clear(*holder);
+                None
+            }
+        }
+    }
+
+    pub fn store(
+        &mut self,
+        holder: usize,
+        parent: Option<u64>,
+        blocks: &[(u64, u64)],
+    ) -> StoreResult {
+        if blocks.is_empty() {
+            return StoreResult::Applied {
+                applied: 0,
+                duplicates: 0,
+            };
+        }
+        let h = &mut self.holders[holder];
+        let (start_pos, mut prefix) = match parent {
+            None => (0u32, Vec::new()),
+            Some(parent_key) => match h.registry.get(&parent_key) {
+                None => return StoreResult::ParentNotFound,
+                Some(rec) => (rec.pos + 1, rec.lineage.as_ref().clone()),
+            },
+        };
+        if start_pos as u64 + blocks.len() as u64 > self.max_chain_len as u64 {
+            return StoreResult::ChainTooLong;
+        }
+        let mut applied = 0u32;
+        let mut duplicates = 0u32;
+        for (i, &(key, content)) in blocks.iter().enumerate() {
+            let pos = start_pos + i as u32;
+            prefix.push(content);
+            let candidate = BlockRec {
+                pos,
+                content,
+                lineage: Rc::new(prefix.clone()),
+            };
+            if h.registry.get(&key) == Some(&candidate) {
+                duplicates += 1;
+                continue;
+            }
+            // Alias: any OTHER key already at this exact triple?
+            let aliased = h
+                .registry
+                .iter()
+                .any(|(&k, rec)| k != key && *rec == candidate);
+            if aliased {
+                // Duplicate in every observable sense; a would-be MOVE
+                // is refused non-destructively (old placement stays).
+                duplicates += 1;
+                continue;
+            }
+            // MOVE or fresh insert: (re)register.
+            h.registry.insert(key, candidate);
+            applied += 1;
+        }
+        StoreResult::Applied {
+            applied,
+            duplicates,
+        }
+    }
+
+    /// Read-only mirror of [`Self::store`]: true iff the store would
+    /// return `Applied { applied: 0, .. }` (every block an exact-triple
+    /// duplicate or alias), false where it would error. Referees the
+    /// subject's shared-lock duplicate fast path.
+    pub fn covered(&self, holder: usize, parent: Option<u64>, blocks: &[(u64, u64)]) -> bool {
+        self.dup_prefix(holder, parent, blocks).1
+    }
+
+    /// Read-only mirror of the subjects' `dup_prefix`: (leading run of
+    /// plain same-key duplicates, store-would-apply-nothing).
+    pub fn dup_prefix(
+        &self,
+        holder: usize,
+        parent: Option<u64>,
+        blocks: &[(u64, u64)],
+    ) -> (u32, bool) {
+        if blocks.is_empty() {
+            return (0, true);
+        }
+        let h = &self.holders[holder];
+        let (start_pos, mut prefix) = match parent {
+            None => (0u32, Vec::new()),
+            Some(parent_key) => match h.registry.get(&parent_key) {
+                None => return (0, false),
+                Some(rec) => (rec.pos + 1, rec.lineage.as_ref().clone()),
+            },
+        };
+        if start_pos as u64 + blocks.len() as u64 > self.max_chain_len as u64 {
+            return (0, false);
+        }
+        let mut run = 0u32;
+        let mut run_live = true;
+        for (i, &(key, content)) in blocks.iter().enumerate() {
+            let pos = start_pos + i as u32;
+            prefix.push(content);
+            let candidate = BlockRec {
+                pos,
+                content,
+                lineage: Rc::new(prefix.clone()),
+            };
+            let plain = h.registry.get(&key) == Some(&candidate);
+            let held = plain
+                || h.registry
+                    .iter()
+                    .any(|(&k, rec)| k != key && *rec == candidate);
+            if !held {
+                return (run, false);
+            }
+            if run_live {
+                if plain {
+                    run += 1;
+                } else {
+                    run_live = false;
+                }
+            }
+        }
+        (run, true)
+    }
+
+    /// Read-only mirror of the subjects' `position_of`.
+    pub fn position_of(&self, holder: usize, key: u64) -> Option<u32> {
+        self.holders[holder].registry.get(&key).map(|r| r.pos)
+    }
+
+    pub fn remove(&mut self, holder: usize, keys: &[u64]) -> u32 {
+        let h = &mut self.holders[holder];
+        let mut removed = 0;
+        for key in keys {
+            if h.registry.remove(key).is_some() {
+                removed += 1;
+            }
+        }
+        removed
+    }
+
+    pub fn clear(&mut self, holder: usize) {
+        self.holders[holder] = Holder::default();
+    }
+
+    /// Forest-wide §4 truncate: strictly decreasing positions, ties
+    /// by key, until `keep` remain.
+    pub fn truncate_tail(&mut self, holder: usize, keep: u64) -> u64 {
+        let h = &mut self.holders[holder];
+        if h.registry.len() as u64 <= keep {
+            return 0;
+        }
+        let mut ordered: Vec<(u32, u64)> = h.registry.iter().map(|(&k, r)| (r.pos, k)).collect();
+        ordered.sort_unstable();
+        let mut dropped = 0u64;
+        while h.registry.len() as u64 > keep {
+            let (_, key) = ordered.pop().expect("non-empty");
+            h.registry.remove(&key);
+            dropped += 1;
+        }
+        dropped
+    }
+
+    /// §6 depth: largest d such that for every p < d the holder has a
+    /// block at position p whose content is query[p] and whose
+    /// LITERAL lineage equals query[0..=p].
+    pub fn depth(&self, holder: usize, query: &[u64]) -> u32 {
+        let mut d = 0u32;
+        'outer: for (p, &q) in query.iter().enumerate() {
+            for rec in self.holders[holder].registry.values() {
+                if rec.pos == p as u32
+                    && rec.content == q
+                    && rec.lineage.len() == p + 1
+                    && rec.lineage[..] == query[..=p]
+                {
+                    d = p as u32 + 1;
+                    continue 'outer;
+                }
+            }
+            break;
+        }
+        d
+    }
+
+    /// Full holder->depth map (§10.1: map equality, depth-0 absent).
+    pub fn overlap(&self, query: &[u64]) -> BTreeMap<usize, u32> {
+        let mut out = BTreeMap::new();
+        for holder in 0..self.holders.len() {
+            let d = self.depth(holder, query);
+            if d > 0 {
+                out.insert(holder, d);
+            }
+        }
+        out
+    }
+
+    pub fn holder_blocks(&self, holder: usize) -> u64 {
+        self.holders[holder].registry.len() as u64
+    }
+
+    /// Position-ordered (pos, key, content) — the model's `enumerate`.
+    pub fn enumerate(&self, holder: usize) -> Vec<(u32, u64, u64)> {
+        let mut v: Vec<(u32, u64, u64)> = self.holders[holder]
+            .registry
+            .iter()
+            .map(|(&k, r)| (r.pos, k, r.content))
+            .collect();
+        v.sort_unstable();
+        v
+    }
+
+    /// Distinct (position, content, lineage) across all holders — the
+    /// model's stats().distinct_entries.
+    pub fn distinct_entries(&self) -> u64 {
+        let mut set = std::collections::HashSet::new();
+        for h in &self.holders {
+            for rec in h.registry.values() {
+                set.insert((rec.pos, rec.content, rec.lineage.clone()));
+            }
+        }
+        set.len() as u64
+    }
+
+    /// Census discriminator: content match at pos under ANY lineage.
+    pub fn holds_content_at(&self, holder: usize, pos: u32, q: u64) -> bool {
+        self.holders[holder]
+            .registry
+            .values()
+            .any(|r| r.pos == pos && r.content == q)
+    }
+
+    /// Census discriminator: lineage-true block at pos for this query
+    /// (model depth stopped earlier only because of a gap).
+    pub fn holds_lineage_true_at(&self, holder: usize, pos: u32, query: &[u64]) -> bool {
+        self.holders[holder].registry.values().any(|r| {
+            r.pos == pos
+                && r.content == query[pos as usize]
+                && r.lineage.len() == pos as usize + 1
+                && r.lineage[..] == query[..=pos as usize]
+        })
+    }
+
+    /// Keep the compiler honest about BTreeMap being intentional.
+    #[allow(dead_code)]
+    fn _uses(_: &BTreeMap<usize, u32>) {}
+}

--- a/crates/radix_tree/tests/common/oracle.rs
+++ b/crates/radix_tree/tests/common/oracle.rs
@@ -1,0 +1,89 @@
+//! The differential oracle: `kv_index::PositionalIndexer` behind the
+//! same glue the service engine holds today (per-holder caller-owned
+//! reverse maps, worker interning, id->holder resolution), driven by
+//! the harness's operation stream.
+
+use std::collections::BTreeMap;
+
+use kv_index::{ContentHash, PositionalIndexer, SequenceHash, StoredBlock, WorkerBlockMap};
+
+use super::Op;
+
+pub struct Oracle {
+    index: PositionalIndexer,
+    /// worker_id by holder index (dense).
+    ids: Vec<u32>,
+    /// The engine-side caller-owned reverse maps, one per holder.
+    blocks: Vec<WorkerBlockMap>,
+}
+
+impl Oracle {
+    pub fn new(holder_count: usize) -> Self {
+        let index = PositionalIndexer::new(64);
+        let mut ids = Vec::with_capacity(holder_count);
+        let mut blocks = Vec::with_capacity(holder_count);
+        for h in 0..holder_count {
+            let id = index
+                .intern_worker(&format!("holder-{h}"))
+                .expect("id space");
+            ids.push(id);
+            blocks.push(WorkerBlockMap::default());
+        }
+        Self { index, ids, blocks }
+    }
+
+    /// Apply one op the way the engine does. Returns false when the
+    /// oracle rejected a store (parent not found / not tracked) — the
+    /// model must have rejected it too.
+    pub fn apply(&mut self, op: &Op) -> bool {
+        match op {
+            Op::Store {
+                holder,
+                parent,
+                blocks,
+            } => {
+                let stored: Vec<StoredBlock> = blocks
+                    .iter()
+                    .map(|&(key, content)| StoredBlock {
+                        seq_hash: SequenceHash(key),
+                        content_hash: ContentHash(content),
+                    })
+                    .collect();
+                self.index
+                    .apply_stored(
+                        self.ids[*holder],
+                        &stored,
+                        parent.map(SequenceHash),
+                        &mut self.blocks[*holder],
+                    )
+                    .is_ok()
+            }
+            Op::Remove { holder, keys } => {
+                let seqs: Vec<SequenceHash> = keys.iter().copied().map(SequenceHash).collect();
+                self.index
+                    .apply_removed(self.ids[*holder], &seqs, &mut self.blocks[*holder]);
+                true
+            }
+            Op::Clear { holder } => {
+                self.index
+                    .apply_cleared(self.ids[*holder], &mut self.blocks[*holder]);
+                true
+            }
+        }
+    }
+
+    /// Full holder->depth map for one query (depth-0 absent).
+    pub fn overlap(&self, query: &[u64]) -> BTreeMap<usize, u32> {
+        let hashes: Vec<ContentHash> = query.iter().copied().map(ContentHash).collect();
+        let scores = self.index.find_matches(&hashes, false);
+        let mut out = BTreeMap::new();
+        for (holder, &id) in self.ids.iter().enumerate() {
+            if let Some(&depth) = scores.scores.get(&id) {
+                if depth > 0 {
+                    out.insert(holder, depth);
+                }
+            }
+        }
+        out
+    }
+}

--- a/crates/radix_tree/tests/common/workload.rs
+++ b/crates/radix_tree/tests/common/workload.rs
@@ -1,0 +1,398 @@
+//! Seeded workload generator producing §7-scoped operation streams.
+//!
+//! Shape (mirrors the pinned-workload structure at test
+//! scale): prefix FAMILIES — shared base chains that several holders
+//! store identically (same keys, same contents: exactly what the
+//! placement feed produces) — plus per-holder divergent tails,
+//! duplicate re-stores, gap-punching removes, rare clears, and
+//! optional cross-family content coincidence to arm the oracle's
+//! Single-entry lineage skip.
+//!
+//! Ordering scope: the emitted stream preserves each holder's own
+//! order (ops interleave only ACROSS holders), matching §7. The
+//! convergence tests additionally reorder within that scope.
+
+use super::{Op, Rng};
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub holders: usize,
+    pub families: usize,
+    /// Blocks per family base chain: uniform in [min, max].
+    pub family_len: (usize, usize),
+    /// Holders per family: uniform in [min, max].
+    pub holders_per_family: (usize, usize),
+    /// Divergent tail blocks per holder per family: uniform [min, max].
+    pub tail_len: (usize, usize),
+    pub store_batch: usize,
+    /// Percent of batches re-sent verbatim later (duplicates).
+    pub duplicate_pct: u64,
+    /// Percent of (holder, family) pairs that lose a mid-chain block
+    /// (gap injection via remove).
+    pub gap_pct: u64,
+    /// Percent of holders cleared once mid-stream.
+    pub clear_pct: u64,
+    /// Reuse content values across families at this percent per
+    /// block, arming content coincidence (oracle quirk class 3).
+    pub coincidence_pct: u64,
+}
+
+impl Config {
+    pub fn small() -> Self {
+        Self {
+            holders: 24,
+            families: 8,
+            family_len: (8, 96),
+            holders_per_family: (1, 8),
+            tail_len: (2, 16),
+            store_batch: 8,
+            duplicate_pct: 10,
+            gap_pct: 15,
+            clear_pct: 8,
+            coincidence_pct: 0,
+        }
+    }
+
+    pub fn with_coincidence() -> Self {
+        Self {
+            coincidence_pct: 25,
+            ..Self::small()
+        }
+    }
+}
+
+/// The generated workload: an op stream (per-holder order already
+/// legal per §7) plus the query set derived from stored prefixes and
+/// misses.
+#[derive(Debug, Clone)]
+pub struct Workload {
+    pub ops: Vec<Op>,
+    pub queries: Vec<Vec<u64>>,
+    pub holders: usize,
+}
+
+pub fn generate(seed: u64, cfg: &Config) -> Workload {
+    let mut rng = Rng::new(seed);
+    let mut content_pool: Vec<u64> = Vec::new();
+    let fresh_content = |rng: &mut Rng, pool: &mut Vec<u64>, coincidence_pct: u64| -> u64 {
+        if !pool.is_empty() && rng.chance(coincidence_pct) {
+            pool[rng.below(pool.len())]
+        } else {
+            let c = rng.next_u64() | 1; // avoid 0 (the model's lineage filler)
+            pool.push(c);
+            c
+        }
+    };
+
+    // Families: shared (key, content) base chains. Keys are the
+    // deterministic placement chain of the contents — identical
+    // across holders for identical prefixes, as on the wire.
+    let mut families: Vec<Vec<(u64, u64)>> = Vec::new();
+    for _ in 0..cfg.families {
+        let len = cfg.family_len.0 + rng.below(cfg.family_len.1 - cfg.family_len.0 + 1);
+        let mut chain = Vec::with_capacity(len);
+        let mut prev_key = 0u64;
+        for i in 0..len {
+            // Position 0 contents stay unique: pos-0 keys ARE the
+            // content (wire position-0 rule), so coincidence there
+            // would fuse two families into one chain — out of the §7
+            // chain-consistent scope this generator promises.
+            let coincidence = if i == 0 { 0 } else { cfg.coincidence_pct };
+            let content = fresh_content(&mut rng, &mut content_pool, coincidence);
+            // Chain-hash-shaped keys without depending on the wire
+            // scheme: mix prev key and content deterministically.
+            let key = if i == 0 {
+                content
+            } else {
+                let mut k = prev_key ^ content.rotate_left(17);
+                k = k.wrapping_mul(0x2545F4914F6CDD1D) | 1;
+                k
+            };
+            chain.push((key, content));
+            prev_key = key;
+        }
+        families.push(chain);
+    }
+
+    // Assignment + per-holder scripts (sequences that MUST keep their
+    // relative order for that holder). A repeat assignment of the
+    // same family to the same holder re-stores the shared chain
+    // (pure duplicates) but must NOT grow a second divergent tail:
+    // two different keys at one chain position is outside the §7
+    // chain-consistent scope this generator promises (caught by the
+    // enumerate parity check).
+    let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); cfg.holders];
+    let mut tailed: std::collections::HashSet<(usize, usize)> = std::collections::HashSet::new();
+    // (holder, fork-position, tail blocks) pending mid-chain diverging
+    // queries.
+    type PendingTail = (usize, u32, Vec<(u64, u64)>);
+    let mut tails: Vec<PendingTail> = Vec::new();
+    for (fi, family) in families.iter().enumerate() {
+        let count = cfg.holders_per_family.0
+            + rng.below(cfg.holders_per_family.1 - cfg.holders_per_family.0 + 1);
+        for _ in 0..count {
+            let holder = rng.below(cfg.holders);
+            let first_assignment = tailed.insert((holder, fi));
+            // A third of members store only a PREFIX of the family,
+            // so membership decays with depth (the run-boundary
+            // structure real fleets produce; audit finding: constant
+            // membership along every spine left split/merge
+            // maintenance under-exercised).
+            let span = if rng.chance(33) && family.len() > 2 {
+                1 + rng.below(family.len() - 1)
+            } else {
+                family.len()
+            };
+            let stored_spine = &family[..span];
+            let mut parent = None;
+            let mut batches = Vec::new();
+            for batch in stored_spine.chunks(cfg.store_batch) {
+                batches.push(Op::Store {
+                    holder,
+                    parent,
+                    blocks: batch.to_vec(),
+                });
+                parent = Some(batch.last().expect("non-empty").0);
+            }
+            // Divergent tail (first assignment only): unique
+            // contents, keys mixed with holder and family so tails
+            // never collide. A third of tails fork MID-CHAIN (audit
+            // finding: tip-only forks left interior branch handling
+            // untested in-contract).
+            if first_assignment {
+                let fork_at = if rng.chance(33) && span > 2 {
+                    1 + rng.below(span - 1)
+                } else {
+                    span
+                };
+                let fork_parent = stored_spine[fork_at - 1].0;
+                let tail_len = cfg.tail_len.0 + rng.below(cfg.tail_len.1 - cfg.tail_len.0 + 1);
+                let mut tail = Vec::with_capacity(tail_len);
+                let mut prev_key = fork_parent;
+                for _ in 0..tail_len {
+                    let content = fresh_content(&mut rng, &mut content_pool, 0);
+                    let key = (prev_key ^ content.rotate_left(29))
+                        .wrapping_mul(0x9E3779B97F4A7C15)
+                        .wrapping_add(holder as u64 ^ (fi as u64) << 32)
+                        | 1;
+                    tail.push((key, content));
+                    prev_key = key;
+                }
+                let mut tail_parent = Some(fork_parent);
+                for batch in tail.chunks(cfg.store_batch) {
+                    batches.push(Op::Store {
+                        holder,
+                        parent: tail_parent,
+                        blocks: batch.to_vec(),
+                    });
+                    tail_parent = Some(batch.last().expect("non-empty").0);
+                }
+                // Record the tail for query generation.
+                tails.push((fi, fork_at as u32, tail));
+            }
+            // Duplicates: re-send some batches verbatim (later in the
+            // holder's script — legal §7 duplication).
+            let mut dups = Vec::new();
+            for b in &batches {
+                if rng.chance(cfg.duplicate_pct) {
+                    dups.push(b.clone());
+                }
+            }
+            // Gap: remove one mid-chain block the holder actually
+            // STORED (drawn from the stored span, not the whole family:
+            // a victim past `span` was never held, so its Remove would
+            // be a no-op and the gap rate would silently undershoot
+            // `gap_pct`, under-exercising the bridged-gap census).
+            let mut gaps = Vec::new();
+            if rng.chance(cfg.gap_pct) && span > 2 {
+                let victim = stored_spine[1 + rng.below(span - 2)].0;
+                gaps.push(Op::Remove {
+                    holder,
+                    keys: vec![victim],
+                });
+            }
+            let script = &mut per_holder[holder];
+            script.extend(batches);
+            script.extend(dups);
+            script.extend(gaps);
+        }
+    }
+    for (holder, script) in per_holder.iter_mut().enumerate() {
+        if rng.chance(cfg.clear_pct) && !script.is_empty() {
+            // Clear mid-script: everything before it is discarded
+            // state; everything after rebuilds. Insert at a random
+            // point rather than the end so post-clear stores exist.
+            let at = rng.below(script.len());
+            script.insert(at, Op::Clear { holder });
+        }
+    }
+
+    // Interleave across holders preserving each holder's order.
+    let mut cursors = vec![0usize; cfg.holders];
+    let mut ops = Vec::new();
+    loop {
+        let live: Vec<usize> = (0..cfg.holders)
+            .filter(|&h| cursors[h] < per_holder[h].len())
+            .collect();
+        if live.is_empty() {
+            break;
+        }
+        let h = live[rng.below(live.len())];
+        ops.push(per_holder[h][cursors[h]].clone());
+        cursors[h] += 1;
+    }
+
+    // Post-clear stores may reference parents wiped by the clear;
+    // both sides must reject those identically (ParentNotFound), so
+    // they stay in the stream on purpose.
+
+    // Queries: spine prefixes, TAIL-EXTENDING (into one holder's
+    // divergent tail — distinguishes that holder's deeper answer),
+    // MID-DIVERGING (match d blocks then differ in content), and
+    // pure misses. The first shape set alone let off-query-path
+    // corruption hide (audit finding).
+    let mut queries = Vec::new();
+    for family in &families {
+        for _ in 0..3 {
+            let d = 1 + rng.below(family.len());
+            queries.push(family[..d].iter().map(|&(_, c)| c).collect::<Vec<u64>>());
+        }
+        // Mid-diverging: real prefix then foreign content.
+        let d = 1 + rng.below(family.len());
+        let mut q: Vec<u64> = family[..d].iter().map(|&(_, c)| c).collect();
+        q.extend((0..1 + rng.below(8)).map(|_| rng.next_u64() | 1));
+        queries.push(q);
+    }
+    for (fi, fork_at, tail) in &tails {
+        if queries.len() > families.len() * 8 {
+            break;
+        }
+        let spine = &families[*fi];
+        let mut q: Vec<u64> = spine[..*fork_at as usize].iter().map(|&(_, c)| c).collect();
+        let take = 1 + rng.below(tail.len());
+        q.extend(tail[..take].iter().map(|&(_, c)| c));
+        queries.push(q);
+    }
+    for _ in 0..families.len() {
+        let miss: Vec<u64> = (0..1 + rng.below(24)).map(|_| rng.next_u64() | 1).collect();
+        queries.push(miss);
+    }
+    Workload {
+        ops,
+        queries,
+        holders: cfg.holders,
+    }
+}
+
+/// Reorder a stream within the FULL §7 scope: arbitrary cross-holder
+/// interleaving always; and for holders whose scripts carry no
+/// remove/clear, their OWN store order is also shuffled arbitrarily
+/// (the stronger half of the guarantee — audit finding: it was never
+/// exercised). Order-bearing holders keep their sequence.
+pub fn reinterleave(seed: u64, ops: &[Op], holders: usize) -> Vec<Op> {
+    let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); holders];
+    for op in ops {
+        per_holder[op.holder()].push(op.clone());
+    }
+    let mut rng0 = Rng::new(seed ^ 0x5EED);
+    for script in per_holder.iter_mut() {
+        if !script.iter().any(|op| op.orders_holder()) && script.len() > 1 {
+            // Fisher-Yates over the store-only script. Parent links
+            // may now arrive before their anchor: §7 excludes
+            // ParentNotFound compensation from the guarantee, so the
+            // comparison target must apply the SAME order — callers
+            // compare two subjects on one order, or model-vs-subject
+            // on the same order, never across orders with rejects.
+            // We keep it in-contract instead: shuffle only WHOLE
+            // parent-linked chains (contiguous runs where each op's
+            // parent is the previous op's last key).
+            let mut runs: Vec<Vec<Op>> = Vec::new();
+            let mut current: Vec<Op> = Vec::new();
+            let mut last_key: Option<u64> = None;
+            for op in script.drain(..) {
+                let anchors_prev = matches!(
+                    (&op, last_key),
+                    (Op::Store { parent: Some(p), .. }, Some(k)) if *p == k
+                );
+                if !anchors_prev && !current.is_empty() {
+                    runs.push(std::mem::take(&mut current));
+                }
+                last_key = match &op {
+                    Op::Store { blocks, .. } => blocks.last().map(|&(k, _)| k),
+                    _ => None,
+                };
+                current.push(op);
+            }
+            if !current.is_empty() {
+                runs.push(current);
+            }
+            // Random TOPOLOGICAL order: a run whose anchor parent
+            // key is produced by another run must stay after it —
+            // literal arbitrary order would change which stores get
+            // ACCEPTED (ParentNotFound), which is outside §7's
+            // chain-consistent scope (rejected stores leave the
+            // multiset). Within the dependency partial order, the
+            // shuffle is free.
+            let produced: Vec<std::collections::HashSet<u64>> = runs
+                .iter()
+                .map(|run| {
+                    run.iter()
+                        .flat_map(|op| match op {
+                            Op::Store { blocks, .. } => {
+                                blocks.iter().map(|&(k, _)| k).collect::<Vec<_>>()
+                            }
+                            _ => Vec::new(),
+                        })
+                        .collect()
+                })
+                .collect();
+            let needs: Vec<Option<u64>> = runs
+                .iter()
+                .map(|run| match run.first() {
+                    Some(Op::Store { parent, .. }) => *parent,
+                    _ => None,
+                })
+                .collect();
+            let n = runs.len();
+            let mut placed = vec![false; n];
+            let mut ordered: Vec<Vec<Op>> = Vec::with_capacity(n);
+            let mut produced_so_far: std::collections::HashSet<u64> =
+                std::collections::HashSet::new();
+            while ordered.len() < n {
+                let ready: Vec<usize> = (0..n)
+                    .filter(|&i| {
+                        !placed[i] && needs[i].is_none_or(|k| produced_so_far.contains(&k))
+                    })
+                    .collect();
+                // Runs whose parent was never produced in this script
+                // (anchored on another assignment's spine already
+                // present) are always ready.
+                let ready = if ready.is_empty() {
+                    (0..n).filter(|&i| !placed[i]).collect()
+                } else {
+                    ready
+                };
+                let pick = ready[rng0.below(ready.len())];
+                placed[pick] = true;
+                produced_so_far.extend(produced[pick].iter().copied());
+                ordered.push(std::mem::take(&mut runs[pick]));
+            }
+            *script = ordered.into_iter().flatten().collect();
+        }
+    }
+    let mut rng = Rng::new(seed);
+    let mut cursors = vec![0usize; holders];
+    let mut out = Vec::with_capacity(ops.len());
+    loop {
+        let live: Vec<usize> = (0..holders)
+            .filter(|&h| cursors[h] < per_holder[h].len())
+            .collect();
+        if live.is_empty() {
+            break;
+        }
+        let h = live[rng.below(live.len())];
+        out.push(per_holder[h][cursors[h]].clone());
+        cursors[h] += 1;
+    }
+    out
+}

--- a/crates/radix_tree/tests/differential.rs
+++ b/crates/radix_tree/tests/differential.rs
@@ -1,0 +1,429 @@
+//! The model-referee differential harness, R0 stage:
+//! model vs oracle. When the R1 core exists it joins as the third
+//! side with the HARD assertion `RadixTree == model`; until then this
+//! file proves the model, the oracle adapter, and the generator agree
+//! on the contract's terms:
+//!
+//! - the oracle never under-matches the model (an under-match has no
+//!   quirk explanation and fails the run — §10.1's "unclassifiable");
+//! - every oracle over-match position is tagged into three classes:
+//!   gap-bridged (right block present, an earlier position missing),
+//!   cross-lineage (content coincidence under another chain), or
+//!   absent (pure skip overshoot) — §6's quirk surface, measured;
+//! - both sides accept/reject every store identically;
+//! - the model itself converges under §7-scoped reordering.
+
+mod common;
+
+use std::collections::BTreeMap;
+
+use common::{
+    model::{Model, StoreResult},
+    oracle::Oracle,
+    workload, Op,
+};
+use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree, StoreError};
+
+/// The implementations under test (flat R1 and chain-native R3),
+/// driven by the harness Op protocol. Every observable is asserted
+/// for BOTH against the model.
+enum Core {
+    Flat(FlatTree),
+    Chain(RadixTree),
+}
+
+struct Subject {
+    core: Core,
+    ids: Vec<HolderId>,
+    scratch: Vec<radix_tree::Overlap>,
+    qscratch: OverlapScratch,
+}
+
+impl Subject {
+    fn new_flat(holders: usize) -> Self {
+        let mut tree = FlatTree::new(Config::default());
+        let ids = (0..holders)
+            .map(|h| tree.create_holder(&format!("holder-{h}")))
+            .collect();
+        Self {
+            core: Core::Flat(tree),
+            ids,
+            scratch: Vec::new(),
+            qscratch: OverlapScratch::default(),
+        }
+    }
+
+    fn new_chain(holders: usize) -> Self {
+        let mut tree = RadixTree::new(Config::default());
+        let ids = (0..holders)
+            .map(|h| tree.create_holder(&format!("holder-{h}")))
+            .collect();
+        Self {
+            core: Core::Chain(tree),
+            ids,
+            scratch: Vec::new(),
+            qscratch: OverlapScratch::default(),
+        }
+    }
+
+    /// Returns false when the store was rejected (must match model).
+    fn apply(&mut self, op: &Op) -> bool {
+        match op {
+            Op::Store {
+                holder,
+                parent,
+                blocks,
+            } => {
+                let r = match &mut self.core {
+                    Core::Flat(t) => t.store(self.ids[*holder], *parent, blocks),
+                    Core::Chain(t) => t.store(self.ids[*holder], *parent, blocks),
+                };
+                match r {
+                    Ok(_) => true,
+                    Err(StoreError::ParentNotFound) => false,
+                    Err(e) => panic!("unexpected store error {e:?}"),
+                }
+            }
+            Op::Remove { holder, keys } => {
+                match &mut self.core {
+                    Core::Flat(t) => t.remove(self.ids[*holder], keys),
+                    Core::Chain(t) => t.remove(self.ids[*holder], keys),
+                };
+                true
+            }
+            Op::Clear { holder } => {
+                match &mut self.core {
+                    Core::Flat(t) => t.clear(self.ids[*holder]),
+                    Core::Chain(t) => t.clear(self.ids[*holder]),
+                }
+                true
+            }
+        }
+    }
+
+    fn overlap(&mut self, query: &[u64]) -> BTreeMap<usize, u32> {
+        let scratch = &mut self.scratch;
+        match &mut self.core {
+            Core::Flat(t) => t.overlap(query, &mut self.qscratch, scratch),
+            Core::Chain(t) => t.overlap(query, &mut self.qscratch, scratch),
+        }
+        // Shape check on the RAW Vec before the BTreeMap collapse: every
+        // holder must appear at most once. The map projection would hide a
+        // merge-loop regression that emitted a holder twice (a downstream
+        // consumer iterating the Vec would then double-count).
+        let mut out = BTreeMap::new();
+        for o in scratch.iter() {
+            assert!(
+                out.insert(o.holder.parts().0 as usize, o.depth).is_none(),
+                "overlap emitted holder {} twice in the raw Vec",
+                o.holder.parts().0
+            );
+        }
+        out
+    }
+
+    fn holder_blocks(&self, h: usize) -> u64 {
+        match &self.core {
+            Core::Flat(t) => t.holder_blocks(self.ids[h]),
+            Core::Chain(t) => t.holder_blocks(self.ids[h]),
+        }
+    }
+
+    fn enumerate(&self, h: usize) -> Vec<(u32, u64, u64)> {
+        match &self.core {
+            Core::Flat(t) => t.enumerate(self.ids[h]).collect(),
+            Core::Chain(t) => t.enumerate(self.ids[h]).collect(),
+        }
+    }
+
+    fn distinct_entries(&self) -> u64 {
+        match &self.core {
+            Core::Flat(t) => t.stats().distinct_entries,
+            Core::Chain(t) => t.stats().distinct_entries,
+        }
+    }
+
+    fn audit(&self) -> Result<(), String> {
+        match &self.core {
+            Core::Flat(t) => t.audit(),
+            Core::Chain(t) => t.audit(),
+        }
+    }
+}
+
+struct Census {
+    queries: usize,
+    holder_answers: usize,
+    over_matches: usize,
+    /// Excess position holds the right block, an EARLIER position is
+    /// missing: the oracle bridged a gap (jump landing / retain
+    /// guard) — the quirk M2 measured as prediction error.
+    excess_gap_bridged: usize,
+    /// Excess position holds the content under a DIFFERENT lineage:
+    /// cross-chain coincidence (Single-entry lineage skip / retain
+    /// guard on coincident content).
+    excess_cross_lineage: usize,
+    /// Excess position holds nothing matching: pure skip overshoot.
+    excess_absent: usize,
+}
+
+/// Drive one workload through all three sides with periodic
+/// checkpoints. RadixTree == model is the HARD gate; the oracle is
+/// the >=-side sanity anchor with the quirk census.
+fn run_differential(seed: u64, cfg: &workload::Config) -> Census {
+    let wl = workload::generate(seed, cfg);
+    let mut model = Model::new(wl.holders);
+    let mut oracle = Oracle::new(wl.holders);
+    let mut subjects = [
+        Subject::new_flat(wl.holders),
+        Subject::new_chain(wl.holders),
+    ];
+    let mut census = Census {
+        queries: 0,
+        holder_answers: 0,
+        over_matches: 0,
+        excess_gap_bridged: 0,
+        excess_cross_lineage: 0,
+        excess_absent: 0,
+    };
+    let checkpoint_every = (wl.ops.len() / 8).max(1);
+    for (i, op) in wl.ops.iter().enumerate() {
+        let model_outcome = model.apply(op);
+        let oracle_ok = oracle.apply(op);
+        if let Op::Store { .. } = op {
+            let model_ok = !matches!(model_outcome, Some(StoreResult::ParentNotFound));
+            assert_eq!(
+                model_ok, oracle_ok,
+                "oracle store acceptance diverged at op {i} (seed {seed}): {op:?}"
+            );
+        }
+        for (ci, subject) in subjects.iter_mut().enumerate() {
+            let subject_ok = subject.apply(op);
+            if let Op::Store { .. } = op {
+                let model_ok = !matches!(model_outcome, Some(StoreResult::ParentNotFound));
+                assert_eq!(
+                    model_ok, subject_ok,
+                    "core{ci} store acceptance diverged at op {i} (seed {seed}): {op:?}"
+                );
+            }
+        }
+        if i % checkpoint_every == 0 || i + 1 == wl.ops.len() {
+            checkpoint(
+                seed,
+                i,
+                &model,
+                &oracle,
+                &mut subjects,
+                &wl.queries,
+                &mut census,
+            );
+        }
+    }
+    // Terminal per-holder accounting, enumeration, and distinct-entry
+    // parity, for BOTH cores.
+    for (ci, subject) in subjects.iter().enumerate() {
+        for h in 0..wl.holders {
+            assert_eq!(
+                subject.holder_blocks(h),
+                model.holder_blocks(h),
+                "core{ci} holder_blocks diverged for holder {h} (seed {seed})"
+            );
+            assert_eq!(
+                subject.enumerate(h),
+                model.enumerate(h),
+                "core{ci} enumerate diverged for holder {h} (seed {seed})"
+            );
+        }
+        assert_eq!(
+            subject.distinct_entries(),
+            model.distinct_entries(),
+            "core{ci} distinct_entries diverged (seed {seed})"
+        );
+    }
+    census
+}
+
+fn checkpoint(
+    seed: u64,
+    at: usize,
+    model: &Model,
+    oracle: &Oracle,
+    subjects: &mut [Subject; 2],
+    queries: &[Vec<u64>],
+    census: &mut Census,
+) {
+    for (ci, subject) in subjects.iter().enumerate() {
+        subject
+            .audit()
+            .unwrap_or_else(|e| panic!("core{ci} audit failed (seed {seed}, op {at}): {e}"));
+    }
+    for query in queries {
+        census.queries += 1;
+        let want = model.overlap(query);
+        // THE gate: both implementations equal the model, always.
+        for (ci, subject) in subjects.iter_mut().enumerate() {
+            let subject_map = subject.overlap(query);
+            assert_eq!(
+                subject_map,
+                want,
+                "core{ci} != model (seed {seed}, op {at}, query len {})",
+                query.len()
+            );
+            for o in subject.scratch.iter() {
+                let h = o.holder.parts().0 as usize;
+                assert_eq!(
+                    o.total_blocks,
+                    model.holder_blocks(h),
+                    "core{ci} total_blocks diverged for holder {h} (seed {seed}, op {at})"
+                );
+            }
+        }
+        let got = oracle.overlap(query);
+        // Under-match anywhere = unclassifiable = fail.
+        for (&holder, &depth) in &want {
+            let oracle_depth = got.get(&holder).copied().unwrap_or(0);
+            assert!(
+                oracle_depth >= depth,
+                "oracle under-matches model (seed {seed}, op {at}, holder {holder}): \
+                 oracle {oracle_depth} < model {depth} on query len {}",
+                query.len()
+            );
+        }
+        census.holder_answers += want.len();
+        // Over-matches: every excess position must classify.
+        for (&holder, &oracle_depth) in &got {
+            let model_depth = want.get(&holder).copied().unwrap_or(0);
+            if oracle_depth > model_depth {
+                census.over_matches += 1;
+                for p in model_depth..oracle_depth {
+                    if model.holds_lineage_true_at(holder, p, query) {
+                        census.excess_gap_bridged += 1;
+                    } else if model.holds_content_at(holder, p, query[p as usize]) {
+                        census.excess_cross_lineage += 1;
+                    } else {
+                        census.excess_absent += 1;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn model_vs_oracle_content_unique() {
+    let mut total_over = 0usize;
+    for seed in 1..=8u64 {
+        let census = run_differential(seed, &workload::Config::small());
+        total_over += census.over_matches;
+        println!(
+            "seed {seed}: {} queries, {} holder answers, {} over-matches \
+             (excess positions: {} gap-bridged / {} cross-lineage / {} absent)",
+            census.queries,
+            census.holder_answers,
+            census.over_matches,
+            census.excess_gap_bridged,
+            census.excess_cross_lineage,
+            census.excess_absent
+        );
+    }
+    println!("content-unique total over-matches: {total_over}");
+}
+
+#[test]
+fn model_vs_oracle_with_coincidence() {
+    let mut total_over = 0usize;
+    for seed in 100..=107u64 {
+        let census = run_differential(seed, &workload::Config::with_coincidence());
+        total_over += census.over_matches;
+    }
+    println!("coincidence total over-matches: {total_over}");
+}
+
+/// §7: the model's observable state is identical under any
+/// §7-scoped reordering of the same multiset.
+#[test]
+fn model_converges_within_scope() {
+    for seed in 1..=6u64 {
+        let wl = workload::generate(seed, &workload::Config::small());
+        let mut reference = Model::new(wl.holders);
+        for op in &wl.ops {
+            reference.apply(op);
+        }
+        for reorder_seed in [7u64, 8, 9] {
+            let ops = workload::reinterleave(reorder_seed, &wl.ops, wl.holders);
+            let mut other = Model::new(wl.holders);
+            let mut subjects = [
+                Subject::new_flat(wl.holders),
+                Subject::new_chain(wl.holders),
+            ];
+            for op in &ops {
+                other.apply(op);
+                for subject in subjects.iter_mut() {
+                    subject.apply(op);
+                }
+            }
+            for query in &wl.queries {
+                let want = reference.overlap(query);
+                assert_eq!(
+                    want,
+                    other.overlap(query),
+                    "model diverged under scoped reordering (seed {seed}/{reorder_seed})"
+                );
+                for (ci, subject) in subjects.iter_mut().enumerate() {
+                    assert_eq!(
+                        subject.overlap(query),
+                        want,
+                        "core{ci} diverged under scoped reordering (seed {seed}/{reorder_seed})"
+                    );
+                }
+            }
+            for h in 0..wl.holders {
+                assert_eq!(reference.holder_blocks(h), other.holder_blocks(h));
+                for subject in subjects.iter() {
+                    assert_eq!(subject.holder_blocks(h), reference.holder_blocks(h));
+                }
+            }
+        }
+    }
+}
+
+/// §4: a rejected store applies nothing, on both sides.
+#[test]
+fn rejected_store_applies_nothing() {
+    let mut model = Model::new(1);
+    let mut oracle = Oracle::new(1);
+    let mut subjects = [Subject::new_flat(1), Subject::new_chain(1)];
+    let seeded = Op::Store {
+        holder: 0,
+        parent: None,
+        blocks: vec![(11, 101), (12, 102)],
+    };
+    model.apply(&seeded);
+    oracle.apply(&seeded);
+    for subject in subjects.iter_mut() {
+        subject.apply(&seeded);
+    }
+    let before_model = model.overlap(&[101, 102]);
+    let before_oracle = oracle.overlap(&[101, 102]);
+    let before_subject: Vec<_> = subjects
+        .iter_mut()
+        .map(|s| s.overlap(&[101, 102]))
+        .collect();
+    let bad = Op::Store {
+        holder: 0,
+        parent: Some(999),
+        blocks: vec![(13, 103)],
+    };
+    assert_eq!(model.apply(&bad), Some(StoreResult::ParentNotFound));
+    assert!(!oracle.apply(&bad));
+    for subject in subjects.iter_mut() {
+        assert!(!subject.apply(&bad));
+    }
+    assert_eq!(model.overlap(&[101, 102]), before_model);
+    assert_eq!(oracle.overlap(&[101, 102]), before_oracle);
+    for (subject, before) in subjects.iter_mut().zip(&before_subject) {
+        assert_eq!(subject.overlap(&[101, 102]), *before);
+        assert_eq!(subject.holder_blocks(0), 2);
+    }
+    assert_eq!(model.holder_blocks(0), 2);
+}

--- a/crates/radix_tree/tests/fuzz_differential.rs
+++ b/crates/radix_tree/tests/fuzz_differential.rs
@@ -1,0 +1,711 @@
+//! Campaign C1/C3/C4: wide-config differential fuzz plus
+//! out-of-contract chaos.
+//!
+//! In-contract mode: randomized workload configs far beyond the
+//! normative shapes, RadixTree == model at every checkpoint, full
+//! `audit()` at every checkpoint (and after EVERY op on small
+//! workloads).
+//!
+//! Chaos mode: deliberately violates every §7 precondition — random
+//! parents (including keys inside the same batch and never-seen
+//! keys), keys reused across positions and chains, interleaved
+//! retires/recreates, operations through stale ids, truncates at
+//! random keeps. The contract here is: NO panics, `audit()` holds
+//! after EVERY op, stale ids are loud no-ops, and a bit-for-bit
+//! replay of the same sequence lands in an identical observable
+//! state (determinism).
+//!
+//! `fuzz_quick` (8+3 seeds) always runs — sized for the debug-build
+//! CI lane, where the reference model's per-op audit dominates (32+8
+//! seeds pushed the whole workspace's test step past its 30-minute
+//! limit). The wide-sharing (H<=64) distribution and the seed volume
+//! run in `fuzz_campaign`, which the scheduled workflow
+//! `.github/workflows/radix-tree-fuzz.yml` runs nightly in release
+//! (600 seeds by default, more on dispatch); locally:
+//!   RADIX_FUZZ_SEEDS=10000 cargo test -p smg-radix-tree --release \
+//!     --test fuzz_differential -- --ignored --nocapture
+
+mod common;
+
+use std::collections::BTreeMap;
+
+use common::{
+    env_u64,
+    model::{Model, StoreResult},
+    workload::{self, Config as WlConfig},
+    Op, Rng,
+};
+use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree, StoreError};
+
+/// `wide` raises the sharing cap to the bench's H=64 width — model
+/// scans at that width are too slow for the always-on debug quick
+/// suite, so wide configs belong to the release campaign entry point
+/// (audit finding: correctness past ~27 holders/block was previously
+/// never model-gated ANYWHERE).
+fn random_config(rng: &mut Rng, wide: bool) -> WlConfig {
+    let holders = 2 + rng.below(255);
+    let share_cap = if wide { 64 } else { 24 };
+    WlConfig {
+        holders,
+        families: 1 + rng.below(64),
+        family_len: {
+            let lo = 1 + rng.below(64);
+            (lo, lo + 1 + rng.below(448))
+        },
+        holders_per_family: {
+            // Both bounds clamped to what the workload can honor: the
+            // documented sharing cap (24 / 64) and the holder count —
+            // an oversized upper bound would assign more members than
+            // the cap promises (with-replacement sampling silently
+            // duplicates past `holders`).
+            let cap = holders.min(share_cap);
+            let lo = (1 + rng.below(4)).min(cap);
+            let hi = (lo + rng.below(cap)).min(cap);
+            (lo, hi)
+        },
+        tail_len: (1 + rng.below(8), 9 + rng.below(56)),
+        store_batch: 1 + rng.below(16),
+        duplicate_pct: rng.below(41) as u64,
+        gap_pct: rng.below(41) as u64,
+        clear_pct: rng.below(31) as u64,
+        coincidence_pct: rng.below(51) as u64,
+    }
+}
+
+enum Core {
+    Flat(FlatTree),
+    Chain(RadixTree),
+}
+
+struct Subject {
+    core: Core,
+    ids: Vec<HolderId>,
+    scratch: Vec<radix_tree::Overlap>,
+    qscratch: OverlapScratch,
+}
+
+impl Subject {
+    fn new_flat(holders: usize) -> Self {
+        let mut tree = FlatTree::new(Config::default());
+        let ids = (0..holders)
+            .map(|h| tree.create_holder(&format!("holder-{h}")))
+            .collect();
+        Self {
+            core: Core::Flat(tree),
+            ids,
+            scratch: Vec::new(),
+            qscratch: OverlapScratch::default(),
+        }
+    }
+    fn new_chain(holders: usize) -> Self {
+        let mut tree = RadixTree::new(Config::default());
+        let ids = (0..holders)
+            .map(|h| tree.create_holder(&format!("holder-{h}")))
+            .collect();
+        Self {
+            core: Core::Chain(tree),
+            ids,
+            scratch: Vec::new(),
+            qscratch: OverlapScratch::default(),
+        }
+    }
+    fn apply(&mut self, op: &Op) -> Option<(u32, u32)> {
+        match op {
+            Op::Store {
+                holder,
+                parent,
+                blocks,
+            } => {
+                // covered() is the shared-lock duplicate fast path's
+                // load-bearing predicate: gate it as an exact no-op
+                // oracle on EVERY store of every seed.
+                let predicted = match &self.core {
+                    Core::Flat(t) => Some(t.covered(self.ids[*holder], *parent, blocks)),
+                    Core::Chain(t) => Some(t.covered(self.ids[*holder], *parent, blocks)),
+                };
+                let r = match &mut self.core {
+                    Core::Flat(t) => t.store(self.ids[*holder], *parent, blocks),
+                    Core::Chain(t) => t.store(self.ids[*holder], *parent, blocks),
+                };
+                if let Some(predicted) = predicted {
+                    let no_op = matches!(&r, Ok(o) if o.applied == 0);
+                    assert_eq!(
+                        predicted, no_op,
+                        "covered() disagreed with store outcome {r:?}"
+                    );
+                }
+                match r {
+                    Ok(o) => Some((o.applied, o.duplicates)),
+                    Err(StoreError::ParentNotFound) => None,
+                    Err(e) => panic!("unexpected store error {e:?}"),
+                }
+            }
+            Op::Remove { holder, keys } => {
+                match &mut self.core {
+                    Core::Flat(t) => t.remove(self.ids[*holder], keys),
+                    Core::Chain(t) => t.remove(self.ids[*holder], keys),
+                };
+                Some((0, 0))
+            }
+            Op::Clear { holder } => {
+                match &mut self.core {
+                    Core::Flat(t) => t.clear(self.ids[*holder]),
+                    Core::Chain(t) => t.clear(self.ids[*holder]),
+                }
+                Some((0, 0))
+            }
+        }
+    }
+    fn overlap(&mut self, query: &[u64]) -> BTreeMap<usize, u32> {
+        let scratch = &mut self.scratch;
+        match &mut self.core {
+            Core::Flat(t) => t.overlap(query, &mut self.qscratch, scratch),
+            Core::Chain(t) => t.overlap(query, &mut self.qscratch, scratch),
+        }
+        let mut out = BTreeMap::new();
+        for o in scratch.iter() {
+            // Same uniqueness gate as differential.rs: a holder emitted
+            // twice in the raw Vec would otherwise be silently
+            // overwritten here, hiding a duplicate-emission regression
+            // exactly where the widest seed space runs.
+            assert!(
+                out.insert(o.holder.parts().0 as usize, o.depth).is_none(),
+                "overlap emitted holder {} twice in the raw Vec",
+                o.holder.parts().0
+            );
+        }
+        out
+    }
+    fn holder_blocks(&self, h: usize) -> u64 {
+        match &self.core {
+            Core::Flat(t) => t.holder_blocks(self.ids[h]),
+            Core::Chain(t) => t.holder_blocks(self.ids[h]),
+        }
+    }
+    fn enumerate(&self, h: usize) -> Vec<(u32, u64, u64)> {
+        match &self.core {
+            Core::Flat(t) => t.enumerate(self.ids[h]).collect(),
+            Core::Chain(t) => t.enumerate(self.ids[h]).collect(),
+        }
+    }
+    fn distinct_entries(&self) -> u64 {
+        match &self.core {
+            Core::Flat(t) => t.stats().distinct_entries,
+            Core::Chain(t) => t.stats().distinct_entries,
+        }
+    }
+    fn dup_prefix(&self, h: usize, parent: Option<u64>, blocks: &[(u64, u64)]) -> (u32, bool) {
+        match &self.core {
+            Core::Flat(t) => t.dup_prefix(self.ids[h], parent, blocks),
+            Core::Chain(t) => t.dup_prefix(self.ids[h], parent, blocks),
+        }
+    }
+    fn position_of(&self, h: usize, key: u64) -> Option<u32> {
+        match &self.core {
+            Core::Flat(t) => t.position_of(self.ids[h], key),
+            Core::Chain(t) => t.position_of(self.ids[h], key),
+        }
+    }
+    fn audit(&self) -> Result<(), String> {
+        match &self.core {
+            Core::Flat(t) => t.audit(),
+            Core::Chain(t) => t.audit(),
+        }
+    }
+}
+
+fn run_one_in_contract(seed: u64, wide: bool) {
+    let mut rng = Rng::new(seed ^ 0xF00D);
+    let cfg = random_config(&mut rng, wide);
+    let wl = workload::generate(seed, &cfg);
+    let audit_every_op = wl.ops.len() < 4000;
+    let mut model = Model::new(wl.holders);
+    let mut subjects = [
+        Subject::new_flat(wl.holders),
+        Subject::new_chain(wl.holders),
+    ];
+    let checkpoint_every = (wl.ops.len() / 6).max(1);
+    for (i, op) in wl.ops.iter().enumerate() {
+        if let Op::Store {
+            holder,
+            parent,
+            blocks,
+        } = op
+        {
+            // dup_prefix parity: the engine's split-apply re-anchors a
+            // store at blocks[run-1] and applies only the suffix, so a
+            // wrong run means silently corrupted placements.
+            let expect = model.dup_prefix(*holder, *parent, blocks);
+            for subject in subjects.iter() {
+                assert_eq!(
+                    subject.dup_prefix(*holder, *parent, blocks),
+                    expect,
+                    "dup_prefix diverged from model"
+                );
+                for &(key, _) in blocks.iter() {
+                    assert_eq!(
+                        subject.position_of(*holder, key),
+                        model.position_of(*holder, key),
+                        "position_of diverged from model"
+                    );
+                }
+            }
+        }
+        let model_outcome = model.apply(op);
+        for (ci, subject) in subjects.iter_mut().enumerate() {
+            let subject_out = subject.apply(op);
+            if let Op::Store { .. } = op {
+                // StoreOutcome PARITY, not just acceptance: the relay
+                // gate depends on applied counts (audit finding — the
+                // payload was discarded everywhere).
+                match (&model_outcome, &subject_out) {
+                    (Some(StoreResult::ParentNotFound), None) => {}
+                    (
+                        Some(StoreResult::Applied {
+                            applied,
+                            duplicates,
+                        }),
+                        Some((a, d)),
+                    ) => {
+                        assert_eq!(
+                            (*applied, *duplicates),
+                            (*a, *d),
+                            "core{ci} StoreOutcome diverged: seed {seed} op {i}"
+                        );
+                    }
+                    other => panic!("core{ci} acceptance diverged: seed {seed} op {i}: {other:?}"),
+                }
+            }
+            if audit_every_op {
+                subject
+                    .audit()
+                    .unwrap_or_else(|e| panic!("core{ci} audit failed: seed {seed} op {i}: {e}"));
+            }
+        }
+        if i % checkpoint_every == 0 || i + 1 == wl.ops.len() {
+            if !audit_every_op {
+                for (ci, subject) in subjects.iter().enumerate() {
+                    subject.audit().unwrap_or_else(|e| {
+                        panic!("core{ci} audit failed: seed {seed} op {i}: {e}")
+                    });
+                }
+            }
+            // The model's answer is the slow scan: compute it once per
+            // query and hold both cores to it.
+            for query in &wl.queries {
+                let want = model.overlap(query);
+                for (ci, subject) in subjects.iter_mut().enumerate() {
+                    assert_eq!(
+                        subject.overlap(query),
+                        want,
+                        "core{ci} != model: seed {seed} op {i}"
+                    );
+                }
+            }
+        }
+    }
+    for (ci, subject) in subjects.iter().enumerate() {
+        for h in 0..wl.holders {
+            assert_eq!(
+                subject.holder_blocks(h),
+                model.holder_blocks(h),
+                "core{ci} holder_blocks diverged: seed {seed} holder {h}"
+            );
+            // Terminal ENUMERATE parity: per-block position/key/
+            // content — off-query-path corruption was invisible to
+            // the whole campaign without this (audit finding).
+            assert_eq!(
+                subject.enumerate(h),
+                model.enumerate(h),
+                "core{ci} enumerate diverged: seed {seed} holder {h}"
+            );
+        }
+        assert_eq!(
+            subject.distinct_entries(),
+            model.distinct_entries(),
+            "core{ci} distinct_entries diverged: seed {seed}"
+        );
+    }
+}
+
+/// Uniform surface over both cores for the generic chaos driver.
+trait CoreApi {
+    fn create_holder(&mut self, name: &str) -> HolderId;
+    fn dup_prefix(&self, id: HolderId, parent: Option<u64>, blocks: &[(u64, u64)]) -> (u32, bool);
+    fn position_of(&self, id: HolderId, key: u64) -> Option<u32>;
+    fn store(
+        &mut self,
+        id: HolderId,
+        parent: Option<u64>,
+        blocks: &[(u64, u64)],
+    ) -> Result<radix_tree::StoreOutcome, StoreError>;
+    fn remove(&mut self, id: HolderId, keys: &[u64]) -> u32;
+    fn clear(&mut self, id: HolderId);
+    fn truncate_tail(&mut self, id: HolderId, keep: u64) -> u64;
+    fn retire_holder(&mut self, id: HolderId);
+    fn holder_blocks(&self, id: HolderId) -> u64;
+    fn holder_name(&self, id: HolderId) -> Option<&str>;
+    fn overlap(&self, q: &[u64], sc: &mut OverlapScratch, out: &mut Vec<radix_tree::Overlap>);
+    fn audit(&self) -> Result<(), String>;
+    fn distinct_entries(&self) -> u64;
+}
+
+macro_rules! impl_core_api {
+    ($t:ty) => {
+        impl CoreApi for $t {
+            fn create_holder(&mut self, name: &str) -> HolderId {
+                <$t>::create_holder(self, name)
+            }
+            fn dup_prefix(
+                &self,
+                id: HolderId,
+                parent: Option<u64>,
+                blocks: &[(u64, u64)],
+            ) -> (u32, bool) {
+                <$t>::dup_prefix(self, id, parent, blocks)
+            }
+            fn position_of(&self, id: HolderId, key: u64) -> Option<u32> {
+                <$t>::position_of(self, id, key)
+            }
+            fn store(
+                &mut self,
+                id: HolderId,
+                parent: Option<u64>,
+                blocks: &[(u64, u64)],
+            ) -> Result<radix_tree::StoreOutcome, StoreError> {
+                <$t>::store(self, id, parent, blocks)
+            }
+            fn remove(&mut self, id: HolderId, keys: &[u64]) -> u32 {
+                <$t>::remove(self, id, keys)
+            }
+            fn clear(&mut self, id: HolderId) {
+                <$t>::clear(self, id)
+            }
+            fn truncate_tail(&mut self, id: HolderId, keep: u64) -> u64 {
+                <$t>::truncate_tail(self, id, keep)
+            }
+            fn retire_holder(&mut self, id: HolderId) {
+                <$t>::retire_holder(self, id)
+            }
+            fn holder_blocks(&self, id: HolderId) -> u64 {
+                <$t>::holder_blocks(self, id)
+            }
+            fn holder_name(&self, id: HolderId) -> Option<&str> {
+                <$t>::holder_name(self, id)
+            }
+            fn overlap(
+                &self,
+                q: &[u64],
+                sc: &mut OverlapScratch,
+                out: &mut Vec<radix_tree::Overlap>,
+            ) {
+                <$t>::overlap(self, q, sc, out)
+            }
+            fn audit(&self) -> Result<(), String> {
+                <$t>::audit(self)
+            }
+            fn distinct_entries(&self) -> u64 {
+                <$t>::stats(self).distinct_entries
+            }
+        }
+    };
+}
+impl_core_api!(FlatTree);
+impl_core_api!(RadixTree);
+
+/// Chaos: arbitrary op soup. Contract: no panic, audit always green,
+/// stale-id ops are loud no-ops, replay is deterministic — for BOTH
+/// cores, each against the total model.
+fn run_one_chaos(seed: u64) {
+    #[derive(Clone, Debug)]
+    enum COp {
+        Store {
+            slot: usize,
+            parent_pick: u64,
+            blocks: Vec<(u64, u64)>,
+        },
+        Remove {
+            slot: usize,
+            keys: Vec<u64>,
+        },
+        Clear {
+            slot: usize,
+        },
+        Truncate {
+            slot: usize,
+            keep: u64,
+        },
+        Retire {
+            slot: usize,
+        },
+        Recreate {
+            slot: usize,
+        },
+        StaleProbe {
+            slot: usize,
+        },
+        Query {
+            probe: Vec<u64>,
+        },
+    }
+    let mut rng = Rng::new(seed ^ 0xC4A05);
+    let slots = 2 + rng.below(12);
+    let ops_count = 400 + rng.below(1200);
+    // Key pool encourages collisions across positions and holders.
+    let key_pool: Vec<u64> = (0..64).map(|_| rng.next_u64() | 1).collect();
+    let content_pool: Vec<u64> = (0..48).map(|_| rng.next_u64() | 1).collect();
+    let mut script = Vec::with_capacity(ops_count);
+    for _ in 0..ops_count {
+        let slot = rng.below(slots);
+        script.push(match rng.below(100) {
+            0..=44 => {
+                let len = 1 + rng.below(12);
+                let blocks: Vec<(u64, u64)> = (0..len)
+                    .map(|_| {
+                        (
+                            key_pool[rng.below(key_pool.len())],
+                            content_pool[rng.below(content_pool.len())],
+                        )
+                    })
+                    .collect();
+                COp::Store {
+                    slot,
+                    parent_pick: rng.next_u64(),
+                    blocks,
+                }
+            }
+            45..=59 => COp::Remove {
+                slot,
+                keys: (0..1 + rng.below(6))
+                    .map(|_| key_pool[rng.below(key_pool.len())])
+                    .collect(),
+            },
+            60..=66 => COp::Clear { slot },
+            67..=74 => COp::Truncate {
+                slot,
+                keep: rng.below(40) as u64,
+            },
+            75..=81 => COp::Retire { slot },
+            82..=88 => COp::Recreate { slot },
+            89..=92 => COp::StaleProbe { slot },
+            _ => COp::Query {
+                probe: (0..1 + rng.below(16))
+                    .map(|_| content_pool[rng.below(content_pool.len())])
+                    .collect(),
+            },
+        });
+    }
+
+    fn chaos_run<T: CoreApi>(
+        seed: u64,
+        slots: usize,
+        key_pool: &[u64],
+        script: &[COp],
+        mut tree: T,
+    ) -> (Vec<BTreeMap<usize, u32>>, u64) {
+        // The model is total (defined on arbitrary inputs), so chaos
+        // now runs under the same hard referee gate as the
+        // in-contract fuzz — keyed by chaos slot.
+        let mut model = Model::with_max(slots, 64);
+        let mut ids: Vec<Option<HolderId>> = (0..slots)
+            .map(|s| Some(tree.create_holder(&format!("chaos-{s}"))))
+            .collect();
+        let mut stale: Vec<HolderId> = Vec::new();
+        let mut answers = Vec::new();
+        let mut scratch = Vec::new();
+        let mut qscratch = OverlapScratch::default();
+        for (i, op) in script.iter().enumerate() {
+            match op {
+                COp::Store {
+                    slot,
+                    parent_pick,
+                    blocks,
+                } => {
+                    if let Some(id) = ids[*slot] {
+                        // Parent: none / a pooled key / a never-seen key.
+                        let parent = match parent_pick % 3 {
+                            0 => None,
+                            1 => Some(key_pool[(*parent_pick as usize / 3) % key_pool.len()]),
+                            _ => Some(parent_pick | 1),
+                        };
+                        // Chaos-side covered() gate: subject and model
+                        // must agree on the no-op prediction too.
+                        let predicted_pair = tree.dup_prefix(id, parent, blocks);
+                        assert_eq!(
+                            predicted_pair,
+                            model.dup_prefix(*slot, parent, blocks),
+                            "dup_prefix diverged from model (chaos)"
+                        );
+                        for &(key, _) in blocks.iter() {
+                            assert_eq!(
+                                tree.position_of(id, key),
+                                model.position_of(*slot, key),
+                                "position_of diverged from model (chaos)"
+                            );
+                        }
+                        let predicted = predicted_pair.1;
+                        let subject = tree.store(id, parent, blocks);
+                        let modeled = model.store(*slot, parent, blocks);
+                        let no_op = matches!(&subject, Ok(o) if o.applied == 0);
+                        assert_eq!(predicted, no_op, "covered() wrong vs chaos store");
+                        let pair = (
+                            subject.is_ok(),
+                            !matches!(
+                                modeled,
+                                StoreResult::ParentNotFound | StoreResult::ChainTooLong
+                            ),
+                        );
+                        assert!(
+                            pair.0 == pair.1,
+                            "store acceptance diverged (seed {seed} op {i}): {subject:?} vs {modeled:?}"
+                        );
+                    }
+                }
+                COp::Remove { slot, keys } => {
+                    if let Some(id) = ids[*slot] {
+                        let a = tree.remove(id, keys);
+                        let b = model.remove(*slot, keys);
+                        assert_eq!(a, b, "remove count diverged (seed {seed} op {i})");
+                    }
+                }
+                COp::Clear { slot } => {
+                    if let Some(id) = ids[*slot] {
+                        tree.clear(id);
+                        model.clear(*slot);
+                    }
+                }
+                COp::Truncate { slot, keep } => {
+                    if let Some(id) = ids[*slot] {
+                        let a = tree.truncate_tail(id, *keep);
+                        let b = model.truncate_tail(*slot, *keep);
+                        assert_eq!(a, b, "truncate count diverged (seed {seed} op {i})");
+                    }
+                }
+                COp::Retire { slot } => {
+                    if let Some(id) = ids[*slot].take() {
+                        tree.retire_holder(id);
+                        model.clear(*slot);
+                        stale.push(id);
+                    }
+                }
+                COp::Recreate { slot } => {
+                    if ids[*slot].is_none() {
+                        ids[*slot] = Some(tree.create_holder(&format!("chaos-{slot}-re{i}")));
+                    }
+                }
+                COp::StaleProbe { slot } => {
+                    // Every stale id must be a loud no-op forever.
+                    if let Some(&old) = stale.last() {
+                        assert_eq!(
+                            tree.store(old, None, &[(1, 1)]),
+                            Err(StoreError::UnknownHolder),
+                            "stale id accepted a store (seed {seed} op {i} slot {slot})"
+                        );
+                        assert_eq!(tree.remove(old, &[1]), 0);
+                        assert_eq!(tree.holder_blocks(old), 0);
+                        assert_eq!(tree.holder_name(old), None);
+                    }
+                }
+                COp::Query { probe } => {
+                    tree.overlap(probe, &mut qscratch, &mut scratch);
+                    let mut by_slot = BTreeMap::new();
+                    for o in scratch.iter() {
+                        // Map subject holder ids back to chaos slots;
+                        // an unmapped id would be a stale-holder leak.
+                        let slot = ids
+                            .iter()
+                            .position(|x| *x == Some(o.holder))
+                            .unwrap_or_else(|| {
+                                panic!("answer for unknown holder (seed {seed} op {i})")
+                            });
+                        assert!(
+                            by_slot.insert(slot, o.depth).is_none(),
+                            "overlap emitted slot {slot} twice (seed {seed} op {i})"
+                        );
+                    }
+                    assert_eq!(
+                        by_slot,
+                        model.overlap(probe),
+                        "chaos subject != model (seed {seed} op {i})"
+                    );
+                    answers.push(by_slot);
+                }
+            }
+            tree.audit()
+                .unwrap_or_else(|e| panic!("chaos audit failed: seed {seed} op {i}: {e}"));
+            for (slot, id) in ids.iter().enumerate() {
+                if let Some(id) = id {
+                    assert_eq!(
+                        tree.holder_blocks(*id),
+                        model.holder_blocks(slot),
+                        "chaos holder_blocks diverged (seed {seed} op {i} slot {slot})"
+                    );
+                }
+            }
+        }
+        let distinct = tree.distinct_entries();
+        assert_eq!(
+            distinct,
+            model.distinct_entries(),
+            "chaos distinct_entries diverged (seed {seed})"
+        );
+        (answers, distinct)
+    }
+    // Determinism per core, and cross-core agreement, all vs model.
+    let flat_a = chaos_run(
+        seed,
+        slots,
+        &key_pool,
+        &script,
+        FlatTree::new(Config { max_chain_len: 64 }),
+    );
+    let flat_b = chaos_run(
+        seed,
+        slots,
+        &key_pool,
+        &script,
+        FlatTree::new(Config { max_chain_len: 64 }),
+    );
+    assert_eq!(flat_a, flat_b, "flat chaos replay diverged (seed {seed})");
+    let chain_a = chaos_run(
+        seed,
+        slots,
+        &key_pool,
+        &script,
+        RadixTree::new(Config { max_chain_len: 64 }),
+    );
+    assert_eq!(
+        flat_a, chain_a,
+        "flat vs chain chaos diverged (seed {seed})"
+    );
+}
+
+#[test]
+fn fuzz_quick() {
+    for seed in 1..=8u64 {
+        run_one_in_contract(seed, false);
+    }
+    for seed in 1..=3u64 {
+        run_one_chaos(seed);
+    }
+}
+
+#[test]
+#[ignore = "campaign entry point; set RADIX_FUZZ_SEEDS"]
+fn fuzz_campaign() {
+    let seeds = env_u64("RADIX_FUZZ_SEEDS", 1000);
+    assert!(seeds > 0, "RADIX_FUZZ_SEEDS must be greater than 0");
+    let start = env_u64("RADIX_FUZZ_START", 1000);
+    for seed in start..start + seeds {
+        // Every 4th campaign seed runs the wide-sharing (H<=64)
+        // distribution under the full model gate.
+        run_one_in_contract(seed, seed % 4 == 0);
+        if seed % 3 == 0 {
+            run_one_chaos(seed);
+        }
+        if (seed - start) % 250 == 249 {
+            println!("fuzz: {} seeds green", seed - start + 1);
+        }
+    }
+    println!("fuzz campaign: {seeds} seeds green");
+}

--- a/crates/radix_tree/tests/pinned_bench.rs
+++ b/crates/radix_tree/tests/pinned_bench.rs
@@ -1,0 +1,705 @@
+//! The pinned performance workload, oracle baseline.
+//!
+//! Normative constants live HERE; gates pass on this configuration
+//! only. R0 runs it against the oracle plus the engine's replicated
+//! glue (per-holder reverse map, last-chain Vec, id maps) to record
+//! the baseline; R1 adds the RadixTree side under the same driver.
+//!
+//! Run (numbers are meaningless in debug):
+//!   cargo test -p smg-radix-tree --release --test pinned_bench \
+//!     -- --ignored --nocapture
+//!
+//! Protocol (§11): RSS sampled after fill, before query-phase
+//! allocations; no asserts or allocation inside timed regions;
+//! quote the median of >=3 runs.
+
+mod common;
+
+use std::time::Instant;
+
+use common::{env_u64, oracle::Oracle, rss_kib, Op, Rng};
+use radix_tree::{Config, FlatTree, HolderId, OverlapScratch, RadixTree, StoreError};
+
+// ---- §11 normative constants (default scale) ----
+// RADIX_BENCH_SCALE=large runs 8x blocks / 8x holders (~20 GB peak,
+// ~60% of the 1.7e8 production target) to expose growth
+// nonlinearities the normative scale can't: hash-table growth stalls,
+// TLB pressure on a ~17 GB resident structure, query latency vs
+// table size. Gates are quoted at the DEFAULT scale; large-scale
+// runs are diagnostics.
+/// RADIX_BENCH_SCALE: unset (the gated default scale) or `large`. Any
+/// other value is an operator error, not a silent default — a typo'd
+/// scale would otherwise produce a complete run recorded as a baseline.
+fn large_scale() -> bool {
+    match std::env::var("RADIX_BENCH_SCALE").as_deref() {
+        Ok("large") => true,
+        Err(_) => false,
+        Ok(other) => panic!("unknown RADIX_BENCH_SCALE {other:?} (expected unset or \"large\")"),
+    }
+}
+fn target_blocks() -> u64 {
+    if large_scale() {
+        100_000_000
+    } else {
+        10_000_000
+    }
+}
+fn holders() -> usize {
+    if large_scale() {
+        2048
+    } else {
+        profile().holders_default
+    }
+}
+const BATCH: usize = 8;
+const MISS_QUERY_PCT: u64 = 20;
+/// The gate cell: depth 78 with 64 candidate holders.
+const GATE_DEPTH: u32 = 78;
+
+/// One workload stream shape. `pinned` is the §11 NORMATIVE config —
+/// gates are quoted on it and its parameters must never drift. The
+/// other profiles answer "does the win hold on different input
+/// distributions?" (audit follow-up: one stream shape proves one
+/// point on the workload space): RADIX_BENCH_PROFILE=agentic|churn|
+/// fleet|fragmented selects them; they are diagnostics, not gates.
+struct Profile {
+    name: &'static str,
+    holders_default: usize,
+    /// (sharing factor H, share of total holder-blocks in percent).
+    sharing_mix: [(usize, u64); 3],
+    /// Log-uniform shared-prefix length range.
+    shared_depth: (u32, u32),
+    /// Uniform divergent-tail length range.
+    tail_len: (u32, u32),
+    duplicate_pct: u64,
+    gaps: Gaps,
+}
+
+/// How mid-chain gaps (blocks evicted from the inside of a resident
+/// chain) are distributed over an instance.
+#[derive(Clone, Copy)]
+enum Gaps {
+    /// This share of instances (percent) loses ONE interior block. The
+    /// §11 pinned shape: eviction mostly takes tails, so interior holes
+    /// are rare and isolated.
+    Instances(u64),
+    /// Every instance loses this share (percent) of its interior blocks,
+    /// at distinct random positions (fractional part drawn as a
+    /// Bernoulli, so the expectation is exact per instance). Long
+    /// instances become heavily fragmented — a different regime, kept
+    /// as its own profile because the gates are quoted on the pinned
+    /// shape and that shape must not drift.
+    BlockShare(u64),
+}
+
+/// The §11 constants, verbatim.
+const PINNED: Profile = Profile {
+    name: "pinned",
+    holders_default: 256,
+    sharing_mix: [(1, 50), (8, 35), (64, 15)],
+    shared_depth: (8, 512),
+    tail_len: (4, 64),
+    duplicate_pct: 5,
+    gaps: Gaps::Instances(20),
+};
+/// Long-context / agentic traffic: deep shared prefixes (system
+/// prompts, long conversations), heavy cross-worker sharing.
+const AGENTIC: Profile = Profile {
+    name: "agentic",
+    holders_default: 256,
+    sharing_mix: [(1, 20), (8, 40), (64, 40)],
+    shared_depth: (64, 2048),
+    tail_len: (16, 256),
+    duplicate_pct: 5,
+    gaps: Gaps::Instances(20),
+};
+/// Short-prompt chat with aggressive eviction churn: shallow chains,
+/// little sharing, lots of duplicate re-publish and mid-chain gaps.
+const CHURN: Profile = Profile {
+    name: "churn",
+    holders_default: 256,
+    sharing_mix: [(1, 70), (8, 25), (64, 5)],
+    shared_depth: (4, 64),
+    tail_len: (2, 16),
+    duplicate_pct: 20,
+    gaps: Gaps::Instances(100),
+};
+/// Wide fleet at the default block budget: 4x the workers, each
+/// holding proportionally less — stresses holder-set interning and
+/// span fan-out rather than chain depth.
+const FLEET: Profile = Profile {
+    name: "fleet",
+    holders_default: 1024,
+    sharing_mix: [(1, 40), (8, 30), (64, 30)],
+    shared_depth: (8, 512),
+    tail_len: (4, 64),
+    duplicate_pct: 5,
+    gaps: Gaps::Instances(20),
+};
+/// The pinned shape with heavy interior fragmentation: 2% of every
+/// instance's interior blocks removed at random positions, so a 512-block
+/// shared prefix carries ~10 holes. Measures how much the query walk
+/// pays per extra segment (the oracle's positional map is nearly
+/// indifferent to holes; the chain walk is not).
+const FRAGMENTED: Profile = Profile {
+    name: "fragmented",
+    gaps: Gaps::BlockShare(2),
+    ..PINNED
+};
+
+fn profile() -> &'static Profile {
+    match std::env::var("RADIX_BENCH_PROFILE").as_deref() {
+        Ok("agentic") => &AGENTIC,
+        Ok("churn") => &CHURN,
+        Ok("fleet") => &FLEET,
+        Ok("fragmented") => &FRAGMENTED,
+        Ok(other) if other != "pinned" => panic!("unknown RADIX_BENCH_PROFILE {other:?}"),
+        _ => &PINNED,
+    }
+}
+
+fn log_uniform(rng: &mut Rng, lo: u32, hi: u32) -> u32 {
+    let (llo, lhi) = ((lo as f64).ln(), (hi as f64).ln());
+    let u = (rng.next_u64() >> 11) as f64 / (1u64 << 53) as f64;
+    (llo + u * (lhi - llo)).exp().round() as u32
+}
+
+struct Family {
+    blocks: Vec<(u64, u64)>,
+    holders: Vec<usize>,
+}
+
+fn build_families(rng: &mut Rng) -> Vec<Family> {
+    let mut families = Vec::new();
+    let next_content = |rng: &mut Rng| rng.next_u64() | 1;
+    // One forced gate family: H=64, shared length >= GATE_DEPTH.
+    let mut budgets: Vec<(usize, u64)> = profile()
+        .sharing_mix
+        .iter()
+        .map(|&(h, pct)| (h, target_blocks() * pct / 100))
+        .collect();
+    let mut force_gate = true;
+    for (h, budget) in budgets.iter_mut() {
+        let mut used = 0u64;
+        while used < *budget {
+            let shared_len = if force_gate && *h == 64 {
+                force_gate = false;
+                96
+            } else {
+                log_uniform(rng, profile().shared_depth.0, profile().shared_depth.1)
+            };
+            let mut blocks = Vec::with_capacity(shared_len as usize);
+            let mut prev_key = 0u64;
+            for i in 0..shared_len {
+                let content = next_content(rng);
+                let key = if i == 0 {
+                    content
+                } else {
+                    (prev_key ^ content.rotate_left(17)).wrapping_mul(0x2545F4914F6CDD1D) | 1
+                };
+                blocks.push((key, content));
+                prev_key = key;
+            }
+            let holder_count = holders();
+            let mut members = Vec::with_capacity(*h);
+            let base = rng.below(holder_count);
+            for k in 0..*h {
+                members.push((base + k * 7) % holder_count);
+            }
+            members.sort_unstable();
+            members.dedup();
+            used += shared_len as u64 * members.len() as u64;
+            families.push(Family {
+                blocks,
+                holders: members,
+            });
+        }
+    }
+    families
+}
+
+/// Expand families into the mixed write stream (stores + duplicates +
+/// gap removes), per-holder order preserved, §7-scoped interleave.
+fn build_ops(rng: &mut Rng, families: &[Family]) -> (Vec<Op>, u64, u64) {
+    let mut per_holder: Vec<Vec<Op>> = vec![Vec::new(); holders()];
+    let mut holder_blocks = 0u64;
+    // Exact count of blocks the gap removes take back out: the
+    // resident cross-check must not blame the structure for blocks
+    // the WORKLOAD removed (the churn profile's 10% gaps tripped the
+    // pinned-calibrated 97% floor and killed the run).
+    let mut removed_blocks = 0u64;
+    for family in families {
+        for &holder in &family.holders {
+            let mut parent = None;
+            let mut batches = Vec::new();
+            for chunk in family.blocks.chunks(BATCH) {
+                batches.push(Op::Store {
+                    holder,
+                    parent,
+                    blocks: chunk.to_vec(),
+                });
+                parent = Some(chunk.last().expect("non-empty").0);
+            }
+            // Divergent tail.
+            let (tail_lo, tail_hi) = profile().tail_len;
+            let tail_len = tail_lo + (rng.next_u64() % (tail_hi - tail_lo + 1) as u64) as u32;
+            let mut prev_key = parent.expect("family non-empty");
+            let mut tail = Vec::with_capacity(tail_len as usize);
+            for _ in 0..tail_len {
+                let content = rng.next_u64() | 1;
+                let key = (prev_key ^ content.rotate_left(29))
+                    .wrapping_mul(0x9E3779B97F4A7C15)
+                    .wrapping_add(holder as u64)
+                    | 1;
+                tail.push((key, content));
+                prev_key = key;
+            }
+            for chunk in tail.chunks(BATCH) {
+                batches.push(Op::Store {
+                    holder,
+                    parent,
+                    blocks: chunk.to_vec(),
+                });
+                parent = Some(chunk.last().expect("non-empty").0);
+            }
+            holder_blocks += (family.blocks.len() + tail.len()) as u64;
+            let mut dups = Vec::new();
+            for b in &batches {
+                if rng.chance(profile().duplicate_pct) {
+                    dups.push(b.clone());
+                }
+            }
+            let mut gaps = Vec::new();
+            let interior = family.blocks.len().saturating_sub(2);
+            if interior > 0 {
+                let victims = match profile().gaps {
+                    Gaps::Instances(pct) => usize::from(rng.chance(pct)),
+                    Gaps::BlockShare(pct) => {
+                        let scaled = pct * interior as u64; // in 1/100 blocks
+                        let mut victims = (scaled / 100) as usize;
+                        if rng.chance(scaled % 100) {
+                            victims += 1;
+                        }
+                        victims
+                    }
+                };
+                let victims = victims.min(interior);
+                if victims > 0 {
+                    // Distinct interior victims: a partial Fisher-Yates over
+                    // the interior positions.
+                    let mut pool: Vec<usize> = (1..=interior).collect();
+                    let mut keys = Vec::with_capacity(victims);
+                    for v in 0..victims {
+                        let pick = v + rng.below(pool.len() - v);
+                        pool.swap(v, pick);
+                        keys.push(family.blocks[pool[v]].0);
+                    }
+                    // Dups precede gaps in the script, so each victim is
+                    // present exactly once when the remove lands.
+                    removed_blocks += keys.len() as u64;
+                    gaps.push(Op::Remove { holder, keys });
+                }
+            }
+            let script = &mut per_holder[holder];
+            script.extend(batches);
+            script.extend(dups);
+            script.extend(gaps);
+        }
+    }
+    let mut cursors = vec![0usize; holders()];
+    let mut ops = Vec::new();
+    let mut live: Vec<usize> = (0..holders())
+        .filter(|&h| !per_holder[h].is_empty())
+        .collect();
+    while !live.is_empty() {
+        let li = rng.below(live.len());
+        let h = live[li];
+        ops.push(per_holder[h][cursors[h]].clone());
+        cursors[h] += 1;
+        if cursors[h] == per_holder[h].len() {
+            live.swap_remove(li);
+        }
+    }
+    (ops, holder_blocks, removed_blocks)
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted.len() as f64 - 1.0) * p).round() as usize;
+    sorted[idx]
+}
+
+/// Which implementation this process measures. One side per process
+/// so RSS deltas are clean (§11 protocol):
+///   RADIX_BENCH_SIDE=oracle (default) | r1 | r3
+/// An unknown value panics: falling through to the oracle would record
+/// the wrong side's numbers under the requested name.
+fn side() -> String {
+    let side = std::env::var("RADIX_BENCH_SIDE").unwrap_or_else(|_| "oracle".into());
+    assert!(
+        matches!(side.as_str(), "oracle" | "r1" | "r3"),
+        "unknown RADIX_BENCH_SIDE {side:?} (expected oracle | r1 | r3)"
+    );
+    side
+}
+
+#[allow(clippy::large_enum_variant)] // bench-local, two instances ever
+enum Sider {
+    Oracle(Oracle, Vec<Vec<u64>>),
+    R1(
+        FlatTree,
+        Vec<HolderId>,
+        Vec<radix_tree::Overlap>,
+        OverlapScratch,
+    ),
+    R3(
+        RadixTree,
+        Vec<HolderId>,
+        Vec<radix_tree::Overlap>,
+        OverlapScratch,
+    ),
+}
+
+impl Sider {
+    fn apply(&mut self, op: &Op) {
+        match self {
+            Sider::Oracle(oracle, chains) => {
+                oracle.apply(op);
+                if let Op::Store {
+                    holder,
+                    parent,
+                    blocks,
+                } = op
+                {
+                    // Engine glue the §11 oracle side must carry:
+                    // last-chain Vec (reset on parent-None anchors).
+                    let chain = &mut chains[*holder];
+                    if parent.is_none() {
+                        chain.clear();
+                    }
+                    chain.extend(blocks.iter().map(|&(k, _)| k));
+                }
+            }
+            Sider::R1(tree, ids, _, _) => match op {
+                Op::Store {
+                    holder,
+                    parent,
+                    blocks,
+                } => {
+                    // The soak replays the op stream cyclically, so a
+                    // store may name a parent an earlier gap removed:
+                    // re-anchor at position 0 exactly as the engine does
+                    // on `ParentNotFound` (a real feed shape, not a bug).
+                    match tree.store(ids[*holder], *parent, blocks) {
+                        Ok(_) => {}
+                        Err(StoreError::ParentNotFound) => {
+                            tree.store(ids[*holder], None, blocks)
+                                .expect("re-anchored bench store");
+                        }
+                        Err(e) => panic!("bench store failed: {e:?}"),
+                    }
+                }
+                Op::Remove { holder, keys } => {
+                    tree.remove(ids[*holder], keys);
+                }
+                Op::Clear { holder } => tree.clear(ids[*holder]),
+            },
+            Sider::R3(tree, ids, _, _) => match op {
+                Op::Store {
+                    holder,
+                    parent,
+                    blocks,
+                } => {
+                    // The soak replays the op stream cyclically, so a
+                    // store may name a parent an earlier gap removed:
+                    // re-anchor at position 0 exactly as the engine does
+                    // on `ParentNotFound` (a real feed shape, not a bug).
+                    match tree.store(ids[*holder], *parent, blocks) {
+                        Ok(_) => {}
+                        Err(StoreError::ParentNotFound) => {
+                            tree.store(ids[*holder], None, blocks)
+                                .expect("re-anchored bench store");
+                        }
+                        Err(e) => panic!("bench store failed: {e:?}"),
+                    }
+                }
+                Op::Remove { holder, keys } => {
+                    tree.remove(ids[*holder], keys);
+                }
+                Op::Clear { holder } => tree.clear(ids[*holder]),
+            },
+        }
+    }
+
+    fn query(&mut self, q: &[u64]) -> usize {
+        match self {
+            Sider::Oracle(oracle, _) => oracle.overlap(q).len(),
+            Sider::R1(tree, _, out, qscratch) => {
+                tree.overlap(q, qscratch, out);
+                out.len()
+            }
+            Sider::R3(tree, _, out, qscratch) => {
+                tree.overlap(q, qscratch, out);
+                out.len()
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore = "pinned benchmark; run --release --ignored --nocapture"]
+fn pinned_workload() {
+    let mut rng = Rng::new(20260901);
+    let families = build_families(&mut rng);
+    let (ops, holder_blocks, removed_blocks) = build_ops(&mut rng, &families);
+    let total_blocks: u64 = ops
+        .iter()
+        .map(|op| match op {
+            Op::Store { blocks, .. } => blocks.len() as u64,
+            Op::Remove { keys, .. } => keys.len() as u64,
+            Op::Clear { .. } => 0,
+        })
+        .sum();
+    println!(
+        "workload: {} families, {} ops, {} stream blocks, {} resident holder-blocks",
+        families.len(),
+        ops.len(),
+        total_blocks,
+        holder_blocks
+    );
+
+    let side_name = side();
+    println!("side: {side_name}");
+    println!("profile: {} ({} holders)", profile().name, holders());
+    // P4 mixed-phase probes: built BEFORE the fill so latency can be
+    // sampled while the write stream runs.
+    let mut mixed_probes: Vec<Vec<u64>> = Vec::new();
+    for fam in families.iter().filter(|f| f.holders.len() == 64) {
+        if fam.blocks.len() >= GATE_DEPTH as usize && mixed_probes.len() < 32 {
+            mixed_probes.push(
+                fam.blocks[..GATE_DEPTH as usize]
+                    .iter()
+                    .map(|&(_, c)| c)
+                    .collect(),
+            );
+        }
+    }
+    for fam in families.iter().filter(|f| f.holders.len() == 1) {
+        if mixed_probes.len() < 64 {
+            let d = fam.blocks.len().min(64);
+            mixed_probes.push(fam.blocks[..d].iter().map(|&(_, c)| c).collect());
+        }
+    }
+    let rss_before = rss_kib();
+    let mut sider = match side_name.as_str() {
+        "r1" => {
+            let mut tree = FlatTree::new(Config::default());
+            let ids = (0..holders())
+                .map(|h| tree.create_holder(&format!("holder-{h}")))
+                .collect();
+            Sider::R1(tree, ids, Vec::new(), OverlapScratch::default())
+        }
+        "r3" => {
+            let mut tree = RadixTree::new(Config::default());
+            let ids = (0..holders())
+                .map(|h| tree.create_holder(&format!("holder-{h}")))
+                .collect();
+            Sider::R3(tree, ids, Vec::new(), OverlapScratch::default())
+        }
+        _ => Sider::Oracle(Oracle::new(holders()), vec![Vec::new(); holders()]),
+    };
+    let fill_start = Instant::now();
+    let mut mixed_lat: Vec<u64> = Vec::new();
+    let mut since_probe = 0u64;
+    let mut probe_idx = 0usize;
+    for op in &ops {
+        sider.apply(op);
+        if let Op::Store { blocks, .. } = op {
+            since_probe += blocks.len() as u64;
+        }
+        // P4: one probe query every ~250k stream blocks, timed inside
+        // the live write phase.
+        if since_probe >= 250_000 && !mixed_probes.is_empty() {
+            since_probe = 0;
+            let q = &mixed_probes[probe_idx % mixed_probes.len()];
+            probe_idx += 1;
+            let t = Instant::now();
+            let n = sider.query(q);
+            mixed_lat.push(t.elapsed().as_nanos() as u64);
+            std::hint::black_box(n);
+        }
+    }
+    let fill = fill_start.elapsed();
+    // Cross-check the memory-gate denominator against the structure
+    // itself: a silent drop would otherwise flatter every number at
+    // once (audit finding). Gap removes make resident slightly less
+    // than generated.
+    let resident = match &sider {
+        Sider::Oracle(_, _) => holder_blocks, // oracle side has no cheap recount
+        Sider::R1(tree, _, _, _) => tree.stats().holder_blocks,
+        Sider::R3(tree, _, _, _) => tree.stats().holder_blocks,
+    };
+    let expected = holder_blocks - removed_blocks;
+    assert!(
+        resident * 100 >= expected * 97,
+        "structure holds {resident} of {expected} expected holder-blocks \
+         ({holder_blocks} generated - {removed_blocks} removed) — silent loss"
+    );
+    let rss_after = rss_kib();
+    println!(
+        "fill: {:.2}s -> {:.2}M stream blocks/s",
+        fill.as_secs_f64(),
+        total_blocks as f64 / fill.as_secs_f64() / 1e6
+    );
+    // RSS can dip between samples (page reclaim); saturate rather than
+    // wrap in release builds.
+    let rss_delta = rss_after.saturating_sub(rss_before);
+    // Per block actually RESIDENT (generated minus gap-removed), the
+    // same denominator the resident-count check above uses; dividing by
+    // the generated count would understate B/block by the gap share.
+    println!(
+        "memory: {} KiB delta -> {:.1} B/holder-block ({} holder-blocks resident)",
+        rss_delta,
+        rss_delta as f64 * 1024.0 / expected as f64,
+        expected
+    );
+
+    // Query phase: prefix probes per sharing cell + misses. Build all
+    // query vectors BEFORE timing (no allocation inside the region).
+    let mut cells: Vec<(String, Vec<Vec<u64>>)> = Vec::new();
+    let mut gate_queries = Vec::new();
+    let warm = |fam: &Family, depth: u32| -> Vec<u64> {
+        fam.blocks[..depth as usize]
+            .iter()
+            .map(|&(_, c)| c)
+            .collect()
+    };
+    for &(h, _) in &profile().sharing_mix {
+        let mut queries = Vec::new();
+        for fam in families.iter().filter(|f| f.holders.len() == h) {
+            if queries.len() >= 2000 {
+                break;
+            }
+            let d = 1 + rng.below(fam.blocks.len());
+            queries.push(warm(fam, d as u32));
+        }
+        cells.push((format!("H={h}"), queries));
+    }
+    for fam in families.iter().filter(|f| f.holders.len() == 64) {
+        if fam.blocks.len() >= GATE_DEPTH as usize && gate_queries.len() < 2000 {
+            gate_queries.push(warm(fam, GATE_DEPTH));
+        }
+    }
+    cells.push((format!("gate d={GATE_DEPTH} W=64"), gate_queries));
+    let mut misses = Vec::new();
+    for _ in 0..1000 {
+        let len = 1 + rng.below(96);
+        misses.push((0..len).map(|_| rng.next_u64() | 1).collect::<Vec<u64>>());
+    }
+    cells.push(("miss".to_string(), misses));
+
+    if !mixed_lat.is_empty() {
+        mixed_lat.sort_unstable();
+        println!(
+            "cell mixed-phase: n={} p50={}ns p90={}ns p95={}ns p99={}ns (queries during live writes)",
+            mixed_lat.len(),
+            percentile(&mixed_lat, 0.50),
+            percentile(&mixed_lat, 0.90),
+            percentile(&mixed_lat, 0.95),
+            percentile(&mixed_lat, 0.99),
+        );
+    }
+    for (label, queries) in &cells {
+        if queries.is_empty() {
+            println!("cell {label}: EMPTY (workload bug)");
+            continue;
+        }
+        // MISS_QUERY_PCT is embodied by the dedicated miss cell; warm
+        // cells stay pure so percentiles are per-shape.
+        let _ = MISS_QUERY_PCT;
+        let mut lat: Vec<u64> = Vec::with_capacity(queries.len());
+        for q in queries {
+            let t = Instant::now();
+            let n = sider.query(q);
+            let ns = t.elapsed().as_nanos() as u64;
+            std::hint::black_box(n);
+            lat.push(ns);
+        }
+        lat.sort_unstable();
+        println!(
+            "cell {label}: n={} p50={}ns p90={}ns p95={}ns p99={}ns",
+            lat.len(),
+            percentile(&lat, 0.50),
+            percentile(&lat, 0.90),
+            percentile(&lat, 0.95),
+            percentile(&lat, 0.99),
+        );
+    }
+    // P4 soak (RADIX_BENCH_SOAK_SECS): steady-state churn — cyclic
+    // duplicate re-publish (idempotent placement churn), retire/create
+    // holder cycles, and a query stream. RSS must stay flat: growth
+    // here is a leak by definition (no new state is being added).
+    // Absent => no soak; present but unparsable => an operator error
+    // (silently skipping the soak would report a leak-free run that
+    // never ran).
+    let soak_secs = env_u64("RADIX_BENCH_SOAK_SECS", 0);
+    if soak_secs > 0 {
+        println!("soak: {soak_secs}s of duplicate/holder churn + queries");
+        let soak_start = Instant::now();
+        let mut last_report = Instant::now();
+        let rss_soak_start = rss_kib();
+        let mut op_i = 0usize;
+        let mut probe_i = 0usize;
+        let mut churn_cycle = 0u64;
+        let mut qps = 0u64;
+        let mut ops_applied = 0u64;
+        while soak_start.elapsed().as_secs() < soak_secs {
+            for _ in 0..2000 {
+                sider.apply(&ops[op_i % ops.len()]);
+                op_i += 1;
+            }
+            ops_applied += 2000;
+            for _ in 0..64 {
+                if !mixed_probes.is_empty() {
+                    let q = &mixed_probes[probe_i % mixed_probes.len()];
+                    probe_i += 1;
+                    std::hint::black_box(sider.query(q));
+                    qps += 1;
+                }
+            }
+            if let Sider::R1(tree, _, _, _) = &mut sider {
+                churn_cycle += 1;
+                let h = tree.create_holder(&format!("soak-churn-{churn_cycle}"));
+                let _ = tree.store(h, None, &[(churn_cycle | 1, churn_cycle | 1)]);
+                tree.retire_holder(h);
+            } else if let Sider::R3(tree, _, _, _) = &mut sider {
+                churn_cycle += 1;
+                let h = tree.create_holder(&format!("soak-churn-{churn_cycle}"));
+                let _ = tree.store(h, None, &[(churn_cycle | 1, churn_cycle | 1)]);
+                tree.retire_holder(h);
+            }
+            if last_report.elapsed().as_secs() >= 60 {
+                last_report = Instant::now();
+                println!(
+                    "soak t={}s rss={} KiB (drift {:+} KiB) ops={} queries={}",
+                    soak_start.elapsed().as_secs(),
+                    rss_kib(),
+                    rss_kib() as i64 - rss_soak_start as i64,
+                    ops_applied,
+                    qps
+                );
+                if let Sider::R3(tree, _, _, _) = &sider {
+                    println!("  footprint: {}", tree.debug_footprint());
+                }
+            }
+        }
+        let drift = rss_kib() as i64 - rss_soak_start as i64;
+        println!(
+            "soak done: rss drift {:+} KiB over {soak_secs}s ({} ops, {} queries)",
+            drift, ops_applied, qps
+        );
+    }
+    std::hint::black_box(&sider as *const _);
+}

--- a/crates/radix_tree/tests/tree_compare.rs
+++ b/crates/radix_tree/tests/tree_compare.rs
@@ -1,0 +1,302 @@
+//! Cross-structure comparison: the gateway's TokenTree (per-token
+//! radix) and StringTree (per-character radix) vs the new block-hash
+//! RadixTree, on one shared token corpus — build rate, resident
+//! bytes, match latency, and MATCHING RESOLUTION (what each promises
+//! vs what an engine paging KV in fixed blocks can physically reuse).
+//!
+//! Block size is a swept axis (64/128/256/512), exercising the same
+//! knob the wire exposes end to end (gateway --kv-indexer-block-size,
+//! bridge --block-size, keyspace-keyed on the service).
+//!
+//! One structure per process for clean RSS deltas:
+//!   RADIX_COMPARE_SIDE=token|string|radix64|radix128|radix256|radix512
+//!
+//! Run: RADIX_COMPARE_SIDE=... cargo test -p smg-radix-tree --release \
+//!   --test tree_compare -- --ignored --nocapture
+
+mod common;
+
+use std::time::Instant;
+
+use common::{rss_kib, Rng};
+use kv_index::{compute_request_content_hashes, RadixTree as _, StringTree, TokenTree};
+use radix_tree::{Config, HolderId, OverlapScratch, RadixTree};
+
+const TENANTS: usize = 64;
+const FAMILIES: usize = 400;
+/// Shared prefix length in tokens, log-uniform.
+const SHARED_TOKENS: (u32, u32) = (512, 8192);
+const TAIL_TOKENS: (u32, u32) = (128, 1024);
+const TENANTS_PER_FAMILY: (usize, usize) = (1, 6);
+const TOKEN_SPACE: u64 = 150_000;
+/// The engine's actual page size: the amount of matching resolution
+/// that is PHYSICALLY reusable, whatever the index promises.
+const ENGINE_PAGE: u32 = 256;
+
+fn log_uniform(rng: &mut Rng, lo: u32, hi: u32) -> u32 {
+    let (llo, lhi) = ((lo as f64).ln(), (hi as f64).ln());
+    let u = (rng.next_u64() >> 11) as f64 / (1u64 << 53) as f64;
+    (llo + u * (lhi - llo)).exp().round() as u32
+}
+
+struct Corpus {
+    /// (tokens of shared prefix, member tenants)
+    families: Vec<(Vec<u32>, Vec<usize>)>,
+    /// (tenant, full sequence = family prefix + private tail, family)
+    inserts: Vec<(usize, Vec<u32>, usize)>,
+    /// (family, query length clamped to family prefix, tenant known
+    /// to hold it) — the TRUE cached-prefix length equals the query
+    /// length by construction.
+    queries: Vec<(usize, u32, usize)>,
+}
+
+fn build_corpus(seed: u64) -> Corpus {
+    let mut rng = Rng::new(seed);
+    let mut families = Vec::with_capacity(FAMILIES);
+    for _ in 0..FAMILIES {
+        let len = log_uniform(&mut rng, SHARED_TOKENS.0, SHARED_TOKENS.1);
+        let tokens: Vec<u32> = (0..len)
+            .map(|_| (rng.next_u64() % TOKEN_SPACE) as u32)
+            .collect();
+        let n = TENANTS_PER_FAMILY.0 + rng.below(TENANTS_PER_FAMILY.1 - TENANTS_PER_FAMILY.0 + 1);
+        let mut members: Vec<usize> = (0..n).map(|_| rng.below(TENANTS)).collect();
+        members.sort_unstable();
+        members.dedup();
+        families.push((tokens, members));
+    }
+    let mut inserts = Vec::new();
+    for (fi, (tokens, members)) in families.iter().enumerate() {
+        for &tenant in members {
+            let tail_len = TAIL_TOKENS.0
+                + (rng.next_u64() % (TAIL_TOKENS.1 - TAIL_TOKENS.0 + 1) as u64) as u32;
+            let mut seq = tokens.clone();
+            seq.extend((0..tail_len).map(|_| (rng.next_u64() % TOKEN_SPACE) as u32));
+            inserts.push((tenant, seq, fi));
+        }
+    }
+    let mut queries = Vec::new();
+    for (fi, (tokens, members)) in families.iter().enumerate() {
+        if members.is_empty() {
+            continue;
+        }
+        for _ in 0..8 {
+            let d = 1 + rng.below(tokens.len()) as u32;
+            queries.push((fi, d, members[rng.below(members.len())]));
+        }
+    }
+    Corpus {
+        families,
+        inserts,
+        queries,
+    }
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    sorted[((sorted.len() as f64 - 1.0) * p).round() as usize]
+}
+
+/// Tokens -> 4-hex-char words, the string-side rendering of the same
+/// corpus (per-character tree granularity, 4 chars per token).
+fn to_text(tokens: &[u32]) -> String {
+    let mut s = String::with_capacity(tokens.len() * 4);
+    for &t in tokens {
+        s.push_str(&format!("{:04x}", t & 0xFFFF));
+    }
+    s
+}
+
+fn placement_chain_keys(hashes: &[kv_index::ContentHash]) -> Vec<(u64, u64)> {
+    let mut out = Vec::with_capacity(hashes.len());
+    let mut prev = kv_index::SequenceHash(0);
+    for (i, &h) in hashes.iter().enumerate() {
+        let seq = if i == 0 {
+            kv_index::SequenceHash(h.0)
+        } else {
+            kv_index::chain_prefix_hash(prev, h)
+        };
+        out.push((seq.0, h.0));
+        prev = seq;
+    }
+    out
+}
+
+#[allow(clippy::large_enum_variant)] // bench-local, one instance per process
+enum Side {
+    Token(TokenTree),
+    String(StringTree),
+    Radix {
+        tree: RadixTree,
+        ids: Vec<HolderId>,
+        block: u32,
+        out: Vec<radix_tree::Overlap>,
+        qscratch: OverlapScratch,
+    },
+}
+
+#[test]
+#[ignore = "comparison benchmark; run --release --ignored --nocapture with RADIX_COMPARE_SIDE"]
+fn tree_compare() {
+    let side_name = std::env::var("RADIX_COMPARE_SIDE").unwrap_or_else(|_| "radix256".into());
+    let corpus = build_corpus(20260902);
+    let total_tokens: u64 = corpus.inserts.iter().map(|(_, s, _)| s.len() as u64).sum();
+    println!(
+        "side: {side_name}; corpus: {} families, {} inserts, {:.1}M tokens",
+        corpus.families.len(),
+        corpus.inserts.len(),
+        total_tokens as f64 / 1e6
+    );
+
+    let mut side = match side_name.as_str() {
+        "token" => Side::Token(TokenTree::new()),
+        "string" => Side::String(StringTree::new()),
+        other => {
+            let block: u32 = other
+                .strip_prefix("radix")
+                .and_then(|b| b.parse().ok())
+                .expect("radix<block>");
+            let mut tree = RadixTree::new(Config::default());
+            let ids = (0..TENANTS)
+                .map(|t| tree.create_holder(&format!("tenant-{t}")))
+                .collect();
+            Side::Radix {
+                tree,
+                ids,
+                block,
+                out: Vec::new(),
+                qscratch: OverlapScratch::default(),
+            }
+        }
+    };
+
+    // Pre-render side-specific insert inputs OUTSIDE the timed region.
+    enum Prepared {
+        Tokens(usize, Vec<u32>),
+        Text(usize, String),
+        Blocks(usize, Vec<(u64, u64)>),
+        /// Query-side radix input: the content chain only (the query
+        /// path never reads keys), pre-rendered so the timed region
+        /// does no per-query allocation — the same protocol the token
+        /// and string sides get.
+        Chain(usize, Vec<u64>),
+    }
+    let prepared: Vec<Prepared> = corpus
+        .inserts
+        .iter()
+        .map(|(tenant, seq, _)| match &side {
+            Side::Token(_) => Prepared::Tokens(*tenant, seq.clone()),
+            Side::String(_) => Prepared::Text(*tenant, to_text(seq)),
+            Side::Radix { block, .. } => Prepared::Blocks(
+                *tenant,
+                placement_chain_keys(&compute_request_content_hashes(seq, *block as usize)),
+            ),
+        })
+        .collect();
+
+    // Sampled AFTER the pre-rendered inputs exist so the delta measures
+    // only the structure: the token/string inputs are ~4 B per token
+    // and would otherwise be charged to those sides but not to the
+    // radix side (whose block inputs are ~0.06 B per token).
+    // Tenant names pre-rendered too: the radix side resolves its holder
+    // ids before the timer, so the token/string sides must not pay a
+    // per-insert String allocation the radix side does not.
+    let tenant_names: Vec<String> = (0..TENANTS).map(|t| format!("tenant-{t}")).collect();
+    let rss_before = rss_kib();
+    let build_start = Instant::now();
+    for item in &prepared {
+        match (&mut side, item) {
+            (Side::Token(t), Prepared::Tokens(tenant, seq)) => {
+                t.insert_tokens(seq, &tenant_names[*tenant]);
+            }
+            (Side::String(t), Prepared::Text(tenant, text)) => {
+                t.insert_text(text, &tenant_names[*tenant]);
+            }
+            (Side::Radix { tree, ids, .. }, Prepared::Blocks(tenant, blocks)) => {
+                tree.store(ids[*tenant], None, blocks).expect("store");
+            }
+            _ => unreachable!(),
+        }
+    }
+    let build = build_start.elapsed();
+    let rss_after = rss_kib();
+    // RSS can dip between samples (page reclaim); saturate rather than
+    // wrap in release builds.
+    let rss_delta = rss_after.saturating_sub(rss_before);
+    println!(
+        "build: {:.2}s -> {:.2}M tokens/s; memory: {:.1} MiB -> {:.2} B/token",
+        build.as_secs_f64(),
+        total_tokens as f64 / build.as_secs_f64() / 1e6,
+        rss_delta as f64 / 1024.0,
+        rss_delta as f64 * 1024.0 / total_tokens as f64
+    );
+
+    // Queries: latency + promised-vs-physical matching resolution.
+    // True cached prefix = query length L (by construction). Physical
+    // ceiling = floor(L / ENGINE_PAGE) * ENGINE_PAGE.
+    let mut prepared_queries = Vec::new();
+    for &(fi, len, tenant) in &corpus.queries {
+        let toks = &corpus.families[fi].0[..len as usize];
+        match &side {
+            Side::Token(_) => prepared_queries.push((Prepared::Tokens(tenant, toks.to_vec()), len)),
+            Side::String(_) => prepared_queries.push((Prepared::Text(tenant, to_text(toks)), len)),
+            Side::Radix { block, .. } => prepared_queries.push((
+                Prepared::Chain(
+                    tenant,
+                    compute_request_content_hashes(toks, *block as usize)
+                        .iter()
+                        .map(|h| h.0)
+                        .collect(),
+                ),
+                len,
+            )),
+        }
+    }
+    let mut lat: Vec<u64> = Vec::with_capacity(prepared_queries.len());
+    let mut promised_minus_true = 0i64;
+    let mut promised_minus_physical = 0i64;
+    let mut n = 0i64;
+    for (q, true_len) in &prepared_queries {
+        let physical = (*true_len / ENGINE_PAGE) * ENGINE_PAGE;
+        let t = Instant::now();
+        let matched_tokens: u32 = match (&mut side, q) {
+            (Side::Token(tree), Prepared::Tokens(_, toks)) => {
+                tree.prefix_match_with_counts(toks).matched_token_count as u32
+            }
+            (Side::String(tree), Prepared::Text(_, text)) => {
+                (tree.prefix_match_with_counts(text).matched_char_count as u32) / 4
+            }
+            (
+                Side::Radix {
+                    tree,
+                    ids,
+                    block,
+                    out,
+                    qscratch,
+                },
+                Prepared::Chain(tenant, chain),
+            ) => {
+                tree.overlap(chain, qscratch, out);
+                let (idx, _) = ids[*tenant].parts();
+                out.iter()
+                    .find(|o| o.holder.parts().0 == idx)
+                    .map_or(0, |o| o.depth * *block)
+            }
+            _ => unreachable!(),
+        };
+        lat.push(t.elapsed().as_nanos() as u64);
+        promised_minus_true += matched_tokens as i64 - *true_len as i64;
+        promised_minus_physical += matched_tokens as i64 - physical as i64;
+        n += 1;
+    }
+    lat.sort_unstable();
+    println!(
+        "match: n={} p50={}ns p99={}ns; promised-vs-true avg {:+.1} tokens; promised-vs-physical(page {ENGINE_PAGE}) avg {:+.1} tokens",
+        n,
+        percentile(&lat, 0.50),
+        percentile(&lat, 0.99),
+        promised_minus_true as f64 / n as f64,
+        promised_minus_physical as f64 / n as f64,
+    );
+}

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -68,6 +68,7 @@ CRATES=(
     "smg-auth|crates/auth|smg-auth"
     "smg-mcp|crates/mcp|smg-mcp"
     "kv-index|crates/kv_index|kv-index"
+    "smg-radix-tree|crates/radix_tree|smg-radix-tree"
     "data-connector|crates/data_connector|smg-data-connector"
     "llm-multimodal|crates/multimodal|llm-multimodal"
     "smg-wasm|crates/wasm|smg-wasm"


### PR DESCRIPTION
> [!NOTE]
> **1 of 3** in the shared prefix-cache index stack: this PR is the data structure only. Next: the index service (#2437) on top of this; then the gateway integration (#2438). The simulation harness (#2439) reviews independently.

## Description

### Problem

Cache-aware routing needs one question answered fast and exactly: *given a request's chain of content-addressed blocks, which workers already hold the longest prefix of it, and how deep?* The gateway's existing index (`kv_index::PositionalIndexer`) answers it for one gateway's local view, at 166.7 B/block and with a worst-case cell that is not exact. A fleet-wide shared index (next PR) needs a structure that is smaller, exact, dependency-free, and verifiable to a much higher bar — it will hold every worker's state, not one gateway's.

### Solution

`smg-radix-tree`: a chain-native prefix-membership index with **zero SMG dependencies** — everything it sees is a hash. Chains store block contents once and are shared by every holder that holds them; membership is maximal position-runs pointing at hash-consed holder sets; a query is one hash probe, a contiguous content scan, and a few span reads. Holder lifecycle (create/retire with generation-tagged ids, truncate, clear, remove) and the two fast-path oracles the service relies on (`dup_prefix` for covered-prefix splits, `position_of` for digest confirmation) are first-class API.

Two cores implement one contract: `RadixTree` (`src/chain.rs`, the primary) and `FlatTree` (`src/lib.rs`, the first-generation flat positional core), held equal to each other and to a reference model on every test.

## Changes

- `crates/radix_tree/src/lib.rs` — public API, `FlatTree`, holder-set interner.
- `crates/radix_tree/src/chain.rs` — `RadixTree`, the chain-native primary; full-state `audit()`.
- `crates/radix_tree/tests/` — the referee: `differential.rs` (reference model + production `kv_index` oracle, every op), `fuzz_differential.rs` (seeded campaign — 600 seeds nightly in release, up to 10k on dispatch — chaos ops, replay determinism, cross-core agreement, audit after every op; an 8+3-seed slice always runs), `api.rs` (lifecycle/stale-id/truncation/`ChainTooLong` contracts, every case against both cores), `alloc_gate.rs` (counting allocator on write and read paths), `pinned_bench.rs`, `tree_compare.rs`.
- `crates/kv_index` — exports `chain_prefix_hash` (a 5-line pure helper, base case documented with a doctest) and `XXH3_SEED` so the oracle and the service can build byte-identical chains. No behavior change.
- Workspace member + `smg-radix-tree` dependency entry; release workflow tier 1 (the bare `radix-tree` name is taken on crates.io; the import path stays `radix_tree`). The `kv-index` dev-dependency is path-only, so the published manifest carries no SMG dependency and tier 1 has no ordering race.

Suggested reading order: `README.md` → `lib.rs` (API) → `chain.rs` → `tests/differential.rs`.

## Test Plan

- Reference-model + `kv_index`-oracle differential on every operation; nightly release chaos fuzz campaign (600 seeds by default — 1000 took 52 min on an M-series laptop; `.github/workflows/radix-tree-fuzz.yml`) with replay determinism and cross-core agreement; a full-state audit that also detects chain double-free, interner orphans, and a stale holder→chain index; allocation gates on the write path and a zero-allocation gate on the warm read path. `cargo publish --dry-run` passes.
- Pinned numbers (12.8M holder-blocks, 256 workers) vs. the incumbent: memory **166.7 → 26.9 B/block**, query p50 **917 → 292 ns**, worst-cell p99 exact at 7.6 µs. Known sensitivity, measured on the new `fragmented` profile (2% of every instance's interior blocks evicted): the worst cell's p99 rises to 18.5 µs against the incumbent's 8.3 µs because the chain walk pays per segment; the pinned (tail-heavy eviction) shape is unaffected.
- The always-on fuzz slice is sized for the debug CI lane (~3 min locally); the full campaign is the `--ignored` entry point, run nightly in release by `.github/workflows/radix-tree-fuzz.yml` (dispatchable with a seed count and start).

## Validation (end-to-end campaign, 2026-09-08, M-series laptop, release)

- Correctness: 1000-seed differential fuzz campaign green (every 4th seed at the wide H≤64 sharing width, plus chaos runs; 52 min), and the 20 unit / API / differential / allocation-gate tests.
- Pinned workload (12.8M holder-blocks, 256 holders), `RadixTree` vs the `kv_index` oracle:

| | oracle | `RadixTree` |
|---|---|---|
| bytes / holder-block | 167.0 | **26.7** |
| single-holder query p50 | 875 ns | **291 ns** |
| gate cell (d=78, 64 holders) p99 | 7.1 µs | **6.6 µs** |
| fill | 6.25M blk/s | 4.83M blk/s |

- Fragmented profile (pinned shape, 2% of every instance's interior blocks evicted): gate cell p99 18.5 µs vs oracle 8.3 µs at 27.5 B/block — the documented sensitivity to interior holes; the pinned shape is unaffected.
- `tree_compare` (5.0M tokens): token tree 2.36 B/token, match p50 958 ns; string tree 2.91 B/token, 1.5 µs; radix256 0.35 B/token, 42 ns.
