### PR TITLE
feat(routers): compile provider routers behind per-provider Cargo features

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -317,6 +317,18 @@ jobs:
           rustup component add clippy
           cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Lint the self-hosted-only build (no provider routers)
+        # Meaningful only because the crate's self dev-dependency disables
+        # default features; see model_gateway/Cargo.toml.
+        run: |
+          source "$HOME/.cargo/env"
+          cargo clippy -p smg --no-default-features --features grpc-client,jemalloc-stats --all-targets -- -D warnings
+
+      - name: Lint a single-provider build (Anthropic only)
+        run: |
+          source "$HOME/.cargo/env"
+          cargo clippy -p smg --no-default-features --features grpc-client,jemalloc-stats,provider-anthropic --all-targets -- -D warnings
+
       - name: Run fmt
         run: |
           source "$HOME/.cargo/env"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -16,7 +16,7 @@ serde_yaml = "0.9"
 [dependencies.smg]
 path = "../../model_gateway"
 default-features = false
-features = ["grpc-client", "jemalloc-stats"]
+features = ["grpc-client", "jemalloc-stats", "providers"]
 
 [dependencies.smg-auth]
 workspace = true

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -15,13 +15,21 @@ readme = "../README.md"
 categories = ["web-programming", "network-programming"]
 
 [features]
-default = ["grpc-client", "jemalloc-stats"]
+default = ["grpc-client", "jemalloc-stats", "providers"]
 grpc-client = []
 grpc-server = []
 jemalloc-stats = ["tikv-jemallocator/stats", "dep:tikv-jemalloc-ctl"]
 jemalloc-profiling = ["tikv-jemallocator/profiling"]
 opencv-video = ["llm-multimodal/opencv-video"]
 mm-rdma = ["smg-mm-rdma/nixl"]
+# Third-party provider routers, one feature each. A build picks the providers
+# it serves; IGW mode registers every router compiled in, and a worker that
+# targets a provider is admitted only when its router is present. Leave them
+# all out for a self-hosted-only build.
+provider-openai = []
+provider-anthropic = []
+provider-gemini = []
+providers = ["provider-openai", "provider-anthropic", "provider-gemini"]
 # Client-injection seam for this crate's own K8s discovery integration tests
 # (auto-enabled by the self dev-dependency below, never in production builds).
 test-util = []
@@ -142,8 +150,11 @@ chrono = { version = "0.4", features = ["clock"] }
 toml = "1.1"
 
 [dev-dependencies]
