### PR TITLE
test(e2e): cover reasoning effort tiers and streaming error shapes

### DIFF
--- a/e2e_test/chat_completions/test_error_shapes.py
+++ b/e2e_test/chat_completions/test_error_shapes.py
@@ -1,0 +1,94 @@
+"""Error responses to streaming requests keep the worker's JSON shape.
+
+When ``stream: true`` is set and the worker rejects the request before
+generation starts, it answers with a JSON error and an ``application/json``
+content type. The gateway used to relay the status and body but relabel the
+response as ``text/event-stream``, so an SSE client could drop the error body
+(#2404). The upstream content type must survive; only a successful stream is
+an event stream.
+
+The rejection is triggered by a tool whose ``parameters`` is not a valid JSON
+Schema. The gateway does not validate tool schemas, so the request reaches the
+worker, and SGLang's OpenAI server rejects it before opening a stream.
+
+Usage:
+    E2E_RUNTIME=sglang pytest e2e_test/chat_completions/test_error_shapes.py -v
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+logger = logging.getLogger(__name__)
+
+_INVALID_SCHEMA_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "lookup",
+        "description": "A tool with a parameters block that is not a JSON Schema.",
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "not-a-json-schema-type"}},
+        },
+    },
+}
+
+
+@pytest.mark.engine("sglang")
+@pytest.mark.gpu(1)
+@pytest.mark.e2e
+@pytest.mark.model("meta-llama/Llama-3.2-1B-Instruct")
+@pytest.mark.parametrize("setup_backend", ["http"], indirect=True)
+class TestStreamingErrorShape:
+    """Worker-side rejections of a streaming request stay JSON; real streams stay SSE."""
+
+    def test_worker_rejection_keeps_json_content_type(self, setup_backend):
+        _, model, _, gateway = setup_backend
+        body = {
+            "model": model,
+            "stream": True,
+            "messages": [{"role": "user", "content": "Look up the weather."}],
+            "tools": [_INVALID_SCHEMA_TOOL],
+            "max_tokens": 16,
+        }
+
+        resp = httpx.post(f"{gateway.base_url}/v1/chat/completions", json=body, timeout=60.0)
+
+        logger.info(
+            "status=%s content-type=%s body=%s",
+            resp.status_code,
+            resp.headers.get("content-type"),
+            resp.text[:300],
+        )
+        assert resp.status_code == 400, (
+            f"expected the worker's 400, got {resp.status_code}: {resp.text[:300]}"
+        )
+        content_type = resp.headers.get("content-type", "")
+        assert content_type.startswith("application/json"), (
+            f"error content type was relabelled: {content_type!r}"
+        )
+        error = resp.json()
+        message = error.get("message") or error.get("error", {}).get("message", "")
+        assert "schema" in message.lower(), f"unexpected error body: {error}"
+
+    def test_successful_stream_is_an_event_stream(self, setup_backend):
+        _, model, _, gateway = setup_backend
+        body = {
+            "model": model,
+            "stream": True,
+            "messages": [{"role": "user", "content": "Say hello."}],
+            "max_tokens": 8,
+        }
+
+        with httpx.stream(
+            "POST", f"{gateway.base_url}/v1/chat/completions", json=body, timeout=60.0
+        ) as resp:
+            assert resp.status_code == 200, resp.read()[:300]
+            assert resp.headers.get("content-type", "").startswith("text/event-stream")
+            frames = [line for line in resp.iter_lines() if line.startswith("data:")]
+
+        assert frames, "stream carried no data frames"
+        assert frames[-1].strip() == "data: [DONE]", f"stream did not terminate: {frames[-1]!r}"

--- a/e2e_test/responses/test_reasoning_effort.py
+++ b/e2e_test/responses/test_reasoning_effort.py
@@ -1,0 +1,60 @@
+"""Every OpenAI ``reasoning.effort`` tier must be accepted on the Responses API.
+
+OpenAI defines seven tiers: ``none``, ``minimal``, ``low``, ``medium``,
+``high``, ``xhigh`` and ``max``. The Responses request type used to know four
+of them, so ``none``, ``xhigh`` and ``max`` failed deserialization with a 422
+before any handler ran while the same values worked on Chat Completions
+(#2410). Harmony models clamp the outer tiers inward, so every tier must
+produce a normal response on gpt-oss.
+
+Usage:
+    E2E_RUNTIME=sglang pytest e2e_test/responses/test_reasoning_effort.py -v
+"""
+
+from __future__ import annotations
+
+import logging
+
+import openai
+import pytest
+
+logger = logging.getLogger(__name__)
+
+# OpenAI's tiers, lowest to highest. ``none`` is distinct from omitting the field.
+REASONING_EFFORT_TIERS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+
+@pytest.mark.engine("sglang")
+@pytest.mark.gpu(1)
+@pytest.mark.e2e
+@pytest.mark.model("openai/gpt-oss-20b")
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestReasoningEffortTiers:
+    """Each tier reaches the model and yields output; an unknown tier is rejected."""
+
+    @pytest.mark.parametrize("effort", REASONING_EFFORT_TIERS)
+    def test_tier_is_accepted(self, model, api_client, effort):
+        response = api_client.responses.create(
+            model=model,
+            input="What is 12 times 12? Reply with the number only.",
+            reasoning={"effort": effort},
+            max_output_tokens=512,
+        )
+
+        item_types = [item.type for item in response.output]
+        logger.info("effort=%s status=%s output=%s", effort, response.status, item_types)
+        assert response.output, f"effort={effort!r} produced no output items"
+        assert {"reasoning", "message"} & set(item_types), (
+            f"effort={effort!r} produced neither reasoning nor a message: {item_types}"
+        )
+
+    def test_unknown_tier_is_rejected(self, model, api_client):
+        with pytest.raises(openai.APIStatusError) as exc_info:
+            api_client.responses.create(
+                model=model,
+                input="Reply with OK.",
+                reasoning={"effort": "extreme"},
+                max_output_tokens=32,
+            )
+
+        assert exc_info.value.status_code in (400, 422), exc_info.value


### PR DESCRIPTION
## Description

### Problem

Two merged fixes changed behaviour that clients see on the wire, and neither left a check in the e2e suite:

- #2410: the Responses API rejected `reasoning.effort` values `none`, `xhigh` and `max` with a 422 during deserialization, while Chat Completions accepted all seven OpenAI tiers. Nothing in `e2e_test/responses` sends a reasoning effort.
- #2404: when a worker rejects a `stream: true` request before generation starts, it answers with a JSON error and `application/json`. The gateway relayed the status and body but relabelled the response as `text/event-stream`, so SSE clients could drop the error. Nothing in `e2e_test/chat_completions` inspects the content type of an error to a streaming request.

### Solution

- `e2e_test/responses/test_reasoning_effort.py` (sglang, gpt-oss-20b, gRPC): every one of the seven tiers must produce a response with reasoning or a message; the Harmony clamping of the outer tiers means all of them reach the model. An unknown tier must be rejected with 400/422.
- `e2e_test/chat_completions/test_error_shapes.py` (sglang, Llama-3.2-1B, HTTP): a streaming request carrying a tool whose `parameters` is not a valid JSON Schema passes the gateway (it does not validate tool schemas) and is rejected by SGLang's OpenAI server before it opens a stream. The relayed response must be a 400 with `application/json` and a JSON body naming the schema problem. A successful streaming request must still be `text/event-stream` and end with `[DONE]`.

## Changes

- `e2e_test/responses/test_reasoning_effort.py`: new, 8 tests.
- `e2e_test/chat_completions/test_error_shapes.py`: new, 2 tests.

## Test Plan

- `ruff check` / `ruff format --check` and `mypy --config-file mypy.ini` on both files: clean.
- Collection under the lane filters: sglang tier 1 selects 8 + 2 tests; vllm deselects both files (HTTP mode is SGLang-only, and the responses lane is SGLang).
- Lanes exercising them on this PR: `e2e-1gpu-responses` and `e2e-1gpu-chat (sglang)`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
