### PR TITLE
feat(external-router): document the crate and judge discovered models at admission

### DIFF
--- a/crates/external_router/README.md
+++ b/crates/external_router/README.md
@@ -1,0 +1,89 @@
+# smg-external-router
+
+Routers for third-party providers behind the SMG gateway, and the contract they
+are built on. The gateway depends on this crate; this crate never depends on the
+gateway.
+
+## What is in here
+
+| Module | Role |
+|---|---|
+| `router` | `ExternalRouter`, the trait a provider router implements; `ExternalRouterSpec`, how the gateway knows a router; `known`, the identity table of the built-in routers |
+| `context` | `ExternalContext`, everything a router may borrow from the gateway |
+| `worker` | `WorkerSource` and `ExternalWorker`, the gateway's workers as a router sees them; `SelectWorkerRequest` |
+| `openai`, `anthropic`, `gemini` | the built-in routers, one Cargo feature each |
+| `error`, `sse`, `openai_bridge`, `mcp_utils`, `header_utils`, `retry`, `persistence_utils`, `realtime`, `metrics`, `tenant`, `sglang_fields` | protocol-level glue shared by every router family; the gateway re-exports these at their old paths |
+
+## The contract
+
+A provider router implements `ExternalRouter`. It has the same method names as
+the gateway's router trait for the endpoints a provider can serve: chat,
+Responses, Messages, Interactions, the realtime entry points, health and server
+info. Every method defaults to 501, so a router implements only what its
+provider offers.
+
+The gateway hands each router an `ExternalContext`: the HTTP client, request
+timeout, retry policy, the MCP orchestrator and format registry, response and
+conversation storage, the realtime registry, WebRTC settings, and `workers`, a
+`WorkerSource`. The source selects a worker for a request, reports per-model
+retry policy and fleet stats, and lists the provider-backed workers. A selected
+worker is an `ExternalWorker` handle: URL, API key, model, health, provider for
+a model, outcome recording, its HTTP client, and a load hold for long-lived
+sessions.
+
+Selection carries the selecting router (`SelectWorkerRequest::router`), so in a
+mixed-provider registry a router only reaches the workers it takes and a
+caller's credentials never reach another provider's worker.
+
+## How the gateway mounts a router
+
+`router::known` lists the built-in routers whether or not this build carries
+them: router id, backend name, label, the gateway Cargo feature that compiles it
+in, the providers it takes (`serves`), whether it is the fallback for external
+workers that name no provider, a `compiled` flag, and a constructor. On a build
+without the router the constructor answers with the feature to enable.
+
+- `builtin_routers()` is the compiled subset; IGW mode mounts all of it.
+- `spec_for_backend(name)` serves `--backend <name>`; a known but absent router
+  fails at startup naming its feature.
+- `spec_for_provider(provider)` is the one resolution rule shared by dispatch
+  and admission: a router that names a provider beats the fallback, so a
+  provider-specific router can coexist with the OpenAI-compatible fallback that
+  takes every custom provider.
+
+## Features
+
+| Crate feature | Gateway feature | Router |
+|---|---|---|
+| `openai` | `provider-openai` | OpenAI-compatible: OpenAI, xAI, custom providers, and the fallback |
+| `anthropic` | `provider-anthropic` | Anthropic Messages |
+| `gemini` | `provider-gemini` | Gemini Interactions |
+
+The gateway's `providers` feature turns on all three and is in its default set.
+A self-hosted build takes none and compiles only the glue:
+
+```sh
+cargo build -p smg --no-default-features --features grpc-client,jemalloc-stats
+```
+
+## Adding a provider
+
+1. Add a module with a type implementing `ExternalRouter`, taking
+   `&ExternalContext` in its constructor and selecting workers through
+   `ctx.workers` with `router: Some(known::YOURS)`.
+2. Add a crate feature and gate the module on it.
+3. Add the identity to `router::known`: id, backend, label, feature, `serves`,
+   `fallback: false`, `compiled: cfg!(feature = "...")`, and the two `build`
+   functions (one per cfg).
+4. Add the entry to `known::all()`.
+5. In the gateway, forward a `provider-<name>` feature to the crate feature.
+
+Admission, startup and dispatch then know the router without further edits.
+
+## Checks
+
+```sh
+cargo clippy -p smg-external-router --features openai,anthropic,gemini --all-targets -- -D warnings
+cargo clippy -p smg-external-router --all-targets -- -D warnings
+cargo test -p smg-external-router --features openai,anthropic,gemini
+```

--- a/model_gateway/src/routers/provider_support.rs
+++ b/model_gateway/src/routers/provider_support.rs
@@ -4,7 +4,10 @@
 //! targets a provider is admitted only when one of those routers takes it;
 //! nothing decides this at runtime.
 
-use openai_protocol::worker::{ProviderType, RuntimeType, WorkerModels, WorkerSpec};
+use openai_protocol::{
+    model_card::ModelCard,
+    worker::{ProviderType, RuntimeType, WorkerModels, WorkerSpec},
+};
 use smg_external_router::{home_among, known, ExternalRouterSpec};
 
 /// The router a provider target needs but this build lacks.
@@ -75,6 +78,48 @@ pub(crate) fn missing_router_among(
             }),
         }
     })