-# Self dev-dependency: turns on `test-util` for this crate's own test targets.
-smg = { path = ".", features = ["test-util"] }
+# Self dev-dependency: turns on `test-util` for this crate's own test targets,
+# and only that. Without `default-features = false` the default set (including
+# the provider routers) would leak into every test target whatever features the
+# build selected, so a `--no-default-features` test run would not be one.
+smg = { path = ".", default-features = false, features = ["test-util"] }
 # Enable the mock engine for the ZMQ client's loopback tests.
 engine-zmq-client = { workspace = true, features = ["mock-engine"] }
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/model_gateway/src/routers/common/realtime/mod.rs
+++ b/model_gateway/src/routers/common/realtime/mod.rs
@@ -31,6 +31,7 @@ pub(crate) struct RealtimeLabels {
 
 impl RealtimeLabels {
     /// Labels for the OpenAI router relaying to an external provider.
+    #[cfg(feature = "provider-openai")]
     pub const OPENAI: Self = Self {
         router: metrics_labels::ROUTER_OPENAI,
         backend: metrics_labels::BACKEND_EXTERNAL,

--- a/model_gateway/src/routers/common/sglang_fields.rs
+++ b/model_gateway/src/routers/common/sglang_fields.rs
@@ -33,6 +33,7 @@ pub(crate) const SGLANG_FIELDS: &[&str] = &[
     "backend_url",
 ];
 
+#[cfg(feature = "provider-openai")]
 pub(crate) fn strip_sglang_fields(payload: &mut Value) {
     if let Some(obj) = payload.as_object_mut() {
         for field in SGLANG_FIELDS {

--- a/model_gateway/src/routers/factory.rs
+++ b/model_gateway/src/routers/factory.rs
@@ -273,7 +273,7 @@ impl RouterFactory {
     pub async fn create_igw_routers(
         policy: &PolicyConfig,
         ctx: &Arc<AppContext>,
-    ) -> Vec<(RouterId, &'static str, Result<Box<dyn RouterTrait>, String>)> {
+    ) -> Vec<IgwRouterEntry> {
         let (encode_policy, prefill_policy, decode_policy) = match &ctx.router_config.mode {
             RoutingMode::PrefillDecode {
                 prefill_policy,

--- a/model_gateway/src/routers/factory.rs
+++ b/model_gateway/src/routers/factory.rs
@@ -2,15 +2,18 @@
 
 use std::sync::Arc;
 
+#[cfg(feature = "provider-anthropic")]
+use super::anthropic::AnthropicRouter;
+#[cfg(feature = "provider-gemini")]
+use super::gemini::GeminiRouter;
+#[cfg(feature = "provider-openai")]
+use super::openai::OpenAIRouter;
 use super::{
-    anthropic::AnthropicRouter,
-    gemini::GeminiRouter,
     grpc::{
         mode::{grpc_mode, Mode},
         router::GrpcRouter,
     },
     http::{pd_router::PDRouter, router::Router},
-    openai::OpenAIRouter,
     RouterTrait,
 };
 use crate::{
@@ -46,6 +49,10 @@ pub mod router_ids {
     pub const GRPC_PD: RouterId = RouterId::new("grpc-pd");
     pub const GRPC_EPD: RouterId = RouterId::new("grpc-epd");
 }
+
+/// One IGW registration: the router id, its label, and the constructed
+/// router or the reason it could not be built.
+type IgwRouterEntry = (RouterId, &'static str, Result<Box<dyn RouterTrait>, String>);
 
 /// Factory for creating router instances based on configuration
 pub struct RouterFactory;
@@ -219,6 +226,7 @@ impl RouterFactory {
     /// Workers should be registered via the external worker registration workflow
     /// before using this router. The workflow discovers models from the provided
     /// endpoints and creates external workers in the registry.
+    #[cfg(feature = "provider-openai")]
     pub async fn create_openai_router(
         ctx: &Arc<AppContext>,
     ) -> Result<Box<dyn RouterTrait>, String> {
@@ -234,6 +242,7 @@ impl RouterFactory {
         clippy::unused_async,
         reason = "async for API consistency with other create_* factory methods"
     )]
+    #[cfg(feature = "provider-anthropic")]
     pub async fn create_anthropic_router(
         ctx: &Arc<AppContext>,
     ) -> Result<Box<dyn RouterTrait>, String> {
@@ -249,6 +258,7 @@ impl RouterFactory {
         clippy::unused_async,
         reason = "async for API consistency with other create_* factory methods"
     )]
+    #[cfg(feature = "provider-gemini")]
     pub async fn create_gemini_router(
         ctx: &Arc<AppContext>,
     ) -> Result<Box<dyn RouterTrait>, String> {
@@ -283,7 +293,7 @@ impl RouterFactory {
             _ => (None, None, None),
         };
 
-        vec![
+        let mut routers = vec![
             (
                 router_ids::HTTP_REGULAR,
                 "HTTP Regular",
@@ -307,22 +317,128 @@ impl RouterFactory {
                 Self::set_epd_policies(encode_policy, prefill_policy, decode_policy, policy, ctx);
                 Self::create_grpc_router(ctx, Mode::EncodePrefillDecode)
             }),
-            (
-                router_ids::HTTP_OPENAI,
-                "OpenAI",
-                Self::create_openai_router(ctx).await,
-            ),
-            (
-                router_ids::HTTP_ANTHROPIC,
-                "Anthropic",
-                Self::create_anthropic_router(ctx).await,
-            ),
-            (
-                router_ids::HTTP_GEMINI,
-                "Gemini",
-                Self::create_gemini_router(ctx).await,
-            ),
-        ]
+        ];
+
+        // Every provider router this build carries. They proxy to third-party
+        // APIs and forward the caller's credentials upstream, so a build that
+        // should never do that simply leaves the features out.
+        routers.extend(
+            [
+                Self::openai_igw_entry(ctx).await,
+                Self::anthropic_igw_entry(ctx).await,
+                Self::gemini_igw_entry(ctx).await,
+            ]
+            .into_iter()
+            .flatten(),
+        );
+
+        routers
+    }
+
+    #[cfg(feature = "provider-openai")]
+    async fn openai_igw_entry(ctx: &Arc<AppContext>) -> Option<IgwRouterEntry> {
+        Some((
+            router_ids::HTTP_OPENAI,
+            "OpenAI",
+            Self::create_openai_router(ctx).await,
+        ))
+    }
+
+    #[cfg(feature = "provider-anthropic")]
+    async fn anthropic_igw_entry(ctx: &Arc<AppContext>) -> Option<IgwRouterEntry> {
+        Some((
+            router_ids::HTTP_ANTHROPIC,
+            "Anthropic",
+            Self::create_anthropic_router(ctx).await,
+        ))
+    }
+
+    #[cfg(feature = "provider-gemini")]
+    async fn gemini_igw_entry(ctx: &Arc<AppContext>) -> Option<IgwRouterEntry> {
+        Some((
+            router_ids::HTTP_GEMINI,
+            "Gemini",
+            Self::create_gemini_router(ctx).await,
+        ))
+    }
+}
+
+/// A build without the OpenAI-compatible provider router: the constructor
+/// keeps its signature so callers do not change, and answers with the reason.
+#[cfg(not(feature = "provider-openai"))]
+impl RouterFactory {
+    #[expect(
+        clippy::unused_async,
+        reason = "signature shared with the provider build"
+    )]
+    pub async fn create_openai_router(
+        _ctx: &Arc<AppContext>,
+    ) -> Result<Box<dyn RouterTrait>, String> {
+        Err(
+            "OpenAI-compatible provider routing is not compiled into this build; rebuild with \
+             the `provider-openai` Cargo feature"
+                .to_string(),
+        )
+    }
+
+    #[expect(
+        clippy::unused_async,
+        reason = "signature shared with the provider build"
+    )]
+    async fn openai_igw_entry(_ctx: &Arc<AppContext>) -> Option<IgwRouterEntry> {
+        None
+    }
+}
+
+/// A build without the Anthropic router; see the OpenAI-compatible twin.
+#[cfg(not(feature = "provider-anthropic"))]
+impl RouterFactory {
+    #[expect(
+        clippy::unused_async,
+        reason = "signature shared with the provider build"
+    )]
+    pub async fn create_anthropic_router(
+        _ctx: &Arc<AppContext>,
+    ) -> Result<Box<dyn RouterTrait>, String> {
+        Err(
+            "Anthropic routing is not compiled into this build; rebuild with the \
+             `provider-anthropic` Cargo feature"
+                .to_string(),
+        )
+    }
+
+    #[expect(
+        clippy::unused_async,
+        reason = "signature shared with the provider build"
+    )]
+    async fn anthropic_igw_entry(_ctx: &Arc<AppContext>) -> Option<IgwRouterEntry> {
+        None
+    }
+}
+
+/// A build without the Gemini router; see the OpenAI-compatible twin.
+#[cfg(not(feature = "provider-gemini"))]
+impl RouterFactory {
+    #[expect(
+        clippy::unused_async,
+        reason = "signature shared with the provider build"
+    )]
+    pub async fn create_gemini_router(
+        _ctx: &Arc<AppContext>,
+    ) -> Result<Box<dyn RouterTrait>, String> {
+        Err(
+            "Gemini routing is not compiled into this build; rebuild with the \
+             `provider-gemini` Cargo feature"
+                .to_string(),
+        )
+    }
+
+    #[expect(
+        clippy::unused_async,
+        reason = "signature shared with the provider build"
+    )]
+    async fn gemini_igw_entry(_ctx: &Arc<AppContext>) -> Option<IgwRouterEntry> {
+        None
     }
 }
 

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -28,14 +28,18 @@ use openai_protocol::{
 
 use crate::middleware::TenantRequestMeta;
 
+#[cfg(feature = "provider-anthropic")]
 pub mod anthropic;
 pub mod common;
 pub mod error;
 pub mod factory;
+#[cfg(feature = "provider-gemini")]
 pub mod gemini;
 pub mod grpc;
 pub mod http;
+#[cfg(feature = "provider-openai")]
 pub mod openai;
+pub(crate) mod provider_support;
 pub mod router_manager;
 
 pub use common::body_policy::BodyPolicy;

--- a/model_gateway/src/routers/provider_support.rs
+++ b/model_gateway/src/routers/provider_support.rs
@@ -5,7 +5,7 @@
 //! admitted only when the router its traffic would reach exists in this
 //! build; nothing decides this at runtime.
 
-use openai_protocol::worker::{ProviderType, RuntimeType, WorkerSpec};
+use openai_protocol::worker::{ProviderType, RuntimeType, WorkerModels, WorkerSpec};
 
 /// The provider routers a build carries, one flag per feature.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -82,14 +82,39 @@ fn targets_provider(spec: &WorkerSpec) -> bool {
     spec.runtime_type == RuntimeType::External || provider_of(spec).is_some()
 }
 
