### PR TITLE
fix(reasoning-parser): strip MiniMax M3 close markers

### DIFF
--- a/crates/reasoning_parser/src/parsers/minimax_m3.rs
+++ b/crates/reasoning_parser/src/parsers/minimax_m3.rs
@@ -1,43 +1,266 @@
 // MiniMax M3 specific reasoning parser.
 //
-// MiniMax M3 emits reasoning inside `<mm:think>...</mm:think>` blocks. The vLLM
-// reference parser constructs its delimited state machine with the
-// `initial_in_reasoning = false` argument and only flips to "already reasoning"
-// when the rendered prompt prefills the start marker (thinking_mode="enabled").
-// SMG's `BaseReasoningParser` derives its starting state from a single static
-// flag rather than the rendered prompt, so this parser uses
-// `always_in_reasoning = false` to match the default (non-prefilled) behavior:
-// output is normal text until an explicit `<mm:think>` token appears.
+// MiniMax M3 can emit stray '</mm:think>' delimiters before normal content.
+// Its markers may also be decoded across arbitrary streaming chunk boundaries.
 
-use crate::{
-    parsers::BaseReasoningParser,
-    traits::{ParseError, ParserConfig, ParserResult, ReasoningParser, DEFAULT_MAX_BUFFER_SIZE},
-};
+use crate::traits::{ParseError, ParserResult, ReasoningParser, DEFAULT_MAX_BUFFER_SIZE};
+
+const THINK_START: &str = "<mm:think>";
+const THINK_END: &str = "</mm:think>";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamingState {
+    BeforeReasoning,
+    InReasoning,
+    AfterReasoning,
+    Content,
+}
 
 /// MiniMax M3 reasoning parser.
 ///