+}
+
+/// Split discovered model cards into the ones a router in `known` takes and
+/// the ones nothing compiled in can route, judged as dispatch will judge
+/// them: the card's own provider first, else the worker's.
+pub(crate) fn partition_routable_among(
+    spec: &WorkerSpec,
+    cards: Vec<ModelCard>,
+    known: &[ExternalRouterSpec],
+) -> (Vec<ModelCard>, Vec<(ModelCard, MissingRouter)>) {
+    let default = provider_of(spec);
+    let mut routable = Vec::with_capacity(cards.len());
+    let mut unroutable = Vec::new();
+    for card in cards {
+        let provider = card.provider.clone().or_else(|| default.clone());
+        match home_among(known, provider.as_ref()) {
+            Some(router) if router.compiled => routable.push(card),
+            Some(router) => unroutable.push((
+                card,
+                MissingRouter {
+                    label: router.label,
+                    feature: router.feature,
+                },
+            )),
+            None => unroutable.push((
+                card,
+                MissingRouter {
+                    label: "external",
+                    feature: "providers",
+                },
+            )),
+        }
+    }
+    (routable, unroutable)
+}
+
+/// [`partition_routable_among`] against this build.
+pub(crate) fn partition_routable(
+    spec: &WorkerSpec,
+    cards: Vec<ModelCard>,
+) -> (Vec<ModelCard>, Vec<(ModelCard, MissingRouter)>) {
+    partition_routable_among(spec, cards, &known::all())
 }
 
 /// [`missing_router_among`] against this build.
@@ -179,5 +224,26 @@ mod tests {
             Some("Gemini")
         );
         assert_eq!(missing_router_among(&mixed, &everything()), None);
+    }
+
+    #[test]
+    fn discovered_cards_are_kept_only_when_their_router_is_compiled_in() {
+        // A proxy that lists models of two providers on a build carrying
+        // only the OpenAI-compatible router keeps the routable models and
+        // names the feature for the rest.
+        let worker = spec(json!({"url": "https://llm.internal:8443", "runtime_type": "external"}));
+        let cards = vec![
+            ModelCard::new("gpt-4o"),
+            ModelCard::new("claude-3-5-sonnet").with_provider(ProviderType::Anthropic),
+        ];
+        let (routable, unroutable) =
+            partition_routable_among(&worker, cards, &with_compiled(&["openai"]));
+        assert_eq!(
+            routable.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
+            ["gpt-4o"]
+        );
+        assert_eq!(unroutable.len(), 1);
+        assert_eq!(unroutable[0].0.id, "claude-3-5-sonnet");
+        assert_eq!(unroutable[0].1.feature, "provider-anthropic");
     }
 }

--- a/model_gateway/src/workflow/steps/external/discover_models.rs
+++ b/model_gateway/src/workflow/steps/external/discover_models.rs
@@ -8,10 +8,13 @@ use openai_protocol::{model_card::ModelCard, model_type::ModelType, worker::Prov
 use regex::Regex;
 use reqwest::Client;
 use serde::Deserialize;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
-use crate::workflow::data::{WorkerKind, WorkerWorkflowData};
+use crate::{
+    routers::provider_support,
+    workflow::data::{WorkerKind, WorkerWorkflowData},
+};
 
 // HTTP client for API calls
 #[expect(
@@ -303,6 +306,29 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverModelsStep {
             });
         }
 
+        // A discovered model reaches the provider router its id implies, which
+        // may not be compiled into this build. Keep what this build can route
+        // and say what the rest would need; a worker left with nothing is
+        // refused, since admission could not judge models it had not seen.
+        let (model_cards, unroutable) = provider_support::partition_routable(config, model_cards);
+        for (card, missing) in &unroutable {
+            warn!(
+                "Dropping model {} discovered from {}: this build carries no {} router; rebuild \
+                 with the `{}` Cargo feature to serve it",
+                card.id, config.url, missing.label, missing.feature
+            );
+        }
+        if model_cards.is_empty() {
+            let (_, missing) = &unroutable[0];
+            return Err(WorkflowError::StepFailed {
+                step_id: StepId::new("discover_models"),
+                message: format!(
+                    "every model discovered from {} needs the {} router, which this build does \
+                     not carry; rebuild with the `{}` Cargo feature",
+                    config.url, missing.label, missing.feature
+                ),
+            });
+        }
         info!(
             "Discovered {} models from {}: {:?}",
             model_cards.len(),


### PR DESCRIPTION
## Description

### Problem

Two loose ends from the external-router move. The crate had no README, so the contract a provider router is built on, how the gateway mounts one, and how to add a provider lived only in doc comments. And a worker whose models are discovered at registration time was admitted before its models were known: discovery infers a model's provider from its id (`claude-*`, `gemini-*`), so a wildcard worker on a build without that provider's router could register models nothing could route, and requests for them would fail at dispatch instead of at admission.

### Solution

- `crates/external_router/README.md` documents the contract, the identity table and resolution rule, the feature mapping, the steps to add a provider, and the check commands.
- The discovery step judges each discovered model card the way dispatch will: the card's own provider first, else the worker's. Cards whose router this build does not carry are dropped with a warning that names the feature; a worker left with no routable model is refused with the same message. `provider_support::partition_routable_among` is the pure helper, unit-tested against an OpenAI-only table.

## Changes

- `crates/external_router/README.md` (new).
- `model_gateway/src/routers/provider_support.rs`: `partition_routable_among` / `partition_routable`, test `discovered_cards_are_kept_only_when_their_router_is_compiled_in`.
- `model_gateway/src/workflow/steps/external/discover_models.rs`: prune and refuse after discovery.

## Test Plan

| Lane | Result |
|---|---|
| clippy default | clean |
| clippy slim | clean |
| lib provider_support+discover | 4 passed, 0 failed |
| api_tests | 109 passed, 0 failed |

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
