### PR TITLE
ci(multimodal): keep the vision golden fixtures under transformers 5 and fail loudly

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -340,7 +340,7 @@ jobs:
         run: |
           python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
           python -m pip install transformers pillow numpy scipy
-          python crates/multimodal/scripts/generate_vision_golden.py
+          python crates/multimodal/scripts/generate_vision_golden.py --strict
 
       - name: Create isolated Postgres test database
         # No continue-on-error here: the Postgres regression suite must

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -336,7 +336,14 @@ jobs:
           rustup toolchain install nightly --profile minimal
           cargo +nightly fmt -- --check
 
+      # --strict makes a fixture that fails to generate fail this step (the Rust
+      # golden tests skip a missing fixture directory, so a silent skip here
+      # would silently drop coverage). The step does not block the Rust tests,
+      # because a transient hub or pip failure should still leave a test
+      # signal; the outcome is re-raised after the tests run.
       - name: Generate vision golden fixtures
+        id: vision-golden
+        continue-on-error: true
         run: |
           python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
           python -m pip install transformers pillow numpy scipy
@@ -357,6 +364,12 @@ jobs:
           source "$HOME/.cargo/env"
           cargo test
           cargo test -p data-connector --test postgres_integration -- --ignored --test-threads=1
+
+      - name: Fail if vision golden fixtures did not generate
+        if: steps.vision-golden.outcome == 'failure'
+        run: |
+          echo "::error::Vision golden fixture generation failed; see the 'Generate vision golden fixtures' step"
+          exit 1
 
       - name: Cleanup Postgres test database
         if: always()

--- a/crates/multimodal/scripts/generate_vision_golden.py
+++ b/crates/multimodal/scripts/generate_vision_golden.py
@@ -257,8 +257,16 @@ def generate_golden_qwen2_vl(image_path: str, output_dir: str) -> dict:
     # transformers < 5 exposes the pixel bounds as attributes; 5.x keeps them
     # only in size={"shortest_edge": min_pixels, "longest_edge": max_pixels}.
     size = getattr(processor, "size", None) or {}
-    min_pixels = getattr(processor, "min_pixels", None) or size.get("shortest_edge")
-    max_pixels = getattr(processor, "max_pixels", None) or size.get("longest_edge")
+    min_pixels = getattr(processor, "min_pixels", None)
+    max_pixels = getattr(processor, "max_pixels", None)
+    if min_pixels is None:
+        min_pixels = size.get("shortest_edge") if hasattr(size, "get") else None
+    if max_pixels is None:
+        max_pixels = size.get("longest_edge") if hasattr(size, "get") else None
+    if min_pixels is None or max_pixels is None:
+        raise RuntimeError(
+            f"could not resolve Qwen2-VL pixel bounds from processor (size={size!r})"
+        )
 
     # Calculate number of tokens
     # tokens = (T * H * W) / merge_size²
@@ -633,7 +641,8 @@ def generate_for_model(model_key: str, image_paths: list, output_dir: str) -> in
     failures = 0
     for image_path in image_paths:
         if not os.path.exists(image_path):
-            print(f"  Image not found: {image_path}, skipping")
+            failures += 1
+            print(f"  Image not found: {image_path}")
             continue
 
         image_name = Path(image_path).stem
@@ -641,12 +650,16 @@ def generate_for_model(model_key: str, image_paths: list, output_dir: str) -> in
 
         try:
             data = generator_fn(image_path, output_dir)
-            if data is not None:
-                save_golden(model_key, image_name, data, output_dir)
-                print(f"    pixel_values shape: {data['pixel_values'].shape}")
-                print(
-                    f"    pixel_values range: [{data['pixel_values'].min():.4f}, {data['pixel_values'].max():.4f}]"
-                )
+            if data is None:
+                # The generator printed why (typically the processor class is
+                # missing from the installed transformers); no fixture was written.
+                failures += 1
+                continue
+            save_golden(model_key, image_name, data, output_dir)
+            print(f"    pixel_values shape: {data['pixel_values'].shape}")
+            print(
+                f"    pixel_values range: [{data['pixel_values'].min():.4f}, {data['pixel_values'].max():.4f}]"
+            )
         except Exception as e:
             failures += 1
             print(f"    Error: {e}")

--- a/crates/multimodal/scripts/generate_vision_golden.py
+++ b/crates/multimodal/scripts/generate_vision_golden.py
@@ -254,8 +254,11 @@ def generate_golden_qwen2_vl(image_path: str, output_dir: str) -> dict:
     patch_size = processor.patch_size
     merge_size = processor.merge_size
     temporal_patch_size = getattr(processor, "temporal_patch_size", 2)
