### PR TITLE
refactor(gateway): move the SGLang field list out of the OpenAI provider router

### DIFF
--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -40,6 +40,7 @@ pub mod persistence_utils;
 pub mod realtime;
 pub mod request_lease;
 pub mod retry;
+pub mod sglang_fields;
 pub mod sse;
 pub mod worker_selection;
 

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -27,6 +27,8 @@
 //!   used by every router for transport-level retries. Has zero
 //!   coupling to the `Worker` trait — it lived in `worker/` for
 //!   historical reasons before this extraction.
+//! - [`sglang_fields`] — the SGLang-only request fields the HTTP proxy
+//!   strips at their defaults and the provider transformers drop outright
 //! - [`sse`] — shared SSE codec (encoder + decoder) for streaming
 //!   responses to clients and parsing upstream SSE byte streams
 
@@ -40,7 +42,7 @@ pub mod persistence_utils;
 pub mod realtime;
 pub mod request_lease;
 pub mod retry;
-pub mod sglang_fields;
+pub(crate) mod sglang_fields;
 pub mod sse;
 pub mod worker_selection;
 

--- a/model_gateway/src/routers/common/sglang_fields.rs
+++ b/model_gateway/src/routers/common/sglang_fields.rs
@@ -1,0 +1,114 @@
+//! SGLang-specific request fields that the gateway strips before forwarding
+//! a request to a backend that does not understand them.
+//!
+//! Shared by the HTTP proxy, which drops a field only when it carries its
+//! default value, and by the external-provider transformers, which drop the
+//! fields unconditionally because no third-party API accepts them.
+
+use serde_json::Value;
+
+pub(crate) const SGLANG_FIELDS: &[&str] = &[
+    "request_id",
+    "priority",
+    "top_k",
+    "min_p",
+    "min_tokens",
+    "regex",
+    "ebnf",
+    "json_schema",
+    "stop_token_ids",
+    "no_stop_trim",
+    "ignore_eos",
+    "continue_final_message",
+    "skip_special_tokens",
+    "lora_path",
+    "session_params",
+    "separate_reasoning",
+    "stream_reasoning",
+    "chat_template",
+    "chat_template_kwargs",
+    "return_hidden_states",
+    "repetition_penalty",
+    "sampling_seed",
+    "backend_url",
+];
+
+pub(crate) fn strip_sglang_fields(payload: &mut Value) {
+    if let Some(obj) = payload.as_object_mut() {
+        for field in SGLANG_FIELDS {
+            obj.remove(*field);
+        }
+    }
+}
+
+pub(crate) fn strip_default_sglang_fields(payload: &mut Value) {
+    if let Some(obj) = payload.as_object_mut() {
+        for field in SGLANG_FIELDS {
+            if obj.get(*field).is_some_and(|value| {
+                value.is_null()
+                    || value == false
+                    || (matches!(*field, "separate_reasoning" | "stream_reasoning")
+                        && value == true)
+            }) {
+                obj.remove(*field);
+            }
+        }
+    }
+}
+
+/// Raw-slice twin of [`strip_default_sglang_fields`]: decides whether a
+/// [`SGLANG_FIELDS`] entry would be stripped, given the compact serde_json
+/// rendering of its value. Must mirror the `Value` version above.
+pub(crate) fn is_stripped_sglang_default(field: &str, raw_json: &str) -> bool {
+    matches!(raw_json, "null" | "false")
+        || (matches!(field, "separate_reasoning" | "stream_reasoning") && raw_json == "true")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn strip_default_sglang_fields_removes_false_and_null_values() {
+        let mut payload = json!({
+            "continue_final_message": false,
+            "messages": [],
+            "model": "test-model",
+            "no_stop_trim": true,
+            "return_hidden_states": null,
+            "separate_reasoning": true,
+            "stream_reasoning": true
+        });
+
+        strip_default_sglang_fields(&mut payload);
+
+        assert_eq!(payload.get("continue_final_message"), None);
+        assert_eq!(payload.get("return_hidden_states"), None);
+        assert_eq!(payload.get("separate_reasoning"), None);
+        assert_eq!(payload.get("stream_reasoning"), None);
+        assert_eq!(payload.get("no_stop_trim"), Some(&json!(true)));
+        assert_eq!(payload.get("model"), Some(&json!("test-model")));
+    }
+
+    #[test]
+    fn raw_predicate_agrees_with_value_strip_for_every_field() {
+        for field in SGLANG_FIELDS {
+            for raw in ["null", "false", "true", "0", "1.5", "\"false\"", "[false]"] {
+                let value: Value = serde_json::from_str(raw).expect("literal parses");
+                let mut fields = serde_json::Map::new();
+                fields.insert((*field).to_string(), value);
+                let mut payload = Value::Object(fields);
+                strip_default_sglang_fields(&mut payload);
+
+                let value_stripped = payload.get(*field).is_none();
+                assert_eq!(
+                    is_stripped_sglang_default(field, raw),
+                    value_stripped,
+                    "field={field} raw={raw}"
+                );
+            }
+        }
+    }
+}

