### PR TITLE
fix(grpc_servicer): read SGLang's renamed prefill queue counter in GetLoads

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/sglang/loads.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/loads.py
@@ -1,0 +1,102 @@
+"""Conversion of SGLang load snapshots into the gateway's protobuf messages.
+
+Kept free of engine imports so the field mapping can be unit-tested without
+SGLang installed (see grpc_servicer/tests/test_sglang_get_loads.py).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from smg_grpc_proto import sglang_scheduler_pb2
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.load_snapshot import LoadSnapshot
+
+# SGLang renamed the prefill pre-allocation queue counter to the bootstrap
+# queue while the gateway proto kept the original field name. Reading only the
+# old attribute raised AttributeError on every GetLoads from a disaggregated
+# worker, so the gateway never received load reports from PD SGLang workers.
+_PREFILL_QUEUE_ATTRS = ("prefill_bootstrap_queue_reqs", "prefill_prealloc_queue_reqs")
+
+
+def _first_attr(obj: Any, names: tuple[str, ...], default: Any = 0) -> Any:
+    """Return the first attribute of ``obj`` present in ``names``."""
+    for name in names:
+        if hasattr(obj, name):
+            return getattr(obj, name)
+    return default
+
+
+def convert_loads_to_protobuf(result: LoadSnapshot) -> sglang_scheduler_pb2.SchedulerLoad:
+    """Convert a LoadSnapshot to a protobuf SchedulerLoad message."""
+    scheduler_load = sglang_scheduler_pb2.SchedulerLoad(
+        dp_rank=result.dp_rank,
+        num_running_reqs=result.num_running_reqs,
+        num_waiting_reqs=result.num_waiting_reqs,
+        num_total_reqs=result.num_running_reqs + result.num_waiting_reqs,
+        num_used_tokens=result.num_used_tokens,
+        max_total_num_tokens=result.max_total_num_tokens,
+        token_usage=result.token_usage,
+        gen_throughput=result.gen_throughput,
+        cache_hit_rate=result.cache_hit_rate,
+        utilization=result.utilization,
+        max_running_requests=result.max_running_requests,
+        # Queued token-work: waiting-queue tokens not served from cache.
+        num_waiting_uncached_tokens=result.num_waiting_uncached_tokens,
+    )
+
+    # Add optional sections using CopyFrom for proper protobuf assignment
+    if result.memory:
+        scheduler_load.memory.CopyFrom(
+            sglang_scheduler_pb2.MemoryMetrics(
+                weight_gb=result.memory.weight_gb,
+                kv_cache_gb=result.memory.kv_cache_gb,
+                graph_gb=result.memory.graph_gb,
+                token_capacity=result.memory.token_capacity,
+            )
+        )
+
+    if result.speculative:
+        scheduler_load.speculative.CopyFrom(
+            sglang_scheduler_pb2.SpeculativeMetrics(
+                accept_length=result.speculative.accept_length,
+                accept_rate=result.speculative.accept_rate,
+            )
+        )
+
+    if result.lora:
+        scheduler_load.lora.CopyFrom(
+            sglang_scheduler_pb2.LoRAMetrics(
+                slots_used=result.lora.slots_used,
+                slots_total=result.lora.slots_total,
+                utilization=result.lora.utilization,
+            )
+        )
+
+    if result.disaggregation:
+        disaggregation = result.disaggregation
+        scheduler_load.disaggregation.CopyFrom(
+            sglang_scheduler_pb2.DisaggregationMetrics(
+                mode=disaggregation.mode,
+                prefill_prealloc_queue_reqs=_first_attr(disaggregation, _PREFILL_QUEUE_ATTRS),
+                prefill_inflight_queue_reqs=disaggregation.prefill_inflight_queue_reqs,
+                decode_prealloc_queue_reqs=disaggregation.decode_prealloc_queue_reqs,
+                decode_transfer_queue_reqs=disaggregation.decode_transfer_queue_reqs,
+                decode_retracted_queue_reqs=disaggregation.decode_retracted_queue_reqs,
+                kv_transfer_speed_gb_s=disaggregation.kv_transfer_speed_gb_s,
+                kv_transfer_latency_ms=disaggregation.kv_transfer_latency_ms,
+            )
+        )
+
+    if result.queues:
+        scheduler_load.queues.CopyFrom(
+            sglang_scheduler_pb2.QueueMetrics(
+                waiting=result.queues.waiting,
+                grammar=result.queues.grammar,
+                paused=result.queues.paused,
+                retracted=result.queues.retracted,
+            )
+        )
+
+    return scheduler_load

--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -43,7 +43,6 @@ from sglang.srt.managers.io_struct import (
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
 )
-from sglang.srt.managers.load_snapshot import LoadSnapshot
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
@@ -58,6 +57,7 @@ from smg_grpc_proto import sglang_scheduler_pb2, sglang_scheduler_pb2_grpc
 from smg_grpc_proto.generated import common_pb2
 
 from smg_grpc_servicer.sglang.health_servicer import SGLangHealthServicer
+from smg_grpc_servicer.sglang.loads import convert_loads_to_protobuf
 from smg_grpc_servicer.sglang.request_manager import GrpcRequestManager
 from smg_grpc_servicer.sglang.utils import abort_code_from_output, to_token_id_array
 from smg_grpc_servicer.tokenizer_bundle import CHUNK_SIZE, build_tokenizer_zip
@@ -95,81 +95,6 @@ def _filtered_sampling_defaults(params: dict | None) -> dict:
         for key in SAMPLING_DEFAULT_KEYS
         if key in params and params[key] is not None
     }
-
-
-def _convert_loads_to_protobuf(
-    result: LoadSnapshot,
-) -> sglang_scheduler_pb2.SchedulerLoad:
-    """Convert a LoadSnapshot to a protobuf SchedulerLoad message."""
-    scheduler_load = sglang_scheduler_pb2.SchedulerLoad(
-        dp_rank=result.dp_rank,
-        num_running_reqs=result.num_running_reqs,
-        num_waiting_reqs=result.num_waiting_reqs,
-        num_total_reqs=result.num_running_reqs + result.num_waiting_reqs,
-        num_used_tokens=result.num_used_tokens,
-        max_total_num_tokens=result.max_total_num_tokens,
-        token_usage=result.token_usage,
-        gen_throughput=result.gen_throughput,
-        cache_hit_rate=result.cache_hit_rate,
-        utilization=result.utilization,
-        max_running_requests=result.max_running_requests,
-        # Queued token-work: waiting-queue tokens not served from cache.
-        num_waiting_uncached_tokens=result.num_waiting_uncached_tokens,
-    )
-
-    # Add optional sections using CopyFrom for proper protobuf assignment
-    if result.memory:
-        scheduler_load.memory.CopyFrom(
-            sglang_scheduler_pb2.MemoryMetrics(
-                weight_gb=result.memory.weight_gb,
-                kv_cache_gb=result.memory.kv_cache_gb,
-                graph_gb=result.memory.graph_gb,
-                token_capacity=result.memory.token_capacity,
-            )
-        )
-
-    if result.speculative:
-        scheduler_load.speculative.CopyFrom(
-            sglang_scheduler_pb2.SpeculativeMetrics(
-                accept_length=result.speculative.accept_length,
-                accept_rate=result.speculative.accept_rate,
-            )
-        )
-
-    if result.lora:
-        scheduler_load.lora.CopyFrom(
-            sglang_scheduler_pb2.LoRAMetrics(
-                slots_used=result.lora.slots_used,
-                slots_total=result.lora.slots_total,
-                utilization=result.lora.utilization,
-            )
-        )
-
-    if result.disaggregation:
-        scheduler_load.disaggregation.CopyFrom(
-            sglang_scheduler_pb2.DisaggregationMetrics(
-                mode=result.disaggregation.mode,
-                prefill_prealloc_queue_reqs=result.disaggregation.prefill_prealloc_queue_reqs,
-                prefill_inflight_queue_reqs=result.disaggregation.prefill_inflight_queue_reqs,
-                decode_prealloc_queue_reqs=result.disaggregation.decode_prealloc_queue_reqs,
-                decode_transfer_queue_reqs=result.disaggregation.decode_transfer_queue_reqs,
-                decode_retracted_queue_reqs=result.disaggregation.decode_retracted_queue_reqs,
-                kv_transfer_speed_gb_s=result.disaggregation.kv_transfer_speed_gb_s,
-                kv_transfer_latency_ms=result.disaggregation.kv_transfer_latency_ms,
-            )
-        )
-
-    if result.queues:
-        scheduler_load.queues.CopyFrom(
-            sglang_scheduler_pb2.QueueMetrics(
-                waiting=result.queues.waiting,
-                grammar=result.queues.grammar,
-                paused=result.queues.paused,
-                retracted=result.queues.retracted,
-            )
-        )
-
-    return scheduler_load
 
 
 def _compute_aggregate_protobuf(
@@ -630,7 +555,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
             context.set_details(f"Failed to get load metrics: {e}")
             return sglang_scheduler_pb2.GetLoadsResponse()
 
-        loads = [_convert_loads_to_protobuf(r) for r in results]
+        loads = [convert_loads_to_protobuf(r) for r in results]
 
         return sglang_scheduler_pb2.GetLoadsResponse(
             timestamp=datetime.now(timezone.utc).isoformat(),

--- a/grpc_servicer/tests/test_sglang_get_loads.py
+++ b/grpc_servicer/tests/test_sglang_get_loads.py
@@ -1,0 +1,85 @@
+"""GetLoads must convert a disaggregated SGLang load snapshot.
+
+SGLang renamed the prefill pre-allocation queue counter to
+``prefill_bootstrap_queue_reqs``. The servicer read the old name, so every
+GetLoads from a prefill or decode worker raised AttributeError and the gateway
+never received load reports from PD SGLang workers.
+
+Run with: pytest grpc_servicer/tests/test_sglang_get_loads.py
+"""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("smg_grpc_proto")
+
+
+@pytest.fixture(scope="module")
+def loads_mod():
+    """Load loads.py by path: the sglang package __init__ imports the engine."""
+    path = Path(__file__).resolve().parent.parent / "smg_grpc_servicer" / "sglang" / "loads.py"
+    spec = importlib.util.spec_from_file_location("sglang_loads_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _snapshot(disaggregation):
+    return SimpleNamespace(
+        dp_rank=0,
+        num_running_reqs=2,
+        num_waiting_reqs=1,
+        num_used_tokens=10,
+        max_total_num_tokens=100,
+        token_usage=0.1,
+        gen_throughput=12.5,
+        cache_hit_rate=0.25,
+        utilization=0.5,
+        max_running_requests=8,
+        num_waiting_uncached_tokens=3,
+        memory=None,
+        speculative=None,
+        lora=None,
+        disaggregation=disaggregation,
+        queues=None,
+    )
+
+
+def _disaggregation(**prefill_queue):
+    return SimpleNamespace(
+        mode="prefill",
+        prefill_inflight_queue_reqs=4,
+        decode_prealloc_queue_reqs=0,
+        decode_transfer_queue_reqs=0,
+        decode_retracted_queue_reqs=0,
+        kv_transfer_speed_gb_s=1.5,
+        kv_transfer_latency_ms=2.5,
+        **prefill_queue,
+    )
+
+
+class TestDisaggregationMetrics:
+    def test_bootstrap_queue_maps_to_prealloc_field(self, loads_mod):
+        load = loads_mod.convert_loads_to_protobuf(
+            _snapshot(_disaggregation(prefill_bootstrap_queue_reqs=3))
+        )
+
+        assert load.disaggregation.mode == "prefill"
+        assert load.disaggregation.prefill_prealloc_queue_reqs == 3
+        assert load.disaggregation.prefill_inflight_queue_reqs == 4
+        assert load.num_total_reqs == 3
+
+    def test_legacy_prealloc_queue_still_converts(self, loads_mod):
+        load = loads_mod.convert_loads_to_protobuf(
+            _snapshot(_disaggregation(prefill_prealloc_queue_reqs=7))
+        )
+
+        assert load.disaggregation.prefill_prealloc_queue_reqs == 7
+
+    def test_regular_worker_has_no_disaggregation_section(self, loads_mod):
+        load = loads_mod.convert_loads_to_protobuf(_snapshot(None))
+
+        assert not load.HasField("disaggregation")


### PR DESCRIPTION
## Description

### Problem

SGLang's `DisaggregationMetrics` (in `sglang/srt/managers/load_snapshot.py`, on 0.5.18 and on current main) names the prefill queue counter `prefill_bootstrap_queue_reqs`. The gateway proto and the servicer still use `prefill_prealloc_queue_reqs`, so `_convert_loads_to_protobuf` dereferenced an attribute that does not exist. Whenever a snapshot carries a disaggregation section, every `GetLoads` call fails:

```
Unexpected [AttributeError] raised by servicer method [/sglang.grpc.scheduler.SglangScheduler/GetLoads]
  File ".../grpc_servicer/smg_grpc_servicer/sglang/servicer.py", line 152, in _convert_loads_to_protobuf
    prefill_prealloc_queue_reqs=result.disaggregation.prefill_prealloc_queue_reqs,
AttributeError: 'DisaggregationMetrics' object has no attribute 'prefill_prealloc_queue_reqs'. Did you mean: 'decode_prealloc_queue_reqs'?
```

(seen repeatedly, once per load poll, in the `e2e-1gpu-chat (sglang)` log of run 34160176067.) For disaggregated SGLang workers this means the gateway never receives a load report, and load-aware routing silently falls back to in-flight counting. Nothing in the e2e suite asserts that load reports arrive, so the lanes stayed green.

### Solution

- Move the snapshot conversion into `smg_grpc_servicer/sglang/loads.py`, a module with no engine imports, and map the prefill queue counter from whichever attribute the running SGLang exposes (`prefill_bootstrap_queue_reqs` first, the legacy `prefill_prealloc_queue_reqs` second).
- Add `grpc_servicer/tests/test_sglang_get_loads.py`, which loads the module by path (the `sglang` package `__init__` imports the engine) and pins both spellings plus the regular-worker case where the section is absent.

## Changes

- `grpc_servicer/smg_grpc_servicer/sglang/loads.py`: new module, `convert_loads_to_protobuf()` moved here with the tolerant field lookup.
- `grpc_servicer/smg_grpc_servicer/sglang/servicer.py`: imports the moved function; the unused `LoadSnapshot` import goes.
- `grpc_servicer/tests/test_sglang_get_loads.py`: three unit tests.

## Test Plan

- `pytest grpc_servicer/tests` in a venv with `smg_grpc_proto` installed: 111 passed, 5 skipped (the three new tests included; without the fix the first test raises the AttributeError above).
- `ruff check` / `ruff format` clean on the touched files.
- `e2e-2gpu-pd (sglang)` on this PR exercises the real path; a follow-up e2e assertion that every gRPC worker reports loads is planned separately.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
