### PR TITLE
refactor(gateway): share prefill/decode pair placement and slice-based selection

### DIFF
--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -1,19 +1,21 @@
-//! Single-worker placement shared by the HTTP and gRPC families.
+//! Worker placement shared by the HTTP and gRPC families.
+//!
+//! Every family used to carry its own copy of the same sequences: take the
+//! routing pool for the model, narrow it to the retained wire on a retry,
+//! drop unavailable workers unless the policy does that itself, hand the
+//! survivors to the policy registry, record the selection; and for a
+//! disaggregated request, do that per leg from one snapshot under one
+//! runtime. This module is those sequences written once. A family still
+//! decides which pools it draws from and what a failure means on its wire.
 //!
 //! Distinct from [`super::worker_selection`], the least-load selector with
 //! refresh-on-miss that the provider and realtime paths use; this is the
 //! policy-registry path over the self-hosted routing pools.
-//!
-//! Every family used to carry its own copy of the same sequence: take the
-//! routing pool for the model, narrow it to the retained wire on a retry,
-//! drop unavailable workers unless the policy does that itself, hand the
-//! survivors to the policy registry, record the selection. This module is
-//! that sequence written once. A family still decides which pool it draws
-//! from and what a failure means on its wire.
 
 use std::sync::Arc;
 
 use axum::{http::HeaderMap, response::Response};
+use tracing::warn;
 
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
@@ -67,8 +69,8 @@ impl Candidates {
     }
 }
 