--- a/model_gateway/src/routers/http/request_body.rs
+++ b/model_gateway/src/routers/http/request_body.rs
@@ -15,9 +15,9 @@ use serde::{
 use serde_json::value::{to_raw_value, RawValue};
 
 use crate::{
-    routers::{
-        common::{serialize_json_sized, serialized_capacity},
-        openai::{is_stripped_sglang_default, strip_default_sglang_fields, SGLANG_FIELDS},
+    routers::common::{
+        serialize_json_sized, serialized_capacity,
+        sglang_fields::{is_stripped_sglang_default, strip_default_sglang_fields, SGLANG_FIELDS},
     },
     worker::{Worker, WorkerError},
 };

--- a/model_gateway/src/routers/openai/mod.rs
+++ b/model_gateway/src/routers/openai/mod.rs
@@ -15,5 +15,4 @@ mod provider;
 pub mod responses;
 mod router;
 
-pub(crate) use provider::{is_stripped_sglang_default, strip_default_sglang_fields, SGLANG_FIELDS};
 pub use router::OpenAIRouter;

--- a/model_gateway/src/routers/openai/provider/gemini.rs
+++ b/model_gateway/src/routers/openai/provider/gemini.rs
@@ -1,7 +1,10 @@
 use serde_json::Value;
 
 use super::{Provider, ProviderError};
-use crate::worker::{Endpoint, ProviderType};
+use crate::{
+    routers::common::sglang_fields::strip_sglang_fields,
+    worker::{Endpoint, ProviderType},
+};
 
 pub struct GeminiProvider;
 
@@ -15,7 +18,7 @@ impl Provider for GeminiProvider {
         payload: &mut Value,
         endpoint: Endpoint,
     ) -> Result<(), ProviderError> {
-        super::types::strip_sglang_fields(payload);
+        strip_sglang_fields(payload);
 
         if endpoint == Endpoint::Chat {
             if let Some(obj) = payload.as_object_mut() {

--- a/model_gateway/src/routers/openai/provider/mod.rs
+++ b/model_gateway/src/routers/openai/provider/mod.rs
@@ -18,5 +18,4 @@ pub use provider_trait::Provider;
 pub use registry::ProviderRegistry;
 pub use sglang::SGLangProvider;
 pub use types::ProviderError;
-pub(crate) use types::{is_stripped_sglang_default, strip_default_sglang_fields, SGLANG_FIELDS};
 pub use xai::XAIProvider;

--- a/model_gateway/src/routers/openai/provider/provider_trait.rs
+++ b/model_gateway/src/routers/openai/provider/provider_trait.rs
@@ -1,8 +1,11 @@
 use reqwest::RequestBuilder;
 use serde_json::Value;
 
-use super::{types::strip_sglang_fields, ProviderError};
-use crate::worker::{Endpoint, ProviderType};
+use super::ProviderError;
+use crate::{
+    routers::common::sglang_fields::strip_sglang_fields,
+    worker::{Endpoint, ProviderType},
+};
 
 /// Default `transform_request` strips SGLang fields.
 pub trait Provider: Send + Sync {

--- a/model_gateway/src/routers/openai/provider/tests.rs
+++ b/model_gateway/src/routers/openai/provider/tests.rs
@@ -13,10 +13,7 @@ use openai_protocol::{
 };
 use serde_json::{json, to_value, Value};
 
-use super::{
-    types::{is_stripped_sglang_default, strip_default_sglang_fields, SGLANG_FIELDS},
-    OpenAIProvider, Provider, XAIProvider,
-};
+use super::{OpenAIProvider, Provider, XAIProvider};
 use crate::worker::Endpoint;
 
 /// Build a `ResponsesRequest` whose single input message carries every
@@ -68,48 +65,6 @@ fn first_content_array(payload: &Value) -> &Vec<Value> {
     payload["input"][0]["content"]
         .as_array()
         .expect("content array present on first input item")
-}
-
-#[test]
-fn strip_default_sglang_fields_removes_false_and_null_values() {
-    let mut payload = json!({
-        "continue_final_message": false,
-        "messages": [],
-        "model": "test-model",
-        "no_stop_trim": true,
-        "return_hidden_states": null,
-        "separate_reasoning": true,
-        "stream_reasoning": true
-    });
-
-    strip_default_sglang_fields(&mut payload);
-
-    assert_eq!(payload.get("continue_final_message"), None);
-    assert_eq!(payload.get("return_hidden_states"), None);
-    assert_eq!(payload.get("separate_reasoning"), None);
-    assert_eq!(payload.get("stream_reasoning"), None);
-    assert_eq!(payload.get("no_stop_trim"), Some(&json!(true)));
-    assert_eq!(payload.get("model"), Some(&json!("test-model")));
-}
-
-#[test]
-fn raw_predicate_agrees_with_value_strip_for_every_field() {
-    for field in SGLANG_FIELDS {
-        for raw in ["null", "false", "true", "0", "1.5", "\"false\"", "[false]"] {
-            let value: Value = serde_json::from_str(raw).expect("literal parses");
-            let mut fields = serde_json::Map::new();
-            fields.insert((*field).to_string(), value);
-            let mut payload = Value::Object(fields);
-            strip_default_sglang_fields(&mut payload);
-
-            let value_stripped = payload.get(*field).is_none();
-            assert_eq!(
-                is_stripped_sglang_default(field, raw),
-                value_stripped,
-                "field={field} raw={raw}"
-            );
-        }
-    }
 }
 
 #[test]

--- a/model_gateway/src/routers/openai/provider/types.rs
+++ b/model_gateway/src/routers/openai/provider/types.rs
@@ -1,64 +1,6 @@
-use serde_json::Value;
 use thiserror::Error;
 
 use crate::worker::Endpoint;
-
-pub(crate) const SGLANG_FIELDS: &[&str] = &[
-    "request_id",
-    "priority",
-    "top_k",
-    "min_p",
-    "min_tokens",
-    "regex",
-    "ebnf",
-    "json_schema",
-    "stop_token_ids",
-    "no_stop_trim",
-    "ignore_eos",
-    "continue_final_message",
-    "skip_special_tokens",
-    "lora_path",
-    "session_params",
-    "separate_reasoning",
-    "stream_reasoning",
-    "chat_template",
-    "chat_template_kwargs",
-    "return_hidden_states",
-    "repetition_penalty",
-    "sampling_seed",
-    "backend_url",
-];
-
-pub(crate) fn strip_sglang_fields(payload: &mut Value) {
-    if let Some(obj) = payload.as_object_mut() {
-        for field in SGLANG_FIELDS {
-            obj.remove(*field);
-        }
-    }
-}
-
-pub(crate) fn strip_default_sglang_fields(payload: &mut Value) {
-    if let Some(obj) = payload.as_object_mut() {
-        for field in SGLANG_FIELDS {
-            if obj.get(*field).is_some_and(|value| {
-                value.is_null()
-                    || value == false
-                    || (matches!(*field, "separate_reasoning" | "stream_reasoning")
-                        && value == true)
-            }) {
-                obj.remove(*field);
-            }
-        }
-    }
-}
-
-/// Raw-slice twin of [`strip_default_sglang_fields`]: decides whether a
-/// [`SGLANG_FIELDS`] entry would be stripped, given the compact serde_json
-/// rendering of its value. Must mirror the `Value` version above.
-pub(crate) fn is_stripped_sglang_default(field: &str, raw_json: &str) -> bool {
-    matches!(raw_json, "null" | "false")
-        || (matches!(field, "separate_reasoning" | "stream_reasoning") && raw_json == "true")
-}
 
 #[derive(Error, Debug)]
 pub enum ProviderError {

--- a/model_gateway/src/routers/openai/provider/xai.rs
+++ b/model_gateway/src/routers/openai/provider/xai.rs
@@ -1,7 +1,10 @@
 use serde_json::Value;
 
 use super::{Provider, ProviderError};
-use crate::worker::{Endpoint, ProviderType};
+use crate::{
+    routers::common::sglang_fields::strip_sglang_fields,
+    worker::{Endpoint, ProviderType},
+};
 
 pub struct XAIProvider;
 
@@ -15,7 +18,7 @@ impl Provider for XAIProvider {
         payload: &mut Value,
         endpoint: Endpoint,
     ) -> Result<(), ProviderError> {
-        super::types::strip_sglang_fields(payload);
+        strip_sglang_fields(payload);
 
         if endpoint == Endpoint::Responses {
             if let Some(obj) = payload.as_object_mut() {


### PR DESCRIPTION
## Description

### Problem

The HTTP proxy strips SGLang-only request fields before forwarding a body to a worker, and it imported the field list and the strip helpers from `routers::openai::provider::types`. Core proxying therefore depended on a third-party provider module, which is the one hard link that stops the gateway from compiling without provider routers.

### Solution

Move `SGLANG_FIELDS`, `strip_sglang_fields`, `strip_default_sglang_fields` and `is_stripped_sglang_default`, together with their two tests, into a new `routers::common::sglang_fields` module. The provider transformers and the HTTP proxy import from there. The OpenAI router no longer re-exports them. No behavior change.

## Changes

- `model_gateway/src/routers/common/sglang_fields.rs`: new home for the list, the three helpers and their tests, contents unchanged.
- `model_gateway/src/routers/common/mod.rs`: declare the module.
- `model_gateway/src/routers/http/request_body.rs`: import from `common::sglang_fields`.
- `model_gateway/src/routers/openai/provider/{types,mod,provider_trait,gemini,xai,tests}.rs` and `routers/openai/mod.rs`: drop the definitions and re-exports, import the shared helper.

## Test Plan

- `make fmt`, `cargo +nightly fmt --all`: clean.
- `cargo clippy -p smg --all-targets -- -D warnings`: clean.
- `cargo test -p smg --lib`: 1946 passed, including the moved `strip_default_sglang_fields_removes_false_and_null_values` and `raw_predicate_agrees_with_value_strip_for_every_field` plus the request-body golden tests.
- `cargo test -p smg --test api_tests --test routing_tests`: 109 and 132 passed, covering the HTTP proxy's field stripping on buffered and streamed bodies.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (ran `-p smg --all-targets` locally; the full matrix runs in CI)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>