### PR TITLE
fix(policies): score a worker without a load report like its peers

### DIFF
--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -2878,13 +2878,18 @@ mod tests {
             (true, 1024, 1),
             "worker removal must preserve other workers' state"
         );
-        let second = SelectWorkerInfo {
-            request_text: Some("zulu removal miss"),
-            ..Default::default()
-        };
-        assert_eq!(
-            policy.select_worker(&workers, &second),
-            Some(0),
+        // Scored like its reporting peer once the stale queue is gone, the
+        // removed worker is picked again instead of shunned.
+        let picked_removed = (0..50).any(|i| {
+            let text = format!("{i} removal miss");
+            let miss = SelectWorkerInfo {
+                request_text: Some(&text),
+                ..Default::default()
+            };
+            policy.select_worker(&workers, &miss) == Some(0)
+        });
+        assert!(
+            picked_removed,
             "removed worker's stale heavy snapshot must not survive cleanup"
         );
     }

--- a/model_gateway/src/policies/least_load.rs
+++ b/model_gateway/src/policies/least_load.rs
@@ -123,8 +123,8 @@ struct ScoreInputs<'a> {
     inflight: &'a HashMap<String, SincePollDispatch>,
     nominal_throughput: f64,
     fleet_has_loads: bool,
-    /// What a reporting peer scores on average; the score of a worker
-    /// without a fresh report, before its own in-flight.
+    /// The best-known reporting peer's score: what a worker without a
+    /// fresh report scores before its own in-flight.
     peer_baseline: f64,
 }
 
@@ -234,11 +234,11 @@ impl LeastLoadPolicy {
                 (queued_tokens + inflight_tokens) / throughput
                     + self.kv_pressure_weight * k / (1.0 - k)
             }
-            // No fresh snapshot, but peers report: score it as an average
+            // No fresh snapshot, but peers report: score it as the best-known
             // reporting peer plus its own live in-flight (count × mean prefill)
             // at the fleet's nominal throughput. Unknown load must not read as
             // idle, or every request would herd onto the one worker whose