-/// Why a single-worker placement produced nothing, judged from exactly the
-/// pool selection drew from.
+/// Why a placement produced nothing, judged from exactly the pool selection
+/// drew from.
 pub(crate) enum PlacementFailure {
     /// Nothing serves the model on this wire.
     NoCandidates,
@@ -76,6 +78,32 @@ pub(crate) enum PlacementFailure {
     AllOverloaded(Response),
     /// Candidates exist but none is available (health, circuit breaker).
     Unavailable,
+    /// Available candidates existed but the named policy picked none.
+    PolicyDeclined(&'static str),
+}
+
+/// The two legs of a disaggregated placement, each the pool it selects over
+/// before the availability filter. Both must come from one registry snapshot
+/// so the pair cannot straddle a membership change.
+pub(crate) struct PairCandidates<'a> {
+    pub prefill: &'a [Arc<dyn Worker>],
+    pub decode: &'a [Arc<dyn Worker>],
+}
+
+/// A selected prefill/decode pair.
+pub(crate) struct Pair {
+    pub prefill: Arc<dyn Worker>,
+    pub decode: Arc<dyn Worker>,
+    /// The runtime both legs run when homogeneity was required; otherwise
+    /// the prefill worker's.
+    pub runtime: RuntimeType,
+}
+
+/// Which leg of a pair placement failed, and why. Boxed at the `Err`
+/// site: a shed verdict carries a whole response.
+pub(crate) struct PairFailure {
+    pub leg: WorkerLeg,
+    pub verdict: PlacementFailure,
 }
 
 /// The candidates for `model_id` in `pool`, narrowed to `wire` when a retry
@@ -113,8 +141,19 @@ pub(crate) fn select_single(
     inputs: PlacementInputs<'_>,
 ) -> Option<Arc<dyn Worker>> {
     let candidates = candidates(registry, model_id, pool, wire);
-    let candidates = candidates.as_slice();
+    select_from(registry, policies, model_id, candidates.as_slice(), inputs)
+}
 
+/// [`select_single`] over an explicit candidate slice: the entry for a caller
+/// with a candidate rule the pools cannot express, such as dropping DP-aware
+/// workers from a path that cannot pin a rank.
+pub(crate) fn select_from(
+    registry: &WorkerRegistry,
+    policies: &PolicyRegistry,
+    model_id: &str,
+    candidates: &[Arc<dyn Worker>],
+    inputs: PlacementInputs<'_>,
+) -> Option<Arc<dyn Worker>> {
     let policy = policies.get_policy_or_default(model_id);
 
     // Most policies already apply the complete availability predicate. Give
@@ -175,7 +214,11 @@ pub(crate) fn single_failure(
     wire: Option<WireConstraint>,
 ) -> PlacementFailure {
     let candidates = candidates(registry, model_id, pool, wire);
-    let candidates = candidates.as_slice();
+    failure_from(candidates.as_slice(), model_id)
+}
+
+/// Classify a failed placement from the candidates it drew from.
+pub(crate) fn failure_from(candidates: &[Arc<dyn Worker>], model_id: &str) -> PlacementFailure {
     if candidates.is_empty() {
         return PlacementFailure::NoCandidates;
     }
@@ -183,6 +226,141 @@ pub(crate) fn single_failure(
         return PlacementFailure::AllOverloaded(shed);
     }
     PlacementFailure::Unavailable
+}
+
+/// Pick a prefill/decode pair for `model_id`, one worker per leg, each under
+/// its own policy and sticky namespace.
+///
+/// Every leg is judged live for availability; `wire` pins both legs to the
+/// retained plan's runtime on a retry; `homogeneous_runtime` narrows both
+/// legs to the first available prefill worker's runtime, which the gRPC
+/// wire needs because its rendezvous is runtime-specific. A miss names the
+/// leg and carries the verdict judged from that leg's own candidates.
+pub(crate) fn select_pair(
+    registry: &WorkerRegistry,
+    policies: &PolicyRegistry,
+    model_id: &str,
+    candidates: PairCandidates<'_>,
+    wire: Option<WireConstraint>,
+    homogeneous_runtime: bool,
+    inputs: PlacementInputs<'_>,
+) -> Result<Pair, Box<PairFailure>> {
+    let available = |leg: &[Arc<dyn Worker>]| -> Vec<Arc<dyn Worker>> {
+        leg.iter()
+            .filter(|w| {
+                w.is_available()
+                    && wire.is_none_or(|wire| w.metadata().spec.runtime_type == wire.runtime)
+            })
+            .cloned()
+            .collect()
+    };
+    let mut prefill = available(candidates.prefill);
+    let mut decode = available(candidates.decode);
+
+    if prefill.is_empty() {
+        warn!("No available prefill workers");
+        return Err(Box::new(PairFailure {
+            leg: WorkerLeg::Prefill,
+            verdict: failure_from(candidates.prefill, model_id),
+        }));
+    }
+    if decode.is_empty() {
+        warn!("No available decode workers");
+        return Err(Box::new(PairFailure {
+            leg: WorkerLeg::Decode,
+            verdict: failure_from(candidates.decode, model_id),
+        }));
+    }
+
+    // Where the wire's rendezvous is runtime-specific, both legs must share a
+    // runtime: take the first prefill worker's and narrow both legs to it.
+    let runtime = prefill[0].metadata().spec.runtime_type;
+    if homogeneous_runtime {
+        let prefill_mixed = prefill
+            .iter()
+            .skip(1)
+            .any(|w| w.metadata().spec.runtime_type != runtime);
+        let decode_mixed = decode
+            .iter()
+            .any(|w| w.metadata().spec.runtime_type != runtime);
+        if prefill_mixed || decode_mixed {
+            warn!(
+                "Mixed runtime types in PD workers (prefill_mixed={}, decode_mixed={}). Using {:?}.",
+                prefill_mixed, decode_mixed, runtime
+            );
+        }
+        prefill.retain(|w| w.metadata().spec.runtime_type == runtime);
+        decode.retain(|w| w.metadata().spec.runtime_type == runtime);
+        if decode.is_empty() {
+            warn!("No available PD pair for runtime {:?}", runtime);
+            return Err(Box::new(PairFailure {
+                leg: WorkerLeg::Decode,
+                verdict: PlacementFailure::Unavailable,
+            }));
+        }
+    }
+
+    // Independent prefill/decode policies so stateful ones (round robin) do
+    // not share a counter; each leg tags the sticky key with its own prefix.
+    let prefill_policy = policies.get_prefill_policy();
+    let decode_policy = policies.get_decode_policy();
+    let hash_ring = registry.get_hash_ring(model_id);
+    let mut info = SelectWorkerInfo {
+        request_text: inputs.text,
+        tokens: inputs.tokens,
+        headers: inputs.headers,
+        routing_key: policies.resolve_routing_key(inputs.headers),
+        rid_key: inputs.rid_key,
+        cache_namespace: inputs.cache_namespace,
+        hash_ring,
+        leg: WorkerLeg::Prefill,
+    };
+    // A policy that sees an unfiltered pool can miss because every worker is
+    // overloaded; judge the verdict from the leg's candidates so a shed
+    // stays a shed.
+    let declined = |leg: WorkerLeg, pool: &[Arc<dyn Worker>], policy: &'static str| {
+        let verdict = match failure_from(pool, model_id) {
+            PlacementFailure::AllOverloaded(shed) => PlacementFailure::AllOverloaded(shed),
+            _ => PlacementFailure::PolicyDeclined(policy),
+        };
+        Box::new(PairFailure { leg, verdict })
+    };
+    let Some(prefill_idx) = policies.select_worker(&prefill_policy, &prefill, &info) else {
+        return Err(declined(
+            WorkerLeg::Prefill,
+            candidates.prefill,
+            prefill_policy.name(),
+        ));
+    };
+    info.leg = WorkerLeg::Decode;
+    let Some(decode_idx) = policies.select_worker(&decode_policy, &decode, &info) else {
+        return Err(declined(
+            WorkerLeg::Decode,
+            candidates.decode,
+            decode_policy.name(),
+        ));
+    };
+
+    let selected_prefill = prefill[prefill_idx].clone();
+    let selected_decode = decode[decode_idx].clone();
+    Metrics::record_worker_selection(
+        metrics_labels::WORKER_PREFILL,
+        selected_prefill.connection_mode().as_metric_label(),
+        model_id,
+        prefill_policy.name(),
+    );
+    Metrics::record_worker_selection(
+        metrics_labels::WORKER_DECODE,
+        selected_decode.connection_mode().as_metric_label(),
+        model_id,
+        decode_policy.name(),
+    );
+
+    Ok(Pair {
+        prefill: selected_prefill,
+        decode: selected_decode,
+        runtime,
+    })
 }
 
 #[cfg(test)]
@@ -198,13 +376,21 @@ mod tests {
     const MODEL: &str = "m";
 
     fn registry_with(workers: &[(&str, ConnectionMode, RuntimeType)]) -> WorkerRegistry {
+        let typed: Vec<_> = workers
+            .iter()
+            .map(|(url, connection, runtime)| (*url, WorkerType::Regular, *connection, *runtime))
+            .collect();
+        registry_of(&typed)
+    }
+
+    fn registry_of(workers: &[(&str, WorkerType, ConnectionMode, RuntimeType)]) -> WorkerRegistry {
         let registry = WorkerRegistry::new();
-        for (url, connection, runtime) in workers {
+        for (url, worker_type, connection, runtime) in workers {
             registry
                 .register(Arc::new(
                     BasicWorkerBuilder::new(*url)
                         .model(ModelCard::new(MODEL))
-                        .worker_type(WorkerType::Regular)
+                        .worker_type(*worker_type)
                         .connection_mode(*connection)
                         .runtime_type(*runtime)
                         .health_config(HealthCheckConfig {
@@ -278,6 +464,113 @@ mod tests {
             )),
             ["grpc://g:2"]
         );
+    }
+
+    #[test]
+    fn a_pair_shares_the_first_prefill_runtime_and_names_a_missing_leg() {
+        let registry = registry_of(&[
+            (
+                "grpc://p:1",
+                WorkerType::Prefill,
+                ConnectionMode::Grpc,
+                RuntimeType::Sglang,
+            ),
+            (
+                "grpc://p:2",
+                WorkerType::Prefill,
+                ConnectionMode::Grpc,
+                RuntimeType::Vllm,
+            ),
+            (
+                "grpc://d:1",
+                WorkerType::Decode,
+                ConnectionMode::Grpc,
+                RuntimeType::Vllm,
+            ),
+            (
+                "grpc://d:2",
+                WorkerType::Decode,
+                ConnectionMode::Grpc,
+                RuntimeType::Sglang,
+            ),
+        ]);
+        let policies = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        let snapshot = registry.get_routing_snapshot(MODEL);
+        let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
+        let decode = snapshot.pool(RoutingPool::GrpcDecode);
+
+        let pair = select_pair(
+            &registry,
+            &policies,
+            MODEL,
+            PairCandidates {
+                prefill: &prefill,
+                decode: &decode,
+            },
+            None,
+            true,
+            PlacementInputs::default(),
+        )
+        .ok()
+        .expect("a pair exists under either runtime");
+        assert_eq!(pair.prefill.metadata().spec.runtime_type, pair.runtime);
+        assert_eq!(pair.decode.metadata().spec.runtime_type, pair.runtime);
+
+        // A retry pinned to a runtime with no decode worker names the leg.
+        let only_prefill = registry_of(&[(
+            "grpc://p:1",
+            WorkerType::Prefill,
+            ConnectionMode::Grpc,
+            RuntimeType::Sglang,
+        )]);
+        let snapshot = only_prefill.get_routing_snapshot(MODEL);
+        let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
+        let decode = snapshot.pool(RoutingPool::GrpcDecode);
+        let failure = select_pair(
+            &only_prefill,
+            &policies,
+            MODEL,
+            PairCandidates {
+                prefill: &prefill,
+                decode: &decode,
+            },
+            None,
+            true,
+            PlacementInputs::default(),
+        )
+        .err()
+        .expect("no decode worker exists");
+        assert_eq!(failure.leg, WorkerLeg::Decode);
+        assert!(matches!(failure.verdict, PlacementFailure::NoCandidates));
+    }
+
+    #[test]
+    fn a_caller_can_narrow_the_candidates_itself() {
+        let registry = registry_with(&[
+            ("http://h:1", ConnectionMode::Http, RuntimeType::Sglang),
+            ("http://h:2", ConnectionMode::Http, RuntimeType::Sglang),
+        ]);
+        let policies = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        let pool = registry.get_routing_pool(MODEL, RoutingPool::HttpRegular);
+        let only_second: Vec<Arc<dyn Worker>> = pool
+            .iter()
+            .filter(|w| w.url() == "http://h:2")
+            .cloned()
+            .collect();
+
+        let selected = select_from(
+            &registry,
+            &policies,
+            MODEL,
+            &only_second,
+            PlacementInputs::default(),
+        )
+        .expect("the narrowed slice still has a worker");
+        assert_eq!(selected.url(), "http://h:2");
+        assert!(matches!(
+            failure_from(&[], MODEL),
+            PlacementFailure::NoCandidates
+        ));
     }
 
     #[test]

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use axum::{http::HeaderMap, response::Response};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
@@ -94,8 +94,9 @@ pub(crate) struct PairCandidates<'a> {
 pub(crate) struct Pair {
     pub prefill: Arc<dyn Worker>,
     pub decode: Arc<dyn Worker>,
-    /// The runtime both legs run when homogeneity was required; otherwise
-    /// the prefill worker's.
+    /// The runtime both legs run when homogeneity was required. Otherwise
+    /// it is the first available prefill worker's, which says nothing about
+    /// the selected pair; only a homogeneous caller should read it.
     pub runtime: RuntimeType,
 }
 
@@ -232,7 +233,7 @@ pub(crate) fn failure_from(candidates: &[Arc<dyn Worker>], model_id: &str) -> Pl
 /// its own policy and sticky namespace.
 ///
 /// Every leg is judged live for availability; `wire` pins both legs to the
-/// retained plan's runtime on a retry; `homogeneous_runtime` narrows both
+/// retained plan's runtime and transport on a retry; `homogeneous_runtime` narrows both
 /// legs to the first available prefill worker's runtime, which the gRPC
 /// wire needs because its rendezvous is runtime-specific. A miss names the
 /// leg and carries the verdict judged from that leg's own candidates.
@@ -249,7 +250,10 @@ pub(crate) fn select_pair(
         leg.iter()
             .filter(|w| {
                 w.is_available()
-                    && wire.is_none_or(|wire| w.metadata().spec.runtime_type == wire.runtime)
+                    && wire.is_none_or(|wire| {
+                        w.metadata().spec.runtime_type == wire.runtime
+                            && *w.connection_mode() == wire.connection
+                    })
             })
             .cloned()
             .collect()
@@ -258,14 +262,14 @@ pub(crate) fn select_pair(
     let mut decode = available(candidates.decode);
 
     if prefill.is_empty() {
-        warn!("No available prefill workers");
+        debug!("No available prefill workers");
         return Err(Box::new(PairFailure {
             leg: WorkerLeg::Prefill,
             verdict: failure_from(candidates.prefill, model_id),
         }));
     }
     if decode.is_empty() {
-        warn!("No available decode workers");
+        debug!("No available decode workers");
         return Err(Box::new(PairFailure {
             leg: WorkerLeg::Decode,
             verdict: failure_from(candidates.decode, model_id),
@@ -292,7 +296,7 @@ pub(crate) fn select_pair(
         prefill.retain(|w| w.metadata().spec.runtime_type == runtime);
         decode.retain(|w| w.metadata().spec.runtime_type == runtime);
         if decode.is_empty() {
-            warn!("No available PD pair for runtime {:?}", runtime);
+            debug!("No available PD pair for runtime {:?}", runtime);
             return Err(Box::new(PairFailure {
                 leg: WorkerLeg::Decode,
                 verdict: PlacementFailure::Unavailable,
@@ -315,30 +319,20 @@ pub(crate) fn select_pair(
         hash_ring,
         leg: WorkerLeg::Prefill,
     };
-    // A policy that sees an unfiltered pool can miss because every worker is
-    // overloaded; judge the verdict from the leg's candidates so a shed
-    // stays a shed.
-    let declined = |leg: WorkerLeg, pool: &[Arc<dyn Worker>], policy: &'static str| {
-        let verdict = match failure_from(pool, model_id) {
-            PlacementFailure::AllOverloaded(shed) => PlacementFailure::AllOverloaded(shed),
-            _ => PlacementFailure::PolicyDeclined(policy),
-        };
-        Box::new(PairFailure { leg, verdict })
+    // Both legs were filtered for availability above, so a miss here is the
+    // policy's own decision, never an overloaded pool.
+    let declined = |leg: WorkerLeg, policy: &'static str| {
+        Box::new(PairFailure {
+            leg,
+            verdict: PlacementFailure::PolicyDeclined(policy),
+        })
     };
     let Some(prefill_idx) = policies.select_worker(&prefill_policy, &prefill, &info) else {
-        return Err(declined(
-            WorkerLeg::Prefill,
-            candidates.prefill,
-            prefill_policy.name(),
-        ));
+        return Err(declined(WorkerLeg::Prefill, prefill_policy.name()));
     };
     info.leg = WorkerLeg::Decode;
     let Some(decode_idx) = policies.select_worker(&decode_policy, &decode, &info) else {
-        return Err(declined(
-            WorkerLeg::Decode,
-            candidates.decode,
-            decode_policy.name(),
-        ));
+        return Err(declined(WorkerLeg::Decode, decode_policy.name()));
     };
 
     let selected_prefill = prefill[prefill_idx].clone();
@@ -516,7 +510,7 @@ mod tests {
         assert_eq!(pair.prefill.metadata().spec.runtime_type, pair.runtime);
         assert_eq!(pair.decode.metadata().spec.runtime_type, pair.runtime);
 
-        // A retry pinned to a runtime with no decode worker names the leg.
+        // A model with no decode worker at all names the leg.
         let only_prefill = registry_of(&[(
             "grpc://p:1",
             WorkerType::Prefill,
@@ -542,6 +536,69 @@ mod tests {
         .expect("no decode worker exists");
         assert_eq!(failure.leg, WorkerLeg::Decode);
         assert!(matches!(failure.verdict, PlacementFailure::NoCandidates));
+    }
+
+    #[test]
+    fn a_pinned_pair_keeps_the_retained_runtime_and_transport() {
+        // Same runtime on both legs, but the only decode worker speaks ZMQ.
+        let registry = registry_of(&[
+            (
+                "grpc://p:1",
+                WorkerType::Prefill,
+                ConnectionMode::Grpc,
+                RuntimeType::Sglang,
+            ),
+            (
+                "zmq://d:1",
+                WorkerType::Decode,
+                ConnectionMode::Zmq,
+                RuntimeType::Sglang,
+            ),
+        ]);
+        let policies = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        let by_type = |worker_type: WorkerType| -> Vec<Arc<dyn Worker>> {
+            registry
+                .get_all()
+                .into_iter()
+                .filter(|w| *w.worker_type() == worker_type)
+                .collect()
+        };
+        let prefill = by_type(WorkerType::Prefill);
+        let decode = by_type(WorkerType::Decode);
+        let candidates = || PairCandidates {
+            prefill: &prefill,
+            decode: &decode,
+        };
+
+        // Unpinned, the ZMQ decode worker is a candidate like any other.
+        assert!(select_pair(
+            &registry,
+            &policies,
+            MODEL,
+            candidates(),
+            None,
+            false,
+            PlacementInputs::default(),
+        )
+        .is_ok());
+
+        // A retry that retained a gRPC plan must not land on it.
+        let failure = select_pair(
+            &registry,
+            &policies,
+            MODEL,
+            candidates(),
+            Some(WireConstraint {
+                runtime: RuntimeType::Sglang,
+                connection: ConnectionMode::Grpc,
+            }),
+            false,
+            PlacementInputs::default(),
+        )
+        .err()
+        .expect("the retained transport has no decode worker");
+        assert_eq!(failure.leg, WorkerLeg::Decode);
+        assert!(matches!(failure.verdict, PlacementFailure::Unavailable));
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -16,7 +16,7 @@ use crate::{
     routers::{
         common::{
             overload,
-            placement::{self, PairCandidates, PlacementFailure, PlacementInputs},
+            placement::{self, PairCandidates, PairFailure, PlacementFailure, PlacementInputs},
         },
         error,
         grpc::{
@@ -157,19 +157,13 @@ impl PipelineStage for WorkerSelectionStage {
                     cache_namespace,
                     None,
                 ) {
-                    Some((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
+                    Ok((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
                         encode_assignments: None,
                         prefill,
                         decode,
                         runtime_type,
                     },
-                    None => {
-                        return Err(self.selection_failure(
-                            model_id,
-                            &[WorkerType::Prefill, WorkerType::Decode],
-                            None,
-                        ))
-                    }
+                    Err(response) => return Err(response),
                 }
             }
             WorkerSelectionMode::EncodePrefillDecode => {
@@ -301,19 +295,13 @@ impl WorkerSelectionStage {
                     cache_namespace,
                     wire,
                 ) {
-                    Some((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
+                    Ok((prefill, decode, runtime_type)) => WorkerSelection::Disaggregated {
                         encode_assignments: None,
                         prefill,
                         decode,
                         runtime_type,
                     },
-                    None => {
-                        return Err(self.selection_failure(
-                            model_id,
-                            &[WorkerType::Prefill, WorkerType::Decode],
-                            wire,
-                        ))
-                    }
+                    Err(response) => return Err(response),
                 }
             }
         };
@@ -386,6 +374,28 @@ impl WorkerSelectionStage {
             "No available workers for model"
         );
         error::model_not_found(model_id)
+    }
+
+    /// The response for a failed pair placement. The verdict was judged from
+    /// the leg's own candidates inside the placement, so a shed is answered
+    /// as it was built and counted once; every other miss keeps the
+    /// not-found answer this router always gave.
+    fn pair_failure(&self, model_id: &str, failure: PairFailure) -> Response {
+        match failure.verdict {
+            PlacementFailure::AllOverloaded(shed) => shed,
+            PlacementFailure::NoCandidates
+            | PlacementFailure::Unavailable
+            | PlacementFailure::PolicyDeclined(_) => {
+                error!(
+                    function = "WorkerSelectionStage::execute",
+                    mode = ?self.mode,
+                    model_id = %model_id,
+                    leg = ?failure.leg,
+                    "No available workers for model"
+                );
+                error::model_not_found(model_id)
+            }
+        }
     }
 
     /// The shed verdict for one disaggregated leg, judged from the pool it
@@ -468,7 +478,7 @@ impl WorkerSelectionStage {
         rid_key: Option<&str>,
         cache_namespace: Option<CacheNamespace>,
         wire: Option<WireConstraint>,
-    ) -> Option<PdWorkerPair> {
+    ) -> Result<PdWorkerPair, Response> {
         // Both legs derive from ONE membership snapshot: separate pool
         // lookups could straddle a concurrent replacement and pair workers
         // that never coexisted. The pools are strictly gRPC (a ZMQ leg would
@@ -497,8 +507,8 @@ impl WorkerSelectionStage {
                 cache_namespace,
             },
         )
-        .ok()?;
-        Some((pair.prefill, pair.decode, pair.runtime))
+        .map_err(|failure| self.pair_failure(model_id, *failure))?;
+        Ok((pair.prefill, pair.decode, pair.runtime))
     }
 
     /// Select per-item encode workers + a prefill/decode pair for EPD routing.
@@ -871,7 +881,7 @@ mod tests {
         );
         assert!(stage
             .select_pd_pair(model_id, None, None, None, None, None, None)
-            .is_some());
+            .is_ok());
 
         for url in &prefill_urls {
             let worker = worker_registry.get_by_url(url).expect("registered");
@@ -881,7 +891,7 @@ mod tests {
         assert!(
             stage
                 .select_pd_pair(model_id, None, None, None, None, None, None)
-                .is_none(),
+                .is_err(),
             "the veto empties the prefill pool"
         );
         let response =
@@ -1051,7 +1061,7 @@ mod tests {
         assert!(
             stage
                 .select_pd_pair(model_id, None, None, None, None, None, None)
-                .is_none(),
+                .is_err(),
             "ZMQ-only PD pools must not yield a pair"
         );
 

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -16,7 +16,7 @@ use crate::{
     routers::{
         common::{
             overload,
-            placement::{self, PlacementFailure, PlacementInputs},
+            placement::{self, PairCandidates, PlacementFailure, PlacementInputs},
         },
         error,
         grpc::{
@@ -361,7 +361,9 @@ impl WorkerSelectionStage {
                     wire,
                 ) {
                     PlacementFailure::AllOverloaded(shed) => Some(shed),
-                    PlacementFailure::NoCandidates | PlacementFailure::Unavailable => None,
+                    PlacementFailure::NoCandidates
+                    | PlacementFailure::Unavailable
+                    | PlacementFailure::PolicyDeclined(_) => None,
                 },
                 WorkerType::Prefill => {
                     self.disaggregated_leg_shed(model_id, RoutingPool::GrpcPrefill, wire)
@@ -471,128 +473,32 @@ impl WorkerSelectionStage {
         // lookups could straddle a concurrent replacement and pair workers
         // that never coexisted. The pools are strictly gRPC (a ZMQ leg would
         // silently drop the PD bootstrap info, see `RoutingPool::GrpcPrefill`;
-        // the wildcard model maps to the global snapshot), and availability
-        // stays a live per-request check.
+        // the wildcard model maps to the global snapshot). The legs must
+        // share a runtime, the rendezvous being runtime-specific, and a retry
+        // pins both to the retained plan's runtime.
         let snapshot = self.worker_registry.get_routing_snapshot(model_id);
-        let all_prefill = Self::available_workers(&snapshot, RoutingPool::GrpcPrefill);
-        let all_decode = Self::available_workers(&snapshot, RoutingPool::GrpcDecode);
-
-        // Retry re-selection pins both legs to the retained plan's runtime.
-        let (all_prefill, all_decode) = match wire {
-            Some(constraint) => (
-                all_prefill
-                    .into_iter()
-                    .filter(|w| w.metadata().spec.runtime_type == constraint.runtime)
-                    .collect::<Vec<_>>(),
-                all_decode
-                    .into_iter()
-                    .filter(|w| w.metadata().spec.runtime_type == constraint.runtime)
-                    .collect::<Vec<_>>(),
-            ),
-            None => (all_prefill, all_decode),
-        };
-
-        if all_prefill.is_empty() {
-            warn!("No available prefill workers");
-            return None;
-        }
-
-        if all_decode.is_empty() {
-            warn!("No available decode workers");
-            return None;
-        }
-
-        // Determine the runtime type from prefill workers.
-        // All workers in a PD pair must use the same runtime.
-        let first_runtime = all_prefill.first()?.metadata().spec.runtime_type;
-
-        // Check for mixed runtimes in both prefill and decode pools
-        let prefill_mixed = all_prefill
-            .iter()
-            .skip(1)
-            .any(|w| w.metadata().spec.runtime_type != first_runtime);
-        let decode_mixed = all_decode
-            .iter()
-            .any(|w| w.metadata().spec.runtime_type != first_runtime);
-
-        if prefill_mixed || decode_mixed {
-            warn!(
-                "Mixed runtime types in PD workers (prefill_mixed={}, decode_mixed={}). Using {:?}.",
-                prefill_mixed,
-                decode_mixed,
-                first_runtime
-            );
-        }
-
-        let target_runtime = first_runtime;
-
-        // Filter both pools to the target runtime
-        let available_prefill: Vec<_> = all_prefill
-            .into_iter()
-            .filter(|w| w.metadata().spec.runtime_type == target_runtime)
-            .collect();
-        let available_decode: Vec<_> = all_decode
-            .into_iter()
-            .filter(|w| w.metadata().spec.runtime_type == target_runtime)
-            .collect();
-
-        if available_prefill.is_empty() || available_decode.is_empty() {
-            warn!("No available PD pair for runtime {:?}", target_runtime);
-            return None;
-        }
-
-        // Independent P/D policies so stateful ones (e.g. round_robin) don't share a counter.
-        let prefill_policy = self.policy_registry.get_prefill_policy();
-        let decode_policy = self.policy_registry.get_decode_policy();
-
-        // Get cached hash ring for consistent hashing (O(log n) lookup)
-        let hash_ring = self.worker_registry.get_hash_ring(model_id);
-
-        // Prefill and decode are separate pools; tag each leg so the routing-key
-        // override keys its sticky map per leg (a key sticks independently).
-        let mut info = SelectWorkerInfo {
-            request_text: text,
-            tokens,
-            headers,
-            routing_key: self.policy_registry.resolve_routing_key(headers),
-            rid_key,
-            cache_namespace,
-            hash_ring,
-            leg: WorkerLeg::Prefill,
-        };
-        let prefill_idx =
-            self.policy_registry
-                .select_worker(&prefill_policy, &available_prefill, &info)?;
-        info.leg = WorkerLeg::Decode;
-        let decode_idx =
-            self.policy_registry
-                .select_worker(&decode_policy, &available_decode, &info)?;
-
-        let model = model_id;
-
-        // Record worker selection metrics for both prefill and decode
-        Metrics::record_worker_selection(
-            metrics_labels::WORKER_PREFILL,
-            available_prefill[prefill_idx]
-                .connection_mode()
-                .as_metric_label(),
-            model,
-            prefill_policy.name(),
-        );
-        Metrics::record_worker_selection(
-            metrics_labels::WORKER_DECODE,
-            available_decode[decode_idx]
-                .connection_mode()
-                .as_metric_label(),
-            model,
-            decode_policy.name(),
-        );
-
-        Some((
-            available_prefill[prefill_idx].clone(),
-            available_decode[decode_idx].clone(),
-            target_runtime,
-        ))
+        let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
+        let decode = snapshot.pool(RoutingPool::GrpcDecode);
+        let pair = placement::select_pair(
+            &self.worker_registry,
+            &self.policy_registry,
+            model_id,
+            PairCandidates {
+                prefill: &prefill,
+                decode: &decode,
+            },
+            wire,
+            true,
+            PlacementInputs {
+                text,
+                tokens,
+                headers,
+                rid_key,
+                cache_namespace,
+            },
+        )
+        .ok()?;
+        Some((pair.prefill, pair.decode, pair.runtime))
     }
 
     /// Select per-item encode workers + a prefill/decode pair for EPD routing.

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -33,7 +33,7 @@ use crate::{
         metrics::{bool_to_static_str, metrics_labels, Metrics},
         otel_trace::inject_trace_context_http,
     },
-    policies::{CacheNamespace, LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
+    policies::{CacheNamespace, PolicyRegistry, WorkerLeg},
     routers::{
         common::{
             attach_sized_body, header_utils,
@@ -42,6 +42,7 @@ use crate::{
                 KvConnectorMode, NIXL_PREFILL_KV_PARAMS,
             },
             overload,
+            placement::{self, PairCandidates, PairFailure, PlacementFailure, PlacementInputs},
             request_lease::{ReleasePoint, RequestLease, RoutingDerivatives},
             retry::{is_retryable_response, RetryExecutor},
             serialize_json_sized,
@@ -53,10 +54,7 @@ use crate::{
         http::router::send_with_stale_conn_retry,
         RouterTrait,
     },
-    worker::{
-        HashRing, RoutingPool, RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry,
-        UNKNOWN_MODEL_ID,
-    },
+    worker::{RoutingPool, RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry, UNKNOWN_MODEL_ID},
 };
 
 /// Why PD pair selection produced nothing.
@@ -216,21 +214,6 @@ impl PDRouter {
                     format!("No available servers: {error}"),
                 )
             }
-        }
-    }
-
-    /// Classify one leg's selection miss. `candidates` is the leg pool before
-    /// the `is_available()` filter, so the verdict describes the pool that
-    /// actually emptied rather than the model's whole registry entry — a
-    /// saturated prefill leg leaves the decode workers unflagged.
-    fn leg_failure(
-        candidates: &[Arc<dyn Worker>],
-        model_id: &str,
-        error: String,
-    ) -> PdSelectionFailure {
-        match overload::shed_if_all_overloaded(candidates, model_id) {
-            Some(shed) => PdSelectionFailure::Shed(shed),
-            None => PdSelectionFailure::Unavailable(error),
         }
     }
 
@@ -1353,120 +1336,49 @@ impl PDRouter {
             }
         };
 
-        let prefill_policy = self.policy_registry.get_prefill_policy();
-        let decode_policy = self.policy_registry.get_decode_policy();
-
-        // Get cached hash ring for consistent hashing
-        let hash_ring = self.worker_registry.get_hash_ring(model_id);
-
-        let prefill = self
-            .pick_worker_by_policy_arc(
-                &prefill_workers,
-                &prefill_policy,
-                request_text,
+        let pair = placement::select_pair(
+            &self.worker_registry,
+            &self.policy_registry,
+            model_id,
+            PairCandidates {
+                prefill: &prefill_workers,
+                decode: &decode_workers,
+            },
+            None,
+            false,
+            PlacementInputs {
+                text: request_text,
                 tokens,
+                headers,
                 rid_key,
                 cache_namespace,
-                headers,
-                hash_ring.clone(),
-                "prefill",
-                crate::policies::WorkerLeg::Prefill,
-            )
-            .map_err(|e| Box::new(Self::leg_failure(&prefill_workers, model_id, e)))?;
+            },
+        )
+        .map_err(|failure| Box::new(Self::pair_failure(*failure)))?;
 
-        let decode = self
-            .pick_worker_by_policy_arc(
-                &decode_workers,
-                &decode_policy,
-                request_text,
-                tokens,
-                rid_key,
-                cache_namespace,
-                headers,
-                hash_ring,
-                "decode",
-                crate::policies::WorkerLeg::Decode,
-            )
-            .map_err(|e| Box::new(Self::leg_failure(&decode_workers, model_id, e)))?;
-
-        // Record worker selection metrics (Layer 3)
-        let model = model_id;
-        Metrics::record_worker_selection(
-            metrics_labels::WORKER_PREFILL,
-            metrics_labels::CONNECTION_HTTP,
-            model,
-            prefill_policy.name(),
-        );
-        Metrics::record_worker_selection(
-            metrics_labels::WORKER_DECODE,
-            metrics_labels::CONNECTION_HTTP,
-            model,
-            decode_policy.name(),
-        );
-
-        Ok((prefill, decode))
+        Ok((pair.prefill, pair.decode))
     }
 
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "HTTP PD worker pick threads policy + request context + leg"
-    )]
-    fn pick_worker_by_policy_arc(
-        &self,
-        workers: &[Arc<dyn Worker>],
-        policy: &Arc<dyn LoadBalancingPolicy>,
-        request_text: Option<&str>,
-        tokens: Option<&[u32]>,
-        rid_key: Option<&str>,
-        cache_namespace: Option<CacheNamespace>,
-        headers: Option<&HeaderMap>,
-        hash_ring: Option<Arc<HashRing>>,
-        worker_type: &str,
-        leg: crate::policies::WorkerLeg,
-    ) -> Result<Arc<dyn Worker>, String> {
-        if workers.is_empty() {
-            return Err(format!(
-                "No {worker_type} workers available. Please check if {worker_type} servers are configured and healthy."
-            ));
+    /// Map a leg's placement verdict to this router's selection failure,
+    /// keeping the operator-facing messages the legs always produced.
+    fn pair_failure(failure: PairFailure) -> PdSelectionFailure {
+        let leg = match failure.leg {
+            WorkerLeg::Prefill => "prefill",
+            WorkerLeg::Decode => "decode",
+            WorkerLeg::Single => "worker",
+        };
+        match failure.verdict {
+            PlacementFailure::AllOverloaded(shed) => PdSelectionFailure::Shed(shed),
+            PlacementFailure::NoCandidates => PdSelectionFailure::Unavailable(format!(
+                "No {leg} workers available. Please check if {leg} servers are configured and healthy."
+            )),
+            PlacementFailure::Unavailable => PdSelectionFailure::Unavailable(format!(
+                "No available {leg} workers (all circuits open or unhealthy)"
+            )),
+            PlacementFailure::PolicyDeclined(policy) => PdSelectionFailure::Unavailable(
+                format!("Policy {policy} failed to select a {leg} worker"),
+            ),
         }
-
-        let available_workers: Vec<Arc<dyn Worker>> = workers
-            .iter()
-            .filter(|w| w.is_available())
-            .cloned()
-            .collect();
-
-        if available_workers.is_empty() {
-            return Err(format!(
-                "No available {worker_type} workers (all circuits open or unhealthy)"
-            ));
-        }
-
-        let selected_idx = self
-            .policy_registry
-            .select_worker(
-                policy,
-                &available_workers,
-                &SelectWorkerInfo {
-                    request_text,
-                    tokens,
-                    headers,
-                    routing_key: self.policy_registry.resolve_routing_key(headers),
-                    rid_key,
-                    cache_namespace,
-                    hash_ring,
-                    leg,
-                },
-            )
-            .ok_or_else(|| {
-                format!(
-                    "Policy {} failed to select a {} worker",
-                    policy.name(),
-                    worker_type
-                )
-            })?;
-
-        Ok(available_workers[selected_idx].clone())
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -44,9 +44,7 @@ use crate::{
         metrics::{bool_to_static_str, metrics_labels, Metrics},
         otel_trace::inject_trace_context_http,
     },
-    policies::{
-        policy_filters_unavailable_workers, CacheNamespace, PolicyRegistry, SelectWorkerInfo,
-    },
+    policies::{CacheNamespace, PolicyRegistry},
     routers::{
         common::{
             attach_sized_body,
@@ -516,10 +514,12 @@ impl Router {
                 ) {
                     PlacementFailure::NoCandidates => error::model_not_found(model_id),
                     PlacementFailure::AllOverloaded(shed) => shed,
-                    PlacementFailure::Unavailable => error::service_unavailable(
-                        "no_available_workers",
-                        "All workers are unavailable (circuit breaker open or unhealthy)",
-                    ),
+                    PlacementFailure::Unavailable | PlacementFailure::PolicyDeclined(_) => {
+                        error::service_unavailable(
+                            "no_available_workers",
+                            "All workers are unavailable (circuit breaker open or unhealthy)",
+                        )
+                    }
                 };
             }
         };
@@ -801,70 +801,34 @@ impl Router {
             record_pre_send_error(&resp);
             return resp;
         }
-        let policy = self.policy_registry.get_policy_or_default(model_id);
-        let filtered;
-        let available: &[Arc<dyn Worker>] = if policy_filters_unavailable_workers(policy.as_ref()) {
-            &non_dp_workers
-        } else {
-            filtered = non_dp_workers
-                .iter()
-                .filter(|worker| worker.is_available())
-                .cloned()
-                .collect::<Vec<_>>();
-            &filtered
-        };
-        if available.is_empty() {
-            let resp =
-                overload::shed_if_all_overloaded(&non_dp_workers, model_id).unwrap_or_else(|| {
-                    error::service_unavailable(
-                        "no_available_workers",
-                        "All workers are unavailable (circuit breaker open or unhealthy)",
-                    )
-                });
-            record_pre_send_error(&resp);
-            return resp;
-        }
-
-        let hash_ring = self.worker_registry.get_hash_ring(model_id);
-        let idx = match self.policy_registry.select_worker(
-            &policy,
-            available,
-            &SelectWorkerInfo {
-                request_text: text.as_deref(),
+        let Some(worker) = placement::select_from(
+            &self.worker_registry,
+            &self.policy_registry,
+            model_id,
+            &non_dp_workers,
+            PlacementInputs {
+                text: text.as_deref(),
                 tokens: hinted_tokens.as_deref(),
                 headers,
-                routing_key: self.policy_registry.resolve_routing_key(headers),
                 rid_key: None,
                 cache_namespace: None,
-                hash_ring,
-                leg: crate::policies::WorkerLeg::Single,
             },
-        ) {
-            Some(i) => i,
-            None => {
-                // Self-filtering policies see the unfiltered pool, so "all
-                // workers overloaded" surfaces here as a policy miss instead
-                // of an empty pre-filter above. Classify the shed on this arm
-                // too, or the 503 loses Retry-After, retryability marking,
-                // and the overload-shed metric.
-                let resp = overload::shed_if_all_overloaded(&non_dp_workers, model_id)
-                    .unwrap_or_else(|| {
-                        error::service_unavailable(
-                            "no_available_workers",
-                            "Policy returned no eligible worker",
-                        )
-                    });
-                record_pre_send_error(&resp);
-                return resp;
-            }
+        ) else {
+            // Judged from the same candidates whether the pre-filter emptied
+            // or a self-filtering policy missed on an all-overloaded pool, so
+            // a shed keeps its Retry-After, retryability and metric.
+            let resp = match placement::failure_from(&non_dp_workers, model_id) {
+                PlacementFailure::AllOverloaded(shed) => shed,
+                PlacementFailure::NoCandidates
+                | PlacementFailure::Unavailable
+                | PlacementFailure::PolicyDeclined(_) => error::service_unavailable(
+                    "no_available_workers",
+                    "All workers are unavailable (circuit breaker open or unhealthy)",
+                ),
+            };
+            record_pre_send_error(&resp);
+            return resp;
         };
-        Metrics::record_worker_selection(
-            metrics_labels::WORKER_REGULAR,
-            metrics_labels::CONNECTION_HTTP,
-            model_id,
-            policy.name(),
-        );
-        let worker = available[idx].clone();
 
         // Same dispatch-time re-check the regular path takes. A transcription
         // occupies its worker for far longer than a chat completion, so a

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -821,10 +821,16 @@ impl Router {
                 PlacementFailure::AllOverloaded(shed) => shed,
                 PlacementFailure::NoCandidates
                 | PlacementFailure::Unavailable
-                | PlacementFailure::PolicyDeclined(_) => error::service_unavailable(
-                    "no_available_workers",
-                    "All workers are unavailable (circuit breaker open or unhealthy)",
-                ),
+                | PlacementFailure::PolicyDeclined(_) => {
+                    // The verdict cannot tell a policy miss from a drained
+                    // pool; the pool can.
+                    let message = if non_dp_workers.iter().any(|w| w.is_available()) {
+                        "Policy returned no eligible worker"
+                    } else {
+                        "All workers are unavailable (circuit breaker open or unhealthy)"
+                    };
+                    error::service_unavailable("no_available_workers", message)
+                }
             };
             record_pre_send_error(&resp);
             return resp;


### PR DESCRIPTION
## Description

### Problem

#2444 moved single-worker selection into `gateway::placement`, which left the module owning one sequence while three more copies of the same steps stayed behind: the gRPC prefill/decode pair selector, the HTTP PD pair selector, and the multipart transcription path, which hand-rolls single selection because it has to drop DP-aware workers before choosing.

### Solution

- `select_pair(registry, policies, model, candidates, wire, homogeneous_runtime, inputs)`: availability per leg, the retry wire pin on runtime, optional runtime homogeneity (the gRPC wire needs it, its rendezvous is runtime-specific), independent prefill and decode policies with leg-tagged sticky keys, per-leg selection metrics under the chosen worker's transport label, and a miss that names the leg and carries a `PlacementFailure` judged from that leg's own candidates. A policy miss on an all-overloaded pool still surfaces as the shed.
- `select_from` and `failure_from`: the single-worker sequence and its verdict over an explicit candidate slice. `select_single` is now a thin wrapper; the transcription path passes its DP-filtered slice.
- `PlacementFailure::PolicyDeclined(policy)` so the HTTP PD router keeps its "Policy X failed to select a prefill worker" message.

Each family keeps its own pool choice, because the two wires draw from different snapshots with different wildcard-model fallbacks, and its own mapping from verdict to response. Responses, messages and metrics are unchanged. EPD keeps its three-leg runtime rule; it is the next candidate once this seam has settled.

Stacked on #2444.

## Changes

- `model_gateway/src/gateway/placement.rs`: `select_pair`, `select_from`, `failure_from`, `PairCandidates`, `Pair`, `PairFailure`, `PlacementFailure::PolicyDeclined`, and two new tests (a pair shares the first prefill runtime and a missing leg names itself; a caller can narrow the candidates itself).
- `model_gateway/src/routers/grpc/common/stages/worker_selection.rs`: `select_pd_pair` delegates; the regular-leg verdict covers the new variant.
- `model_gateway/src/routers/http/pd_router.rs`: `select_pd_pair` delegates through `pair_failure`, which reproduces the existing messages; `pick_worker_by_policy_arc` and `leg_failure` are gone.
- `model_gateway/src/routers/http/router.rs`: the transcription path uses `select_from` and `failure_from`; the typed-path verdict covers the new variant.

## Test Plan

No existing test changed.

- `make fmt`, `cargo +nightly fmt --all`: clean.
- `cargo clippy -p smg --all-targets -- -D warnings`: clean.
- `cargo test -p smg --lib`: 1951 passed, including the PD selection-stage tests that pin even round-robin coverage across both legs, ZMQ legs being ignored, a fully vetoed prefill leg shedding rather than 404, retry pinning to the retained runtime, and the HTTP PD router's own selection tests.
- `cargo test -p smg --test routing_tests --test api_tests --test zmq_backend_test --test tenant_rate_limiting_grpc_test`: 132, 109, 13 and 14 passed. One routing test, `test_no_hint_distinct_bodies_spread_cache_aware_workers`, failed once and passed on rerun; it exercises the single HTTP path this PR does not change and looks timing-dependent on the mock worker's load accounting.

## Review follow-ups

- **Pinned retries keep their transport.** `select_pair` now narrows both legs to the retained plan's runtime *and* connection, as `select_single` already did; a pinned gRPC pair can no longer land on a same-runtime ZMQ worker. Regression test: `a_pinned_pair_keeps_the_retained_runtime_and_transport`.
- **One shed, counted once.** The gRPC stage consumes the pair verdict (`pair_failure`) instead of discarding it and re-deriving a shed through `selection_failure`, so `worker_overload_shed{stage="selection"}` increments once per request as before this PR. Non-shed misses keep the not-found answer the router always gave.
- **Placement misses log at debug.** The operator-facing line stays with each family's failure mapper, so an unconfigured PD fleet no longer emits two lines per health probe.
- **Transcription messages restored.** A policy miss still answers "Policy returned no eligible worker"; a drained pool still answers the circuit-breaker message.
- **Behaviour change, HTTP PD:** both legs are filtered and checked before either policy runs. With prefill available but its policy declining and the decode leg drained, the caller now gets the decode shed (503 `worker_overload_protection_shed`, Retry-After) where it previously got `Unavailable("Policy X failed to select a prefill worker")`. The saturated leg is the more actionable fact and no phantom round-robin advance happens on the prefill counter.
- Docs: `Pair.runtime` is only meaningful under homogeneity; the unreachable all-overloaded branch after the availability filter is gone.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (ran `-p smg --all-targets` locally; the full matrix runs in CI)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
