### PR TITLE
ci(benchmarks): report threshold misses as warnings instead of failures

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -370,7 +370,9 @@ jobs:
 
   # Advisory: the thresholds in e2e_test/benchmarks are absolute latencies on
   # a shared runner pool and sit inside its noise band, so a miss is a warning,
-  # not a merge blocker. Results are still uploaded and summarized.
+  # not a merge blocker: it shows up as a warning annotation and in the step
+  # summary (BENCH_ENFORCE_THRESHOLDS=1 makes it fail). Results are still
+  # uploaded and summarized.
   benchmarks:
     needs: build-wheel
     runs-on: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}

--- a/e2e_test/benchmarks/conftest.py
+++ b/e2e_test/benchmarks/conftest.py
@@ -159,6 +159,35 @@ def _cleanup_procs(procs: list, drain_delay: int) -> None:
     time.sleep(2)
 
 
+def _thresholds_enforced() -> bool:
+    """Threshold misses fail the test only when BENCH_ENFORCE_THRESHOLDS is set."""
+    value = os.environ.get("BENCH_ENFORCE_THRESHOLDS", "").strip().lower()
+    return value in ("1", "true", "yes")
+
+
+def _report_threshold_misses(experiment: str, misses: list[str]) -> None:
+    """Surface threshold misses without failing the run by default.
+
+    The thresholds are absolute latencies and throughputs measured on a shared
+    runner pool and sit inside its noise band, so a miss is advisory: it is
+    logged, annotated on the workflow run, and appended to the step summary.
+    BENCH_ENFORCE_THRESHOLDS=1 turns misses back into test failures.
+    """
+    if not misses:
+        return
+    for miss in misses:
+        logger.warning("genai-bench[%s] threshold miss: %s", experiment, miss)
+        print(f"::warning title=Benchmark threshold miss ({experiment})::{miss}", flush=True)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write(f"### Benchmark threshold misses: {experiment}\n\n")
+            f.writelines(f"- {miss}\n" for miss in misses)
+            f.write("\n")
+    if _thresholds_enforced():
+        pytest.fail(f"{experiment}: " + "; ".join(misses))
+
+
 @pytest.fixture(scope="session")
 def genai_bench_runner():
     """Run genai-bench and validate metrics.
@@ -196,6 +225,9 @@ def genai_bench_runner():
         exp_dir = Path.cwd() / experiment_folder
         if exp_dir.exists():
             shutil.rmtree(exp_dir, ignore_errors=True)
+        # Create the folder before genai-bench does: the container runs as root
+        # and a root-owned folder is unwritable for the host-side GPU monitor.
+        exp_dir.mkdir(parents=True, exist_ok=True)
 
         # Build and run command
         max_requests = max_requests_per_run or (num_concurrency or 32) * 5
@@ -248,26 +280,27 @@ def genai_bench_runner():
                 f"Check CI logs above for details."
             )
 
+        misses: list[str] = []
         try:
-            # Parse and validate results
+            # Parse results; a run without results is broken and still fails
             for path in _find_results(experiment_folder):
                 result = BenchmarkResult.from_json(path)
                 result.log(experiment_folder, logger)
                 if thresholds:
-                    result.validate(thresholds)
+                    misses.extend(
+                        f"{path.name}: {miss}" for miss in result.threshold_misses(thresholds)
+                    )
 
-            # Validate GPU utilization
             if gpu_monitor:
                 gpu_monitor.stop()
                 gpu_monitor.log_summary()
-                gpu_monitor.assert_thresholds(thresholds)
-
-        except AssertionError:
-            raise
+                misses.extend(gpu_monitor.threshold_misses(thresholds))
 
         finally:
             _cleanup_procs(kill_procs or [], drain_delay_sec)
             if gpu_monitor:
                 gpu_monitor.stop(timeout=2)
+
+        _report_threshold_misses(experiment_folder, misses)
 
     return _run

--- a/e2e_test/benchmarks/results.py
+++ b/e2e_test/benchmarks/results.py
@@ -43,8 +43,8 @@ class BenchmarkResult:
             self.output_throughput_mean,
         )
 
-    def validate(self, thresholds: dict) -> None:
-        """Validate metrics against thresholds."""
+    def threshold_misses(self, thresholds: dict) -> list[str]:
+        """Return one line per metric outside its threshold; empty when all pass."""
         checks = [
             ("ttft_mean_max", self.ttft_mean, "<=", "TTFT"),
             ("e2e_latency_mean_max", self.e2e_latency_mean, "<=", "E2E latency"),
@@ -61,14 +61,16 @@ class BenchmarkResult:
                 "Output throughput",
             ),
         ]
+        misses: list[str] = []
         for key, value, op, name in checks:
             if key not in thresholds:
                 continue
             threshold = thresholds[key]
             if op == "<=" and value > threshold:
-                raise AssertionError(f"{name}: {value:.2f} > {threshold}")
+                misses.append(f"{name}: {value:.2f} > {threshold}")
             if op == ">=" and value < threshold:
-                raise AssertionError(f"{name}: {value:.2f} < {threshold}")
+                misses.append(f"{name}: {value:.2f} < {threshold}")
+        return misses
 
 
 @dataclass

--- a/e2e_test/infra/gpu_monitor.py
+++ b/e2e_test/infra/gpu_monitor.py
@@ -214,7 +214,7 @@ class GPUMonitor:
         monitor.start(target_pid=12345)
         # ... run benchmark ...
         result = monitor.stop()
-        monitor.assert_thresholds({"gpu_util_p50_min": 99})
+        misses = monitor.threshold_misses({"gpu_util_p50_min": 99})
     """
 
     def __init__(
@@ -324,37 +324,37 @@ class GPUMonitor:
             result.get("count", 0),
         )
 