+/// Every provider a worker's traffic can be dispatched under, judged the way
+/// the dispatcher judges it: a model's own provider first, else the worker's.
+/// Only the listed models are ever dispatched to a worker that lists any, so
+/// the worker's own provider counts alone when it serves every model.
+/// Empty for a self-hosted engine.
+fn providers_needed(spec: &WorkerSpec) -> Vec<Option<ProviderType>> {
+    let default = provider_of(spec);
+    let cards: &[_] = match &spec.models {
+        WorkerModels::Wildcard => &[],
+        WorkerModels::Single(card) => std::slice::from_ref(card.as_ref()),
+        WorkerModels::Multi(cards) => cards,
+    };
+    if cards.is_empty() {
+        return vec![default];
+    }
+    let mut needed: Vec<Option<ProviderType>> = cards
+        .iter()
+        .map(|card| card.provider.clone().or_else(|| default.clone()))
+        .collect();
+    needed.dedup();
+    needed
+}
+
 /// The family whose router `spec` needs but `compiled` lacks, or `None` when
-/// the spec is not a provider target or its router is present.
+/// the spec is not a provider target or every router it can reach is present.
 pub(crate) fn missing_router_in(spec: &WorkerSpec, compiled: Compiled) -> Option<ProviderFamily> {
     if !targets_provider(spec) {
         return None;
     }
-    let family = ProviderFamily::of(provider_of(spec).as_ref());
-    (!family.compiled_in(compiled)).then_some(family)
+    providers_needed(spec)
+        .into_iter()
+        .map(|provider| ProviderFamily::of(provider.as_ref()))
+        .find(|family| !family.compiled_in(compiled))
 }
 
 /// [`missing_router_in`] against this build.