-/// Uses the `<mm:think>` / `</mm:think>` delimiters. By default the M3 chat
-/// template does not prefill the start marker, so the parser begins outside a
-/// reasoning block (`always_in_reasoning = false`) and enters one only when an
-/// explicit `<mm:think>` token is seen.
+/// Unlike the common reasoning parser, this parser deliberately distinguishes
+/// a leading/boundary close marker from a close marker embedded in visible
+/// content. It also retains the longest marker-prefix suffix between streaming
+/// calls, preventing split delimiters from leaking into either output channel.
 pub struct MinimaxM3Parser {
-    base: BaseReasoningParser,
+    state: StreamingState,
+    buffer: String,
+    /// Whether close markers can still be treated as leading framing noise.
+    /// Whitespace does not end this phase, but substantive normal text does.
+    allow_leading_closers: bool,
+    reasoning_has_text: bool,
 }
 
 impl MinimaxM3Parser {
     /// Create a new MiniMax M3 reasoning parser.
     pub fn new() -> Self {
-        let config = ParserConfig {
-            think_start_token: "<mm:think>".to_string(),
-            think_end_token: "</mm:think>".to_string(),
-            stream_reasoning: true,
-            max_buffer_size: DEFAULT_MAX_BUFFER_SIZE,
-            always_in_reasoning: false,
+        Self {
+            state: StreamingState::BeforeReasoning,
+            buffer: String::new(),
+            allow_leading_closers: true,
+            reasoning_has_text: false,
+        }
+    }
+
+    /// Byte length of the longest trailing slice of 'text' that is a strict
+    /// prefix of 'marker'.
+    fn partial_marker_suffix_len(text: &str, marker: &str) -> usize {
+        let max_len = text.len().min(marker.len().saturating_sub(1));
+        for len in (1..=max_len).rev() {
+            let start = text.len() - len;
+            if text.is_char_boundary(start) && marker.starts_with(&text[start..]) {
+                return len;
+            }
+        }
+        0
+    }
+
+    fn leading_whitespace_len(text: &str) -> usize {
+        text.char_indices()
+            .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index))
+            .unwrap_or(text.len())
+    }
+
+    /// Strip every close delimiter at the beginning of a content segment while
+    /// preserving surrounding whitespace. MiniMax M3 may duplicate this
+    /// delimiter, so stripping exactly one is insufficient.
+    fn strip_repeated_leading_closers(text: &str) -> String {
+        let mut remainder = text;
+        let mut whitespace = String::new();
+        let mut stripped = false;
+
+        loop {
+            let whitespace_len = Self::leading_whitespace_len(remainder);
+            let after_whitespace = &remainder[whitespace_len..];
+            let Some(after_marker) = after_whitespace.strip_prefix(THINK_END) else {
+                break;
+            };
+
+            whitespace.push_str(&remainder[..whitespace_len]);
+            remainder = after_marker;
+            stripped = true;
+        }
+
+        if stripped {
+            whitespace.push_str(remainder);
+            whitespace
+        } else {
+            text.to_string()
+        }
+    }
+
+    fn parse_complete_outside_reasoning(text: &str) -> ParserResult {
+        let text = Self::strip_repeated_leading_closers(text);
+        let Some(start_index) = text.find(THINK_START) else {
+            return ParserResult::normal(text);
         };
 
-        Self {
-            base: BaseReasoningParser::new(config).with_model_type("minimax_m3".to_string()),
+        let content_before = &text[..start_index];
+        let after_start = &text[start_index + THINK_START.len()..];
+        let Some(end_index) = after_start.find(THINK_END) else {
+            return ParserResult::new(content_before.to_string(), after_start.to_string());
+        };
+
+        let reasoning = &after_start[..end_index];
+        let content_after =
+            Self::strip_repeated_leading_closers(&after_start[end_index + THINK_END.len()..]);
+        ParserResult::new(
+            format!("{content_before}{content_after}"),
+            reasoning.to_string(),
+        )
+    }
+
+    fn parse_complete_inside_reasoning(text: &str) -> ParserResult {
+        // A prefilled start marker is normally absent from generated output,
+        // but consume it if the model repeats it.
+        let text = text.strip_prefix(THINK_START).unwrap_or(text);
+        let Some(end_index) = text.find(THINK_END) else {
+            return ParserResult::reasoning(text.to_string());
+        };
+
+        let reasoning = &text[..end_index];
+        let content = Self::strip_repeated_leading_closers(&text[end_index + THINK_END.len()..]);
+        ParserResult::new(content, reasoning.to_string())
+    }
+
+    fn emit_prefix(buffer: &mut String, len: usize, output: &mut String) {
+        output.push_str(&buffer[..len]);
+        buffer.drain(..len);
+    }
+
+    fn parse_stream_buffer(&mut self) -> ParserResult {
+        let mut normal = String::new();
+        let mut reasoning = String::new();
+
+        loop {
+            if self.buffer.is_empty() {
+                break;
+            }
+
+            match self.state {
+                StreamingState::BeforeReasoning => {
+                    if self.allow_leading_closers {
+                        // Whitespace is visible, but does not prevent a following
+                        // close delimiter from being recognized as leading noise.
+                        let whitespace_len = Self::leading_whitespace_len(&self.buffer);
+                        if whitespace_len > 0 {
+                            Self::emit_prefix(&mut self.buffer, whitespace_len, &mut normal);
+                            if self.buffer.is_empty() {
+                                break;
+                            }
+                        }
+
+                        if THINK_END.starts_with(&self.buffer) && self.buffer != THINK_END {
+                            break;
+                        }
+                        if self.buffer.starts_with(THINK_END) {
+                            self.buffer.drain(..THINK_END.len());
+                            continue;
+                        }
+                    }
+
+                    if THINK_START.starts_with(&self.buffer) && self.buffer != THINK_START {
+                        break;
+                    }
+                    if self.buffer.starts_with(THINK_START) {
+                        self.buffer.drain(..THINK_START.len());
+                        self.state = StreamingState::InReasoning;
+                        self.reasoning_has_text = false;
+                        continue;
+                    }
+
+                    if let Some(start_index) = self.buffer.find(THINK_START) {
+                        if start_index > 0 {
+                            let has_text = self.buffer[..start_index]
+                                .chars()
+                                .any(|ch| !ch.is_whitespace());
+                            Self::emit_prefix(&mut self.buffer, start_index, &mut normal);
+                            if has_text {
+                                self.allow_leading_closers = false;
+                            }
+                        }
+                        self.buffer.drain(..THINK_START.len());
+                        self.state = StreamingState::InReasoning;
+                        self.reasoning_has_text = false;
+                        continue;
+                    }
+
+                    // No complete start marker is present. Emit everything except
+                    // a suffix that could become one on the next call.
+                    let holdback = Self::partial_marker_suffix_len(&self.buffer, THINK_START);
+                    let emit_len = self.buffer.len() - holdback;
+                    if emit_len > 0 {
+                        let has_text = self.buffer[..emit_len]
+                            .chars()
+                            .any(|ch| !ch.is_whitespace());
+                        Self::emit_prefix(&mut self.buffer, emit_len, &mut normal);
+                        if has_text {
+                            self.allow_leading_closers = false;
+                        }
+                    }
+                    break;
+                }
+                StreamingState::InReasoning => {
+                    // If thinking was opened by the prompt, tolerate the model
+                    // redundantly generating the opening marker as well.
+                    if !self.reasoning_has_text {
+                        if THINK_START.starts_with(&self.buffer) && self.buffer != THINK_START {
+                            break;
+                        }
+                        if self.buffer.starts_with(THINK_START) {
+                            self.buffer.drain(..THINK_START.len());
+                            continue;
+                        }
+                    }
+
+                    if let Some(end_index) = self.buffer.find(THINK_END) {
+                        if end_index > 0 {
+                            Self::emit_prefix(&mut self.buffer, end_index, &mut reasoning);
+                            self.reasoning_has_text = true;
+                        }
+                        self.buffer.drain(..THINK_END.len());
+                        self.state = StreamingState::AfterReasoning;
+                        continue;
+                    }
+
+                    let holdback = Self::partial_marker_suffix_len(&self.buffer, THINK_END);
+                    let emit_len = self.buffer.len() - holdback;
+                    if emit_len > 0 {
+                        Self::emit_prefix(&mut self.buffer, emit_len, &mut reasoning);
+                        self.reasoning_has_text = true;
+                    }
+                    break;
+                }
+                StreamingState::AfterReasoning => {
+                    // Preserve whitespace between the reasoning boundary and
+                    // content, while continuing to suppress duplicate closers.
+                    let whitespace_len = Self::leading_whitespace_len(&self.buffer);
+                    if whitespace_len > 0 {
+                        Self::emit_prefix(&mut self.buffer, whitespace_len, &mut normal);
+                        if self.buffer.is_empty() {
+                            break;
+                        }
+                    }
+
+                    if THINK_END.starts_with(&self.buffer) && self.buffer != THINK_END {
+                        break;
+                    }
+                    if self.buffer.starts_with(THINK_END) {
+                        self.buffer.drain(..THINK_END.len());
+                        continue;
+                    }
+
+                    self.state = StreamingState::Content;
+                }
+                StreamingState::Content => {
+                    let len = self.buffer.len();
+                    Self::emit_prefix(&mut self.buffer, len, &mut normal);
+                    break;
+                }
+            }
         }
+
+        ParserResult::new(normal, reasoning)
     }
 }
 
