### PR TITLE
refactor(gateway): serve /v1/models from an endpoint module instead of the router manager

### DIFF
--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -16,7 +16,7 @@ use tracing::debug;
 
 use crate::{
     config::RouterConfig,
-    middleware::TokenBucket,
+    middleware::{AuthConfig, TokenBucket},
     observability::inflight_tracker::InFlightRequestTracker,
     policies::PolicyRegistry,
     rate_limit::RateLimitManager,
@@ -52,6 +52,11 @@ impl std::error::Error for AppContextBuildError {}
 pub struct AppContext {
     pub client: Client,
     pub router_config: RouterConfig,
+    /// Every credential that authenticates as this gateway: the shared
+    /// `api_key` plus any per-tenant keys, derived once from `router_config`.
+    /// The serving auth layer and the `/v1/models` BYOK short-circuit both
+    /// read this set, so they cannot drift apart.
+    pub gateway_auth: AuthConfig,
     pub rate_limiter: Option<Arc<TokenBucket>>,
     pub rate_limit_manager: Option<Arc<RateLimitManager>>,
     pub tokenizer_registry: Arc<TokenizerRegistry>,
@@ -359,8 +364,13 @@ impl AppContextBuilder {
         ));
 
         let worker_client_cache = Arc::new(WorkerHttpClientCache::new(&router_config));
+        let gateway_auth = AuthConfig::with_tenant_keys(
+            router_config.api_key.clone(),
+            &router_config.tenant_api_keys,
+        );
 
         Ok(AppContext {
+            gateway_auth,
             client: self
                 .client
                 .ok_or(AppContextBuildError::MissingField("client"))?,

--- a/model_gateway/src/endpoints/mod.rs
+++ b/model_gateway/src/endpoints/mod.rs
@@ -2,10 +2,12 @@
 //!
 //! These handlers serve requests directly from the application context:
 //! tokenizer management and tokenize/detokenize, tool-call and reasoning
-//! parsing, conversation storage, and stored-response retrieval. None of
-//! them select a worker or touch a router, so they live outside `routers`.
+//! parsing, conversation storage, stored-response retrieval, and the model
+//! inventory. None of them select a worker or touch a router, so they live
+//! outside `routers`.
 
 pub mod conversations;
+pub mod models;
 pub mod parse;
 pub mod responses;
 pub mod tokenize;

--- a/model_gateway/src/endpoints/models.rs
+++ b/model_gateway/src/endpoints/models.rs
@@ -27,17 +27,10 @@ use crate::{
 
 /// Answer `GET /v1/models` for the caller identified by `headers`.
 pub async fn list_models(context: &AppContext, headers: &HeaderMap) -> Response {
-    // Every credential that authenticates as this gateway, shared and
-    // per-tenant. Rebuilt per call from the config it derives from; the
-    // endpoint is not hot and the set is small.
-    let gateway_auth = AuthConfig::with_tenant_keys(
-        context.router_config.api_key.clone(),
-        &context.router_config.tenant_api_keys,
-    );
     list_models_with(
         &context.worker_registry,
         &context.client,
-        &gateway_auth,
+        &context.gateway_auth,
         headers,
     )
     .await

--- a/model_gateway/src/endpoints/models.rs
+++ b/model_gateway/src/endpoints/models.rs
@@ -1,0 +1,299 @@
+//! `GET /v1/models`: the gateway's model inventory.
+//!
+//! Self-hosted models are read from the worker registry. A caller presenting
+//! its own provider credential (bring your own key) is answered from the
+//! external upstreams instead, but never when that credential is one of the
+//! gateway's own keys: a tenant-scoped key must not be forwarded to a third
+//! party as if it were the caller's.
+
+use std::collections::HashSet;
+
+use axum::{
+    http::{header, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use futures::future::select_all;
+use openai_protocol::{model_card::ModelCard, models::ListModelsResponse};
+use serde_json::Value;
+use tracing::{debug, warn};
+
+use crate::{
+    app_context::AppContext,
+    middleware::AuthConfig,
+    routers::common::header_utils::apply_provider_headers,
+    worker::{ProviderType, RuntimeType, WorkerRegistry},
+};
+
+/// Answer `GET /v1/models` for the caller identified by `headers`.
+pub async fn list_models(context: &AppContext, headers: &HeaderMap) -> Response {
+    // Every credential that authenticates as this gateway, shared and
+    // per-tenant. Rebuilt per call from the config it derives from; the
+    // endpoint is not hot and the set is small.
+    let gateway_auth = AuthConfig::with_tenant_keys(
+        context.router_config.api_key.clone(),
+        &context.router_config.tenant_api_keys,
+    );
+    list_models_with(
+        &context.worker_registry,
+        &context.client,
+        &gateway_auth,
+        headers,
+    )
+    .await
+}
+
+/// [`list_models`] over explicit collaborators.
+pub(crate) async fn list_models_with(
+    registry: &WorkerRegistry,
+    client: &reqwest::Client,
+    gateway_auth: &AuthConfig,
+    headers: &HeaderMap,
+) -> Response {
+    let bearer_token = bearer_token(headers);
+
+    // Short-circuit: a token that is one of the gateway's own credentials
+    // is answered from the registry. It must never reach the BYOK fan-out
+    // below, which would forward it externally.
+    if let Some(ref token) = bearer_token {
+        if gateway_auth.contains_token(token) {
+            return registry_models_response(registry);
+        }
+    }
+
+    // A foreign token is tried against the external upstreams first (bring
+    // your own key). On total failure fall through to the registry.
+    if let Some(ref token) = bearer_token {
+        let upstream_cards = fetch_upstream_models(registry, client, token).await;
+        if !upstream_cards.is_empty() {
+            let resp = ListModelsResponse::from_model_cards(upstream_cards);
+            return (StatusCode::OK, Json(resp)).into_response();
+        }
+    }
+
+    registry_models_response(registry)
+}
+
+/// The caller's credential: a `Bearer` token (case-insensitive scheme per
+/// RFC 7235) or an Anthropic-style `x-api-key` header.
+fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|h| {
+            let lower = h.to_ascii_lowercase();
+            lower.starts_with("bearer ").then(|| h[7..].to_string())
+        })
+        .or_else(|| {
+            headers
+                .get("x-api-key")
+                .and_then(|h| h.to_str().ok())
+                .map(String::from)
+        })
+}
+
+/// The self-hosted inventory: every model card of every non-external worker.
+fn registry_models_response(registry: &WorkerRegistry) -> Response {
+    let cards: Vec<_> = registry
+        .get_all()
+        .iter()
+        .filter(|w| !matches!(w.metadata().spec.runtime_type, RuntimeType::External))
+        .flat_map(|w| w.models())
+        .collect();
+    if cards.is_empty() {
+        (StatusCode::SERVICE_UNAVAILABLE, "No models available").into_response()
+    } else {
+        let resp = ListModelsResponse::from_model_cards(cards);
+        (StatusCode::OK, Json(resp)).into_response()
+    }
+}
+
+/// Fan out to all healthy external upstreams concurrently with the caller's
+/// bearer token and return the first successful model inventory. Returns an
+/// empty vec on total failure.
+async fn fetch_upstream_models(
+    registry: &WorkerRegistry,
+    client: &reqwest::Client,
+    bearer_token: &str,
+) -> Vec<ModelCard> {
+    let unique_urls: Vec<_> = registry
+        .get_workers_filtered(None, None, None, Some(RuntimeType::External), true)
+        .iter()
+        .map(|w| w.url().to_string())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    if unique_urls.is_empty() {
+        return Vec::new();
+    }
+
+    debug!(
+        "Trying {} upstream(s) for model discovery",
+        unique_urls.len()
+    );
+
+    let auth = match HeaderValue::from_str(&format!("Bearer {bearer_token}")) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            warn!("Bearer token contains invalid header characters: {e}");
+            return Vec::new();
+        }
+    };
+
+    // Fan out concurrently; return the first non-empty result.
+    let mut pending: Vec<_> = unique_urls
+        .into_iter()
+        .map(|url| Box::pin(fetch_models_from(client.clone(), url, auth.clone())))
+        .collect();
+
+    while !pending.is_empty() {
+        let (cards, _index, remaining) = select_all(pending).await;
+        if !cards.is_empty() {
+            return cards;
+        }
+        pending = remaining;
+    }
+
+    Vec::new()
+}
+
+/// Fetch models from a single upstream endpoint.
+async fn fetch_models_from(
+    client: reqwest::Client,
+    base_url: String,
+    auth: Option<HeaderValue>,
+) -> Vec<ModelCard> {
+    let url = format!("{base_url}/v1/models");
+    let req = apply_provider_headers(client.get(&url), &url, auth.as_ref());
+
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            debug!("Failed to reach upstream {url}: {e}");
+            return Vec::new();
+        }
+    };
+
+    if !resp.status().is_success() {
+        debug!(
+            "Upstream {url} returned {} for model discovery",
+            resp.status()
+        );
+        return Vec::new();
+    }
+
+    match resp.json::<Value>().await {
+        Ok(json) => ListModelsResponse::parse_upstream(&json, ProviderType::from_url(&url)),
+        Err(e) => {
+            warn!("Failed to parse upstream models from {url}: {e}");
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use axum::http::Request;
+    use openai_protocol::worker::HealthCheckConfig;
+
+    use super::*;
+    use crate::{
+        config::types::TenantApiKeyEntry,
+        worker::{BasicWorkerBuilder, Worker, WorkerType},
+    };
+
+    /// A tenant-scoped credential must never reach the upstream fan-out:
+    /// that would forward the gateway's own secret to an external provider
+    /// as if it were the caller's BYOK token. Verified against a real mock
+    /// upstream that counts hits, since a stubbed HTTP client can't
+    /// distinguish "short-circuited" from "fell through and failed" by
+    /// response alone: both end up returning registry models on failure.
+    #[tokio::test]
+    #[expect(clippy::disallowed_methods, reason = "test infrastructure")]
+    async fn a_gateway_credential_never_fans_out_upstream() {
+        let hit_count = Arc::new(AtomicUsize::new(0));
+        let hit_count_clone = hit_count.clone();
+        let mock_app = axum::Router::new().route(
+            "/v1/models",
+            axum::routing::get(move || {
+                let hit_count = hit_count_clone.clone();
+                async move {
+                    hit_count.fetch_add(1, Ordering::SeqCst);
+                    Json(serde_json::json!({"object": "list", "data": []}))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, mock_app).await;
+        });
+
+        let registry = WorkerRegistry::new();
+        let external_worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new(format!("http://{addr}"))
+                .worker_type(WorkerType::Regular)
+                .runtime_type(RuntimeType::External)
+                .health_config(HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        );
+        registry.register(external_worker);
+        // A non-external worker so the short-circuit path has something to
+        // return besides 503.
+        let internal_worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://internal.invalid:8000")
+                .worker_type(WorkerType::Regular)
+                .models(vec![ModelCard::new("internal-model")])
+                .health_config(HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        );
+        registry.register(internal_worker);
+
+        let client = reqwest::Client::new();
+        let gateway_auth = AuthConfig::with_tenant_keys(
+            Some("shared-secret".to_string()),
+            &[TenantApiKeyEntry {
+                tenant_id: "team-red".to_string(),
+                key: "team-red-secret".to_string(),
+            }],
+        );
+
+        let req = Request::builder()
+            .header(header::AUTHORIZATION, "Bearer team-red-secret")
+            .body(())
+            .unwrap();
+        let response = list_models_with(&registry, &client, &gateway_auth, req.headers()).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            hit_count.load(Ordering::SeqCst),
+            0,
+            "a tenant-scoped key must never trigger upstream BYOK fan-out"
+        );
+
+        // Control: a genuinely unrecognized token still fans out, which
+        // confirms the short-circuit is keyed on the gateway's own
+        // credentials rather than disabled entirely.
+        let req = Request::builder()
+            .header(header::AUTHORIZATION, "Bearer not-a-gateway-key")
+            .body(())
+            .unwrap();
+        let _ = list_models_with(&registry, &client, &gateway_auth, req.headers()).await;
+        assert_eq!(
+            hit_count.load(Ordering::SeqCst),
+            1,
+            "an unrecognized token should still fan out to upstream providers"
+        );
+    }
+}

--- a/model_gateway/src/middleware/concurrency.rs
+++ b/model_gateway/src/middleware/concurrency.rs
@@ -288,10 +288,7 @@ mod tests {
                 .unwrap(),
         );
         Arc::new(AppState {
-            router: Arc::new(RouterManager::new(
-                context.worker_registry.clone(),
-                context.client.clone(),
-            )),
+            router: Arc::new(RouterManager::new(context.worker_registry.clone())),
             probe_state: ProbeState::new(context.inflight_tracker.clone()),
             context,
             admission_queue,

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -72,11 +72,6 @@ pub trait RouterTrait: Send + Sync + Debug {
         (StatusCode::NOT_IMPLEMENTED, "Server info not implemented").into_response()
     }
 
-    /// Get available models
-    async fn get_models(&self, _req: Request<Body>) -> Response {
-        (StatusCode::NOT_IMPLEMENTED, "Get models not implemented").into_response()
-    }
-
     /// Get model information
     async fn get_model_info(&self, _req: Request<Body>) -> Response {
         (

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -4,18 +4,16 @@
 //! - Single Router Mode (enable_igw=false): Router owns workers directly
 //! - Multi-Router Mode (enable_igw=true): RouterManager coordinates everything
 
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::{
     body::Body,
     extract::Request,
-    http::{header, HeaderMap, HeaderValue, StatusCode},
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
-    Json,
 };
 use dashmap::DashMap;
-use futures::future::select_all;
 use openai_protocol::{
     chat::ChatCompletionRequest,
     classify::ClassifyRequest,
@@ -24,8 +22,6 @@ use openai_protocol::{
     generate::GenerateRequest,
     interactions::InteractionsRequest,
     messages::CreateMessageRequest,
-    model_card::ModelCard,
-    models::ListModelsResponse,
     realtime_session::{
         RealtimeClientSecretCreateRequest, RealtimeSessionCreateRequest,
         RealtimeTranscriptionSessionCreateRequest,
@@ -35,15 +31,14 @@ use openai_protocol::{
     transcription::{AudioFile, TranscriptionRequest},
     UNKNOWN_MODEL_ID,
 };
-use serde_json::Value;
 use tracing::{debug, info, warn};
 
 use crate::{
     app_context::AppContext,
     config::RoutingMode,
-    middleware::{AuthConfig, TenantRequestMeta},
+    middleware::TenantRequestMeta,
     routers::{
-        common::{body_policy::REASON_MODEL_SELECTION, header_utils::apply_provider_headers},
+        common::body_policy::REASON_MODEL_SELECTION,
         error as route_error,
         factory::{router_ids, RouterId},
         BodyPolicy, RouterFactory, RouterTrait,
@@ -54,24 +49,15 @@ use crate::{
 
 pub struct RouterManager {
     worker_registry: Arc<WorkerRegistry>,
-    client: reqwest::Client,
-    /// Every credential that authenticates as *this gateway* (shared
-    /// `api_key` plus any per-tenant keys) — not just the shared key. Used
-    /// to keep `/v1/models`' BYOK short-circuit from mistaking a valid
-    /// tenant-scoped key for a foreign upstream-provider credential and
-    /// forwarding it externally.
-    gateway_auth: AuthConfig,
     routers: Arc<DashMap<RouterId, Arc<dyn RouterTrait>>>,
     default_router: Arc<std::sync::RwLock<Option<RouterId>>>,
     enable_igw: bool,
 }
 
 impl RouterManager {
-    pub fn new(worker_registry: Arc<WorkerRegistry>, client: reqwest::Client) -> Self {
+    pub fn new(worker_registry: Arc<WorkerRegistry>) -> Self {
         Self {
             worker_registry,
-            client,
-            gateway_auth: AuthConfig::new(None),
             routers: Arc::new(DashMap::new()),
             default_router: Arc::new(std::sync::RwLock::new(None)),
             enable_igw: false,
@@ -100,15 +86,8 @@ impl RouterManager {
         config: &ServerConfig,
         app_context: &Arc<AppContext>,
     ) -> Result<Arc<Self>, String> {
-        let mut manager = Self::new(
-            app_context.worker_registry.clone(),
-            app_context.client.clone(),
-        );
+        let mut manager = Self::new(app_context.worker_registry.clone());
         manager.enable_igw = config.router_config.enable_igw;
-        manager.gateway_auth = AuthConfig::with_tenant_keys(
-            config.router_config.api_key.clone(),
-            &config.router_config.tenant_api_keys,
-        );
         let manager = Arc::new(manager);
 
         if config.router_config.enable_igw {
@@ -367,110 +346,6 @@ impl RouterManager {
                     .and_then(|id| self.routers.get(id).map(|r| r.clone()))
             })
     }
-
-    /// Build a response from self-hosted registry models (excludes external workers).
-    fn registry_models_response(&self) -> Response {
-        let cards: Vec<_> = self
-            .worker_registry
-            .get_all()
-            .iter()
-            .filter(|w| !matches!(w.metadata().spec.runtime_type, RuntimeType::External))
-            .flat_map(|w| w.models())
-            .collect();
-        if cards.is_empty() {
-            (StatusCode::SERVICE_UNAVAILABLE, "No models available").into_response()
-        } else {
-            let resp = ListModelsResponse::from_model_cards(cards);
-            (StatusCode::OK, Json(resp)).into_response()
-        }
-    }
-
-    /// Fan out to all healthy external upstreams concurrently with the caller's
-    /// bearer token and return the first successful model inventory. Returns an
-    /// empty vec on total failure.
-    async fn fetch_upstream_models(&self, bearer_token: &str) -> Vec<ModelCard> {
-        let unique_urls: Vec<_> = self
-            .worker_registry
-            .get_workers_filtered(None, None, None, Some(RuntimeType::External), true)
-            .iter()
-            .map(|w| w.url().to_string())
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect();
-
-        if unique_urls.is_empty() {
-            return Vec::new();
-        }
-
-        debug!(
-            "Trying {} upstream(s) for model discovery",
-            unique_urls.len()
-        );
-
-        let auth = match HeaderValue::from_str(&format!("Bearer {bearer_token}")) {
-            Ok(v) => Some(v),
-            Err(e) => {
-                warn!("Bearer token contains invalid header characters: {e}");
-                return Vec::new();
-            }
-        };
-
-        // Fan out concurrently; return first non-empty result.
-        let mut pending: Vec<_> = unique_urls
-            .into_iter()
-            .map(|url| {
-                Box::pin(Self::fetch_models_from(
-                    self.client.clone(),
-                    url,
-                    auth.clone(),
-                ))
-            })
-            .collect();
-
-        while !pending.is_empty() {
-            let (cards, _index, remaining) = select_all(pending).await;
-            if !cards.is_empty() {
-                return cards;
-            }
-            pending = remaining;
-        }
-
-        Vec::new()
-    }
-
-    /// Fetch models from a single upstream endpoint.
-    async fn fetch_models_from(
-        client: reqwest::Client,
-        base_url: String,
-        auth: Option<HeaderValue>,
-    ) -> Vec<ModelCard> {
-        let url = format!("{base_url}/v1/models");
-        let req = apply_provider_headers(client.get(&url), &url, auth.as_ref());
-
-        let resp = match req.send().await {
-            Ok(r) => r,
-            Err(e) => {
-                debug!("Failed to reach upstream {url}: {e}");
-                return Vec::new();
-            }
-        };
-
-        if !resp.status().is_success() {
-            debug!(
-                "Upstream {url} returned {} for model discovery",
-                resp.status()
-            );
-            return Vec::new();
-        }
-
-        match resp.json::<Value>().await {
-            Ok(json) => ListModelsResponse::parse_upstream(&json, ProviderType::from_url(&url)),
-            Err(e) => {
-                warn!("Failed to parse upstream models from {url}: {e}");
-                Vec::new()
-            }
-        }
-    }
 }
 
 #[async_trait]
@@ -510,48 +385,6 @@ impl RouterTrait for RouterManager {
         } else {
             (StatusCode::SERVICE_UNAVAILABLE, "No routers available").into_response()
         }
-    }
-
-    async fn get_models(&self, req: Request<Body>) -> Response {
-        // Extract token from Authorization header (case-insensitive "Bearer " prefix
-        // per RFC 7235) or Anthropic-style x-api-key header.
-        let bearer_token = req
-            .headers()
-            .get(header::AUTHORIZATION)
-            .and_then(|h| h.to_str().ok())
-            .and_then(|h| {
-                let lower = h.to_ascii_lowercase();
-                lower.starts_with("bearer ").then(|| h[7..].to_string())
-            })
-            .or_else(|| {
-                req.headers()
-                    .get("x-api-key")
-                    .and_then(|h| h.to_str().ok())
-                    .map(String::from)
-            });
-
-        // Short-circuit: if the token matches any of the gateway's own
-        // credentials (shared or per-tenant), skip upstream fan-out and
-        // return registry models directly. A tenant-scoped key must never
-        // reach the BYOK fan-out below — that would forward it externally.
-        if let Some(ref token) = bearer_token {
-            if self.gateway_auth.contains_token(token) {
-                return self.registry_models_response();
-            }
-        }
-
-        // If the caller sent a provider token, try to discover models from
-        // upstream providers. This enables BYOK (bring your own key) flows.
-        if let Some(ref token) = bearer_token {
-            let upstream_cards = self.fetch_upstream_models(token).await;
-            if !upstream_cards.is_empty() {
-                let resp = ListModelsResponse::from_model_cards(upstream_cards);
-                return (StatusCode::OK, Json(resp)).into_response();
-            }
-            // All upstreams failed or returned nothing — fall through to registry.
-        }
-
-        self.registry_models_response()
     }
 
     async fn get_model_info(&self, req: Request<Body>) -> Response {
@@ -928,10 +761,10 @@ mod tests {
     use std::collections::HashMap;
 
     use async_trait::async_trait;
+    use openai_protocol::model_card::ModelCard;
 
     use super::*;
     use crate::{
-        config::TenantApiKeyEntry,
         middleware::{RouteRequestMeta, TenantKey},
         routers::factory::router_ids,
         worker::{BasicWorkerBuilder, CircuitBreakerConfig, WorkerRegistry},
@@ -1010,8 +843,7 @@ mod tests {
     }
 
     fn test_manager(enable_igw: bool) -> Arc<RouterManager> {
-        let mut manager =
-            RouterManager::new(Arc::new(WorkerRegistry::new()), reqwest::Client::new());
+        let mut manager = RouterManager::new(Arc::new(WorkerRegistry::new()));
         manager.enable_igw = enable_igw;
         let manager = Arc::new(manager);
         manager.register_router(router_ids::HTTP_REGULAR, Arc::new(StubRouter));
@@ -1042,7 +874,7 @@ mod tests {
         }
 
         let forward_manager = {
-            let mut m = RouterManager::new(Arc::new(WorkerRegistry::new()), reqwest::Client::new());
+            let mut m = RouterManager::new(Arc::new(WorkerRegistry::new()));
             m.enable_igw = false;
             let m = Arc::new(m);
             m.register_router(router_ids::HTTP_REGULAR, Arc::new(ForwardStubRouter));
@@ -1060,7 +892,7 @@ mod tests {
         );
 
         let pd_manager = {
-            let mut m = RouterManager::new(Arc::new(WorkerRegistry::new()), reqwest::Client::new());
+            let mut m = RouterManager::new(Arc::new(WorkerRegistry::new()));
             m.enable_igw = false;
             let m = Arc::new(m);
             m.register_router(router_ids::HTTP_PD, Arc::new(PdStubRouter));
@@ -1081,101 +913,6 @@ mod tests {
 
     fn test_tenant_meta() -> TenantRequestMeta {
         RouteRequestMeta::new(TenantKey::from("test-tenant"))
-    }
-
-    /// A tenant-scoped credential must never reach `fetch_upstream_models`:
-    /// that would forward the gateway's own secret to an external provider
-    /// as if it were the caller's BYOK token. Verified against a real mock
-    /// upstream that counts hits, since a stubbed HTTP client can't
-    /// distinguish "short-circuited" from "fell through and failed" by
-    /// response alone — both end up returning registry models on failure.
-    #[tokio::test]
-    #[expect(clippy::disallowed_methods, reason = "test infrastructure")]
-    async fn get_models_short_circuits_for_tenant_key_without_forwarding_upstream() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        let hit_count = Arc::new(AtomicUsize::new(0));
-        let hit_count_clone = hit_count.clone();
-        let mock_app = axum::Router::new().route(
-            "/v1/models",
-            axum::routing::get(move || {
-                let hit_count = hit_count_clone.clone();
-                async move {
-                    hit_count.fetch_add(1, Ordering::SeqCst);
-                    Json(serde_json::json!({"object": "list", "data": []}))
-                }
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            let _ = axum::serve(listener, mock_app).await;
-        });
-
-        let registry = Arc::new(WorkerRegistry::new());
-        let external_worker: Arc<dyn Worker> = Arc::new(
-            BasicWorkerBuilder::new(format!("http://{addr}"))
-                .worker_type(WorkerType::Regular)
-                .runtime_type(RuntimeType::External)
-                .health_config(openai_protocol::worker::HealthCheckConfig {
-                    disable_health_check: true,
-                    ..Default::default()
-                })
-                .build(),
-        );
-        registry.register(external_worker);
-        // A non-External worker so registry_models_response() (the
-        // short-circuit path) has something to return besides 503.
-        let internal_worker: Arc<dyn Worker> = Arc::new(
-            BasicWorkerBuilder::new("http://internal.invalid:8000")
-                .worker_type(WorkerType::Regular)
-                .models(vec![ModelCard::new("internal-model")])
-                .health_config(openai_protocol::worker::HealthCheckConfig {
-                    disable_health_check: true,
-                    ..Default::default()
-                })
-                .build(),
-        );
-        registry.register(internal_worker);
-
-        let mut manager = RouterManager::new(registry, reqwest::Client::new());
-        manager.gateway_auth = AuthConfig::with_tenant_keys(
-            Some("shared-secret".to_string()),
-            &[TenantApiKeyEntry {
-                tenant_id: "team-red".to_string(),
-                key: "team-red-secret".to_string(),
-            }],
-        );
-
-        let req = Request::builder()
-            .method("GET")
-            .uri("/v1/models")
-            .header(header::AUTHORIZATION, "Bearer team-red-secret")
-            .body(Body::empty())
-            .unwrap();
-        let response = manager.get_models(req).await;
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(
-            hit_count.load(Ordering::SeqCst),
-            0,
-            "a tenant-scoped key must never trigger upstream BYOK fan-out"
-        );
-
-        // Control: a genuinely unrecognized token should still trigger BYOK
-        // fan-out — confirms the short-circuit is keyed on the gateway's own
-        // credentials, not disabled entirely.
-        let req = Request::builder()
-            .method("GET")
-            .uri("/v1/models")
-            .header(header::AUTHORIZATION, "Bearer not-a-gateway-key")
-            .body(Body::empty())
-            .unwrap();
-        let _ = manager.get_models(req).await;
-        assert_eq!(
-            hit_count.load(Ordering::SeqCst),
-            1,
-            "an unrecognized token should still fan out to upstream providers"
-        );
     }
 
     fn generate_request_without_model() -> GenerateRequest {
@@ -1240,7 +977,7 @@ mod tests {
         add_workers(WorkerType::Decode, 2);
         add_workers(WorkerType::Regular, 6);
 
-        let mut manager = RouterManager::new(registry, reqwest::Client::new());
+        let mut manager = RouterManager::new(registry);
         manager.enable_igw = true;
         let manager = Arc::new(manager);
         manager.register_router(router_ids::HTTP_PD, Arc::new(PdStubRouter));
@@ -1284,7 +1021,7 @@ mod tests {
             registry.register(Arc::new(worker)).unwrap();
         }
 
-        let mut manager = RouterManager::new(registry, reqwest::Client::new());
+        let mut manager = RouterManager::new(registry);
         manager.enable_igw = true;
         let manager = Arc::new(manager);
         manager.register_router(router_ids::GRPC_PD, Arc::new(PdStubRouter));
@@ -1315,7 +1052,7 @@ mod tests {
             registry.register(Arc::new(worker)).unwrap();
         }
 
-        let mut manager = RouterManager::new(registry, reqwest::Client::new());
+        let mut manager = RouterManager::new(registry);
         manager.enable_igw = true;
         let manager = Arc::new(manager);
         manager.register_router(router_ids::HTTP_REGULAR, Arc::new(StubRouter));

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -47,7 +47,7 @@ use wfaas::LoggingSubscriber;
 use crate::{
     app_context::AppContext,
     config::RouterConfig,
-    endpoints::{conversations, parse, responses as response_handlers, tokenize},
+    endpoints::{conversations, models, parse, responses as response_handlers, tokenize},
     mesh::MeshAdapters,
     middleware::{self, AdmissionQueue, AuthConfig},
     observability::{
@@ -136,7 +136,7 @@ async fn get_server_info(State(state): State<Arc<AppState>>, req: Request) -> Re
 }
 
 async fn v1_models(State(state): State<Arc<AppState>>, req: Request) -> Response {
-    state.router.get_models(req).await
+    models::list_models(&state.context, req.headers()).await
 }
 
 async fn get_model_info(State(state): State<Arc<AppState>>, req: Request) -> Response {

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -1426,10 +1426,7 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     // keys when falling back to simple API-key auth (no control-plane auth
     // configured) — a tenant credential must not be able to reach
     // `/workers`, `/flush_cache`, etc. Only the shared gateway-wide key does.
-    let serving_auth_config = AuthConfig::with_tenant_keys(
-        config.router_config.api_key.clone(),
-        &config.router_config.tenant_api_keys,
-    );
+    let serving_auth_config = app_context.gateway_auth.clone();
     let admin_auth_config = AuthConfig::new(config.router_config.api_key.clone());
 
     // Initialize control plane authentication if configured

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1108,7 +1108,10 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::routers::{common::openai_bridge, grpc::multimodal::MultimodalConfigRegistry};
+    use crate::{
+        middleware::AuthConfig,
+        routers::{common::openai_bridge, grpc::multimodal::MultimodalConfigRegistry},
+    };
 
     fn create_k8s_pod(
         name: Option<&str>,
@@ -1206,6 +1209,7 @@ mod tests {
         // Note: Using uninitialized queue for tests to avoid spawning background workers
         // Jobs submitted during tests will queue but not be processed
         Arc::new(AppContext {
+            gateway_auth: AuthConfig::new(None),
             client: reqwest::Client::new(),
             router_config: router_config.clone(),
             rate_limiter: Some(Arc::new(TokenBucket::new(1000, 1000))),

--- a/model_gateway/src/workflow/steps/local/drain_workers.rs
+++ b/model_gateway/src/workflow/steps/local/drain_workers.rs
@@ -105,6 +105,7 @@ mod tests {
     use super::*;
     use crate::{
         app_context::AppContext,
+        middleware::AuthConfig,
         worker::{BasicWorkerBuilder, Worker, WorkerType},
         workflow::data::{WorkerList, WorkerRemovalWorkflowData},
     };
@@ -146,6 +147,7 @@ mod tests {
         let job_queue = Arc::new(std::sync::OnceLock::new());
 
         Arc::new(AppContext {
+            gateway_auth: AuthConfig::new(None),
             client: reqwest::Client::new(),
             router_config: router_config.clone(),
             rate_limiter: Some(Arc::new(TokenBucket::new(1000, 1000))),

--- a/model_gateway/src/workflow/steps/local/update_worker_properties.rs
+++ b/model_gateway/src/workflow/steps/local/update_worker_properties.rs
@@ -202,6 +202,7 @@ mod tests {
     use super::*;
     use crate::{
         app_context::AppContext,
+        middleware::AuthConfig,
         routers::grpc::{
             backend_client::BackendClient,
             zmq_client::{EosTokenIds, ZmqEngineClient},
@@ -231,6 +232,7 @@ mod tests {
         let job_queue = Arc::new(std::sync::OnceLock::new());
 
         Arc::new(AppContext {
+            gateway_auth: AuthConfig::new(None),
             client: reqwest::Client::new(),
             router_config: router_config.clone(),
             rate_limiter: Some(Arc::new(TokenBucket::new(1000, 1000))),

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -275,10 +275,7 @@ impl AppTestContext {
             }
 
             let inner_router = RouterFactory::create_router(&app_context).await.unwrap();
-            let manager = RouterManager::new(
-                app_context.worker_registry.clone(),
-                app_context.client.clone(),
-            );
+            let manager = RouterManager::new(app_context.worker_registry.clone());
             let router_id =
                 RouterManager::determine_router_id(&config.mode, config.connection_mode);
             let manager = Arc::new(manager);

--- a/model_gateway/tests/routing/policy_registry_integration.rs
+++ b/model_gateway/tests/routing/policy_registry_integration.rs
@@ -19,7 +19,7 @@ async fn test_policy_registry_with_router_manager() {
     let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin));
 
     // Create RouterManager with shared registries
-    let _router_manager = RouterManager::new(worker_registry.clone(), reqwest::Client::new());
+    let _router_manager = RouterManager::new(worker_registry.clone());
 
     // Add first worker for llama-3 with cache_aware policy hint
     let mut labels1 = HashMap::new();

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -26,10 +26,8 @@ use openai_protocol::{
 use serde_json::json;
 use smg::{
     config::{ConfigError, HistoryBackend, OracleConfig, PolicyConfig, RouterConfig, RoutingMode},
-    routers::{
-        factory::router_ids, openai::OpenAIRouter, router_manager::RouterManager, RouterFactory,
-        RouterTrait,
-    },
+    endpoints::models::list_models,
+    routers::{openai::OpenAIRouter, RouterFactory, RouterTrait},
     tenant::{RouteRequestMeta, TenantKey},
     worker::{BasicWorkerBuilder, RuntimeType, Worker, WorkerType},
 };
@@ -141,19 +139,13 @@ async fn test_openai_router_server_info() {
     assert!(body_str.contains("openai"));
 }
 
-/// Test models endpoint via RouterManager (get_models is centralized there).
-/// A bearer token triggers upstream fan-out to the mock server.
+/// Test the models endpoint: a bearer token triggers upstream fan-out to the
+/// mock server.
 #[tokio::test]
 async fn test_openai_router_models() {
     let mock_server = MockOpenAIServer::new().await;
     let ctx = create_test_app_context().await;
     register_external_worker(&ctx, &mock_server.base_url(), None);
-    let inner = OpenAIRouter::new(&ctx).await.unwrap();
-
-    let manager = RouterManager::new(ctx.worker_registry.clone(), ctx.client.clone());
-    let manager = Arc::new(manager);
-    manager.register_router(router_ids::HTTP_OPENAI, Arc::from(inner));
-
     // Send a bearer token to trigger BYOK fan-out to the mock upstream.
     let req = Request::builder()
         .method(Method::GET)
@@ -162,7 +154,7 @@ async fn test_openai_router_models() {
         .body(Body::empty())
         .unwrap();
 
-    let response = manager.get_models(req).await;
+    let response = list_models(&ctx, req.headers()).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     let (_, body) = response.into_parts();
@@ -964,11 +956,6 @@ async fn test_openai_router_models_from_registry() {
     );
     ctx.worker_registry.register(worker);
 
-    let inner = OpenAIRouter::new(&ctx).await.unwrap();
-    let manager = RouterManager::new(ctx.worker_registry.clone(), ctx.client.clone());
-    let manager = Arc::new(manager);
-    manager.register_router(router_ids::HTTP_OPENAI, Arc::from(inner));
-
     // No bearer token → registry path returns local workers' models.
     let req = Request::builder()
         .method(Method::GET)
@@ -976,7 +963,7 @@ async fn test_openai_router_models_from_registry() {
         .body(Body::empty())
         .unwrap();
 
-    let response = manager.get_models(req).await;
+    let response = list_models(&ctx, req.headers()).await;
     assert_eq!(response.status(), StatusCode::OK);
     let (_, body) = response.into_parts();
     let body_bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();


### PR DESCRIPTION
## Description

### Problem

`GET /v1/models` is not a routing decision: it reads the worker registry and, when the caller presents a provider credential of its own, fans out to the external upstreams (bring your own key). It lived on `RouterManager` only because that type implements every endpoint of `RouterTrait`. That made the manager the sole holder of an `AuthConfig` and a `reqwest::Client`, and it is the one reason the manager had to exist even in single-router deployments.

### Solution

Move the logic, unchanged, into a new `endpoints::models` module next to the other non-routing endpoints. `list_models(&AppContext, &HeaderMap)` derives the gateway's own credentials from `router_config.api_key` and `router_config.tenant_api_keys`, exactly the inputs the manager used at startup, and delegates to `list_models_with` over explicit collaborators, which is what the moved test drives.

`RouterManager` loses its `client` and `gateway_auth` fields, its constructor takes only the registry, and its `get_models` implementation goes. The `RouterTrait::get_models` default is removed too: the manager was its only implementor.

## Changes

- `model_gateway/src/endpoints/models.rs`: `list_models`, `list_models_with`, the bearer or `x-api-key` extraction, the registry response, the upstream fan-out and the per-upstream fetch, plus the moved short-circuit test.
- `model_gateway/src/endpoints/mod.rs`: declare the module.
- `model_gateway/src/server.rs`: `v1_models` calls the endpoint.
- `model_gateway/src/routers/mod.rs`: drop the `get_models` default.
- `model_gateway/src/routers/router_manager.rs`: drop the fields, the listing code, the trait method and the moved test; constructor takes the registry only.
- `model_gateway/src/middleware/concurrency.rs`, `model_gateway/tests/common/mod.rs`, `model_gateway/tests/routing/policy_registry_integration.rs`: constructor call sites.
- `model_gateway/tests/routing/test_openai_routing.rs`: the two models tests call the endpoint directly instead of building a manager for it.

## Test Plan

- `make fmt`, `cargo +nightly fmt --all`: clean.
- `cargo clippy -p smg --all-targets -- -D warnings`: clean.
- `cargo test -p smg --lib`: 1946 passed, including the moved `a_gateway_credential_never_fans_out_upstream`, which runs a counting mock upstream and asserts that a tenant-scoped key never triggers fan-out while an unrecognized token still does.
- `cargo test -p smg --test routing_tests --test api_tests`: 132 and 109 passed, including `test_openai_router_models` (BYOK fan-out to the mock server) and `test_openai_router_models_from_registry`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (ran `-p smg --all-targets` locally; the full matrix runs in CI)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>