### PR TITLE
feat(gateway): gate provider routers and external workers behind --enable-providers

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -528,6 +528,7 @@ struct Router {
     kv_connector_annotation: String,
     kv_engine_id_annotation: String,
     mm_per_request_image_limit: Option<usize>,
+    enable_providers: bool,
 }
 
 impl Router {
@@ -922,6 +923,7 @@ impl Router {
             .multimodal_tensor_transport(multimodal_tensor_transport)
             .multimodal_shm_min_bytes(self.multimodal_shm_min_bytes)
             .mm_per_request_image_limit(self.mm_per_request_image_limit)
+            .providers(self.enable_providers)
             .routing_key_override(config::RoutingKeyOverrideConfig {
                 enabled: self.routing_key_override,
                 eviction_interval_secs: self.eviction_interval_secs,
@@ -1098,6 +1100,7 @@ impl Router {
         kv_connector_annotation = String::from("smg.ai/kv-connector"),
         kv_engine_id_annotation = String::from("smg.ai/kv-engine-id"),
         mm_per_request_image_limit = None,
+        enable_providers = false,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1251,6 +1254,7 @@ impl Router {
         kv_connector_annotation: String,
         kv_engine_id_annotation: String,
         mm_per_request_image_limit: Option<usize>,
+        enable_providers: bool,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1418,6 +1422,7 @@ impl Router {
             kv_connector_annotation,
             kv_engine_id_annotation,
             mm_per_request_image_limit,
+            enable_providers,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -778,6 +778,15 @@ class RouterArgs:
             action="store_true",
             help="Enable IGW (Inference-Gateway) mode for multi-model support",
         )
+        routing_group.add_argument(
+            f"--{prefix}enable-providers",
+            action="store_true",
+            help=(
+                "Register the third-party provider routers (OpenAI-compatible,"
+                " Anthropic, Gemini) and admit external workers; implied by"
+                " --backend openai|anthropic|gemini"
+            ),
+        )
 
         # PD/EPD-specific arguments
         pd_group.add_argument(
@@ -892,15 +901,6 @@ class RouterArgs:
                 "Per-request image-count limit applied to every model, replacing the"
                 " model spec's built-in limit (e.g. to match the engine's"
                 " --limit-mm-per-prompt). Must be >= 1; unset keeps spec limits."
-            ),
-        )
-        parser.add_argument(
-            f"--{prefix}enable-providers",
-            action="store_true",
-            help=(
-                "Register the third-party provider routers (OpenAI-compatible,"
-                " Anthropic, Gemini) and admit external workers; implied by"
-                " --backend openai|anthropic|gemini"
             ),
         )
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -251,6 +251,9 @@ class RouterArgs:
     kv_engine_id_annotation: str = "smg.ai/kv-engine-id"
     # Per-request image-count limit replacing model spec limits; None keeps spec limits
     mm_per_request_image_limit: int | None = None
+    # Register provider routers and admit external workers (implied by
+    # --backend openai|anthropic|gemini)
+    enable_providers: bool = False
 
     @staticmethod
     def add_cli_args(
@@ -889,6 +892,15 @@ class RouterArgs:
                 "Per-request image-count limit applied to every model, replacing the"
                 " model spec's built-in limit (e.g. to match the engine's"
                 " --limit-mm-per-prompt). Must be >= 1; unset keeps spec limits."
+            ),
+        )
+        parser.add_argument(
+            f"--{prefix}enable-providers",
+            action="store_true",
+            help=(
+                "Register the third-party provider routers (OpenAI-compatible,"
+                " Anthropic, Gemini) and admit external workers; implied by"
+                " --backend openai|anthropic|gemini"
             ),
         )
 

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1440,6 +1440,7 @@ class TestRouterArgsFieldOrder:
         "kv_connector_annotation",
         "kv_engine_id_annotation",
         "mm_per_request_image_limit",
+        "enable_providers",
     ]
 
     def test_complete_field_sequence_is_frozen(self):

--- a/e2e_test/router/test_worker_api.py
+++ b/e2e_test/router/test_worker_api.py
@@ -375,7 +375,12 @@ class TestIGWMixedWorkerClassification:
             gateway = Gateway()
             gateway.start(
                 igw_mode=True,
-                extra_args=["--worker-startup-timeout-secs", "300"],
+                extra_args=[
+                    "--worker-startup-timeout-secs",
+                    "300",
+                    # External workers are admitted only when providers are enabled.
+                    "--enable-providers",
+                ],
             )
 
             try:

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -680,6 +680,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn providers(mut self, enable: bool) -> Self {
+        self.config.enable_providers = enable;
+        self
+    }
+
     pub fn dp_minimum_tokens_scheduler(mut self, enable: bool) -> Self {
         self.config.dp_minimum_tokens_scheduler = enable;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -1234,10 +1234,13 @@ impl RouterConfig {
 
     /// Whether provider routers may be registered and external workers admitted.
     ///
-    /// True when `enable_providers` is set or when the routing mode itself is a
-    /// provider mode, which cannot work without its router.
+    /// True when `enable_providers` is set in IGW mode, the only mode that
+    /// registers provider routers next to self-hosted ones, or when the routing
+    /// mode itself is a provider mode, which cannot work without its router. An
+    /// external worker admitted under any other configuration would have no
+    /// router to reach it.
     pub fn providers_enabled(&self) -> bool {
-        self.enable_providers
+        (self.enable_providers && self.enable_igw)
             || matches!(
                 self.mode,
                 RoutingMode::OpenAI { .. }
@@ -1364,14 +1367,24 @@ mod tests {
         assert!(!config.enable_providers);
         assert!(!config.providers_enabled());
 
-        // The flag round-trips.
+        // The flag round-trips and takes effect in IGW mode.
         let config = RouterConfig::builder()
             .regular_mode(vec![])
+            .igw(true)
             .providers(true)
             .build_unchecked();
         let json = serde_json::to_string(&config).unwrap();
         let with: RouterConfig = serde_json::from_str(&json).unwrap();
+        assert!(with.enable_providers);
         assert!(with.providers_enabled());
+
+        // Outside IGW mode nothing registers a provider router, so the flag
+        // alone must not admit external workers.
+        let config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .providers(true)
+            .build_unchecked();
+        assert!(!config.providers_enabled());
 
         // A provider routing mode implies it without the flag.
         let config = RouterConfig::builder()

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -216,6 +216,12 @@ pub struct RouterConfig {
     pub health_check: HealthCheckConfig,
     #[serde(default)]
     pub enable_igw: bool,
+    /// Register the third-party provider routers (OpenAI-compatible, Anthropic,
+    /// Gemini) in IGW mode and admit external workers. Off by default so a
+    /// self-hosted deployment never proxies to a cloud provider by accident.
+    /// Implied by the openai, anthropic and gemini routing modes.
+    #[serde(default)]
+    pub enable_providers: bool,
     /// Can be a HuggingFace model ID or local path
     pub model_path: Option<String>,
     /// Overrides model_path tokenizer if provided
@@ -1130,6 +1136,7 @@ impl Default for RouterConfig {
             disable_circuit_breaker: false,
             health_check: HealthCheckConfig::default(),
             enable_igw: false,
+            enable_providers: false,
             connection_mode: ConnectionMode::Http,
             startup_worker_runtime_type: None,
             zmq_engine_count: None,
@@ -1223,6 +1230,20 @@ impl RouterConfig {
     /// Check if running in IGW (Inference Gateway) mode
     pub fn is_igw_mode(&self) -> bool {
         self.enable_igw
+    }
+
+    /// Whether provider routers may be registered and external workers admitted.
+    ///
+    /// True when `enable_providers` is set or when the routing mode itself is a
+    /// provider mode, which cannot work without its router.
+    pub fn providers_enabled(&self) -> bool {
+        self.enable_providers
+            || matches!(
+                self.mode,
+                RoutingMode::OpenAI { .. }
+                    | RoutingMode::Anthropic { .. }
+                    | RoutingMode::Gemini { .. }
+            )
     }
 }
 
@@ -1332,6 +1353,32 @@ mod tests {
         assert!(json.contains("health_check_port"));
         let with: RouterConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(with.health_check_port, Some(8081));
+    }
+
+    #[test]
+    fn test_enable_providers_serde_default_and_mode_implication() {
+        // Config files predating the field deserialize to "off".
+        let mut json: serde_json::Value = serde_json::to_value(RouterConfig::default()).unwrap();
+        json.as_object_mut().unwrap().remove("enable_providers");
+        let config: RouterConfig = serde_json::from_value(json).unwrap();
+        assert!(!config.enable_providers);
+        assert!(!config.providers_enabled());
+
+        // The flag round-trips.
+        let config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .providers(true)
+            .build_unchecked();
+        let json = serde_json::to_string(&config).unwrap();
+        let with: RouterConfig = serde_json::from_str(&json).unwrap();
+        assert!(with.providers_enabled());
+
+        // A provider routing mode implies it without the flag.
+        let config = RouterConfig::builder()
+            .openai_mode(vec![])
+            .build_unchecked();
+        assert!(!config.enable_providers);
+        assert!(config.providers_enabled());
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -451,6 +451,12 @@ struct CliArgs {
     #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
     enable_igw: bool,
 
+    /// Register the third-party provider routers (OpenAI-compatible, Anthropic,
+    /// Gemini) and admit external workers. Implied by --backend
+    /// openai|anthropic|gemini; off by default for self-hosted deployments
+    #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
+    enable_providers: bool,
+
     /// Enable minimum tokens scheduler for data parallel group
     #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
     dp_minimum_tokens_scheduler: bool,
@@ -1912,6 +1918,7 @@ impl CliArgs {
             .enable_wasm(self.enable_wasm)
             .maybe_storage_hook_wasm_path(self.storage_hook_wasm_path.as_deref())
             .igw(self.enable_igw)
+            .providers(self.enable_providers)
             .dp_minimum_tokens_scheduler(self.dp_minimum_tokens_scheduler)
             .maybe_server_cert_and_key(self.tls_cert_path.as_ref(), self.tls_key_path.as_ref());
 
@@ -2090,6 +2097,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if cli_args.service_discovery && !cli_args.enable_igw {
         println!("INFO: IGW mode automatically enabled because service discovery is turned on");
         cli_args.enable_igw = true;
+    }
+
+    if cli_args.enable_igw && !cli_args.enable_providers {
+        println!(
+            "INFO: provider routers are not registered; pass --enable-providers to proxy to \
+             third-party providers"
+        );
     }
 
     let mode_str = if cli_args.enable_igw {
@@ -2501,6 +2515,32 @@ mod tests {
             server_config.router_config.engine_metrics,
             "engine_metrics must survive into ServerConfig via to_server_config"
         );
+    }
+
+    #[test]
+    fn enable_providers_flows_into_both_configs() {
+        let cli = cli_args_from(&["--enable-providers"]);
+
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert!(router_config.enable_providers);
+        assert!(router_config.providers_enabled());
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert!(server_config.router_config.providers_enabled());
+    }
+
+    #[test]
+    fn provider_backend_implies_enable_providers() {
+        let cli = cli_args_from(&[
+            "--backend",
+            "openai",
+            "--worker-urls",
+            "https://api.openai.com",
+        ]);
+
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert!(!router_config.enable_providers);
+        assert!(router_config.providers_enabled());
     }
 
     /// The overload thresholds must reach `RouterConfig` and survive nesting

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -2099,7 +2099,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli_args.enable_igw = true;
     }
 
-    if cli_args.enable_igw && !cli_args.enable_providers {
+    // A provider backend implies provider routing, so only a self-hosted
+    // IGW run without the flag is worth a line.
+    let provider_backend = matches!(
+        cli_args.backend,
+        Some(Backend::Openai | Backend::Anthropic | Backend::Gemini)
+    );
+    if cli_args.enable_igw && !cli_args.enable_providers && !provider_backend {
         println!(
             "INFO: provider routers are not registered; pass --enable-providers to proxy to \
              third-party providers"
@@ -2519,7 +2525,7 @@ mod tests {
 
     #[test]
     fn enable_providers_flows_into_both_configs() {
-        let cli = cli_args_from(&["--enable-providers"]);
+        let cli = cli_args_from(&["--enable-igw", "--enable-providers"]);
 
         let router_config = cli.to_router_config(vec![], vec![]).unwrap();
         assert!(router_config.enable_providers);

--- a/model_gateway/src/routers/factory.rs
+++ b/model_gateway/src/routers/factory.rs
@@ -283,7 +283,7 @@ impl RouterFactory {
             _ => (None, None, None),
         };
 
-        vec![
+        let mut routers = vec![
             (
                 router_ids::HTTP_REGULAR,
                 "HTTP Regular",
@@ -307,22 +307,32 @@ impl RouterFactory {
                 Self::set_epd_policies(encode_policy, prefill_policy, decode_policy, policy, ctx);
                 Self::create_grpc_router(ctx, Mode::EncodePrefillDecode)
             }),
-            (
-                router_ids::HTTP_OPENAI,
-                "OpenAI",
-                Self::create_openai_router(ctx).await,
-            ),
-            (
-                router_ids::HTTP_ANTHROPIC,
-                "Anthropic",
-                Self::create_anthropic_router(ctx).await,
-            ),
-            (
-                router_ids::HTTP_GEMINI,
-                "Gemini",
-                Self::create_gemini_router(ctx).await,
-            ),
-        ]
+        ];
+
+        // The provider routers proxy to third-party APIs and forward the
+        // caller's credentials upstream, so they exist only when the operator
+        // opted in.
+        if ctx.router_config.providers_enabled() {
+            routers.extend([
+                (
+                    router_ids::HTTP_OPENAI,
+                    "OpenAI",
+                    Self::create_openai_router(ctx).await,
+                ),
+                (
+                    router_ids::HTTP_ANTHROPIC,
+                    "Anthropic",
+                    Self::create_anthropic_router(ctx).await,
+                ),
+                (
+                    router_ids::HTTP_GEMINI,
+                    "Gemini",
+                    Self::create_gemini_router(ctx).await,
+                ),
+            ]);
+        }
+
+        routers
     }
 }
 

--- a/model_gateway/src/worker/service.rs
+++ b/model_gateway/src/worker/service.rs
@@ -11,7 +11,9 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use openai_protocol::worker::{WorkerErrorResponse, WorkerInfo, WorkerSpec, WorkerUpdateRequest};
+use openai_protocol::worker::{
+    ProviderType, RuntimeType, WorkerErrorResponse, WorkerInfo, WorkerSpec, WorkerUpdateRequest,
+};
 use serde_json::json;
 use tracing::warn;
 
@@ -42,6 +44,8 @@ pub enum WorkerServiceError {
     BadRequest { message: String },
     /// Worker with this URL already exists (duplicate POST)
     Conflict { url: String, worker_id: WorkerId },
+    /// The spec targets a third-party provider while provider routing is off
+    ProvidersDisabled { url: String },
     /// Job queue not initialized
     QueueNotInitialized,
     /// Failed to submit job to queue
@@ -55,6 +59,7 @@ impl WorkerServiceError {
             Self::InvalidId { .. } => "BAD_REQUEST",
             Self::BadRequest { .. } => "BAD_REQUEST",
             Self::Conflict { .. } => "WORKER_ALREADY_EXISTS",
+            Self::ProvidersDisabled { .. } => "PROVIDERS_DISABLED",
             Self::QueueNotInitialized => "INTERNAL_SERVER_ERROR",
             Self::QueueSubmitFailed { .. } => "INTERNAL_SERVER_ERROR",
         }
@@ -66,6 +71,7 @@ impl WorkerServiceError {
             Self::InvalidId { .. } => StatusCode::BAD_REQUEST,
             Self::BadRequest { .. } => StatusCode::BAD_REQUEST,
             Self::Conflict { .. } => StatusCode::CONFLICT,
+            Self::ProvidersDisabled { .. } => StatusCode::BAD_REQUEST,
             Self::QueueNotInitialized => StatusCode::INTERNAL_SERVER_ERROR,
             Self::QueueSubmitFailed { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
@@ -91,6 +97,11 @@ impl std::fmt::Display for WorkerServiceError {
                     Use PUT /workers/{id} to replace or PATCH /workers/{id} to update."
                 )
             }
+            Self::ProvidersDisabled { url } => write!(
+                f,
+                "Worker '{url}' targets a third-party provider, but provider routing is \
+                 disabled. Start the gateway with --enable-providers to admit external workers."
+            ),
             Self::QueueNotInitialized => write!(f, "Job queue not initialized"),
             Self::QueueSubmitFailed { message } => write!(f, "{message}"),
         }
@@ -268,6 +279,13 @@ impl WorkerService {
     ) -> Result<CreateWorkerResult, WorkerServiceError> {
         validate_worker_url_request(&config.url)?;
 
+        // External workers are reachable only through the provider routers,
+        // which exist only when the operator opted in. Admitting one otherwise
+        // would leave it routable by nothing.
+        if !self.router_config.providers_enabled() && Self::targets_provider(&config) {
+            return Err(WorkerServiceError::ProvidersDisabled { url: config.url });
+        }
+
         if self.router_config.api_key.is_some() && config.api_key.is_none() {
             warn!(
                 "Adding worker {} without API key while router has API key configured. \
@@ -306,6 +324,14 @@ impl WorkerService {
             url: worker_url,
             location,
         })
+    }
+
+    /// Whether a spec describes a third-party provider rather than a self-hosted
+    /// engine: an explicit external runtime, a provider, or a known provider URL.
+    fn targets_provider(config: &WorkerSpec) -> bool {
+        config.runtime_type == RuntimeType::External
+            || config.provider.is_some()
+            || ProviderType::from_url(&config.url).is_some()
     }
 
     /// Replace a worker by ID (full replace, re-runs registration workflow)
@@ -607,6 +633,52 @@ mod tests {
             .expect_err("mixed-case scheme must be rejected at the boundary");
 
         assert!(matches!(err, WorkerServiceError::BadRequest { .. }));
+    }
+
+    #[tokio::test]
+    async fn create_worker_rejects_external_workers_when_providers_disabled() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let service = make_service(registry);
+
+        let spec: WorkerSpec = serde_json::from_value(json!({
+            "url": "https://example.internal:8443",
+            "runtime_type": "external"
+        }))
+        .expect("worker spec");
+        let err = service
+            .create_worker(spec)
+            .await
+            .expect_err("external worker must be rejected while providers are disabled");
+        assert!(matches!(err, WorkerServiceError::ProvidersDisabled { .. }));
+        assert_eq!(err.error_code(), "PROVIDERS_DISABLED");
+        assert_eq!(err.status_code(), StatusCode::BAD_REQUEST);
+
+        // A known provider URL is rejected even without an explicit runtime type.
+        let err = service
+            .create_worker(worker_spec("https://api.anthropic.com"))
+            .await
+            .expect_err("provider URL must be rejected while providers are disabled");
+        assert!(matches!(err, WorkerServiceError::ProvidersDisabled { .. }));
+    }
+
+    #[tokio::test]
+    async fn create_worker_admits_external_workers_when_providers_enabled() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let service = WorkerService::new(
+            registry,
+            Arc::new(std::sync::OnceLock::new()),
+            RouterConfig::builder()
+                .regular_mode(vec![])
+                .providers(true)
+                .build_unchecked(),
+        );
+
+        // Passes admission and stops at the uninitialized queue.
+        let err = service
+            .create_worker(worker_spec("https://api.openai.com"))
+            .await
+            .expect_err("queue is uninitialized in the test harness");
+        assert!(matches!(err, WorkerServiceError::QueueNotInitialized));
     }
 
     #[tokio::test]

--- a/model_gateway/src/worker/service.rs
+++ b/model_gateway/src/worker/service.rs
@@ -350,6 +350,13 @@ impl WorkerService {
                 })?;
         let url = existing.url().to_string();
 
+        // Same admission rule as creation: a replacement that would turn the
+        // worker into a provider target must fail here, not later in the
+        // background workflow after this call already answered 202.
+        if !self.router_config.providers_enabled() && Self::targets_provider(&config) {
+            return Err(WorkerServiceError::ProvidersDisabled { url: config.url });
+        }
+
         // A data-parallel router expands one spec into one worker per rank,
         // each registered under a rank-suffixed URL. Re-running registration
         // for a single ID cannot express that, so refuse here instead of
@@ -662,6 +669,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn replace_worker_rejects_provider_specs_when_providers_disabled() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let worker_id = registry
+            .register(Arc::new(
+                BasicWorkerBuilder::new("http://local:30000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ))
+            .expect("worker registers");
+        let service = make_service(registry);
+
+        let spec: WorkerSpec = serde_json::from_value(json!({
+            "url": "http://local:30000",
+            "runtime_type": "external"
+        }))
+        .expect("worker spec");
+        let err = service
+            .replace_worker(worker_id.as_str(), spec)
+            .await
+            .expect_err("a replacement targeting a provider must be rejected up front");
+        assert!(matches!(err, WorkerServiceError::ProvidersDisabled { .. }));
+    }
+
+    #[tokio::test]
     async fn create_worker_admits_external_workers_when_providers_enabled() {
         let registry = Arc::new(WorkerRegistry::new());
         let service = WorkerService::new(
@@ -669,6 +700,7 @@ mod tests {
             Arc::new(std::sync::OnceLock::new()),
             RouterConfig::builder()
                 .regular_mode(vec![])
+                .igw(true)
                 .providers(true)
                 .build_unchecked(),
         );

--- a/model_gateway/src/workflow/steps/classify.rs
+++ b/model_gateway/src/workflow/steps/classify.rs
@@ -26,13 +26,14 @@ const CLASSIFY_PROBE_TIMEOUT_SECS: u64 = 2;
 
 /// External workers are reachable only through the provider routers, so a
 /// gateway that did not opt into providers must not classify anything as
-/// external. A missing app context (unit tests) admits everything.
+/// external. The verdict fails closed: without an app context to ask, which
+/// no production workflow lacks, nothing is admitted.
 fn external_workers_admitted(context: &WorkflowContext<WorkerWorkflowData>) -> bool {
     context
         .data
         .app_context
         .as_ref()
-        .is_none_or(|app_context| app_context.router_config.providers_enabled())
+        .is_some_and(|app_context| app_context.router_config.providers_enabled())
 }
 
 fn providers_disabled(url: &str) -> WorkflowError {
@@ -193,12 +194,96 @@ impl StepExecutor<WorkerWorkflowData> for ClassifyWorkerTypeStep {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, OnceLock};
+
     use axum::{routing::get, Json, Router};
+    use llm_tokenizer::registry::TokenizerRegistry;
+    use openai_protocol::worker::WorkerSpec;
     use reqwest::Client;
     use serde_json::json;
+    use smg_data_connector::{
+        MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
+    };
     use tokio::net::TcpListener;
+    use wfaas::WorkflowInstanceId;
 
-    use super::probe_models_owned_by;
+    use super::*;
+    use crate::{
+        app_context::AppContext,
+        config::RouterConfig,
+        policies::PolicyRegistry,
+        worker::WorkerRegistry,
+        workflow::{data::WorkerRegistrationMode, steps::create_worker_workflow_data},
+    };
+
+    fn app_context(providers: bool) -> Arc<AppContext> {
+        let router_config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .igw(providers)
+            .providers(providers)
+            .build_unchecked();
+        Arc::new(
+            AppContext::builder()
+                .client(Client::new())
+                .rate_limiter(None)
+                .tokenizer_registry(Arc::new(TokenizerRegistry::new()))
+                .reasoning_parser_factory(None)
+                .tool_parser_factory(None)
+                .worker_registry(Arc::new(WorkerRegistry::new()))
+                .policy_registry(Arc::new(PolicyRegistry::new(router_config.policy.clone())))
+                .router_config(router_config)
+                .response_storage(Arc::new(MemoryResponseStorage::new()))
+                .conversation_storage(Arc::new(MemoryConversationStorage::new()))
+                .conversation_item_storage(Arc::new(MemoryConversationItemStorage::new()))
+                .worker_monitor(None)
+                .worker_job_queue(Arc::new(OnceLock::new()))
+                .workflow_engines(Arc::new(OnceLock::new()))
+                .mcp_orchestrator(Arc::new(OnceLock::new()))
+                .build()
+                .expect("app context"),
+        )
+    }
+
+    fn context_for(
+        spec: serde_json::Value,
+        providers: bool,
+    ) -> WorkflowContext<WorkerWorkflowData> {
+        let config: WorkerSpec = serde_json::from_value(spec).expect("worker spec");
+        let data = create_worker_workflow_data(
+            config,
+            WorkerRegistrationMode::CreateOnly,
+            app_context(providers),
+        );
+        WorkflowContext::new(WorkflowInstanceId::new(), data)
+    }
+
+    #[tokio::test]
+    async fn external_workers_are_refused_unless_providers_are_enabled() {
+        let step = ClassifyWorkerTypeStep;
+        let explicit = json!({"url": "https://example.internal:8443", "runtime_type": "external"});
+        let provider_url = json!({"url": "https://api.anthropic.com"});
+
+        // Providers off: both an explicit external runtime and a known
+        // provider URL fail the step instead of entering the registry.
+        for spec in [&explicit, &provider_url] {
+            let mut ctx = context_for(spec.clone(), false);
+            assert!(matches!(
+                step.execute(&mut ctx).await,
+                Err(WorkflowError::StepFailed { .. })
+            ));
+            assert_eq!(ctx.data.worker_kind, None);
+        }
+
+        // Providers on: both classify as external.
+        for spec in [&explicit, &provider_url] {
+            let mut ctx = context_for(spec.clone(), true);
+            assert!(matches!(
+                step.execute(&mut ctx).await,
+                Ok(StepResult::Success)
+            ));
+            assert_eq!(ctx.data.worker_kind, Some(WorkerKind::External));
+        }
+    }
 
     #[tokio::test]
     async fn probe_models_owned_by_accepts_nvidia_as_local() {

--- a/model_gateway/src/workflow/steps/classify.rs
+++ b/model_gateway/src/workflow/steps/classify.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use openai_protocol::worker::ProviderType;
 use reqwest::Client;
 use tracing::debug;
-use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
+use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
 use super::util::{http_base_url, try_grpc_reachable, try_http_reachable};
 use crate::{
@@ -23,6 +23,27 @@ use crate::{
 /// Quick-probe timeout for classification. Deliberately short — the full
 /// connection timeout is applied later by `DetectConnectionModeStep`.
 const CLASSIFY_PROBE_TIMEOUT_SECS: u64 = 2;
+
+/// External workers are reachable only through the provider routers, so a
+/// gateway that did not opt into providers must not classify anything as
+/// external. A missing app context (unit tests) admits everything.
+fn external_workers_admitted(context: &WorkflowContext<WorkerWorkflowData>) -> bool {
+    context
+        .data
+        .app_context
+        .as_ref()
+        .is_none_or(|app_context| app_context.router_config.providers_enabled())
+}
+
+fn providers_disabled(url: &str) -> WorkflowError {
+    WorkflowError::StepFailed {
+        step_id: StepId::new("classify_worker_type"),
+        message: format!(
+            "worker {url} targets a third-party provider, but provider routing is disabled; \
+             start the gateway with --enable-providers to admit external workers"
+        ),
+    }
+}
 
 /// Known local backend `owned_by` values returned by `/v1/models`.
 const LOCAL_OWNED_BY: &[&str] = &["sglang", "vllm", "trtllm", "nvidia"];
@@ -93,6 +114,9 @@ impl StepExecutor<WorkerWorkflowData> for ClassifyWorkerTypeStep {
             } else {
                 WorkerKind::Local
             };
+            if kind == WorkerKind::External && !external_workers_admitted(context) {
+                return Err(providers_disabled(&config.url));
+            }
             debug!(
                 "Worker {} explicitly configured as {} → {:?}",
                 config.url, config.runtime_type, kind
@@ -103,6 +127,9 @@ impl StepExecutor<WorkerWorkflowData> for ClassifyWorkerTypeStep {
 
         // 3. URL matches known cloud provider → External (no probing needed)
         if let Some(provider) = ProviderType::from_url(&config.url) {
+            if !external_workers_admitted(context) {
+                return Err(providers_disabled(&config.url));
+            }
             debug!(
                 "Worker {} URL matches known provider ({}) → External",
                 config.url, provider


### PR DESCRIPTION
## Description

### Problem

A self-hosted deployment can proxy to a cloud provider without anyone asking for it. With `--service-discovery`, IGW mode is enabled automatically, and `create_igw_routers` registers the OpenAI-compatible, Anthropic and Gemini routers unconditionally. Any worker that is discovered or posted with `runtime_type: external`, a `provider`, or a known provider URL is then admitted and routed to those routers, with the caller's bearer token forwarded upstream. For an enterprise deployment that exists to keep data and credentials inside its own network, that default is wrong.

### Solution

A runtime switch, `enable_providers`, off by default:

- `RouterConfig.enable_providers` with `providers_enabled()`, which is also true for the openai, anthropic and gemini routing modes since those cannot work without their router. Plumbed through the CLI (`--enable-providers`), both config conversion paths, the builder, and the Python bindings, appended at the tail of `RouterArgs` to keep positional callers working.
- `create_igw_routers` appends the three provider routers only when providers are enabled, so a default IGW install registers five routers.
- `WorkerService::create_worker` rejects a spec that targets a provider with 400 `PROVIDERS_DISABLED` and a message naming the flag.
- The registration workflow's classify step fails, instead of classifying as external, when the worker is explicitly external or matches a known provider URL and providers are off. Discovered cloud endpoints therefore never enter the registry.
- One startup line when IGW runs without providers, so the absence is visible.

This is a runtime gate. The compile-time exclusion of the provider modules behind a Cargo feature follows in a separate PR.

## Changes

- `model_gateway/src/config/types.rs`: field, default, `providers_enabled()`, serde and mode-implication test.
- `model_gateway/src/config/builder.rs`: `providers(bool)` setter.
- `model_gateway/src/main.rs`: `--enable-providers`, wired into `to_router_config`, startup line, two-path config tests.
- `model_gateway/src/routers/factory.rs`: provider routers registered only when enabled.
- `model_gateway/src/worker/service.rs`: `ProvidersDisabled` error, admission check, two tests.
- `model_gateway/src/workflow/steps/classify.rs`: fail external classification when providers are off; no app context (unit tests) admits everything.
- `bindings/python/src/lib.rs`, `bindings/python/src/smg/router_args.py`, `bindings/python/tests/test_arg_parser.py`: `enable_providers` appended at the tail.

## Test Plan

- `make fmt`, `cargo +nightly fmt --all`: clean.
- `cargo clippy -p smg --all-targets -- -D warnings` and `cargo clippy -p smg-python -- -D warnings`: clean.
- `cargo test -p smg --lib`: 1949 passed, including `test_enable_providers_serde_default_and_mode_implication`, `enable_providers_flows_into_both_configs`, `provider_backend_implies_enable_providers`, `create_worker_rejects_external_workers_when_providers_disabled` and `create_worker_admits_external_workers_when_providers_enabled`.
- `cargo test -p smg --test routing_tests --test api_tests`: 132 and 109 passed.
- Python: pytest is not installed on this machine, so `test_complete_field_sequence_is_frozen` was checked offline by parsing the dataclass and the expected list (158 fields each, identical order, `enable_providers` last); CI runs the real suite.
- The e2e vendor lanes pass `--backend openai|anthropic`, which implies the flag, so they exercise the unchanged provider paths.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (ran `-p smg --all-targets` and `-p smg-python` locally; the full matrix runs in CI)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>