### PR TITLE
test(grpc): freeze the regular Responses tool loop against a scripted worker

### DIFF
--- a/crates/mock_worker/src/config.rs
+++ b/crates/mock_worker/src/config.rs
@@ -38,6 +38,9 @@ pub struct Config {
     pub realistic: bool,
     /// Engine-simulator parameters (only used when `realistic`).
     pub engine: EngineParams,
+    /// Token ids to answer successive generate calls with, in order; the
+    /// last entry answers every call past the end. Empty: canned ids.
+    pub scripted_outputs: Vec<Vec<u32>>,
 }
 
 impl Config {
@@ -58,6 +61,7 @@ impl Config {
             output_tokens: 8,
             realistic: false,
             engine: EngineParams::default(),
+            scripted_outputs: Vec::new(),
         };
 
         let mut args = std::env::args().skip(1);

--- a/crates/mock_worker/src/grpc.rs
+++ b/crates/mock_worker/src/grpc.rs
@@ -4,7 +4,10 @@
 use std::{
     net::{IpAddr, SocketAddr},
     pin::Pin,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
 
 use futures::{stream, Stream};
@@ -47,7 +50,11 @@ pub async fn serve_with_listener(cfg: Arc<Config>, listener: TcpListener) {
     let addr = listener.local_addr().ok();
     // One simulated engine per listener (i.e. per virtual worker).
     let engine = cfg.realistic.then(|| Engine::spawn(cfg.engine.clone()));
-    let service = MockScheduler { cfg, engine };
+    let service = MockScheduler {
+        cfg,
+        engine,
+        script_cursor: Arc::new(AtomicUsize::new(0)),
+    };
     if let Err(e) = Server::builder()
         .add_service(TokenSpeedSchedulerServer::new(service))
         .serve_with_incoming(TcpListenerStream::new(listener))
@@ -62,6 +69,8 @@ struct MockScheduler {
     cfg: Arc<Config>,
     /// Present iff the worker runs the realistic engine simulator.
     engine: Option<Engine>,
+    /// Which scripted output the next generate call receives.
+    script_cursor: Arc<AtomicUsize>,
 }
 
 type GenStream = Pin<Box<dyn Stream<Item = Result<ts::GenerateResponse, Status>> + Send>>;
@@ -111,7 +120,14 @@ impl TokenSpeedScheduler for MockScheduler {
         if !self.cfg.gen_delay.is_zero() {
             tokio::time::sleep(self.cfg.gen_delay).await;
         }
-        let ids: Vec<u32> = (0..self.cfg.output_tokens).map(|i| 100 + i).collect();
+        let ids: Vec<u32> = if self.cfg.scripted_outputs.is_empty() {
+            (0..self.cfg.output_tokens).map(|i| 100 + i).collect()
+        } else {
+            let turn = self.script_cursor.fetch_add(1, Ordering::Relaxed);
+            let last = self.cfg.scripted_outputs.len() - 1;
+            self.cfg.scripted_outputs[turn.min(last)].clone()
+        };
+        let completion_tokens = ids.len() as u32;
 
         let mut items: Vec<Result<ts::GenerateResponse, Status>> = Vec::new();
         for id in &ids {
@@ -133,7 +149,7 @@ impl TokenSpeedScheduler for MockScheduler {
                 output_ids: ids,
                 finish_reason: "stop".to_string(),
                 prompt_tokens: 1,
-                completion_tokens: self.cfg.output_tokens,
+                completion_tokens,
                 cached_tokens: 0,
                 output_logprobs: None,
                 matched_stop: None,

--- a/crates/mock_worker/src/zmq.rs
+++ b/crates/mock_worker/src/zmq.rs
@@ -292,6 +292,7 @@ mod tests {
             output_tokens: 4,
             realistic: false,
             engine: EngineParams::default(),
+            scripted_outputs: Vec::new(),
         }
     }
 

--- a/crates/tokenizer/src/mock.rs
+++ b/crates/tokenizer/src/mock.rs
@@ -81,6 +81,16 @@ impl MockTokenizer {
     /// Make `apply_chat_template_with_encoding` return `ids` as a deferred
     /// encode, the way a renderer whose ids are not a function of its text
     /// does. The rendered text is unchanged.
+    /// Extend the vocabulary, so a test can decode chosen ids into exact
+    /// text (a whole tool-call JSON as one token, say) and encode it back.
+    pub fn with_tokens(mut self, tokens: &[(&str, u32)]) -> Self {
+        for (token, id) in tokens {
+            self.vocab.insert((*token).to_string(), *id);
+            self.reverse_vocab.insert(*id, (*token).to_string());
+        }
+        self
+    }
+
     pub fn with_deferred_chat_ids(mut self, ids: Vec<u32>) -> Self {
         self.deferred_chat_ids = Some(ids);
         self

--- a/model_gateway/tests/grpc_tool_loop_test.rs
+++ b/model_gateway/tests/grpc_tool_loop_test.rs
@@ -1,0 +1,356 @@
+//! The gRPC Responses tool loop against a scripted worker and a mock MCP
+//! server: a frozen event sequence per family, so a change to the loop is
+//! judged against what the wire says today rather than by argument.
+//!
+//! The worker answers each turn with scripted token ids and the mock
+//! tokenizer decodes them into exact text, so the first turn is a JSON tool
+//! call the `json` parser recognizes and the second is the final answer.
+
+mod common;
+
+use std::{sync::Arc, time::Duration};
+
+use llm_tokenizer::{traits::Tokenizer, MockTokenizer, TokenizerRegistry};
+use openai_protocol::{
+    model_card::ModelCard, responses::ResponsesRequest, worker::HealthCheckConfig,
+};
+use serde_json::{json, Value};
+use smg::{
+    config::RouterConfig,
+    middleware::TenantRequestMeta,
+    routers::{RouterFactory, RouterTrait},
+    tenant::TenantKey,
+    worker::{BasicWorkerBuilder, ConnectionMode, RuntimeType, WorkerType},
+};
+use tokio::net::TcpListener;
+
+use crate::common::mock_mcp_server::MockMCPServer;
+
+const MODEL: &str = "tool-loop-test-model";
+
+/// Token ids the scripted worker answers with, decoded by the mock
+/// tokenizer into exact text.
+const TOOL_CALL_TOKEN: u32 = 2001;
+const FINAL_TOKEN_A: u32 = 2002;
+const FINAL_TOKEN_B: u32 = 2003;
+const TOOL_CALL_TEXT: &str = r#"{"name": "brave_web_search", "arguments": {"query": "rust"}}"#;
+
+/// The regular family's streaming envelope for one MCP call followed by a
+/// two-token answer, as the wire says it today: the tool item closes after
+/// execution with its output, the answer follows in its own message item,
+/// and the stream ends with `[DONE]`.
+const REGULAR_STREAMING_SEQUENCE: &[&str] = &[
+    "response.created",
+    "response.in_progress",
+    "response.output_item.added(mcp_list_tools)",
+    "response.mcp_list_tools.in_progress",
+    "response.mcp_list_tools.completed",
+    "response.output_item.done(mcp_list_tools)",
+    "response.output_item.added(mcp_call)",
+    "response.mcp_call.in_progress",
+    "response.mcp_call_arguments.delta",
+    "response.mcp_call_arguments.done",
+    "response.mcp_call.completed",
+    "response.output_item.done(mcp_call)",
+    "response.output_item.added(message)",
+    "response.content_part.added",
+    "response.output_text.delta",
+    "response.output_text.delta",
+    "response.output_text.done",
+    "response.content_part.done",
+    "response.output_item.done(message)",
+    "response.completed",
+    "[DONE]",
+];
+
+fn scripted_tokenizer() -> Arc<dyn Tokenizer> {
+    Arc::new(MockTokenizer::new().with_tokens(&[
+        (TOOL_CALL_TEXT, TOOL_CALL_TOKEN),
+        ("Final", FINAL_TOKEN_A),
+        ("answer", FINAL_TOKEN_B),
+    ]))
+}
+
+#[expect(
+    clippy::expect_used,
+    clippy::disallowed_methods,
+    reason = "test helper - panicking on failure is intentional; the spawned mock \
+              server task is fire-and-forget for the test process's lifetime"
+)]
+async fn start_scripted_grpc_worker(scripted_outputs: Vec<Vec<u32>>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock gRPC worker");
+    let port = listener
+        .local_addr()
+        .expect("mock gRPC worker address")
+        .port();
+    let cfg = Arc::new(mock_worker::config::Config {
+        host: "127.0.0.1".to_string(),
+        http_base_port: 0,
+        http_count: 0,
+        grpc_base_port: port,
+        grpc_count: 1,
+        zmq_handshake: None,
+        zmq_count: 0,
+        zmq_start_index: 0,
+        model_id: MODEL.to_string(),
+        tokenizer_path: MODEL.to_string(),
+        gen_delay: Duration::ZERO,
+        output_tokens: 2,
+        realistic: false,
+        engine: mock_worker::engine::EngineParams::default(),
+        scripted_outputs,
+    });
+    tokio::spawn(mock_worker::grpc::serve_with_listener(cfg, listener));
+    port
+}
+
+/// A gRPC regular router over one scripted worker, with the `json` tool
+/// parser and an MCP orchestrator ready for request-scoped servers.
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+async fn build_router(grpc_port: u16) -> Box<dyn RouterTrait> {
+    let mut config = RouterConfig::builder()
+        .grpc_connection()
+        .regular_mode(vec![])
+        .random_policy()
+        .tool_call_parser("json")
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .max_concurrent_requests(64)
+        .queue_timeout_secs(60)
+        .build_unchecked();
+    config.health_check.disable_health_check = true;
+
+    let tokenizer_registry = Arc::new(TokenizerRegistry::new());
+    let tokenizer = scripted_tokenizer();
+    tokenizer_registry
+        .load(
+            "tokenizer-id",
+            MODEL,
+            "test",
+            || async move { Ok(tokenizer) },
+        )
+        .await
+        .unwrap();
+    let app_context =
+        common::create_test_context_with_tokenizer_registry(config, tokenizer_registry).await;
+    let worker = BasicWorkerBuilder::new(format!("grpc://127.0.0.1:{grpc_port}"))
+        .worker_type(WorkerType::Regular)
+        .connection_mode(ConnectionMode::Grpc)
+        .runtime_type(RuntimeType::TokenSpeed)
+        .model(ModelCard::new(MODEL))
+        .health_config(HealthCheckConfig {
+            disable_health_check: true,
+            ..Default::default()
+        })
+        .build();
+    app_context
+        .worker_registry
+        .register(Arc::new(worker))
+        .unwrap();
+    RouterFactory::create_router(&app_context)
+        .await
+        .expect("gRPC router should build")
+}
+
+#[expect(clippy::unwrap_used, reason = "test helper")]
+fn responses_request(mcp_url: &str, stream: bool) -> ResponsesRequest {
+    serde_json::from_value(json!({
+        "model": MODEL,
+        "input": "Hello world",
+        "stream": stream,
+        "store": false,
+        "max_tool_calls": 3,
+        "tools": [{
+            "type": "mcp",
+            "server_label": "mock",
+            "server_url": mcp_url,
+            "require_approval": "never"
+        }]
+    }))
+    .unwrap()
+}
+
+fn tenant_meta() -> TenantRequestMeta {
+    TenantRequestMeta::new(TenantKey::new("tool-loop-test"))
+}
+
+/// One SSE frame: the `event:` name and its parsed `data:`; the `[DONE]`
+/// marker is kept as an event named `[DONE]` so termination is part of the
+/// frozen sequence.
+fn parse_sse(body: &str) -> Vec<(String, Value)> {
+    body.split("\n\n")
+        .filter(|block| !block.trim().is_empty())
+        .filter_map(|block| {
+            let mut event = None;
+            let mut data = Vec::new();
+            for line in block.lines() {
+                if let Some(rest) = line.strip_prefix("event:") {
+                    event = Some(rest.trim().to_string());
+                } else if let Some(rest) = line.strip_prefix("data:") {
+                    data.push(rest.trim_start().to_string());
+                }
+            }
+            let data = data.join("\n");
+            if data == "[DONE]" {
+                return Some(("[DONE]".to_string(), Value::Null));
+            }
+            let parsed: Value = serde_json::from_str(&data).ok()?;
+            let name = event.or_else(|| parsed.get("type")?.as_str().map(str::to_string))?;
+            Some((name, parsed))
+        })
+        .collect()
+}
+
+/// What a frame is, for the frozen sequence: the event type plus the item
+/// type it carries when it announces or closes an output item.
+fn frame_label(name: &str, data: &Value) -> String {
+    match data.pointer("/item/type").and_then(Value::as_str) {
+        Some(item) => format!("{name}({item})"),
+        None => name.to_string(),
+    }
+}
+
+#[expect(clippy::print_stdout, reason = "the sequence is printed for pinning")]
+#[tokio::test]
+async fn regular_family_streams_one_mcp_call_then_the_answer() {
+    let mut mcp = MockMCPServer::start().await.expect("mock MCP server");
+    let port = start_scripted_grpc_worker(vec![
+        vec![TOOL_CALL_TOKEN],
+        vec![FINAL_TOKEN_A, FINAL_TOKEN_B],
+    ])
+    .await;
+    let router = build_router(port).await;
+
+    let req = responses_request(&mcp.url(), true);
+    let response = router
+        .route_responses(None, &tenant_meta(), req, MODEL)
+        .await;
+    assert_eq!(response.status(), 200, "streaming responses request");
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let frames = parse_sse(std::str::from_utf8(&body).unwrap());
+    let labels: Vec<String> = frames
+        .iter()
+        .map(|(name, data)| frame_label(name, data))
+        .collect();
+    println!("regular streaming sequence:\n  {}", labels.join("\n  "));
+
+    // The frozen sequence. A loop change that moves an event must change
+    // this list on purpose, in the same PR, with the reason.
+    assert_eq!(
+        labels,
+        REGULAR_STREAMING_SEQUENCE
+            .iter()
+            .map(|l| (*l).to_string())
+            .collect::<Vec<_>>(),
+        "regular family streaming sequence"
+    );
+
+    // Structure that must hold whatever the exact envelope is.
+    assert_eq!(
+        labels.iter().filter(|l| *l == "response.completed").count(),
+        1,
+        "exactly one response.completed"
+    );
+    assert_eq!(labels.last().map(String::as_str), Some("[DONE]"));
+    let call_idx = labels
+        .iter()
+        .position(|l| l == "response.output_item.added(mcp_call)")
+        .expect("the tool call is announced");
+    let text_idx = labels
+        .iter()
+        .position(|l| l == "response.output_text.delta")
+        .expect("the answer streams as text");
+    assert!(call_idx < text_idx, "tool events precede the answer text");
+    let completed = frames
+        .iter()
+        .find(|(name, _)| name == "response.completed")
+        .map(|(_, data)| data.clone())
+        .unwrap();
+    let outputs: Vec<&str> = completed["response"]["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["type"].as_str())
+        .collect();
+    assert!(
+        outputs.contains(&"mcp_call"),
+        "final output carries the call: {outputs:?}"
+    );
+    assert!(
+        outputs.contains(&"message"),
+        "final output carries the answer: {outputs:?}"
+    );
+    let call = completed["response"]["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["type"] == "mcp_call")
+        .unwrap();
+    assert_eq!(call["name"], "brave_web_search");
+    assert!(
+        call["output"]
+            .as_str()
+            .is_some_and(|o| o.contains("Mock search results for: rust")),
+        "the tool result is on the call item: {call}"
+    );
+
+    mcp.stop().await;
+}
+
+#[tokio::test]
+async fn regular_family_answers_non_streaming_after_one_mcp_call() {
+    let mut mcp = MockMCPServer::start().await.expect("mock MCP server");
+    let port = start_scripted_grpc_worker(vec![
+        vec![TOOL_CALL_TOKEN],
+        vec![FINAL_TOKEN_A, FINAL_TOKEN_B],
+    ])
+    .await;
+    let router = build_router(port).await;
+
+    let req = responses_request(&mcp.url(), false);
+    let response = router
+        .route_responses(None, &tenant_meta(), req, MODEL)
+        .await;
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(status, 200, "non-streaming responses request: {value}");
+    let outputs: Vec<&str> = value["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["type"].as_str())
+        .collect();
+    assert_eq!(value["status"], "completed", "{value}");
+    assert_eq!(
+        outputs,
+        ["mcp_list_tools", "mcp_call", "message"],
+        "output order: {value}"
+    );
+    let message_text = value["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["type"] == "message")
+        .and_then(|m| m.pointer("/content/0/text"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(message_text, "Final answer");
+
+    mcp.stop().await;
+}

--- a/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
+++ b/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
@@ -78,6 +78,7 @@ async fn start_mock_grpc_worker(output_tokens: u32) -> u16 {
         output_tokens,
         realistic: false,
         engine: mock_worker::engine::EngineParams::default(),
+        scripted_outputs: Vec::new(),
     });
     tokio::spawn(mock_worker::grpc::serve_with_listener(cfg, listener));
     port

--- a/model_gateway/tests/zmq_backend_test.rs
+++ b/model_gateway/tests/zmq_backend_test.rs
@@ -87,6 +87,7 @@ fn start_mock_zmq_engines(handshake: &str, count: u16) {
         output_tokens: OUTPUT_TOKENS,
         realistic: false,
         engine: mock_worker::engine::EngineParams::default(),
+        scripted_outputs: Vec::new(),
     });
     for rank in 0..u32::from(count) {
         tokio::spawn(mock_worker::zmq::serve(


### PR DESCRIPTION
## Description

### Problem

Every past attempt to share the Responses tool loop across the gRPC families stalled at the same spot: tool items close at different moments in the regular and Harmony loops, and no test froze either family's event sequence, so each divergence became an unverifiable judgment call. The only gRPC-loop tests are unit tests for usage serialization and argument streaming; the API-level MCP tests run the OpenAI-compatible router against an HTTP mock. There was no way to drive the gRPC loop through a tool call in-process.

### Solution

A harness that runs the real gRPC regular router through a complete tool loop with no engine and no network beyond loopback, and freezes what the wire says.

- **Scripted worker.** The gRPC mock worker gains `scripted_outputs`: token ids returned to successive generate calls in order, the last entry repeating. Empty keeps today's canned ids, so nothing else changes.
- **Exact text from the mock tokenizer.** `MockTokenizer::with_tokens` extends its vocabulary, so a chosen id decodes to a whole tool-call JSON and the gateway's `json` tool parser recognizes it; the answer tokens decode to plain words.
- **The loop under test.** `tests/grpc_tool_loop_test.rs` starts the mock MCP server and a scripted worker whose first turn is a call to `brave_web_search` and whose second turn is the answer, builds the gRPC regular router with the tokenizer-registry test context (parsers and MCP orchestrator included), and drives `/v1/responses` with a request-scoped MCP server.
- **The frozen contract.** The streaming test pins the regular family's event sequence, twenty-one frames from `response.created` to `[DONE]`, and checks the invariants that must hold whatever the envelope is: exactly one `response.completed`, tool events before the answer text, the call item carrying the tool result, the answer in the final output. The non-streaming test pins output order `[mcp_list_tools, mcp_call, message]`, `completed` status, and the answer text.

A loop change that moves an event now has to change the pinned list in the same PR, with the reason. This is the precondition for the shared loop skeleton; the Harmony family's sequence gets the same treatment once its encoding can be loaded offline in tests.

## Changes

- `crates/mock_worker`: `Config::scripted_outputs`; the gRPC scheduler answers from the script with a per-call cursor.
- `crates/tokenizer`: `MockTokenizer::with_tokens`.
- `model_gateway/tests/grpc_tool_loop_test.rs` (new): two tests and the frozen sequence.
- `model_gateway/tests/tenant_rate_limiting_grpc_test.rs`: the one config literal gains the new field.

## Test Plan

| Lane | Result |
|---|---|
| clippy mock-worker + tokenizer | clean |
| clippy smg | clean |
| mock-worker + tokenizer tests | 202 passed, 0 failed |
| harness | 11 passed, 0 failed |
| harness again | 11 passed, 0 failed |
| rate-limit grpc + zmq backend tests | 27 passed, 0 failed |

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