-    def assert_thresholds(self, thresholds: dict[str, float] | None) -> None:
-        """Assert GPU utilization meets thresholds.
+    def threshold_misses(self, thresholds: dict[str, float] | None) -> list[str]:
+        """Return one line per GPU-utilization threshold that was missed.
 
         Supported thresholds:
             - gpu_util_mean_min: Minimum mean GPU utilization %
             - gpu_util_p50_min: Minimum p50 GPU utilization %
         """
         if not thresholds:
-            return
+            return []
 
         result = self._result or self._read_result()
         if not result or result.get("count", 0) <= 0:
             logger.warning("GPU utilization monitor produced no samples")
-            return
+            return []
 
         overall = result.get("overall", {})
+        misses: list[str] = []
 
         mean_threshold = thresholds.get("gpu_util_mean_min")
         if mean_threshold is not None:
             mean_value = overall.get("mean", 0.0)
-            assert mean_value >= mean_threshold, (
-                f"GPU utilization mean below threshold: {mean_value:.2f}% < {mean_threshold}%"
-            )
+            if mean_value < mean_threshold:
+                misses.append(f"GPU utilization mean: {mean_value:.2f}% < {mean_threshold}%")
 
         p50_threshold = thresholds.get("gpu_util_p50_min")
         if p50_threshold is not None:
             p50_value = overall.get("p50")
             if p50_value is not None:
-                assert p50_value >= p50_threshold, (
-                    f"GPU utilization p50 below threshold: {p50_value:.2f}% < {p50_threshold}%"
-                )
+                if p50_value < p50_threshold:
+                    misses.append(f"GPU utilization p50: {p50_value:.2f}% < {p50_threshold}%")
+        return misses
 
 
 def should_monitor(thresholds: dict[str, Any] | None) -> bool:


### PR DESCRIPTION
## Description

### Problem

The `benchmarks` job is meant to be advisory: it runs with `continue-on-error: true` and the workflow comment says a threshold miss is a warning, not a merge blocker. But the pytest run underneath still raised `AssertionError` whenever a threshold was missed (`TTFT: 4.88 > 0.86` is typical on the shared runner pool), so the job showed up red on nearly every PR and the "advisory" intent was invisible to anyone reading the checks list.

A second, silent problem: genai-bench runs as root inside Docker and creates the experiment folder, so the host-side GPU monitor could not write `gpu_utilization.json` into it (`[Errno 13] Permission denied`). The GPU utilization threshold was therefore never evaluated and the benchmark summary lost its GPU numbers.

### Solution

- `BenchmarkResult.threshold_misses()` and `GPUMonitor.threshold_misses()` return the list of misses instead of raising.
- The runner logs every miss, emits a `::warning::` annotation per miss (visible on the workflow run and the PR checks), and appends a section to the step summary. Misses fail the test only when `BENCH_ENFORCE_THRESHOLDS=1` is set, so a nightly or a deliberate perf gate can still enforce them.
- genai-bench crashes, timeouts, and missing result files still fail the test as before.
- The experiment folder is created by the test process before the container starts, so the GPU monitor can write into it.

## Changes

- `e2e_test/benchmarks/results.py`: `validate()` becomes `threshold_misses() -> list[str]`.
- `e2e_test/infra/gpu_monitor.py`: `assert_thresholds()` becomes `threshold_misses() -> list[str]`.
- `e2e_test/benchmarks/conftest.py`: collect misses from both sources, report them via `_report_threshold_misses()`, pre-create the experiment folder.
- `.github/workflows/pr-test-rust.yml`: comment on the benchmarks job documents the new behaviour and the enforcement switch.

## Test Plan

- `uvx ruff check` and `uvx ruff format --check` on `e2e_test/benchmarks` and `e2e_test/infra/gpu_monitor.py`: clean.
- `mypy --config-file mypy.ini` on the three touched modules: no issues.
- No remaining callers of `validate()` / `assert_thresholds()` in `e2e_test/`.
- On this PR's `benchmarks` job: the job should finish green with warning annotations for any threshold miss, and `benchmark_*/gpu_utilization.json` should be present in the `genai-bench-results-all-policies` artifact (it was missing before because of the permission error).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