@@ -154,5 +179,40 @@ mod tests {
             Some(ProviderFamily::Gemini)
         );
         assert_eq!(ProviderFamily::Gemini.feature(), "provider-gemini");
+    }
+
+    #[test]
+    fn a_model_that_names_its_own_provider_is_judged_by_it() {
+        // A proxy on a private host: the worker says nothing about its
+        // provider, the model card does. Dispatch keys on the card.
+        let proxied = spec(json!({
+            "url": "https://llm.internal:8443",
+            "runtime_type": "external",
+            "models": [{"id": "claude-3-5-sonnet", "provider": "anthropic"}]
+        }));
+        assert_eq!(missing_router_in(&proxied, ANTHROPIC_ONLY), None);
+        let openai_only = Compiled {
+            openai: true,
+            anthropic: false,
+            gemini: false,
+        };
+        assert_eq!(
+            missing_router_in(&proxied, openai_only),
+            Some(ProviderFamily::Anthropic)
+        );
+
+        // A worker serving models of two providers needs both routers.
+        let mixed = spec(json!({
+            "url": "https://llm.internal:8443",
+            "runtime_type": "external",
+            "models": [
+                {"id": "gpt-4o"},
+                {"id": "gemini-2.5-pro", "provider": "gemini"}
+            ]
+        }));
+        assert_eq!(
+            missing_router_in(&mixed, openai_only),
+            Some(ProviderFamily::Gemini)
+        );
     }
 }

--- a/model_gateway/src/routers/provider_support.rs
+++ b/model_gateway/src/routers/provider_support.rs
@@ -1,0 +1,158 @@
+//! Which third-party provider routers this build carries.
+//!
+//! Each provider router sits behind its own Cargo feature. IGW mode registers
+//! every router that was compiled in, and a worker that targets a provider is
+//! admitted only when the router its traffic would reach exists in this
+//! build; nothing decides this at runtime.
+
+use openai_protocol::worker::{ProviderType, RuntimeType, WorkerSpec};
+
+/// The provider routers a build carries, one flag per feature.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Compiled {
+    pub openai: bool,
+    pub anthropic: bool,
+    pub gemini: bool,
+}
+
+/// This build's set.
+pub(crate) const COMPILED: Compiled = Compiled {
+    openai: cfg!(feature = "provider-openai"),
+    anthropic: cfg!(feature = "provider-anthropic"),
+    gemini: cfg!(feature = "provider-gemini"),
+};
+
+/// The router family a provider's traffic reaches, mirroring the manager's
+/// dispatch: Anthropic and Gemini have routers of their own; every other
+/// provider rides the OpenAI-compatible router.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProviderFamily {
+    OpenAiCompatible,
+    Anthropic,
+    Gemini,
+}
+
+impl ProviderFamily {
+    pub(crate) fn of(provider: Option<&ProviderType>) -> Self {
+        match provider {
+            Some(ProviderType::Anthropic) => Self::Anthropic,
+            Some(ProviderType::Gemini) => Self::Gemini,
+            _ => Self::OpenAiCompatible,
+        }
+    }
+
+    /// Human name for messages.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::OpenAiCompatible => "OpenAI-compatible",
+            Self::Anthropic => "Anthropic",
+            Self::Gemini => "Gemini",
+        }
+    }
+
+    /// The Cargo feature that compiles this family's router in.
+    pub(crate) fn feature(self) -> &'static str {
+        match self {
+            Self::OpenAiCompatible => "provider-openai",
+            Self::Anthropic => "provider-anthropic",
+            Self::Gemini => "provider-gemini",
+        }
+    }
+
+    pub(crate) fn compiled_in(self, compiled: Compiled) -> bool {
+        match self {
+            Self::OpenAiCompatible => compiled.openai,
+            Self::Anthropic => compiled.anthropic,
+            Self::Gemini => compiled.gemini,
+        }
+    }
+}
+
+/// The provider a worker spec targets: an explicit `provider`, else a known
+/// provider URL. `None` for a self-hosted engine.
+fn provider_of(spec: &WorkerSpec) -> Option<ProviderType> {
+    spec.provider
+        .clone()
+        .or_else(|| ProviderType::from_url(&spec.url))
+}
+
+/// Whether `spec` describes a third-party provider rather than a self-hosted
+/// engine: an explicit external runtime, a provider, or a known provider URL.
+fn targets_provider(spec: &WorkerSpec) -> bool {
+    spec.runtime_type == RuntimeType::External || provider_of(spec).is_some()
+}
+
+/// The family whose router `spec` needs but `compiled` lacks, or `None` when
+/// the spec is not a provider target or its router is present.
+pub(crate) fn missing_router_in(spec: &WorkerSpec, compiled: Compiled) -> Option<ProviderFamily> {
+    if !targets_provider(spec) {
+        return None;
+    }
+    let family = ProviderFamily::of(provider_of(spec).as_ref());
+    (!family.compiled_in(compiled)).then_some(family)
+}
+
+/// [`missing_router_in`] against this build.
+pub(crate) fn missing_router(spec: &WorkerSpec) -> Option<ProviderFamily> {
+    missing_router_in(spec, COMPILED)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn spec(value: serde_json::Value) -> WorkerSpec {
+        serde_json::from_value(value).expect("worker spec")
+    }
+
+    const NONE: Compiled = Compiled {
+        openai: false,
+        anthropic: false,
+        gemini: false,
+    };
+    const ANTHROPIC_ONLY: Compiled = Compiled {
+        openai: false,
+        anthropic: true,
+        gemini: false,
+    };
+
+    #[test]
+    fn self_hosted_engines_need_no_provider_router() {
+        let local = spec(json!({"url": "http://10.0.0.5:8000"}));
+        assert_eq!(missing_router_in(&local, NONE), None);
+        let sglang = spec(json!({"url": "grpc://10.0.0.5:8000", "runtime_type": "sglang"}));
+        assert_eq!(missing_router_in(&sglang, NONE), None);
+    }
+
+    #[test]
+    fn a_provider_target_is_matched_to_the_router_it_would_reach() {
+        let anthropic = spec(json!({"url": "https://api.anthropic.com"}));
+        assert_eq!(missing_router_in(&anthropic, ANTHROPIC_ONLY), None);
+        assert_eq!(
+            missing_router_in(&anthropic, NONE),
+            Some(ProviderFamily::Anthropic)
+        );
+
+        // xAI, an explicit external runtime with an unknown host, and any
+        // custom provider all ride the OpenAI-compatible router.
+        for value in [
+            json!({"url": "https://api.x.ai"}),
+            json!({"url": "https://llm.internal:8443", "runtime_type": "external"}),
+            json!({"url": "https://llm.internal:8443", "provider": "together"}),
+        ] {
+            assert_eq!(
+                missing_router_in(&spec(value), ANTHROPIC_ONLY),
+                Some(ProviderFamily::OpenAiCompatible)
+            );
+        }
+
+        let gemini = spec(json!({"url": "https://generativelanguage.googleapis.com"}));
+        assert_eq!(
+            missing_router_in(&gemini, ANTHROPIC_ONLY),
+            Some(ProviderFamily::Gemini)
+        );
+        assert_eq!(ProviderFamily::Gemini.feature(), "provider-gemini");
+    }
+}

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -227,6 +227,28 @@ impl RouterManager {
         None
     }
 