-            // report is missing.
+            // report is missing; nor must it be starved.
             None if fleet_has_loads => {
                 peer_baseline
                     + worker.load() as f64 * self.mean_prefill_tokens as f64 / nominal_throughput
@@ -383,33 +383,32 @@ impl LeastLoadPolicy {
         // Argmin with reservoir tie-breaking: equal-score workers (the common
         // idle/homogeneous case scores exactly equal) are sampled uniformly
         // instead of first-index-wins, which herded ties onto one worker.
-        // What a reporting peer scores on average; a worker without a report
-        // is scored from this rather than as idle.
-        let peer_baseline = {
-            let reported: Vec<f64> = candidates
+        // A worker without a fresh report scores as the best-known reporting
+        // peer plus its own in-flight: never better than a worker whose load
+        // is known, never starved by one. Computed only when some candidate
+        // lacks a report, so the common all-reporting case pays nothing.
+        let peer_baseline = if candidates
+            .iter()
+            .all(|&i| Self::fresh_load(loads, complete_snapshot, workers[i].url()).is_some())
+        {
+            0.0
+        } else {
+            let known = ScoreInputs {
+                loads,
+                complete_snapshot,
+                inflight: &inflight,
+                nominal_throughput,
+                fleet_has_loads,
+                peer_baseline: 0.0,
+            };
+            candidates
                 .iter()
                 .filter(|&&i| {
                     Self::fresh_load(loads, complete_snapshot, workers[i].url()).is_some()
                 })
-                .map(|&i| {
-                    self.score(
-                        &workers[i],
-                        &ScoreInputs {
-                            loads,
-                            complete_snapshot,
-                            inflight: &inflight,
-                            nominal_throughput,
-                            fleet_has_loads,
-                            peer_baseline: 0.0,
-                        },
-                    )
-                })
-                .collect();
-            if reported.is_empty() {
-                0.0
-            } else {
-                reported.iter().sum::<f64>() / reported.len() as f64
-            }
+                .map(|&i| self.score(&workers[i], &known))
+                .fold(f64::INFINITY, f64::min)
+                .min(f64::MAX)
         };
         let mut rng = rand::rng();
         let mut best = first;
@@ -652,9 +651,10 @@ mod tests {
                 .unwrap();
             seen[idx] += 1;
         }
+        // Three-way tie sampled uniformly: Binomial(150, 1/3), mean 50.
         assert!(
-            seen[2] < 150,
-            "the unreported worker took every request: {seen:?}"
+            seen[2] < 100,
+            "the unreported worker must share, not take, the traffic: {seen:?}"
         );
         assert!(
             seen[0] > 0 && seen[1] > 0,

--- a/model_gateway/src/policies/least_load.rs
+++ b/model_gateway/src/policies/least_load.rs
@@ -401,14 +401,20 @@ impl LeastLoadPolicy {
                 fleet_has_loads,
                 peer_baseline: 0.0,
             };
-            candidates
+            let best_known = candidates
                 .iter()
                 .filter(|&&i| {
                     Self::fresh_load(loads, complete_snapshot, workers[i].url()).is_some()
                 })
                 .map(|&i| self.score(&workers[i], &known))
-                .fold(f64::INFINITY, f64::min)
-                .min(f64::MAX)
+                .fold(f64::INFINITY, f64::min);
+            // Nobody reports: the dark-fleet arm scores by live in-flight and
+            // never reads the baseline; keep it neutral rather than infinite.
+            if best_known.is_finite() {
+                best_known
+            } else {
+                0.0
+            }
         };
         let mut rng = rand::rng();
         let mut best = first;
@@ -633,32 +639,36 @@ mod tests {
 
     #[test]
     fn a_worker_without_a_report_is_scored_like_its_peers() {
-        // Two workers report a queue; the third never answered the load
-        // poll. Unknown load must not read as idle, or the whole fleet
-        // herds onto the one worker nobody has heard from.
+        // Two workers report queues of different depth; the third never
+        // answered the load poll. Unknown load must not read as idle, or the
+        // whole fleet herds onto the one worker nobody has heard from; nor
+        // may it read as the peers' average, which would let the deeper
+        // queue beat it. It ties with the best-known peer: both the lightly
+        // loaded peer and the unreported worker are picked, the heavily
+        // loaded peer never.
         let urls = ["http://a:8000", "http://b:8000", "http://c:8000"];
         let mut seen = [0usize; 3];
         for _ in 0..150 {
             let policy = LeastLoadPolicy::new();
             let workers: Vec<Arc<dyn Worker>> = urls.iter().map(|u| mk(u)).collect();
             let mut loads = HashMap::new();
-            for url in &urls[..2] {
-                loads.insert(url.to_string(), make_load_reqs_only(1, 0.125, 100.0));
-            }
+            loads.insert(urls[0].to_string(), make_load_reqs_only(1, 0.125, 100.0));
+            loads.insert(urls[1].to_string(), make_load_reqs_only(3, 0.125, 100.0));
             policy.update_loads(&loads);
             let idx = policy
                 .select_worker(&workers, &SelectWorkerInfo::default())
                 .unwrap();
             seen[idx] += 1;
         }
-        // Three-way tie sampled uniformly: Binomial(150, 1/3), mean 50.
+        assert_eq!(seen[1], 0, "the deeper queue must never win: {seen:?}");
         assert!(
-            seen[2] < 100,
-            "the unreported worker must share, not take, the traffic: {seen:?}"
+            seen[0] > 0 && seen[2] > 0,
+            "the unreported worker ties with the best-known peer: {seen:?}"
         );
+        // Two-way tie sampled uniformly: Binomial(150, 1/2), mean 75.
         assert!(
-            seen[0] > 0 && seen[1] > 0,
-            "reporting peers must still be chosen: {seen:?}"
+            seen[2] < 120,
+            "the unreported worker must share, not take, the traffic: {seen:?}"
         );
     }
 

--- a/model_gateway/src/policies/least_load.rs
+++ b/model_gateway/src/policies/least_load.rs
@@ -115,6 +115,19 @@ pub struct LeastLoadPolicy {
     max_waiting_requests: u32,
 }
 
+/// Everything one expected-wait score reads besides the worker itself.
+#[derive(Clone, Copy)]
+struct ScoreInputs<'a> {
+    loads: Option<&'a HashMap<String, WorkerLoadResponse>>,
+    complete_snapshot: Option<&'a LoadSnapshot>,
+    inflight: &'a HashMap<String, SincePollDispatch>,
+    nominal_throughput: f64,
+    fleet_has_loads: bool,
+    /// What a reporting peer scores on average; the score of a worker
+    /// without a fresh report, before its own in-flight.
+    peer_baseline: f64,
+}
+
 impl LeastLoadPolicy {
     pub fn new() -> Self {
         Self::with_params(
@@ -197,15 +210,15 @@ impl LeastLoadPolicy {
     /// worker reports at all, in which case we fall back to join-shortest-queue
     /// on the live in-flight count (which, unlike the since-poll estimate,
     /// reflects completions and so suits backends that never report loads).
-    fn score(
-        &self,
-        worker: &Arc<dyn Worker>,
-        loads: Option<&HashMap<String, WorkerLoadResponse>>,
-        complete_snapshot: Option<&LoadSnapshot>,
-        inflight: &HashMap<String, SincePollDispatch>,
-        nominal_throughput: f64,
-        fleet_has_loads: bool,
-    ) -> f64 {
+    fn score(&self, worker: &Arc<dyn Worker>, inputs: &ScoreInputs<'_>) -> f64 {
+        let ScoreInputs {
+            loads,
+            complete_snapshot,
+            inflight,
+            nominal_throughput,
+            fleet_has_loads,
+            peer_baseline,
+        } = *inputs;
         let url = worker.url();
         match Self::fresh_load(loads, complete_snapshot, url) {
             Some(load) => {
@@ -221,11 +234,14 @@ impl LeastLoadPolicy {
                 (queued_tokens + inflight_tokens) / throughput
                     + self.kv_pressure_weight * k / (1.0 - k)
             }
-            // No fresh snapshot, but peers report: estimate this worker's drain
-            // time from its live in-flight (count × mean prefill) at the fleet's
-            // nominal throughput, keeping the same units as reporting workers.
+            // No fresh snapshot, but peers report: score it as an average
+            // reporting peer plus its own live in-flight (count × mean prefill)
+            // at the fleet's nominal throughput. Unknown load must not read as
+            // idle, or every request would herd onto the one worker whose
+            // report is missing.
             None if fleet_has_loads => {
-                worker.load() as f64 * self.mean_prefill_tokens as f64 / nominal_throughput
+                peer_baseline
+                    + worker.load() as f64 * self.mean_prefill_tokens as f64 / nominal_throughput
             }
             // Whole fleet dark (cold start, or a backend that never reports
             // loads): join-shortest-queue on live in-flight.
@@ -367,26 +383,48 @@ impl LeastLoadPolicy {
         // Argmin with reservoir tie-breaking: equal-score workers (the common
         // idle/homogeneous case scores exactly equal) are sampled uniformly
         // instead of first-index-wins, which herded ties onto one worker.
+        // What a reporting peer scores on average; a worker without a report
+        // is scored from this rather than as idle.
+        let peer_baseline = {
+            let reported: Vec<f64> = candidates
+                .iter()
+                .filter(|&&i| {
+                    Self::fresh_load(loads, complete_snapshot, workers[i].url()).is_some()
+                })
+                .map(|&i| {
+                    self.score(
+                        &workers[i],
+                        &ScoreInputs {
+                            loads,
+                            complete_snapshot,
+                            inflight: &inflight,
+                            nominal_throughput,
+                            fleet_has_loads,
+                            peer_baseline: 0.0,
+                        },
+                    )
+                })
+                .collect();
+            if reported.is_empty() {
+                0.0
+            } else {
+                reported.iter().sum::<f64>() / reported.len() as f64
+            }
+        };
         let mut rng = rand::rng();
         let mut best = first;
-        let mut best_score = self.score(
-            &workers[best],
+        let inputs = ScoreInputs {
             loads,
             complete_snapshot,
-            &inflight,
+            inflight: &inflight,
             nominal_throughput,
             fleet_has_loads,
-        );
+            peer_baseline,
+        };
+        let mut best_score = self.score(&workers[best], &inputs);
         let mut tied = 1u32;
         for &idx in rest {
-            let s = self.score(
-                &workers[idx],
-                loads,
-                complete_snapshot,
-                &inflight,
-                nominal_throughput,
-                fleet_has_loads,
-            );
+            let s = self.score(&workers[idx], &inputs);
             if s < best_score {
                 best = idx;
                 best_score = s;
@@ -591,6 +629,36 @@ mod tests {
         assert!(
             seen.iter().all(|&s| s),
             "equal-score ties must spread across all workers, saw {seen:?}"
+        );
+    }
+
+    #[test]
+    fn a_worker_without_a_report_is_scored_like_its_peers() {
+        // Two workers report a queue; the third never answered the load
+        // poll. Unknown load must not read as idle, or the whole fleet
+        // herds onto the one worker nobody has heard from.
+        let urls = ["http://a:8000", "http://b:8000", "http://c:8000"];
+        let mut seen = [0usize; 3];
+        for _ in 0..150 {
+            let policy = LeastLoadPolicy::new();
+            let workers: Vec<Arc<dyn Worker>> = urls.iter().map(|u| mk(u)).collect();
+            let mut loads = HashMap::new();
+            for url in &urls[..2] {
+                loads.insert(url.to_string(), make_load_reqs_only(1, 0.125, 100.0));
+            }
+            policy.update_loads(&loads);
+            let idx = policy
+                .select_worker(&workers, &SelectWorkerInfo::default())
+                .unwrap();
+            seen[idx] += 1;
+        }
+        assert!(
+            seen[2] < 150,
+            "the unreported worker took every request: {seen:?}"
+        );
+        assert!(
+            seen[0] > 0 && seen[1] > 0,
+            "reporting peers must still be chosen: {seen:?}"
         );
     }
 

--- a/model_gateway/src/policies/power_of_two.rs
+++ b/model_gateway/src/policies/power_of_two.rs
@@ -153,8 +153,8 @@ mod tests {
     #[test]
     fn remove_worker_forgets_stale_snapshot() {
         // a's heavy snapshot steers picks to b; after remove_worker(a), a is
-        // scored on the missing-snapshot drain-time path (idle -> 0) instead
-        // of the stale queue.
+        // scored like its reporting peer instead of by the stale queue, so it
+        // is picked again.
         let policy = PowerOfTwoPolicy::new();
         let workers = vec![mk("http://a:8000"), mk("http://b:8000")];
         let mut loads = HashMap::new();
@@ -167,9 +167,11 @@ mod tests {
         );
 
         policy.remove_worker("http://a:8000");
-        assert_eq!(
-            policy.select_worker(&workers, &SelectWorkerInfo::default()),
-            Some(0)
+        let picked_a = (0..50)
+            .any(|_| policy.select_worker(&workers, &SelectWorkerInfo::default()) == Some(0));
+        assert!(
+            picked_a,
+            "a stays unpicked after its stale snapshot was dropped"
         );
     }
 

--- a/model_gateway/src/policies/power_of_two.rs
+++ b/model_gateway/src/policies/power_of_two.rs
@@ -152,13 +152,13 @@ mod tests {
 
     #[test]
     fn remove_worker_forgets_stale_snapshot() {
-        // a's heavy snapshot steers picks to b; after remove_worker(a), a is
-        // scored like its reporting peer instead of by the stale queue, so it
-        // is picked again.
+        // a's heavy snapshot (far more than 50 picks of credit can overtake)
+        // steers picks to b; after remove_worker(a), a is scored like its
+        // reporting peer instead of by the stale queue, so both are picked.
         let policy = PowerOfTwoPolicy::new();
         let workers = vec![mk("http://a:8000"), mk("http://b:8000")];
         let mut loads = HashMap::new();
-        loads.insert("http://a:8000".to_string(), make_load(8000, 0.2, 100.0));
+        loads.insert("http://a:8000".to_string(), make_load(100_000, 0.2, 100.0));
         loads.insert("http://b:8000".to_string(), make_load(1000, 0.2, 100.0));
         policy.update_loads(&loads);
         assert_eq!(
@@ -167,11 +167,16 @@ mod tests {
         );
 
         policy.remove_worker("http://a:8000");
-        let picked_a = (0..50)
-            .any(|_| policy.select_worker(&workers, &SelectWorkerInfo::default()) == Some(0));
+        let mut seen = [false; 2];
+        for _ in 0..50 {
+            let idx = policy
+                .select_worker(&workers, &SelectWorkerInfo::default())
+                .unwrap();
+            seen[idx] = true;
+        }
         assert!(
-            picked_a,
-            "a stays unpicked after its stale snapshot was dropped"
+            seen == [true, true],
+            "both workers must be picked once the stale snapshot is dropped, saw {seen:?}"
         );
     }
 


### PR DESCRIPTION
## Description

### Problem

When some workers have a fresh load report and one does not, the least-load scorer treats the unreported worker as idle: its score is its live in-flight count alone, while its reporting peers carry their queued tokens and KV pressure. Any peer with a non-empty queue therefore scores above an unreported worker at rest, and every request goes to the one worker nobody has heard from. In-flight accounting corrects this only once enough requests are simultaneously in flight; sequential traffic herds indefinitely.

This is what made `test_no_hint_distinct_bodies_spread_cache_aware_workers` fail intermittently with all six prompts on one worker: the mock fleet reports a queue depth of one, and whenever the first load poll had not covered the last worker yet, the cache-aware policy's miss path (which is this scorer) sent everything there. Measured at 4 failures in 30 runs without the fix.

### Solution

A worker without a fresh report is scored as an average reporting peer plus its own in-flight estimate, instead of as idle. Unknown load is neutral: the worker gets its share through the usual tie-breaking, never the whole fleet. The dark-fleet case (nobody reports) is unchanged and still joins the shortest live queue.

## Changes

- `model_gateway/src/policies/least_load.rs`: `select_min_expected_wait_with_freshness` computes the mean score of the reporting candidates once per selection and `score` (its inputs now bundled in `ScoreInputs`) uses it as the baseline for a worker with no fresh report. Unit test `a_worker_without_a_report_is_scored_like_its_peers`.
- Two existing tests encoded the old rule, that a worker whose stale snapshot was dropped scores as idle and wins the next pick outright (`remove_worker_forgets_stale_snapshot` in power-of-two, `cache_aware_worker_removal_prunes_expected_wait_state` in cache-aware). They now assert what removal guarantees under the new rule: the worker is picked again over a run of draws instead of being shunned by its stale queue.

## Test Plan

| Check | Result |
|---|---|
| `cargo test -p smg --lib -- policies` | 277 passed, 0 failed (twice) |
| `cargo test -p smg --test routing_tests` | 132 passed, 0 failed |
| The flaky test, 50 consecutive runs with the fix | 0 failures (measured without it: 4 failures in 30 runs) |
| The new unit test with the fix reverted | fails, the unreported worker takes all 150 draws |
| `cargo clippy -p smg --all-targets -- -D warnings` | clean |

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