-    min_pixels = processor.min_pixels
-    max_pixels = processor.max_pixels
+    # transformers < 5 exposes the pixel bounds as attributes; 5.x keeps them
+    # only in size={"shortest_edge": min_pixels, "longest_edge": max_pixels}.
+    size = getattr(processor, "size", None) or {}
+    min_pixels = getattr(processor, "min_pixels", None) or size.get("shortest_edge")
+    max_pixels = getattr(processor, "max_pixels", None) or size.get("longest_edge")
 
     # Calculate number of tokens
     # tokens = (T * H * W) / merge_size²
@@ -607,8 +610,8 @@ def generate_golden_pixtral(image_path: str, output_dir: str) -> dict:
     return result
 
 
-def generate_for_model(model_key: str, image_paths: list, output_dir: str):
-    """Generate golden outputs for a specific model."""
+def generate_for_model(model_key: str, image_paths: list, output_dir: str) -> int:
+    """Generate golden outputs for a specific model; returns the failure count."""
     print(f"\nGenerating golden outputs for {model_key}...")
 
     generator_fn = {
@@ -625,8 +628,9 @@ def generate_for_model(model_key: str, image_paths: list, output_dir: str):
 
     if generator_fn is None:
         print(f"  No generator for {model_key}, skipping")
-        return
+        return 0
 
+    failures = 0
     for image_path in image_paths:
         if not os.path.exists(image_path):
             print(f"  Image not found: {image_path}, skipping")
@@ -644,7 +648,9 @@ def generate_for_model(model_key: str, image_paths: list, output_dir: str):
                     f"    pixel_values range: [{data['pixel_values'].min():.4f}, {data['pixel_values'].max():.4f}]"
                 )
         except Exception as e:
+            failures += 1
             print(f"    Error: {e}")
+    return failures
 
 
 def main():
@@ -658,6 +664,13 @@ def main():
         "-o",
         default="crates/multimodal/tests/fixtures/golden",
         help="Output directory for golden files",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if any golden output fails to generate. CI uses this so a "
+        "processor API change cannot silently drop fixtures (the Rust golden tests skip "
+        "when a fixture directory is missing).",
     )
     args = parser.parse_args()
 
@@ -679,9 +692,14 @@ def main():
     print(f"Models: {models_to_generate}")
 
     # Generate golden outputs
+    failures = 0
     for model_key in models_to_generate:
-        generate_for_model(model_key, image_paths, args.output_dir)
+        failures += generate_for_model(model_key, image_paths, args.output_dir)
 
+    if failures:
+        print(f"\n{failures} golden output(s) failed to generate")
+        if args.strict:
+            sys.exit(1)
     print("\nDone!")
 
 


### PR DESCRIPTION
## Description

### Problem

The `unit-tests` job installs an unpinned `transformers` (currently 5.16.1) and runs `crates/multimodal/scripts/generate_vision_golden.py` to produce the fixtures the Rust vision golden tests compare against. transformers 5 removed the `min_pixels` / `max_pixels` attributes from `Qwen2VLImageProcessor`, so on every recent run the step prints

```
Generating golden outputs for qwen2_vl...
    Error: 'Qwen2VLImageProcessor' object has no attribute 'min_pixels'
```

for each image, swallows the exception, and exits 0. The Rust golden tests skip when a fixture directory does not exist, so the Qwen2-VL preprocessing parity tests have been silently not running in CI. Nothing was red; the coverage just disappeared.

### Solution

- Read the pixel bounds from `size={"shortest_edge": …, "longest_edge": …}` when the attributes are gone (transformers 5), keeping the attribute path for older versions.
- `generate_for_model()` counts failures and `main()` reports them; a new `--strict` flag exits non-zero when any fixture failed to generate, and the CI step passes it. A future processor API change will then fail the job instead of quietly dropping fixtures.

## Changes

- `crates/multimodal/scripts/generate_vision_golden.py`: transformers 5 fallback for the Qwen2-VL bounds, failure counting, `--strict`.
- `.github/workflows/pr-test-rust.yml`: the "Generate vision golden fixtures" step runs with `--strict`.

## Test Plan

- Ran the generator locally with transformers 5.16.1 (`--strict`, all nine models): exit 0, every fixture written, including `qwen2_vl`.
- `cargo test -p llm-multimodal --test vision_golden_tests` against those fixtures: all tests pass, and the `qwen2_vl` golden tests now execute instead of skipping.
- `ruff check` / `ruff format` clean on the script.
- On this PR the `unit-tests` job should show the Qwen2-VL fixtures being saved rather than the `min_pixels` errors.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