@@ -49,40 +272,68 @@ impl Default for MinimaxM3Parser {
 
 impl ReasoningParser for MinimaxM3Parser {
     fn detect_and_parse_reasoning(&mut self, text: &str) -> Result<ParserResult, ParseError> {
-        self.base.detect_and_parse_reasoning(text)
+        if text.len() > DEFAULT_MAX_BUFFER_SIZE {
+            return Err(ParseError::BufferOverflow(text.len()));
+        }
+
+        Ok(if self.state == StreamingState::InReasoning {
+            Self::parse_complete_inside_reasoning(text)
+        } else {
+            Self::parse_complete_outside_reasoning(text)
+        })
     }
 
     fn parse_reasoning_streaming_incremental(
         &mut self,
         text: &str,
     ) -> Result<ParserResult, ParseError> {
-        self.base.parse_reasoning_streaming_incremental(text)
+        if self.buffer.len() + text.len() > DEFAULT_MAX_BUFFER_SIZE {
+            return Err(ParseError::BufferOverflow(self.buffer.len() + text.len()));
+        }
+
+        self.buffer.push_str(text);
+        Ok(self.parse_stream_buffer())
     }
 
     fn reset(&mut self) {
-        self.base.reset();
+        self.state = StreamingState::BeforeReasoning;
+        self.buffer.clear();
+        self.allow_leading_closers = true;
+        self.reasoning_has_text = false;
     }
 
     fn model_type(&self) -> &str {
-        self.base.model_type()
+        "minimax_m3"
     }
 
     fn is_in_reasoning(&self) -> bool {
-        self.base.is_in_reasoning()
+        self.state == StreamingState::InReasoning
     }
 
     fn mark_reasoning_started(&mut self) {
-        self.base.mark_reasoning_started();
+        self.state = StreamingState::InReasoning;
+        self.reasoning_has_text = false;
     }
 
     fn mark_think_start_stripped(&mut self) {
-        self.base.mark_think_start_stripped();
+        // 'mark_reasoning_started' owns the state transition. The dedicated M3
+        // state machine already knows that a generated start marker is optional.
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn collect_stream(parser: &mut MinimaxM3Parser, chunks: &[&str]) -> ParserResult {
+        let mut result = ParserResult::default();
+        for chunk in chunks {
+            let parsed = parser.parse_reasoning_streaming_incremental(chunk).unwrap();
+            result.normal_text.push_str(&parsed.normal_text);
+            result.reasoning_text.push_str(&parsed.reasoning_text);
+        }
+        result
+    }
 
     #[test]
     fn test_model_type() {
@@ -119,6 +370,28 @@ mod tests {
     }
 
     #[test]
+    fn test_nonstreaming_drops_repeated_leading_closers() {
+        let mut parser = MinimaxM3Parser::new();
+        for (input, expected) in [
+            ("</mm:think>Hello.", "Hello."),
+            ("</mm:think></mm:think>tool", "tool"),
+        ] {
+            let result = parser.detect_and_parse_reasoning(input).unwrap();
+            assert_eq!(result, ParserResult::normal(expected.to_string()));
+        }
+    }
+
+    #[test]
+    fn test_nonstreaming_preserves_non_leading_unmatched_closer() {
+        let mut parser = MinimaxM3Parser::new();
+        let result = parser
+            .detect_and_parse_reasoning("visible</mm:think>text")
+            .unwrap();
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "visible</mm:think>text");
+    }
+
+    #[test]
     fn test_streaming_incremental_across_chunks() {
         let mut parser = MinimaxM3Parser::new();
 
@@ -133,6 +406,45 @@ mod tests {
             .unwrap();
         assert_eq!(r2.reasoning_text, "about it");
         assert_eq!(r2.normal_text, "the answer");
+    }
+
+    #[test]
+    fn test_streaming_holds_end_marker_suffix_after_reasoning_text() {
+        let mut parser = MinimaxM3Parser::new();
+        let result = collect_stream(&mut parser, &["<mm:think>plan</mm:", "think>ANSWER"]);
+        assert_eq!(result.reasoning_text, "plan");
+        assert_eq!(result.normal_text, "ANSWER");
+    }
+
+    #[test]
+    fn test_streaming_drops_repeated_leading_closers_across_chunks() {
+        let mut parser = MinimaxM3Parser::new();
+        let result = collect_stream(
+            &mut parser,
+            &["</mm:", "think></mm:think>", "]<]minimax[>[<tool_call>"],
+        );
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "]<]minimax[>[<tool_call>");
+    }
+
+    #[test]
+    fn test_streaming_one_character_chunks() {
+        let text = "</mm:think></mm:think><mm:think>思考</mm:think>答案";
+        let chunks: Vec<&str> = text
+            .char_indices()
+            .map(|(start, _)| start)
+            .zip(
+                text.char_indices()
+                    .map(|(start, _)| start)
+                    .skip(1)
+                    .chain(std::iter::once(text.len())),
+            )
+            .map(|(start, end)| &text[start..end])
+            .collect();
+        let mut parser = MinimaxM3Parser::new();
+        let result = collect_stream(&mut parser, &chunks);
+        assert_eq!(result.reasoning_text, "思考");
+        assert_eq!(result.normal_text, "答案");
     }
 
     #[test]
@@ -162,6 +474,18 @@ mod tests {
     }
 
     #[test]
+    fn test_prefilled_thinking_drops_duplicate_closers() {
+        let mut parser = MinimaxM3Parser::new();
+        parser.mark_reasoning_started();
+        let result = collect_stream(
+            &mut parser,
+            &["<mm:think>deep</mm:", "think></mm:think>answer"],
+        );
+        assert_eq!(result.reasoning_text, "deep");
+        assert_eq!(result.normal_text, "answer");
+    }
+
+    #[test]
     fn test_reset_behavior() {
         let mut parser = MinimaxM3Parser::new();
         parser
@@ -178,5 +502,15 @@ mod tests {
             .unwrap();
         assert_eq!(result.reasoning_text, "fresh");
         assert_eq!(result.normal_text, "done");
+    }
+
+    #[test]
+    fn test_buffer_overflow() {
+        let mut parser = MinimaxM3Parser::new();
+        let oversized = "x".repeat(DEFAULT_MAX_BUFFER_SIZE + 1);
+        assert!(matches!(
+            parser.detect_and_parse_reasoning(&oversized),
+            Err(ParseError::BufferOverflow(_))
+        ));
     }
 }


### PR DESCRIPTION
## Description

Closes #2447.

### Problem

MiniMax M3 may emit a stray or duplicated `</mm:think>` before normal content or tool-call framing. The existing M3 parser starts outside reasoning and passes that delimiter through as assistant `content`. It can also release partial delimiter text when token decoding splits a marker across streaming chunks.

A sanitized multi-turn request reproduced the non-streaming leak 3/3 times:

```json
{
  "model": "minimax-m3",
  "temperature": 0,
  "messages": [
    {"role": "user", "content": "Say hello."},
    {"role": "assistant", "content": "Hello."},
    {"role": "user", "content": "Say it again."}
  ]
}
```

Observed before this parser fix:

```json
{
  "content": "</mm:think>Hello.",
  "reasoning_content": null
}
```

Streaming exposed the same marker through `delta.content`.

### Solution

Use a dedicated MiniMax M3 state machine that:

- strips repeated close markers only at the response start or immediately after a reasoning boundary;
- retains the longest possible marker-prefix suffix between chunks, so split start/end markers are classified on the next call;
- supports prompt-prefilled thinking, including a redundantly generated start marker;
- preserves whitespace and unmatched close-marker text embedded after substantive visible content;
- enforces the existing 4 MiB parser buffer limit.

## Changes

- Replace the generic `BaseReasoningParser` wrapper for MiniMax M3 with explicit `BeforeReasoning`, `InReasoning`, `AfterReasoning`, and `Content` streaming states.
- Handle single and duplicated leading `</mm:think>` markers in complete and streaming responses.
- Add regressions for real leaked content, tool-call framing, arbitrary chunk boundaries, one-character Unicode chunks, prefilled thinking, reset, and overflow behavior.

## Test Plan

### Reproducible parser behavior

| Case | Input | Before | After |
|---|---|---|---|
| Single leading close | `</mm:think>Hello.` | normal: `</mm:think>Hello.` | normal: `Hello.` |
| Duplicate closes before tool framing | `</mm:think></mm:think>]<]minimax[>[<tool_call>` | close markers leaked | normal: `]<]minimax[>[<tool_call>` |
| Split end marker | chunks `<mm:think>plan</mm:` + `think>ANSWER` | partial marker could leak | reasoning: `plan`, normal: `ANSWER` |
| Embedded unmatched close | `visible</mm:think>text` | preserved | preserved |

The streaming regressions also feed `</mm:think></mm:think><mm:think>思考</mm:think>答案` one Unicode character per call and assert reasoning `思考`, normal `答案`.

### Local gates

- `cargo +nightly fmt --all -- --check`: pass (silent).
- `cargo clippy --workspace --all-targets -- -D warnings`: pass, zero warnings/errors.
- `cargo test -p reasoning-parser`: pass, 115 passed / 0 failed.
- `cargo test -p reasoning-parser minimax_m3`: pass, 15 passed / 0 failed.
- `git diff --check`: pass.

`cargo clippy --all-targets --all-features -- -D warnings` reaches the optional `opencv-video` build but cannot run to completion locally because `opencv4.pc` is not installed. The documented no-OpenCV fallback above passes.

Full `cargo test` runs all preceding suites successfully, then reports one failure in `routing::test_openai_routing::test_openai_router_circuit_breaker` (131 other routing tests pass). The exact test fails with the same assertion on an unmodified worktree at parent commit `e7ae354f`, confirming it is pre-existing and unrelated to the sole changed file under `crates/reasoning_parser`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (documented fallback without optional OpenCV)
- [ ] (Optional) Documentation updated — no user-facing configuration changed
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