+    /// The router that serves an external worker's provider, whether or not
+    /// this build carries it.
+    fn external_router_id(provider: Option<&ProviderType>) -> &'static RouterId {
+        match provider {
+            Some(ProviderType::Gemini) => &router_ids::HTTP_GEMINI,
+            Some(ProviderType::Anthropic) => &router_ids::HTTP_ANTHROPIC,
+            _ => &router_ids::HTTP_OPENAI,
+        }
+    }
+
+    /// Whether an external worker serves `model` through a provider router
+    /// this build does not carry. Such a request must fail rather than fall
+    /// through to a self-hosted router that would proxy it untranslated.
+    fn external_router_missing(&self, workers: &[Arc<dyn Worker>], model: &str) -> bool {
+        workers.iter().any(|w| {
+            matches!(w.metadata().spec.runtime_type, RuntimeType::External)
+                && !self
+                    .routers
+                    .contains_key(Self::external_router_id(w.provider_for_model(model)))
+        })
+    }
+
     fn select_router_for_workers(
         &self,
         workers: &[Arc<dyn Worker>],
@@ -236,11 +258,7 @@ impl RouterManager {
         if let Some(model) = model_id {
             for w in workers {
                 if matches!(w.metadata().spec.runtime_type, RuntimeType::External) {
-                    let router_id = match w.provider_for_model(model) {
-                        Some(ProviderType::Gemini) => &router_ids::HTTP_GEMINI,
-                        Some(ProviderType::Anthropic) => &router_ids::HTTP_ANTHROPIC,
-                        _ => &router_ids::HTTP_OPENAI,
-                    };
+                    let router_id = Self::external_router_id(w.provider_for_model(model));
                     return self.routers.get(router_id).map(|r| r.clone());
                 }
             }
@@ -337,6 +355,15 @@ impl RouterManager {
 
         self.select_router_for_workers(workers, model_id)
             .or_else(|| {
+                if let Some(model) = model_id {
+                    if self.external_router_missing(workers, model) {
+                        warn!(
+                            model = %model,
+                            "No provider router compiled in for this model's external worker"
+                        );
+                        return None;
+                    }
+                }
                 let default = self
                     .default_router
                     .read()

--- a/model_gateway/src/worker/service.rs
+++ b/model_gateway/src/worker/service.rs
@@ -17,6 +17,7 @@ use tracing::warn;
 
 use crate::{
     config::{validate_worker_url, RouterConfig},
+    routers::provider_support,
     worker::{registry::WorkerId, worker::worker_to_info, WorkerRegistry, WorkerType},
     workflow::{Job, JobQueue, WorkerRegistrationMode},
 };
@@ -42,6 +43,12 @@ pub enum WorkerServiceError {
     BadRequest { message: String },
     /// Worker with this URL already exists (duplicate POST)
     Conflict { url: String, worker_id: WorkerId },
+    /// The spec targets a provider whose router this build does not carry
+    ProviderNotCompiled {
+        url: String,
+        family: &'static str,
+        feature: &'static str,
+    },
     /// Job queue not initialized
     QueueNotInitialized,
     /// Failed to submit job to queue
@@ -55,6 +62,7 @@ impl WorkerServiceError {
             Self::InvalidId { .. } => "BAD_REQUEST",
             Self::BadRequest { .. } => "BAD_REQUEST",
             Self::Conflict { .. } => "WORKER_ALREADY_EXISTS",
+            Self::ProviderNotCompiled { .. } => "PROVIDER_NOT_COMPILED",
             Self::QueueNotInitialized => "INTERNAL_SERVER_ERROR",
             Self::QueueSubmitFailed { .. } => "INTERNAL_SERVER_ERROR",
         }
@@ -66,6 +74,7 @@ impl WorkerServiceError {
             Self::InvalidId { .. } => StatusCode::BAD_REQUEST,
             Self::BadRequest { .. } => StatusCode::BAD_REQUEST,
             Self::Conflict { .. } => StatusCode::CONFLICT,
+            Self::ProviderNotCompiled { .. } => StatusCode::BAD_REQUEST,
             Self::QueueNotInitialized => StatusCode::INTERNAL_SERVER_ERROR,
             Self::QueueSubmitFailed { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
@@ -91,6 +100,15 @@ impl std::fmt::Display for WorkerServiceError {
                     Use PUT /workers/{id} to replace or PATCH /workers/{id} to update."
                 )
             }
+            Self::ProviderNotCompiled {
+                url,
+                family,
+                feature,
+            } => write!(
+                f,
+                "Worker '{url}' targets the {family} provider, but this build carries no \
+                 {family} router; rebuild with the `{feature}` Cargo feature to admit it."
+            ),
             Self::QueueNotInitialized => write!(f, "Job queue not initialized"),
             Self::QueueSubmitFailed { message } => write!(f, "{message}"),
         }
@@ -267,6 +285,7 @@ impl WorkerService {
         config: WorkerSpec,
     ) -> Result<CreateWorkerResult, WorkerServiceError> {
         validate_worker_url_request(&config.url)?;
+        Self::require_provider_router(&config)?;
 
         if self.router_config.api_key.is_some() && config.api_key.is_none() {
             warn!(
@@ -308,6 +327,21 @@ impl WorkerService {
         })
     }
 
+    /// A worker that targets a provider is reachable only through that
+    /// provider's router, which exists only in a build that compiled it in.
+    /// Admitting one otherwise would leave it routable by nothing, so refuse
+    /// here rather than after the 202, inside the background workflow.
+    fn require_provider_router(config: &WorkerSpec) -> Result<(), WorkerServiceError> {
+        match provider_support::missing_router(config) {
+            Some(family) => Err(WorkerServiceError::ProviderNotCompiled {
+                url: config.url.clone(),
+                family: family.label(),
+                feature: family.feature(),
+            }),
+            None => Ok(()),
+        }
+    }
+
     /// Replace a worker by ID (full replace, re-runs registration workflow)
     pub async fn replace_worker(
         &self,
@@ -323,6 +357,7 @@ impl WorkerService {
                     worker_id: worker_id_raw.to_string(),
                 })?;
         let url = existing.url().to_string();
+        Self::require_provider_router(&config)?;
 
         // A data-parallel router expands one spec into one worker per rank,
         // each registered under a rank-suffixed URL. Re-running registration

--- a/model_gateway/src/workflow/steps/classify.rs
+++ b/model_gateway/src/workflow/steps/classify.rs
@@ -12,10 +12,11 @@ use async_trait::async_trait;
 use openai_protocol::worker::ProviderType;
 use reqwest::Client;
 use tracing::debug;
-use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
+use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
 use super::util::{http_base_url, try_grpc_reachable, try_http_reachable};
 use crate::{
+    routers::provider_support,
     worker::worker::RuntimeType,
     workflow::data::{WorkerKind, WorkerWorkflowData},
 };
@@ -85,6 +86,23 @@ impl StepExecutor<WorkerWorkflowData> for ClassifyWorkerTypeStep {
         context: &mut WorkflowContext<WorkerWorkflowData>,
     ) -> WorkflowResult<StepResult> {
         let config = &context.data.config;
+
+        // A provider target needs the provider's router, which exists only in
+        // a build that compiled it in; a worker nothing could route to must
+        // not enter the registry.
+        if let Some(family) = provider_support::missing_router(config) {
+            return Err(WorkflowError::StepFailed {
+                step_id: StepId::new("classify_worker_type"),
+                message: format!(
+                    "worker {} targets the {} provider, but this build carries no {} router; \
+                     rebuild with the `{}` Cargo feature to admit it",
+                    config.url,
+                    family.label(),
+                    family.label(),
+                    family.feature()
+                ),
+            });
+        }
 
         // 1. Any explicit runtime → classify immediately, no probing needed
         if config.runtime_type.is_specified() {

--- a/model_gateway/tests/api/api_endpoints_test.rs
+++ b/model_gateway/tests/api/api_endpoints_test.rs
@@ -875,10 +875,9 @@ mod responses_endpoint_tests {
 
     #[tokio::test]
     async fn test_v1_responses_input_items() {
-        // This test uses OpenAI mode because the input_items endpoint
-        // is only implemented in OpenAIRouter and reads from storage (no workers needed)
+        // The input_items endpoint is storage-backed and needs no workers.
         let mut config = RouterConfig::builder()
-            .openai_mode(vec!["http://dummy.local".to_string()]) // Dummy URL (won't be called)
+            .regular_mode(vec![])
             .random_policy()
             .host("127.0.0.1")
             .port(3002)
@@ -945,6 +944,7 @@ mod responses_endpoint_tests {
         ctx.shutdown().await;
     }
 
+    #[cfg(feature = "provider-openai")]
     #[tokio::test]
     async fn test_v1_responses_get_multi_worker_uses_shared_storage() {
         // Start two mock workers
@@ -999,6 +999,7 @@ mod responses_endpoint_tests {
         ctx.shutdown().await;
     }
 
+    #[cfg(feature = "provider-openai")]
     async fn create_openai_ctx(port: u16) -> AppTestContext {
         use smg::config::RouterConfig;
         let mut config = RouterConfig::builder()
@@ -1029,6 +1030,7 @@ mod responses_endpoint_tests {
         .await
     }
 
+    #[cfg(feature = "provider-openai")]
     async fn create_response(
         app: &axum::Router,
         payload: serde_json::Value,
@@ -1048,6 +1050,7 @@ mod responses_endpoint_tests {
         (status, json)
     }
 
+    #[cfg(feature = "provider-openai")]
     #[tokio::test]
     async fn test_v1_responses_store_false_retrieve_404() {
         let ctx = create_openai_ctx(18970).await;
@@ -1077,6 +1080,7 @@ mod responses_endpoint_tests {
         ctx.shutdown().await;
     }
 
+    #[cfg(feature = "provider-openai")]
     #[tokio::test]
     async fn test_v1_responses_store_true_retrieve_200() {
         let ctx = create_openai_ctx(18971).await;
@@ -1112,6 +1116,7 @@ mod responses_endpoint_tests {
         ctx.shutdown().await;
     }
 
+    #[cfg(feature = "provider-openai")]
     #[tokio::test]
     async fn test_v1_responses_store_omitted_retrieve_200() {
         let ctx = create_openai_ctx(18973).await;
@@ -1146,6 +1151,7 @@ mod responses_endpoint_tests {
         ctx.shutdown().await;
     }
 
+    #[cfg(feature = "provider-openai")]
     #[tokio::test]
     async fn test_v1_responses_store_false_as_previous_response_id() {
         let ctx = create_openai_ctx(18972).await;

--- a/model_gateway/tests/api/api_endpoints_test.rs
+++ b/model_gateway/tests/api/api_endpoints_test.rs
@@ -944,7 +944,6 @@ mod responses_endpoint_tests {
         ctx.shutdown().await;
     }
 
-    #[cfg(feature = "provider-openai")]
     #[tokio::test]
     async fn test_v1_responses_get_multi_worker_uses_shared_storage() {
         // Start two mock workers

--- a/model_gateway/tests/api/mod.rs
+++ b/model_gateway/tests/api/mod.rs
@@ -4,5 +4,6 @@ mod api_endpoints_test;
 mod messages_api_test;
 mod parser_endpoints_test;
 mod request_formats_test;
+#[cfg(feature = "provider-openai")]
 mod responses_api_test;
 mod streaming_tests;

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code, clippy::allow_attributes, clippy::large_futures)]
 
 pub mod mock_mcp_server;
+#[cfg(feature = "provider-openai")]
 pub mod mock_openai_server;
 pub mod mock_worker;
 pub mod streaming_helpers;

--- a/model_gateway/tests/routing/mod.rs
+++ b/model_gateway/tests/routing/mod.rs
@@ -16,6 +16,7 @@ pub mod prefix_hash_test;
 pub mod service_discovery_test;
 pub mod stream_relay_disconnect_test;
 pub mod stream_request_body_test;
+#[cfg(feature = "provider-openai")]
 pub mod test_openai_routing;
 pub mod test_pd_routing;
 pub mod upstream_http2_test;


### PR DESCRIPTION
## Description

### Problem

Every build carries the OpenAI-compatible, Anthropic and Gemini provider routers, and IGW mode registers all three unconditionally. An operator who only serves self-hosted engines still ships code whose job is to proxy to third-party APIs and forward the caller's credentials upstream, and an operator who wants exactly one provider has no way to say so. A runtime switch (#2443) was the wrong shape: it is all-or-nothing, it still ships the code, and it adds a flag to reason about at every startup.

### Solution

One Cargo feature per provider router (`provider-openai`, `provider-anthropic`, `provider-gemini`) plus a `providers` umbrella that stays in the default set for this release, so nothing changes for anyone who does not opt out. The choice is made when the binary is built and nowhere else:

- IGW mode registers whatever provider routers are compiled in.
- Worker admission asks "does this build carry the router this worker's traffic would reach". Anthropic and Gemini have routers of their own; every other provider (OpenAI, xAI, a custom `provider`, an explicit `runtime_type: external`) rides the OpenAI-compatible router. A worker whose router is missing is refused with a 400 at the API, and refused in the classify step for workers that arrive through config or discovery, so nothing unroutable reaches the registry.
- `--backend openai|anthropic|gemini` on a build without that feature fails at startup with the feature to enable.

## Changes

- `model_gateway/Cargo.toml`: the three features and the `providers` umbrella (default). The self dev-dependency gets `default-features = false`; without it every test target silently re-enabled the default set, so a `--no-default-features` test run was not one. `bindings/python/Cargo.toml` forwards `providers`.
- `routers/mod.rs`: provider modules gated. `routers/factory.rs`: the three constructors gated, with same-signature stubs that return the feature to enable; the IGW list is assembled from per-provider entries instead of three unconditional ones.
- `routers/provider_support.rs` (new): `ProviderFamily` (the router a provider reaches) and `missing_router`, a pure check unit-tested against injected feature sets so the refusal logic is exercised on every build.
- `worker/service.rs`: `WorkerServiceError::ProviderNotCompiled` (`PROVIDER_NOT_COMPILED`, 400) checked in `create_worker` and `replace_worker` before the 202. `workflow/steps/classify.rs`: the same check for workers that enter through config, discovery or mesh.
- Provider-only helpers gated on the feature that uses them (`RealtimeLabels::OPENAI`, `strip_sglang_fields`).
- Tests: the OpenAI-router suites (`test_openai_routing`, `responses_api_test`, the mock OpenAI server, and the five Responses-store tests in `api_endpoints_test`) are gated on `provider-openai`. `test_v1_responses_input_items` is storage-backed and now runs in regular mode, so it covers every build.
- CI (`pr-test-rust.yml`): two extra clippy lanes next to the existing one: the self-hosted-only build and an Anthropic-only build, so a provider-only symbol can no longer hide behind the umbrella.

No runtime flag, no config field, no behaviour change on the default build.

## Test Plan

Gates (exit codes captured unpiped):

| Command | Result |
|---|---|
| `cargo +nightly fmt --all` | clean |
| `cargo clippy -p smg --all-targets -- -D warnings` (default) | 0 |
| `cargo clippy -p smg --no-default-features --features grpc-client,jemalloc-stats --all-targets -- -D warnings` | 0 |
| `cargo clippy -p smg --no-default-features --features grpc-client,jemalloc-stats,provider-anthropic --all-targets -- -D warnings` | 0 |
| `cargo test -p smg --lib` (default / slim) | 1948 / 1869 passed |
| `cargo test -p smg --test api_tests` (default / slim) | 109 / 80 passed |
| `cargo test -p smg --test routing_tests` (default / slim) | 131 / 114 passed, 1 pre-existing flake (below) |
| `cargo test -p smg --test messages_test --test mcp_test` | 11 + 23 passed |

The slim counts are lower only by the gated OpenAI-router suites; the 79 lib tests that drop out are the provider routers' own unit tests.

Behaviour on the self-hosted-only binary (`cargo build -p smg --no-default-features --features grpc-client,jemalloc-stats --bin smg`):

```
$ smg launch --backend anthropic --worker-urls https://api.anthropic.com
Error: "Anthropic routing is not compiled into this build; rebuild with the `provider-anthropic` Cargo feature"
(exit 1)

$ smg launch --enable-igw
Created HTTP Regular router ... Created gRPC EPD router
RouterManager initialized with 5 routers for multi-router mode
```

On the default build the same commands behave exactly as on `main` (Anthropic router created; IGW initializes with 8 routers).

Flake: `routing::header_routing_hints_test::...::test_no_hint_distinct_bodies_spread_cache_aware_workers` fails intermittently on `main` as well (2 of 5 reruns here; the HTTP cache-aware path is untouched by this PR). Tracked separately.

## Review follow-ups

- **Admission keys like dispatch.** A worker is judged by every provider its traffic can be dispatched under: each model card's own `provider` first, else the worker's `provider` or URL. A proxy on a private host whose cards name Anthropic is admitted on an Anthropic-only build and refused on an OpenAI-only one, naming `provider-anthropic`. Tests: `a_model_that_names_its_own_provider_is_judged_by_it`.
- **No silent fallback.** When an external worker's provider router is not compiled in, request dispatch now returns no router (503) instead of falling through to the default self-hosted router, which would have proxied the request untranslated.
- The shared-storage retrieval test runs in every build again; it never needed the OpenAI router.
- `create_igw_routers` returns `Vec<IgwRouterEntry>`.
- Follow-up: providers inferred at discovery time (`claude-*`, `gemini-*` ids on a wildcard worker) are learned after admission; a discovery-time check is the next step.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

