### PR TITLE
test(e2e): sweep prefill/decode topologies on 4 GPUs for every engine

### DIFF
--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -59,6 +59,11 @@ on:
         type: string
         default: ""
         description: "KV transfer backend for every PD worker, whatever the engine (nixl or mooncake); empty keeps each engine's default"
+      vllm_extra_kv_backends:
+        required: false
+        type: string
+        default: ""
+        description: "Additional vLLM KV transfer backends to install beside the lane's own (e.g. mooncake), for fleets that mix transports"
       connection_mode:
         required: false
         type: string
@@ -93,6 +98,7 @@ jobs:
       E2E_GPU_TIER: ${{ inputs.gpu_tier }}
       E2E_VLLM_KV_BACKEND: ${{ inputs.vllm_kv_backend }}
       E2E_KV_BACKEND: ${{ inputs.kv_backend }}
+      E2E_VLLM_EXTRA_KV_BACKENDS: ${{ inputs.vllm_extra_kv_backends }}
       E2E_CONNECTION_MODE: ${{ inputs.connection_mode }}
       E2E_ZMQ_ENGINE_COUNT: ${{ inputs.zmq_engine_count }}
       TOKENSPEED_PREBUILT_IMAGE: ${{ inputs.tokenspeed_prebuilt_image }}

--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -54,6 +54,11 @@ on:
         type: string
         default: "nixl"
         description: "KV transfer backend for vLLM PD workers: nixl or mooncake"
+      kv_backend:
+        required: false
+        type: string
+        default: ""
+        description: "KV transfer backend for every PD worker, whatever the engine (nixl or mooncake); empty keeps each engine's default"
       connection_mode:
         required: false
         type: string
@@ -87,6 +92,7 @@ jobs:
       E2E_RUNTIME: ${{ inputs.engine }}
       E2E_GPU_TIER: ${{ inputs.gpu_tier }}
       E2E_VLLM_KV_BACKEND: ${{ inputs.vllm_kv_backend }}
+      E2E_KV_BACKEND: ${{ inputs.kv_backend }}
       E2E_CONNECTION_MODE: ${{ inputs.connection_mode }}
       E2E_ZMQ_ENGINE_COUNT: ${{ inputs.zmq_engine_count }}
       TOKENSPEED_PREBUILT_IMAGE: ${{ inputs.tokenspeed_prebuilt_image }}
@@ -200,7 +206,9 @@ jobs:
           LABEL=$(echo '${{ inputs.test_dirs }}' | tr '/' '-')
           # vLLM legs can differ only by KV backend; disambiguate the artifact
           SUFFIX=""
-          if [ "${{ inputs.engine }}" = "vllm" ]; then
+          if [ -n "${{ inputs.kv_backend }}" ]; then
+            SUFFIX="-${{ inputs.kv_backend }}"
+          elif [ "${{ inputs.engine }}" = "vllm" ]; then
             SUFFIX="-${{ inputs.vllm_kv_backend }}"
           fi
           # gRPC and ZMQ chat legs share engine/GPU/test-dir and differ only by

--- a/.github/workflows/nightly-pd.yml
+++ b/.github/workflows/nightly-pd.yml
@@ -1,0 +1,154 @@
+name: Nightly PD Topologies
+
+# Sweeps every prefill/decode topology a 4-GPU node allows (1p1d, 1p2d, 2p1d,
+# 1p3d, 3p1d, 2p2d) plus a fleet assembled at runtime, per engine. The PR lane
+# e2e-4gpu-pd runs one topology; this is where the rest get exercised.
+
+on:
+  schedule:
+    - cron: "45 9 * * *" # 09:45 UTC daily, after the nightly benchmarks release the GPU pool
+  workflow_dispatch:
+    inputs:
+      engines:
+        description: "Space-separated engines to run (sglang vllm tokenspeed); empty = all"
+        required: false
+        default: ""
+      filter:
+        description: "pytest -k expression (e.g. 1p3d, or 'not AssembledAtRuntime'); empty = every topology"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-pd
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      engines: ${{ steps.plan.outputs.engines }}
+    steps:
+      - id: plan
+        env:
+          ENGINES: ${{ inputs.engines }}
+        run: |
+          wanted="${ENGINES:-sglang vllm tokenspeed}"
+          json=$(printf '%s\n' $wanted | jq -R . | jq -sc .)
+          echo "engines=$json" >> "$GITHUB_OUTPUT"
+          echo "engines: $json"
+
+  build-wheel:
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Build Python wheel
+        run: |
+          rm -rf bindings/python/dist/
+          bash scripts/ci_setup_python_venv.sh
+          bash scripts/ci_build_wheel.sh
+
+      - name: Generate Python client types
+        run: |
+          source "$HOME/.cargo/env"
+          mkdir -p clients/openapi
+          cargo run -p openapi-gen -- clients/openapi/smg-openapi.yaml
+          pip install 'datamodel-code-generator==0.54.0'
+          datamodel-codegen \
+            --input clients/openapi/smg-openapi.yaml \
+            --input-file-type openapi \
+            --output clients/python/smg_client/types/_generated.py \
+            --output-model-type pydantic_v2.BaseModel \
+            --use-annotated \
+            --field-constraints \
+            --target-python-version 3.10 \
+            --collapse-root-models \
+            --use-standard-collections \
+            --use-union-operator
+          sed -i 's/class \(.*\)(Enum):/class \1(str, Enum):/' clients/python/smg_client/types/_generated.py
+
+      - name: Build WASM test fixtures
+        run: |
+          source "$HOME/.cargo/env"
+          bash crates/wasm/tests/fixtures/build_fixtures.sh
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: smg-wheel
+          path: bindings/python/dist/*.whl
+          retention-days: 1
+
+      - name: Upload Python client types
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-client-types
+          path: clients/python/smg_client/types/_generated.py
+          retention-days: 1
+
+      - name: Upload WASM test fixtures
+        uses: actions/upload-artifact@v7
+        with:
+          name: wasm-test-fixtures
+          path: crates/wasm/tests/fixtures/*.wasm
+          retention-days: 1
+          if-no-files-found: ignore
+
+  # Same resolution as detect-changes in pr-test-rust.yml: the prebuilt
+  # TokenSpeed carrier image, or empty to build from source.
+  tokenspeed-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve TokenSpeed CI image
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="$(bash scripts/ci_tokenspeed_image_tag.sh 2>/dev/null || true)"
+          image=""
+          if [ -n "$tag" ]; then
+            candidate="ghcr.io/${{ github.repository_owner }}/smg:${tag}"
+            if docker login ghcr.io -u "${{ github.actor }}" --password-stdin <<< "$GH_TOKEN" > /dev/null 2>&1 \
+               && docker manifest inspect "$candidate" > /dev/null 2>&1; then
+              image="$candidate"
+            fi
+          fi
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          echo "TokenSpeed image: ${image:-none (source build)}"
+
+  pd-topologies:
+    name: pd-topologies (${{ matrix.engine }})
+    needs: [plan, build-wheel, tokenspeed-image]
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: ${{ fromJSON(needs.plan.outputs.engines) }}
+    uses: ./.github/workflows/e2e-gpu-job.yml
+    with:
+      engine: ${{ matrix.engine }}
+      gpu_tier: "4"
+      runner: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
+      # Six topologies, each with worker restarts; TokenSpeed also extracts
+      # its engine image and loads a slower model.
+      timeout: ${{ matrix.engine == 'tokenspeed' && 170 || 130 }}
+      test_timeout: ${{ matrix.engine == 'tokenspeed' && 150 || 115 }}
+      test_dirs: e2e_test/router/test_pd_topologies.py
+      test_filter: ${{ inputs.filter != '' && format('-k "{0}"', inputs.filter) || '' }}
+      extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
+      min_selected: 0
+      tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.tokenspeed-image.outputs.image || '' }}
+    secrets: inherit

--- a/.github/workflows/nightly-pd.yml
+++ b/.github/workflows/nightly-pd.yml
@@ -149,10 +149,11 @@ jobs:
       engine: ${{ matrix.engine }}
       gpu_tier: "4"
       runner: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
-      # The whole sweep: eight topologies on SGLang (six gRPC, two HTTP), six
-      # elsewhere, each with worker restarts; TokenSpeed also extracts its
-      # engine image and loads a slower model. Run 34433711319 took 58 min
-      # (sglang), 55 (vllm), 35 (vllm-mooncake) and 78 (tokenspeed) end to end.
+      # The whole sweep: ten topologies (eight gRPC, two HTTP), eight on
+      # TokenSpeed (no HTTP frontend), each with worker restarts; TokenSpeed
+      # also extracts its engine image and loads a slower model. Run
+      # 34433711319 took 58 min (sglang), 55 (vllm), 35 (vllm-mooncake) and
+      # 78 (tokenspeed) end to end.
       timeout: ${{ matrix.engine == 'tokenspeed' && 190 || 170 }}
       test_timeout: ${{ matrix.engine == 'tokenspeed' && 170 || 150 }}
       test_dirs: e2e_test/router/test_pd_topologies.py

--- a/.github/workflows/nightly-pd.yml
+++ b/.github/workflows/nightly-pd.yml
@@ -36,11 +36,11 @@ jobs:
           ENGINES: ${{ inputs.engines }}
         run: |
           wanted="${ENGINES:-sglang vllm tokenspeed}"
-          # One row per engine; vLLM also runs over Mooncake next to its NIXL default.
+          # One row per engine; vLLM also runs over Mooncake next to its NIXL
+          # default. SGLang over NIXL waits on a NIXL install for its venv (#2498).
           matrix=$(printf '%s\n' $wanted | jq -Rsc '
             split("\n") | map(select(length > 0)) |
             map(if . == "vllm" then [{engine: "vllm"}, {engine: "vllm", kv_backend: "mooncake"}]
-                elif . == "sglang" then [{engine: "sglang"}, {engine: "sglang", kv_backend: "nixl"}]
                 else [{engine: .}] end) | add')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "matrix: $matrix"
@@ -122,12 +122,14 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           tag="$(bash scripts/ci_tokenspeed_image_tag.sh 2>/dev/null || true)"
           image=""
           if [ -n "$tag" ]; then
-            candidate="ghcr.io/${{ github.repository_owner }}/smg:${tag}"
-            if docker login ghcr.io -u "${{ github.actor }}" --password-stdin <<< "$GH_TOKEN" > /dev/null 2>&1 \
+            candidate="ghcr.io/${REPO_OWNER}/smg:${tag}"
+            if docker login ghcr.io -u "$GH_ACTOR" --password-stdin <<< "$GH_TOKEN" > /dev/null 2>&1 \
                && docker manifest inspect "$candidate" > /dev/null 2>&1; then
               image="$candidate"
             fi
@@ -147,8 +149,10 @@ jobs:
       engine: ${{ matrix.engine }}
       gpu_tier: "4"
       runner: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
-      # Six topologies, each with worker restarts; TokenSpeed also extracts
-      # its engine image and loads a slower model.
+      # The whole sweep: eight topologies on SGLang (six gRPC, two HTTP), six
+      # elsewhere, each with worker restarts; TokenSpeed also extracts its
+      # engine image and loads a slower model. Run 34433711319 took 58 min
+      # (sglang), 55 (vllm), 35 (vllm-mooncake) and 78 (tokenspeed) end to end.
       timeout: ${{ matrix.engine == 'tokenspeed' && 190 || 170 }}
       test_timeout: ${{ matrix.engine == 'tokenspeed' && 170 || 150 }}
       test_dirs: e2e_test/router/test_pd_topologies.py

--- a/.github/workflows/nightly-pd.yml
+++ b/.github/workflows/nightly-pd.yml
@@ -40,6 +40,7 @@ jobs:
           matrix=$(printf '%s\n' $wanted | jq -Rsc '
             split("\n") | map(select(length > 0)) |
             map(if . == "vllm" then [{engine: "vllm"}, {engine: "vllm", kv_backend: "mooncake"}]
+                elif . == "sglang" then [{engine: "sglang"}, {engine: "sglang", kv_backend: "nixl"}]
                 else [{engine: .}] end) | add')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "matrix: $matrix"
@@ -151,7 +152,10 @@ jobs:
       timeout: ${{ matrix.engine == 'tokenspeed' && 190 || 170 }}
       test_timeout: ${{ matrix.engine == 'tokenspeed' && 170 || 150 }}
       test_dirs: e2e_test/router/test_pd_topologies.py
+      kv_backend: ${{ matrix.kv_backend || '' }}
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
+      # The mixed-transport fleet needs both vLLM backends installed whatever the row's own
+      vllm_extra_kv_backends: ${{ matrix.engine == 'vllm' && 'mooncake' || '' }}
       test_filter: ${{ inputs.filter != '' && format('-k "{0}"', inputs.filter) || '' }}
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
       min_selected: 0

--- a/.github/workflows/nightly-pd.yml
+++ b/.github/workflows/nightly-pd.yml
@@ -29,16 +29,20 @@ jobs:
   plan:
     runs-on: ubuntu-latest
     outputs:
-      engines: ${{ steps.plan.outputs.engines }}
+      matrix: ${{ steps.plan.outputs.matrix }}
     steps:
       - id: plan
         env:
           ENGINES: ${{ inputs.engines }}
         run: |
           wanted="${ENGINES:-sglang vllm tokenspeed}"
-          json=$(printf '%s\n' $wanted | jq -R . | jq -sc .)
-          echo "engines=$json" >> "$GITHUB_OUTPUT"
-          echo "engines: $json"
+          # One row per engine; vLLM also runs over Mooncake next to its NIXL default.
+          matrix=$(printf '%s\n' $wanted | jq -Rsc '
+            split("\n") | map(select(length > 0)) |
+            map(if . == "vllm" then [{engine: "vllm"}, {engine: "vllm", kv_backend: "mooncake"}]
+                else [{engine: .}] end) | add')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "matrix: $matrix"
 
   build-wheel:
     runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
@@ -131,12 +135,12 @@ jobs:
           echo "TokenSpeed image: ${image:-none (source build)}"
 
   pd-topologies:
-    name: pd-topologies (${{ matrix.engine }})
+    name: pd-topologies (${{ matrix.engine }}${{ matrix.kv_backend && format('-{0}', matrix.kv_backend) || '' }})
     needs: [plan, build-wheel, tokenspeed-image]
     strategy:
       fail-fast: false
       matrix:
-        engine: ${{ fromJSON(needs.plan.outputs.engines) }}
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -144,9 +148,10 @@ jobs:
       runner: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
       # Six topologies, each with worker restarts; TokenSpeed also extracts
       # its engine image and loads a slower model.
-      timeout: ${{ matrix.engine == 'tokenspeed' && 170 || 130 }}
-      test_timeout: ${{ matrix.engine == 'tokenspeed' && 150 || 115 }}
+      timeout: ${{ matrix.engine == 'tokenspeed' && 190 || 170 }}
+      test_timeout: ${{ matrix.engine == 'tokenspeed' && 170 || 150 }}
       test_dirs: e2e_test/router/test_pd_topologies.py
+      vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
       test_filter: ${{ inputs.filter != '' && format('-k "{0}"', inputs.filter) || '' }}
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
       min_selected: 0

--- a/.github/workflows/nightly-triage.yml
+++ b/.github/workflows/nightly-triage.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  WATCHED_WORKFLOWS: nightly-bfcl.yml nightly-tau2.yml nightly-benchmark.yml nightly-docker.yml nightly-engine-docker.yml nightly-mlx-bench.yml
+  WATCHED_WORKFLOWS: nightly-bfcl.yml nightly-tau2.yml nightly-benchmark.yml nightly-docker.yml nightly-engine-docker.yml nightly-mlx-bench.yml nightly-pd.yml
 
 jobs:
   collect:

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1075,6 +1075,9 @@ jobs:
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
       min_selected: ${{ matrix.min_selected || 116 }} # floor ≈ 95% of the 122 collected cases
       kv_backend: ${{ matrix.kv_backend || '' }}
+      vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
+      # The mixed-transport fleet needs both vLLM backends installed whatever the lane's own
+      vllm_extra_kv_backends: ${{ matrix.engine == 'vllm' && 'mooncake' || '' }}
       tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
     secrets: inherit
 

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -388,7 +388,6 @@ jobs:
   # uploaded and summarized.
   benchmarks:
     needs: build-wheel
-    if: false # PD-ONLY ITERATION MODE — TEMPORARY, REVERT BEFORE MERGE (frees the 4-GPU runner)
     runs-on: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
     container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
     continue-on-error: true
@@ -470,20 +469,14 @@ jobs:
       pull-requests: read
       packages: read
     outputs:
-      # PD-ONLY ITERATION MODE — TEMPORARY, REVERT BEFORE MERGE.
-      # Every change flag is forced off so only e2e-4gpu-pd runs on this
-      # branch (build-wheel and the CPU checks are unaffected). Restore the
-      # `steps.filter.outputs.*` values and drop `pd-only` when the sweep is
-      # done finding bugs.
-      pd-only: "true"
-      common: "false"
-      chat-completions: "false"
-      completions: "false"
-      agentic: "false"
-      embeddings: "false"
-      realtime: "false"
-      go-bindings: "false"
-      rust-ci: "false"
+      common: ${{ steps.filter.outputs.common }}
+      chat-completions: ${{ steps.filter.outputs.chat-completions }}
+      completions: ${{ steps.filter.outputs.completions }}
+      agentic: ${{ steps.filter.outputs.agentic }}
+      embeddings: ${{ steps.filter.outputs.embeddings }}
+      realtime: ${{ steps.filter.outputs.realtime }}
+      go-bindings: ${{ steps.filter.outputs.go-bindings }}
+      rust-ci: ${{ steps.filter.outputs.rust-ci }}
       tokenspeed-image: ${{ steps.tokenspeed-image.outputs.image }}
     steps:
       - uses: actions/checkout@v7
@@ -1019,44 +1012,37 @@ jobs:
   # every PR with the topology that exercises both legs' load balancing.
   e2e-4gpu-pd:
     name: e2e-4gpu-pd (${{ matrix.engine }}${{ matrix.kv_backend && format('-{0}', matrix.kv_backend) || '' }})
-    # PD-ONLY ITERATION MODE — TEMPORARY, REVERT BEFORE MERGE: depends on
-    # build-wheel instead of e2e-1gpu-gateway, honours `pd-only`, and runs
-    # the whole topology sweep with the nightly budgets instead of the
-    # 2p2d slice. Restore `needs: [e2e-1gpu-gateway, detect-changes]`, the
-    # gateway result check, the 50/42 and 85/60 budgets, the `-k` filter
-    # and `min_selected: 13` afterwards.
-    needs: [build-wheel, detect-changes]
+    needs: [e2e-1gpu-gateway, detect-changes]
     if: >-
       always()
       && !cancelled()
-      && needs.build-wheel.result == 'success'
+      && needs.e2e-1gpu-gateway.result == 'success'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
-              && (needs.detect-changes.outputs.pd-only == 'true'
-                  || needs.detect-changes.outputs.common == 'true'
+              && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.chat-completions == 'true')))
     strategy:
       fail-fast: false
       matrix:
         include:
           - engine: sglang
-            timeout: 170
-            test_timeout: 150
+            timeout: 50
+            test_timeout: 42
           - engine: vllm
-            timeout: 170
-            test_timeout: 150
+            timeout: 50
+            test_timeout: 42
           # Qwen3.5-9B loads slower and the prebuilt image is extracted first;
           # a cold path builds the engine from source.
           - engine: tokenspeed
-            timeout: 190
-            test_timeout: 170
+            timeout: 85
+            test_timeout: 60
           # The other KV transport of each engine (TokenSpeed only has
-          # Mooncake): the whole sweep on vLLM over Mooncake, and a 1p1d
-          # smoke of SGLang over NIXL, which has never run in CI.
+          # Mooncake): the same slice on vLLM over Mooncake, and a 1p1d
+          # smoke of SGLang over NIXL. The full sweeps run in nightly-pd.
           - engine: vllm
             kv_backend: mooncake
-            timeout: 170
-            test_timeout: 150
+            timeout: 50
+            test_timeout: 42
           - engine: sglang
             kv_backend: nixl
             timeout: 60
@@ -1071,9 +1057,12 @@ jobs:
       timeout: ${{ matrix.timeout }}
       test_timeout: ${{ matrix.test_timeout }}
       test_dirs: e2e_test/router/test_pd_topologies.py
-      test_filter: ${{ matrix.test_filter || '' }} # PD-only iteration mode: the whole sweep unless the row narrows it
+      # The 2p2d slice (which carries the mixed-transport fleet on vLLM), the
+      # runtime-assembled fleet, the over-window burst, and the mismatched
+      # fleet that placement must refuse; the full sweep runs in nightly-pd.
+      test_filter: ${{ matrix.test_filter || '-k "(2p2d and not http) or AssembledAtRuntime or SmallWindow or MismatchedTransport"' }}
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
-      min_selected: ${{ matrix.min_selected || 116 }} # floor ≈ 95% of the 122 collected cases
+      min_selected: ${{ matrix.min_selected || 13 }} # floor ≈ 95% of the 14 cases the slice keeps on every engine
       kv_backend: ${{ matrix.kv_backend || '' }}
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
       # The mixed-transport fleet needs both vLLM backends installed whatever the lane's own

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -388,6 +388,7 @@ jobs:
   # uploaded and summarized.
   benchmarks:
     needs: build-wheel
+    if: false # PD-ONLY ITERATION MODE — TEMPORARY, REVERT BEFORE MERGE (frees the 4-GPU runner)
     runs-on: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
     container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
     continue-on-error: true
@@ -469,14 +470,20 @@ jobs:
       pull-requests: read
       packages: read
     outputs:
-      common: ${{ steps.filter.outputs.common }}
-      chat-completions: ${{ steps.filter.outputs.chat-completions }}
-      completions: ${{ steps.filter.outputs.completions }}
-      agentic: ${{ steps.filter.outputs.agentic }}
-      embeddings: ${{ steps.filter.outputs.embeddings }}
-      realtime: ${{ steps.filter.outputs.realtime }}
-      go-bindings: ${{ steps.filter.outputs.go-bindings }}
-      rust-ci: ${{ steps.filter.outputs.rust-ci }}
+      # PD-ONLY ITERATION MODE — TEMPORARY, REVERT BEFORE MERGE.
+      # Every change flag is forced off so only e2e-4gpu-pd runs on this
+      # branch (build-wheel and the CPU checks are unaffected). Restore the
+      # `steps.filter.outputs.*` values and drop `pd-only` when the sweep is
+      # done finding bugs.
+      pd-only: "true"
+      common: "false"
+      chat-completions: "false"
+      completions: "false"
+      agentic: "false"
+      embeddings: "false"
+      realtime: "false"
+      go-bindings: "false"
+      rust-ci: "false"
       tokenspeed-image: ${{ steps.tokenspeed-image.outputs.image }}
     steps:
       - uses: actions/checkout@v7
@@ -1012,30 +1019,37 @@ jobs:
   # every PR with the topology that exercises both legs' load balancing.
   e2e-4gpu-pd:
     name: e2e-4gpu-pd (${{ matrix.engine }})
-    needs: [e2e-1gpu-gateway, detect-changes]
+    # PD-ONLY ITERATION MODE — TEMPORARY, REVERT BEFORE MERGE: depends on
+    # build-wheel instead of e2e-1gpu-gateway, honours `pd-only`, and runs
+    # the whole topology sweep with the nightly budgets instead of the
+    # 2p2d slice. Restore `needs: [e2e-1gpu-gateway, detect-changes]`, the
+    # gateway result check, the 50/42 and 85/60 budgets, the `-k` filter
+    # and `min_selected: 13` afterwards.
+    needs: [build-wheel, detect-changes]
     if: >-
       always()
       && !cancelled()
-      && needs.e2e-1gpu-gateway.result == 'success'
+      && needs.build-wheel.result == 'success'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
-              && (needs.detect-changes.outputs.common == 'true'
+              && (needs.detect-changes.outputs.pd-only == 'true'
+                  || needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.chat-completions == 'true')))
     strategy:
       fail-fast: false
       matrix:
         include:
           - engine: sglang
-            timeout: 50
-            test_timeout: 42
+            timeout: 170
+            test_timeout: 150
           - engine: vllm
-            timeout: 50
-            test_timeout: 42
+            timeout: 170
+            test_timeout: 150
           # Qwen3.5-9B loads slower and the prebuilt image is extracted first;
           # a cold path builds the engine from source.
           - engine: tokenspeed
-            timeout: 85
-            test_timeout: 60
+            timeout: 190
+            test_timeout: 170
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -1044,9 +1058,9 @@ jobs:
       timeout: ${{ matrix.timeout }}
       test_timeout: ${{ matrix.test_timeout }}
       test_dirs: e2e_test/router/test_pd_topologies.py
-      test_filter: -k "(2p2d and not http) or AssembledAtRuntime or SmallWindow"
+      test_filter: "" # PD-only iteration mode: the whole sweep (98 cases per engine)
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
-      min_selected: 13 # floor ≈ 95% of the 14 cases the -k filter keeps
+      min_selected: 93 # floor ≈ 95% of the 98 collected cases
       tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
     secrets: inherit
 

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1036,19 +1036,13 @@ jobs:
           - engine: tokenspeed
             timeout: 85
             test_timeout: 60
-          # The other KV transport of each engine (TokenSpeed only has
-          # Mooncake): the same slice on vLLM over Mooncake, and a 1p1d
-          # smoke of SGLang over NIXL. The full sweeps run in nightly-pd.
+          # vLLM's other KV transport: the same slice over Mooncake. TokenSpeed
+          # only has Mooncake; SGLang over NIXL waits on a NIXL install for its
+          # venv (#2498). The full sweeps run in nightly-pd.
           - engine: vllm
             kv_backend: mooncake
             timeout: 50
             test_timeout: 42
-          - engine: sglang
-            kv_backend: nixl
-            timeout: 60
-            test_timeout: 50
-            test_filter: -k "1p1d and not http"
-            min_selected: 11
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -1060,9 +1054,10 @@ jobs:
       # The 2p2d slice (which carries the mixed-transport fleet on vLLM), the
       # runtime-assembled fleet, the over-window burst, and the mismatched
       # fleet that placement must refuse; the full sweep runs in nightly-pd.
-      test_filter: ${{ matrix.test_filter || '-k "(2p2d and not http) or AssembledAtRuntime or SmallWindow or MismatchedTransport"' }}
+      # Run 34440725835: 9-16 min of tests per row against the 42/60 budgets.
+      test_filter: -k "(2p2d and not http) or AssembledAtRuntime or SmallWindow or MismatchedTransport"
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
-      min_selected: ${{ matrix.min_selected || 13 }} # floor ≈ 95% of the 14 cases the slice keeps on every engine
+      min_selected: 13 # floor ≈ 95% of the slice: 14 cases on sglang/tokenspeed, 16 on vllm (its two transport classes)
       kv_backend: ${{ matrix.kv_backend || '' }}
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
       # The mixed-transport fleet needs both vLLM backends installed whatever the lane's own

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1018,7 +1018,7 @@ jobs:
   # topology sweep (1p1d .. 3p1d) runs in nightly-pd.yml; this lane guards
   # every PR with the topology that exercises both legs' load balancing.
   e2e-4gpu-pd:
-    name: e2e-4gpu-pd (${{ matrix.engine }})
+    name: e2e-4gpu-pd (${{ matrix.engine }}${{ matrix.kv_backend && format('-{0}', matrix.kv_backend) || '' }})
     # PD-ONLY ITERATION MODE — TEMPORARY, REVERT BEFORE MERGE: depends on
     # build-wheel instead of e2e-1gpu-gateway, honours `pd-only`, and runs
     # the whole topology sweep with the nightly budgets instead of the
@@ -1050,6 +1050,19 @@ jobs:
           - engine: tokenspeed
             timeout: 190
             test_timeout: 170
+          # The other KV transport of each engine (TokenSpeed only has
+          # Mooncake): the whole sweep on vLLM over Mooncake, and a 1p1d
+          # smoke of SGLang over NIXL, which has never run in CI.
+          - engine: vllm
+            kv_backend: mooncake
+            timeout: 170
+            test_timeout: 150
+          - engine: sglang
+            kv_backend: nixl
+            timeout: 60
+            test_timeout: 50
+            test_filter: -k "1p1d and not http"
+            min_selected: 11
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -1058,9 +1071,10 @@ jobs:
       timeout: ${{ matrix.timeout }}
       test_timeout: ${{ matrix.test_timeout }}
       test_dirs: e2e_test/router/test_pd_topologies.py
-      test_filter: "" # PD-only iteration mode: the whole sweep (98 cases per engine)
+      test_filter: ${{ matrix.test_filter || '' }} # PD-only iteration mode: the whole sweep unless the row narrows it
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
-      min_selected: 116 # floor ≈ 95% of the 122 collected cases
+      min_selected: ${{ matrix.min_selected || 116 }} # floor ≈ 95% of the 122 collected cases
+      kv_backend: ${{ matrix.kv_backend || '' }}
       tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
     secrets: inherit
 

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1006,6 +1006,50 @@ jobs:
       tokenspeed_prebuilt_image: ${{ needs.detect-changes.outputs.tokenspeed-image }}
     secrets: inherit
 
+  # PD disaggregation under one 4-GPU topology (2 prefill + 2 decode) plus a
+  # fleet assembled at runtime through the worker API, per engine. The full
+  # topology sweep (1p1d .. 3p1d) runs in nightly-pd.yml; this lane guards
+  # every PR with the topology that exercises both legs' load balancing.
+  e2e-4gpu-pd:
+    name: e2e-4gpu-pd (${{ matrix.engine }})
+    needs: [e2e-1gpu-gateway, detect-changes]
+    if: >-
+      always()
+      && !cancelled()
+      && needs.e2e-1gpu-gateway.result == 'success'
+      && (github.event_name != 'pull_request'
+          || (needs.detect-changes.result == 'success'
+              && (needs.detect-changes.outputs.common == 'true'
+                  || needs.detect-changes.outputs.chat-completions == 'true')))
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - engine: sglang
+            timeout: 50
+            test_timeout: 42
+          - engine: vllm
+            timeout: 50
+            test_timeout: 42
+          # Qwen3.5-9B loads slower and the prebuilt image is extracted first;
+          # a cold path builds the engine from source.
+          - engine: tokenspeed
+            timeout: 85
+            test_timeout: 60
+    uses: ./.github/workflows/e2e-gpu-job.yml
+    with:
+      engine: ${{ matrix.engine }}
+      gpu_tier: "4"
+      runner: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
+      timeout: ${{ matrix.timeout }}
+      test_timeout: ${{ matrix.test_timeout }}
+      test_dirs: e2e_test/router/test_pd_topologies.py
+      test_filter: -k "2p2d or AssembledAtRuntime"
+      extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
+      min_selected: 10 # floor ≈ 95% of the 11 cases the -k filter keeps
+      tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
+    secrets: inherit
+
   # --- Vendor E2E: CPU-only cloud backend tests ---
 
   e2e-vendor:
@@ -1318,7 +1362,7 @@ jobs:
           path: benchmark_go_bindings/
 
   finish:
-    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-chat-zmq, e2e-2gpu-chat-zmq-dp, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-realtime, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-vendor, go-unit-tests, go-bindings-e2e]
+    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-chat-zmq, e2e-2gpu-chat-zmq-dp, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-realtime, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-4gpu-pd, e2e-vendor, go-unit-tests, go-bindings-e2e]
     if: always()
     runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
@@ -1387,6 +1431,7 @@ jobs:
                 "${{ needs.e2e-4gpu-chat.result }}" == "failure" || \
                 "${{ needs.e2e-4gpu-gateway.result }}" == "failure" || \
                 "${{ needs.e2e-4gpu-epd.result }}" == "failure" || \
+                "${{ needs.e2e-4gpu-pd.result }}" == "failure" || \
                 "${{ needs.e2e-vendor.result }}" == "failure" || \
                 "${{ needs.go-unit-tests.result }}" == "failure" || \
                 "${{ needs.go-bindings-e2e.result }}" == "failure" ]]; then

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1044,9 +1044,9 @@ jobs:
       timeout: ${{ matrix.timeout }}
       test_timeout: ${{ matrix.test_timeout }}
       test_dirs: e2e_test/router/test_pd_topologies.py
-      test_filter: -k "2p2d or AssembledAtRuntime"
+      test_filter: -k "(2p2d and not http) or AssembledAtRuntime or SmallWindow"
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
-      min_selected: 10 # floor ≈ 95% of the 11 cases the -k filter keeps
+      min_selected: 13 # floor ≈ 95% of the 14 cases the -k filter keeps
       tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
     secrets: inherit
 

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1060,7 +1060,7 @@ jobs:
       test_dirs: e2e_test/router/test_pd_topologies.py
       test_filter: "" # PD-only iteration mode: the whole sweep (98 cases per engine)
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
-      min_selected: 93 # floor ≈ 95% of the 98 collected cases
+      min_selected: 116 # floor ≈ 95% of the 122 collected cases
       tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.detect-changes.outputs.tokenspeed-image || '' }}
     secrets: inherit
 

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -59,6 +59,8 @@ _WORKER_DEFAULTS = {
     "decode": None,
     "gpus": None,
     "extra_engine_args": None,
+    # PD only: spawn every prefill/decode worker first and wait afterwards.
+    "parallel_start": False,
 }
 
 # Track worker startup failures — fail fast after repeated failures
@@ -207,9 +209,9 @@ def setup_backend(request: pytest.FixtureRequest):
     """
     raw_param = request.param
     if isinstance(raw_param, tuple):
-        backend_name, epd_counts = raw_param
+        backend_name, leg_counts = raw_param
     else:
-        backend_name, epd_counts = raw_param, None
+        backend_name, leg_counts = raw_param, None
 
     if os.environ.get(ENV_SKIP_BACKEND_SETUP, "").lower() in ("1", "true", "yes"):
         pytest.skip(f"{ENV_SKIP_BACKEND_SETUP} is set")
@@ -239,6 +241,12 @@ def setup_backend(request: pytest.FixtureRequest):
     _validate_connection_mode(connection_mode, engine)
     model_path = get_model_spec(model_id)["model"]
     workers_config = get_marker_kwargs(request, "workers", defaults=_WORKER_DEFAULTS)
+    if is_pd and leg_counts is not None:
+        # ``("pd_grpc", (n_prefill, n_decode))`` lets one class sweep PD
+        # topologies; setup_backend is class-scoped, so counts ride in the param.
+        if len(leg_counts) != 2:
+            raise ValueError("pd_* backend params take (n_prefill, n_decode) counts")
+        workers_config = {**workers_config, "prefill": leg_counts[0], "decode": leg_counts[1]}
     log_dir = os.environ.get("E2E_LOG_DIR") or gateway_config.get("log_dir")
 
     fail_count = _worker_start_failures.get(engine, 0)
@@ -256,7 +264,7 @@ def setup_backend(request: pytest.FixtureRequest):
                 model_path,
                 engine,
                 connection_mode,
-                epd_counts,
+                leg_counts,
                 gateway_config,
                 gateway,
                 log_dir,
@@ -385,6 +393,7 @@ def _setup_pd(
         num_decode,
     )
 
+    parallel_start = bool(workers_config.get("parallel_start"))
     all_workers: list = []
     try:
         prefill_workers = _start_workers_tracked(
@@ -394,6 +403,7 @@ def _setup_pd(
             count=num_prefill,
             worker_type=WorkerType.PREFILL,
             log_dir=log_dir,
+            wait_ready=not parallel_start,
         )
         all_workers.extend(prefill_workers)
 
@@ -407,8 +417,17 @@ def _setup_pd(
             worker_type=WorkerType.DECODE,
             log_dir=log_dir,
             gpu_offset=decode_gpu_offset,
+            wait_ready=not parallel_start,
         )
         all_workers.extend(decode_workers)
+        if parallel_start:
+            # Each worker loads on its own GPUs, so spawning them all first
+            # makes a topology cost one model load instead of one per worker.
+            # It also brings the legs up in no particular order, which is what
+            # a user launching a fleet does.
+            startup_timeout = spec.get("startup_timeout", DEFAULT_STARTUP_TIMEOUT)
+            for worker in all_workers:
+                worker.wait_ready(startup_timeout)
 
         _start_gateway(
             gateway,

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -60,6 +60,10 @@ _WORKER_DEFAULTS = {
     # PD only: per-leg tensor parallelism (None = the model spec's tp).
     "prefill_tp": None,
     "decode_tp": None,
+    # PD only: KV transfer backend per worker of each leg ("nixl" /
+    # "mooncake"), a list one entry per worker; None = the lane's default.
+    "prefill_kv": None,
+    "decode_kv": None,
     "gpus": None,
     "extra_engine_args": None,
     # PD only: spawn every prefill/decode worker first and wait afterwards.
@@ -206,7 +210,9 @@ def setup_backend(request: pytest.FixtureRequest):
         GPU count and extra engine CLI args (local workers only)
       - ``@pytest.mark.workers(prefill=1, decode=1)``: PD worker counts
       - ``("pd_grpc", (n_prefill, n_decode[, prefill_tp, decode_tp]))`` as
-        the param: PD counts, optionally with asymmetric per-leg tp
+        the param: PD counts, optionally with asymmetric per-leg tp; a
+        trailing dict may add ``prefill_kv`` / ``decode_kv`` lists naming
+        each worker's KV transfer backend, so one fleet can mix transports
       - ``@pytest.mark.gateway(policy=..., timeout=..., extra_args=...)``: Gateway config
 
     Returns:
@@ -249,10 +255,15 @@ def setup_backend(request: pytest.FixtureRequest):
     if is_pd and leg_counts is not None:
         # ``("pd_grpc", (n_prefill, n_decode))`` lets one class sweep PD
         # topologies; setup_backend is class-scoped, so counts ride in the param.
+        leg_options: dict = {}
+        if leg_counts and isinstance(leg_counts[-1], dict):
+            leg_options = dict(leg_counts[-1])
+            leg_counts = tuple(leg_counts[:-1])
         if len(leg_counts) not in (2, 4):
             raise ValueError(
                 "pd_* backend params take (n_prefill, n_decode) or "
-                "(n_prefill, n_decode, prefill_tp, decode_tp)"
+                "(n_prefill, n_decode, prefill_tp, decode_tp), optionally followed by "
+                "a dict of per-worker options"
             )
         workers_config = {**workers_config, "prefill": leg_counts[0], "decode": leg_counts[1]}
         if len(leg_counts) == 4:
@@ -261,6 +272,9 @@ def setup_backend(request: pytest.FixtureRequest):
                 "prefill_tp": leg_counts[2],
                 "decode_tp": leg_counts[3],
             }
+        for key in ("prefill_kv", "decode_kv"):
+            if key in leg_options:
+                workers_config = {**workers_config, key: list(leg_options[key])}
     log_dir = os.environ.get("E2E_LOG_DIR") or gateway_config.get("log_dir")
 
     fail_count = _worker_start_failures.get(engine, 0)
@@ -382,6 +396,62 @@ def _setup_local(
 # ---------------------------------------------------------------------------
 
 
+def _per_worker_kv(raw, count: int, leg: str) -> list[str] | None:
+    """Normalise a per-worker KV backend list for one PD leg (None = lane default)."""
+    if raw is None:
+        return None
+    backends = [str(b).lower() for b in raw]
+    if len(backends) != count:
+        raise ValueError(f"{leg}_kv names {len(backends)} backends for {count} {leg} workers")
+    return backends
+
+
+def _start_pd_leg(
+    *,
+    model_id: str,
+    engine: str,
+    mode,
+    count: int,
+    worker_type,
+    log_dir,
+    gpu_offset: int,
+    wait_ready: bool,
+    tp,
+    kv_backends: list[str] | None,
+) -> list:
+    """Start one PD leg; a per-worker KV backend list starts the workers one by one."""
+    if kv_backends is None:
+        return _start_workers_tracked(
+            model_id=model_id,
+            engine=engine,
+            mode=mode,
+            count=count,
+            worker_type=worker_type,
+            log_dir=log_dir,
+            gpu_offset=gpu_offset,
+            wait_ready=wait_ready,
+            tp=tp,
+        )
+    spec_tp = tp or get_model_spec(model_id).get("tp", 1)
+    workers: list = []
+    for i, backend in enumerate(kv_backends):
+        workers.extend(
+            _start_workers_tracked(
+                model_id=model_id,
+                engine=engine,
+                mode=mode,
+                count=1,
+                worker_type=worker_type,
+                log_dir=log_dir,
+                gpu_offset=gpu_offset + i * spec_tp,
+                wait_ready=wait_ready,
+                tp=tp,
+                kv_backend=backend,
+            )
+        )
+    return workers
+
+
 def _setup_pd(
     model_id,
     model_path,
@@ -398,37 +468,43 @@ def _setup_pd(
     num_decode = workers_config.get("decode") or 1
     prefill_tp = workers_config.get("prefill_tp")
     decode_tp = workers_config.get("decode_tp")
+    prefill_kv = _per_worker_kv(workers_config.get("prefill_kv"), num_prefill, "prefill")
+    decode_kv = _per_worker_kv(workers_config.get("decode_kv"), num_decode, "decode")
     backend_name = f"pd_{connection_mode.value}"
     runtime_label = RUNTIME_LABELS.get(engine, engine)
 
     logger.info(
-        "Starting %s PD backend: model=%s, %d prefill (tp=%s) + %d decode (tp=%s)",
+        "Starting %s PD backend: model=%s, %d prefill (tp=%s, kv=%s) + %d decode (tp=%s, kv=%s)",
         runtime_label,
         model_id,
         num_prefill,
         prefill_tp or spec.get("tp", 1),
+        prefill_kv or "lane default",
         num_decode,
         decode_tp or spec.get("tp", 1),
+        decode_kv or "lane default",
     )
 
     parallel_start = bool(workers_config.get("parallel_start"))
     all_workers: list = []
     try:
-        prefill_workers = _start_workers_tracked(
+        prefill_workers = _start_pd_leg(
             model_id=model_id,
             engine=engine,
             mode=connection_mode,
             count=num_prefill,
             worker_type=WorkerType.PREFILL,
             log_dir=log_dir,
+            gpu_offset=0,
             wait_ready=not parallel_start,
             tp=prefill_tp,
+            kv_backends=prefill_kv,
         )
         all_workers.extend(prefill_workers)
 
         # Decode workers start on GPUs after prefill workers
         decode_gpu_offset = num_prefill * (prefill_tp or spec.get("tp", 1))
-        decode_workers = _start_workers_tracked(
+        decode_workers = _start_pd_leg(
             model_id=model_id,
             engine=engine,
             mode=connection_mode,
@@ -438,6 +514,7 @@ def _setup_pd(
             gpu_offset=decode_gpu_offset,
             wait_ready=not parallel_start,
             tp=decode_tp,
+            kv_backends=decode_kv,
         )
         all_workers.extend(decode_workers)
         if parallel_start:

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -174,6 +174,7 @@ def _wait_for_serving(
     client = _make_openai_client(gateway).with_options(max_retries=0)
     deadline = time.monotonic() + timeout
     last_error: Exception | None = None
+    settled_once: str | None = None
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
@@ -187,16 +188,24 @@ def _wait_for_serving(
             )
             return
         except openai.APIStatusError as exc:
-            if _error_code_of(exc) in _SETTLED_VERDICTS:
-                logger.info(
-                    "Gateway at %s settled on %s for %s; not waiting for it to serve",
-                    gateway.base_url,
-                    _error_code_of(exc),
-                    model_path,
-                )
-                return
-            if exc.status_code not in _NOT_SERVING_YET:
-                raise
+            code = _error_code_of(exc)
+            if code in _SETTLED_VERDICTS:
+                # A fleet still registering shows one worker per leg and can
+                # refuse a pair it accepts moments later; only a verdict that
+                # survives a poll is the fleet's.
+                if code == settled_once:
+                    logger.info(
+                        "Gateway at %s settled on %s for %s; not waiting for it to serve",
+                        gateway.base_url,
+                        code,
+                        model_path,
+                    )
+                    return
+                settled_once = code
+            else:
+                settled_once = None
+                if exc.status_code not in _NOT_SERVING_YET:
+                    raise
             last_error = exc
         except (openai.APIConnectionError, openai.APITimeoutError) as exc:
             last_error = exc
@@ -283,6 +292,8 @@ def setup_backend(request: pytest.FixtureRequest):
                 "(n_prefill, n_decode, prefill_tp, decode_tp), optionally followed by "
                 "a dict of per-worker options"
             )
+        if any(not isinstance(n, int) or isinstance(n, bool) or n < 1 for n in leg_counts):
+            raise ValueError(f"pd_* leg counts and tp must be positive integers, got {leg_counts}")
         workers_config = {**workers_config, "prefill": leg_counts[0], "decode": leg_counts[1]}
         if len(leg_counts) == 4:
             workers_config = {
@@ -436,6 +447,7 @@ def _start_pd_leg(
     wait_ready: bool,
     tp,
     kv_backends: list[str] | None,
+    extra_engine_args: list[str] | None = None,
 ) -> list:
     """Start one PD leg; a per-worker KV backend list starts the workers one by one."""
     if kv_backends is None:
@@ -449,6 +461,7 @@ def _start_pd_leg(
             gpu_offset=gpu_offset,
             wait_ready=wait_ready,
             tp=tp,
+            extra_engine_args=extra_engine_args,
         )
     spec_tp = tp or get_model_spec(model_id).get("tp", 1)
     workers: list = []
@@ -465,6 +478,7 @@ def _start_pd_leg(
                 wait_ready=wait_ready,
                 tp=tp,
                 kv_backend=backend,
+                extra_engine_args=extra_engine_args,
             )
         )
     return workers
@@ -504,6 +518,9 @@ def _setup_pd(
     )
 
     parallel_start = bool(workers_config.get("parallel_start"))
+    # The class marker's engine flags (a decode window, a context length)
+    # reach every leg, as they do for regular workers.
+    extra_engine_args = workers_config.get("extra_engine_args")
     all_workers: list = []
     try:
         prefill_workers = _start_pd_leg(
@@ -517,6 +534,7 @@ def _setup_pd(
             wait_ready=not parallel_start,
             tp=prefill_tp,
             kv_backends=prefill_kv,
+            extra_engine_args=extra_engine_args,
         )
         all_workers.extend(prefill_workers)
 
@@ -533,6 +551,7 @@ def _setup_pd(
             wait_ready=not parallel_start,
             tp=decode_tp,
             kv_backends=decode_kv,
+            extra_engine_args=extra_engine_args,
         )
         all_workers.extend(decode_workers)
         if parallel_start:
@@ -540,9 +559,15 @@ def _setup_pd(
             # makes a topology cost one model load instead of one per worker.
             # It also brings the legs up in no particular order, which is what
             # a user launching a fleet does.
-            startup_timeout = spec.get("startup_timeout", DEFAULT_STARTUP_TIMEOUT)
-            for worker in all_workers:
-                worker.wait_ready(startup_timeout)
+            # One deadline for the fleet, and a failed load still counts toward
+            # the session's fail-fast budget as it does on the sequential path.
+            deadline = time.monotonic() + spec.get("startup_timeout", DEFAULT_STARTUP_TIMEOUT)
+            try:
+                for worker in all_workers:
+                    worker.wait_ready(max(1, int(deadline - time.monotonic())))
+            except (TimeoutError, RuntimeError):
+                _worker_start_failures[engine] = _worker_start_failures.get(engine, 0) + 1
+                raise
 
         _start_gateway(
             gateway,

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -148,6 +148,16 @@ def _make_openai_client(gateway: Gateway) -> openai.OpenAI:
 # Statuses a fresh gateway returns while it is still wiring up (no worker
 # routable yet, tokenizer not registered) rather than rejecting the request.
 _NOT_SERVING_YET = frozenset({404, 408, 425, 429, 500, 502, 503, 504})
+# Error codes that are a settled verdict on the fleet, not a gateway still
+# wiring up: waiting longer cannot change them, and a test that builds such
+# a fleet asserts the verdict itself.
+_SETTLED_VERDICTS = frozenset({"no_compatible_pd_pair"})
+
+
+def _error_code_of(exc: openai.APIStatusError) -> str | None:
+    body = exc.body if isinstance(exc.body, dict) else {}
+    error = body.get("error", body)
+    return error.get("code") if isinstance(error, dict) else None
 
 
 def _wait_for_serving(
@@ -177,6 +187,14 @@ def _wait_for_serving(
             )
             return
         except openai.APIStatusError as exc:
+            if _error_code_of(exc) in _SETTLED_VERDICTS:
+                logger.info(
+                    "Gateway at %s settled on %s for %s; not waiting for it to serve",
+                    gateway.base_url,
+                    _error_code_of(exc),
+                    model_path,
+                )
+                return
             if exc.status_code not in _NOT_SERVING_YET:
                 raise
             last_error = exc

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -57,6 +57,9 @@ _WORKER_DEFAULTS = {
     "count": 1,
     "prefill": None,
     "decode": None,
+    # PD only: per-leg tensor parallelism (None = the model spec's tp).
+    "prefill_tp": None,
+    "decode_tp": None,
     "gpus": None,
     "extra_engine_args": None,
     # PD only: spawn every prefill/decode worker first and wait afterwards.
@@ -202,6 +205,8 @@ def setup_backend(request: pytest.FixtureRequest):
       - ``@pytest.mark.workers(gpus=2, extra_engine_args=[...])``: Per-worker
         GPU count and extra engine CLI args (local workers only)
       - ``@pytest.mark.workers(prefill=1, decode=1)``: PD worker counts
+      - ``("pd_grpc", (n_prefill, n_decode[, prefill_tp, decode_tp]))`` as
+        the param: PD counts, optionally with asymmetric per-leg tp
       - ``@pytest.mark.gateway(policy=..., timeout=..., extra_args=...)``: Gateway config
 
     Returns:
@@ -244,9 +249,18 @@ def setup_backend(request: pytest.FixtureRequest):
     if is_pd and leg_counts is not None:
         # ``("pd_grpc", (n_prefill, n_decode))`` lets one class sweep PD
         # topologies; setup_backend is class-scoped, so counts ride in the param.
-        if len(leg_counts) != 2:
-            raise ValueError("pd_* backend params take (n_prefill, n_decode) counts")
+        if len(leg_counts) not in (2, 4):
+            raise ValueError(
+                "pd_* backend params take (n_prefill, n_decode) or "
+                "(n_prefill, n_decode, prefill_tp, decode_tp)"
+            )
         workers_config = {**workers_config, "prefill": leg_counts[0], "decode": leg_counts[1]}
+        if len(leg_counts) == 4:
+            workers_config = {
+                **workers_config,
+                "prefill_tp": leg_counts[2],
+                "decode_tp": leg_counts[3],
+            }
     log_dir = os.environ.get("E2E_LOG_DIR") or gateway_config.get("log_dir")
 
     fail_count = _worker_start_failures.get(engine, 0)
@@ -382,15 +396,19 @@ def _setup_pd(
     spec = get_model_spec(model_id)
     num_prefill = workers_config.get("prefill") or 1
     num_decode = workers_config.get("decode") or 1
+    prefill_tp = workers_config.get("prefill_tp")
+    decode_tp = workers_config.get("decode_tp")
     backend_name = f"pd_{connection_mode.value}"
     runtime_label = RUNTIME_LABELS.get(engine, engine)
 
     logger.info(
-        "Starting %s PD backend: model=%s, %d prefill + %d decode",
+        "Starting %s PD backend: model=%s, %d prefill (tp=%s) + %d decode (tp=%s)",
         runtime_label,
         model_id,
         num_prefill,
+        prefill_tp or spec.get("tp", 1),
         num_decode,
+        decode_tp or spec.get("tp", 1),
     )
 
     parallel_start = bool(workers_config.get("parallel_start"))
@@ -404,11 +422,12 @@ def _setup_pd(
             worker_type=WorkerType.PREFILL,
             log_dir=log_dir,
             wait_ready=not parallel_start,
+            tp=prefill_tp,
         )
         all_workers.extend(prefill_workers)
 
         # Decode workers start on GPUs after prefill workers
-        decode_gpu_offset = num_prefill * spec.get("tp", 1)
+        decode_gpu_offset = num_prefill * (prefill_tp or spec.get("tp", 1))
         decode_workers = _start_workers_tracked(
             model_id=model_id,
             engine=engine,
@@ -418,6 +437,7 @@ def _setup_pd(
             log_dir=log_dir,
             gpu_offset=decode_gpu_offset,
             wait_ready=not parallel_start,
+            tp=decode_tp,
         )
         all_workers.extend(decode_workers)
         if parallel_start:

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -152,6 +152,8 @@ _NOT_SERVING_YET = frozenset({404, 408, 425, 429, 500, 502, 503, 504})
 # wiring up: waiting longer cannot change them, and a test that builds such
 # a fleet asserts the verdict itself.
 _SETTLED_VERDICTS = frozenset({"no_compatible_pd_pair"})
+# How long a settled verdict must hold before it counts as the fleet's.
+_SETTLED_FOR_SECS = 5.0
 
 
 def _error_code_of(exc: openai.APIStatusError) -> str | None:
@@ -174,7 +176,8 @@ def _wait_for_serving(
     client = _make_openai_client(gateway).with_options(max_retries=0)
     deadline = time.monotonic() + timeout
     last_error: Exception | None = None
-    settled_once: str | None = None
+    settled_code: str | None = None
+    settled_since = 0.0
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
@@ -191,9 +194,11 @@ def _wait_for_serving(
             code = _error_code_of(exc)
             if code in _SETTLED_VERDICTS:
                 # A fleet still registering shows one worker per leg and can
-                # refuse a pair it accepts moments later; only a verdict that
-                # survives a poll is the fleet's.
-                if code == settled_once:
+                # refuse a pair it accepts moments later; only a verdict the
+                # gateway has held for a few seconds is the fleet's.
+                if code != settled_code:
+                    settled_code, settled_since = code, time.monotonic()
+                elif time.monotonic() - settled_since >= _SETTLED_FOR_SECS:
                     logger.info(
                         "Gateway at %s settled on %s for %s; not waiting for it to serve",
                         gateway.base_url,
@@ -201,13 +206,13 @@ def _wait_for_serving(
                         model_path,
                     )
                     return
-                settled_once = code
             else:
-                settled_once = None
+                settled_code = None
                 if exc.status_code not in _NOT_SERVING_YET:
                     raise
             last_error = exc
         except (openai.APIConnectionError, openai.APITimeoutError) as exc:
+            settled_code = None  # an unreachable gateway is not a settled one
             last_error = exc
         time.sleep(min(2.0, max(0.0, deadline - time.monotonic())))
     raise TimeoutError(

--- a/e2e_test/infra/constants.py
+++ b/e2e_test/infra/constants.py
@@ -174,11 +174,22 @@ def get_zmq_engine_count() -> int:
 
 
 ENV_VLLM_KV_BACKEND = "E2E_VLLM_KV_BACKEND"
+# One KV transfer backend for every PD worker in the lane, whatever the
+# engine; the per-engine variables below are the fallbacks.
+ENV_KV_BACKEND = "E2E_KV_BACKEND"
+ENV_SGLANG_TRANSFER_BACKEND = "E2E_SGLANG_TRANSFER_BACKEND"
 
 
 def vllm_kv_backend() -> str:
     """KV transfer backend for vLLM PD workers: "nixl" (default) or "mooncake"."""
-    return os.environ.get(ENV_VLLM_KV_BACKEND, "nixl").lower()
+    lane = os.environ.get(ENV_KV_BACKEND, "").strip().lower()
+    return lane or os.environ.get(ENV_VLLM_KV_BACKEND, "nixl").lower()
+
+
+def sglang_transfer_backend() -> str:
+    """Disaggregation transfer backend for SGLang PD workers: "mooncake" (default) or "nixl"."""
+    lane = os.environ.get(ENV_KV_BACKEND, "").strip().lower()
+    return lane or os.environ.get(ENV_SGLANG_TRANSFER_BACKEND, "mooncake").lower()
 
 
 # Runtime display labels

--- a/e2e_test/infra/gateway.py
+++ b/e2e_test/infra/gateway.py
@@ -103,6 +103,10 @@ class Gateway:
         self.policy: str = "round_robin"
         self.log_level: str = "warn"
         self.log_dir: str | None = None
+        # The leg workers a PD/EPD gateway was started with (tests kill and restart them).
+        self.encode_workers: list[Worker] = []
+        self.prefill_workers: list[Worker] = []
+        self.decode_workers: list[Worker] = []
         self.pd_mode: bool = False
         self.igw_mode: bool = False
         self.cloud_mode: bool = False
@@ -179,6 +183,9 @@ class Gateway:
             encodes = encode_workers or []
             prefills = prefill_workers or []
             decodes = decode_workers or []
+            self.encode_workers = list(encodes)
+            self.prefill_workers = list(prefills)
+            self.decode_workers = list(decodes)
             mode_args = build_epd_mode_args(encodes, prefills, decodes, encode_policy)
             self._launch(
                 mode_args=mode_args,
@@ -195,6 +202,8 @@ class Gateway:
             self.igw_mode = False
             prefills = prefill_workers or []
             decodes = decode_workers or []
+            self.prefill_workers = list(prefills)
+            self.decode_workers = list(decodes)
 
             mode_args = ["--pd-disaggregation"]
             for pf in prefills:
@@ -440,15 +449,23 @@ class Gateway:
         wait_ready: bool = True,
         ready_timeout: float = 60.0,
         labels: dict[str, str] | None = None,
+        worker_type: str | None = None,
+        bootstrap_port: int | None = None,
     ) -> tuple[bool, str | None]:
         """Add a worker to the gateway. Returns (success, worker_id or error).
 
         ``labels`` are attached to the worker's ``WorkerSpec`` (e.g.
         ``{"realtime": "true"}`` to make it eligible for realtime routing).
+        ``worker_type`` (``"prefill"``/``"decode"``/``"encode"``) and the
+        prefill ``bootstrap_port`` register a disaggregated leg at runtime.
         """
         body: dict = {"url": worker_url}
         if labels:
             body["labels"] = labels
+        if worker_type:
+            body["worker_type"] = worker_type
+        if bootstrap_port is not None:
+            body["bootstrap_port"] = bootstrap_port
         try:
             resp = httpx.post(
                 f"{self.base_url}/workers",

--- a/e2e_test/infra/gateway.py
+++ b/e2e_test/infra/gateway.py
@@ -418,6 +418,7 @@ class Gateway:
                 "connection_mode": w.get("connection_mode"),
                 "priority": w.get("priority"),
                 "cost": w.get("cost"),
+                "pd_pairing": w.get("pd_pairing"),
             },
         )
 

--- a/e2e_test/infra/process_utils.py
+++ b/e2e_test/infra/process_utils.py
@@ -96,6 +96,129 @@ def kill_process_tree(pid: int, sig: int = signal.SIGTERM) -> None:
         logger.warning("Failed to kill process tree for PID %d: %s", pid, e)
 
 
+def live_process_group_members(pgid: int, proc_root: str = "/proc") -> list[int]:
+    """PIDs still running in ``pgid``, ignoring zombies that await reaping.
+
+    Reads ``proc_root`` (``/proc`` on Linux). Elsewhere it falls back to
+    probing the group with signal 0, which cannot tell a zombie from a live
+    process.
+    """
+    if not os.path.isdir(proc_root):
+        try:
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return []
+        except PermissionError:
+            pass
+        return [pgid]
+    members: list[int] = []
+    for name in os.listdir(proc_root):
+        if not name.isdigit():
+            continue
+        try:
+            with open(
+                os.path.join(proc_root, name, "stat"), encoding="utf-8", errors="replace"
+            ) as f:
+                stat = f.read()
+        except OSError:
+            continue
+        # ``pid (comm) state ppid pgrp ...``: comm may contain spaces or
+        # parentheses, so split after the last closing parenthesis.
+        fields = stat.rpartition(")")[2].split()
+        if len(fields) < 3:
+            continue
+        state, pgrp = fields[0], fields[2]
+        if state != "Z" and pgrp == str(pgid):
+            members.append(int(name))
+    return members
+
+
+def wait_for_process_group_exit(pgid: int, timeout: float, kill_after: float) -> list[int]:
+    """Block until every live member of ``pgid`` has exited.
+
+    Sends SIGKILL to the whole group once ``kill_after`` seconds pass without
+    it emptying, then keeps waiting until ``timeout``. Returns the PIDs still
+    alive at the deadline (empty on success).
+    """
+    start = time.monotonic()
+    killed = False
+    while True:
+        members = live_process_group_members(pgid)
+        elapsed = time.monotonic() - start
+        if not members or elapsed >= timeout:
+            return members
+        if not killed and elapsed >= kill_after:
+            logger.warning(
+                "Process group %d still has %s alive after %.0fs; sending SIGKILL",
+                pgid,
+                members,
+                elapsed,
+            )
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+            killed = True
+        time.sleep(0.2)
+
+
+def gpu_memory_used_mib(gpu_ids: list[int]) -> dict[int, int] | None:
+    """Used memory per GPU index via ``nvidia-smi``; ``None`` when unavailable."""
+    if not gpu_ids:
+        return {}
+    try:
+        out = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,memory.used",
+                "--format=csv,noheader,nounits",
+                "-i",
+                ",".join(str(g) for g in gpu_ids),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    used: dict[int, int] = {}
+    for line in out.splitlines():
+        parts = [part.strip() for part in line.split(",")]
+        if len(parts) != 2:
+            continue
+        try:
+            used[int(parts[0])] = int(parts[1])
+        except ValueError:
+            continue
+    return used
+
+
+def wait_for_gpu_memory_release(
+    gpu_ids: list[int],
+    baseline: dict[int, int],
+    timeout: float,
+    slack_mib: int = 2048,
+) -> dict[int, int] | None:
+    """Wait until each GPU's used memory is back within ``slack_mib`` of ``baseline``.
+
+    An engine's child processes release their CUDA contexts after the launcher
+    exits; a replacement started on the same GPU before that reads the old
+    allocation as its own shortfall and dies on its startup memory check.
+    Returns the GPUs still above the threshold at the deadline (empty on
+    success), or ``None`` when ``nvidia-smi`` is unavailable.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        used = gpu_memory_used_mib(gpu_ids)
+        if used is None:
+            return None
+        over = {gpu: mib for gpu, mib in used.items() if mib > baseline.get(gpu, 0) + slack_mib}
+        if not over or time.monotonic() >= deadline:
+            return over
+        time.sleep(0.5)
+
+
 def terminate_process(proc: subprocess.Popen, timeout: float = 30) -> None:
     """Gracefully terminate a process, kill if needed.
 

--- a/e2e_test/infra/process_utils.py
+++ b/e2e_test/infra/process_utils.py
@@ -205,8 +205,10 @@ def wait_for_gpu_memory_release(
     An engine's child processes release their CUDA contexts after the launcher
     exits; a replacement started on the same GPU before that reads the old
     allocation as its own shortfall and dies on its startup memory check.
-    Returns the GPUs still above the threshold at the deadline (empty on
-    success), or ``None`` when ``nvidia-smi`` is unavailable.
+    Returns the GPUs still above the threshold (empty on success), or ``None``
+    when ``nvidia-smi`` is unavailable. Gives up before ``timeout`` once that
+    set has held the same values for 5 s: a region another live process still
+    maps never drains, so a static figure is the answer, not a wait.
     """
     deadline = time.monotonic() + timeout
     last_over: dict[int, int] | None = None

--- a/e2e_test/infra/process_utils.py
+++ b/e2e_test/infra/process_utils.py
@@ -209,12 +209,22 @@ def wait_for_gpu_memory_release(
     success), or ``None`` when ``nvidia-smi`` is unavailable.
     """
     deadline = time.monotonic() + timeout
+    last_over: dict[int, int] | None = None
+    last_change = time.monotonic()
     while True:
         used = gpu_memory_used_mib(gpu_ids)
         if used is None:
             return None
         over = {gpu: mib for gpu, mib in used.items() if mib > baseline.get(gpu, 0) + slack_mib}
-        if not over or time.monotonic() >= deadline:
+        now = time.monotonic()
+        if not over or now >= deadline:
+            return over
+        # A region that another live process still maps (a decode holding a
+        # dead prefill's KV) never drains; a teardown in progress shrinks the
+        # figure every second. Give up once it has sat still for 5 s.
+        if over != last_over:
+            last_over, last_change = over, now
+        elif now - last_change >= 5.0:
             return over
         time.sleep(0.5)
 

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -113,7 +113,16 @@ class Worker:
             )
             return
 
-        # Wait for health check
+        self.wait_ready(timeout)
+
+    def wait_ready(self, timeout: int = DEFAULT_STARTUP_TIMEOUT) -> None:
+        """Block until the spawned worker passes its health check.
+
+        ``start(wait_ready=False)`` followed by this call lets a caller spawn
+        several workers and wait for all of them afterwards.
+        """
+        if self.process is None:
+            raise RuntimeError(f"Worker {self.model_id} has not been started")
         if self.mode == ConnectionMode.ZMQ:
             # SMG (the router) binds the ZMQ sockets and this engine dials in;
             # there is no worker port to probe. The gateway's readiness gate

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -256,6 +256,10 @@ class Worker:
             return self.kv_backend.lower()
         if self.engine == "sglang":
             return sglang_transfer_backend()
+        if self.engine == "tokenspeed":
+            # TokenSpeed moves KV over Mooncake only; the lane-wide setting
+            # exists for the engines that have a choice.
+            return "mooncake"
         return vllm_kv_backend()
 
     def _build_cmd(self) -> list[str]:

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -216,11 +216,15 @@ class Worker:
         if self._gpu_mem_baseline is not None:
             # A region another process still maps (a decode holding a dead
             # prefill's KV) never frees, so the wait is a bounded courtesy.
+            waited = time.monotonic()
             held = wait_for_gpu_memory_release(self.gpu_ids, self._gpu_mem_baseline, timeout=30.0)
             if held:
+                # The wait gives up once the figure stops moving, usually well
+                # inside the 30 s cap; report what was actually waited.
                 logger.warning(
-                    "Worker %s: GPU memory still held 30s after stop: used %s MiB, baseline %s MiB",
+                    "Worker %s: GPU memory still held %.0fs after stop: used %s MiB, baseline %s MiB",
                     self.model_id,
+                    time.monotonic() - waited,
                     held,
                     self._gpu_mem_baseline,
                 )
@@ -328,12 +332,14 @@ class Worker:
         # PD disaggregation arguments
         if self.worker_type == WorkerType.PREFILL:
             cmd.extend(["--disaggregation-mode", "prefill"])
+            cmd.extend(["--disaggregation-transfer-backend", self.effective_kv_backend()])
             if self.bootstrap_port:
                 cmd.extend(["--disaggregation-bootstrap-port", str(self.bootstrap_port)])
             if self.ib_device:
                 cmd.extend(["--disaggregation-ib-device", self.ib_device])
         elif self.worker_type == WorkerType.DECODE:
             cmd.extend(["--disaggregation-mode", "decode"])
+            cmd.extend(["--disaggregation-transfer-backend", self.effective_kv_backend()])
             cmd.extend(["--base-gpu-id", "0"])
             if self.ib_device:
                 cmd.extend(["--disaggregation-ib-device", self.ib_device])

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -25,6 +25,7 @@ from .constants import (
     WorkerType,
     get_runtime,
     get_zmq_engine_count,
+    sglang_transfer_backend,
     vllm_kv_backend,
 )
 from .model_specs import get_model_spec
@@ -59,6 +60,9 @@ class Worker:
     extra_engine_args: list[str] | None = None
     # Overrides the model spec's tp, so a PD pair can run asymmetric legs.
     tp: int | None = None
+    # KV transfer backend for this PD worker ("nixl" or "mooncake"); None
+    # takes the lane's default, so one fleet can mix transports.
+    kv_backend: str | None = None
     process: subprocess.Popen | None = field(default=None, repr=False)
     _log_file: IO[Any] | None = field(default=None, repr=False)
     # Used memory per GPU just before launch; ``stop`` waits for it to come back.
@@ -246,6 +250,14 @@ class Worker:
         """Check if the worker process is still running."""
         return self.process is not None and self.process.poll() is None
 
+    def effective_kv_backend(self) -> str:
+        """This worker's KV transfer backend: its own override, else the lane's."""
+        if self.kv_backend:
+            return self.kv_backend.lower()
+        if self.engine == "sglang":
+            return sglang_transfer_backend()
+        return vllm_kv_backend()
+
     def _build_cmd(self) -> list[str]:
         """Build engine-specific launch command using model specs."""
         spec = get_model_spec(self.model_id)
@@ -381,7 +393,7 @@ class Worker:
         # PD disaggregation: KV transfer roles (backend via E2E_VLLM_KV_BACKEND)
         if self.worker_type in (WorkerType.PREFILL, WorkerType.DECODE):
             kv_role = "kv_producer" if self.worker_type == WorkerType.PREFILL else "kv_consumer"
-            if vllm_kv_backend() == "mooncake":
+            if self.effective_kv_backend() == "mooncake":
                 config = {"kv_connector": "MooncakeConnector", "kv_role": kv_role}
             else:
                 config = {"kv_connector": "NixlConnector", "kv_role": kv_role}
@@ -465,7 +477,7 @@ class Worker:
             cmd.extend(["--disaggregation-mode", self.worker_type.value])
             if self.bootstrap_port is not None:
                 cmd.extend(["--disaggregation-bootstrap-port", str(self.bootstrap_port)])
-            cmd.extend(["--disaggregation-transfer-backend", "mooncake"])
+            cmd.extend(["--disaggregation-transfer-backend", self.effective_kv_backend()])
             if self.dist_init_addr:
                 cmd.extend(["--dist-init-addr", self.dist_init_addr])
             if self.worker_type in (WorkerType.PREFILL, WorkerType.DECODE):
@@ -531,7 +543,7 @@ class Worker:
 
         # vLLM PD workers need per-worker side-channel ports for their KV backend
         if self.engine == "vllm" and self.worker_type in (WorkerType.PREFILL, WorkerType.DECODE):
-            if vllm_kv_backend() == "mooncake":
+            if self.effective_kv_backend() == "mooncake":
                 # The producer's bootstrap server must listen on the port the
                 # gateway advertises in remote_bootstrap_addr
                 if self.bootstrap_port is not None:
@@ -657,6 +669,7 @@ def start_workers(
     gpus: int | None = None,
     extra_engine_args: list[str] | None = None,
     tp: int | None = None,
+    kv_backend: str | None = None,
 ) -> list[Worker]:
     """Start N workers for a model. GPU IDs assigned sequentially.
 
@@ -676,6 +689,8 @@ def start_workers(
         extra_engine_args: Extra CLI args appended to the engine launch command.
         tp: Tensor-parallel size for these workers; defaults to the model
             spec's tp. Also sizes the GPU slice unless ``gpus`` says otherwise.
+        kv_backend: KV transfer backend for PD workers ("nixl" or
+            "mooncake"); defaults to the lane's setting.
 
     Returns:
         List of started Worker instances.
@@ -739,6 +754,7 @@ def start_workers(
                 log_dir=log_dir,
                 extra_engine_args=extra_engine_args,
                 tp=tp,
+                kv_backend=kv_backend,
             )
 
             # Stagger launches to avoid resource contention

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -28,7 +28,14 @@ from .constants import (
     vllm_kv_backend,
 )
 from .model_specs import get_model_spec
-from .process_utils import detect_ib_device, get_open_port, wait_for_health
+from .process_utils import (
+    detect_ib_device,
+    get_open_port,
+    gpu_memory_used_mib,
+    wait_for_gpu_memory_release,
+    wait_for_health,
+    wait_for_process_group_exit,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +59,8 @@ class Worker:
     extra_engine_args: list[str] | None = None
     process: subprocess.Popen | None = field(default=None, repr=False)
     _log_file: IO[Any] | None = field(default=None, repr=False)
+    # Used memory per GPU just before launch; ``stop`` waits for it to come back.
+    _gpu_mem_baseline: dict[int, int] | None = field(default=None, repr=False)
 
     @property
     def base_url(self) -> str:
@@ -102,6 +111,7 @@ class Worker:
         )
         logger.debug("Command: %s", " ".join(cmd))
 
+        self._gpu_mem_baseline = gpu_memory_used_mib(self.gpu_ids)
         self.process = self._spawn_process(cmd, env)
 
         if not wait_ready:
@@ -158,18 +168,28 @@ class Worker:
         pid = self.process.pid
         logger.info("Stopping worker %s (PID %d)", self.model_id, pid)
 
-        # Kill entire process group (workers run in their own session)
+        # Workers run in their own session, so the launcher and every engine
+        # child process share one group.
+        pgid: int | None
         try:
             pgid = os.getpgid(pid)
-            os.killpg(pgid, signal.SIGTERM)
         except (ProcessLookupError, OSError):
+            pgid = None
+
+        if pgid is not None:
+            try:
+                os.killpg(pgid, signal.SIGTERM)
+            except (ProcessLookupError, OSError):
+                self.process.terminate()
+        else:
             self.process.terminate()
 
         try:
             self.process.wait(timeout=10)
         except subprocess.TimeoutExpired:
             try:
-                pgid = os.getpgid(pid)
+                if pgid is None:
+                    raise ProcessLookupError
                 os.killpg(pgid, signal.SIGKILL)
             except (ProcessLookupError, OSError):
                 self.process.kill()
@@ -177,6 +197,25 @@ class Worker:
                 self.process.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 logger.error("Worker PID %d did not die after SIGKILL", pid)
+
+        # ``process.wait`` only reaps the launcher. The engine's children
+        # (vLLM's EngineCore, SGLang's scheduler) outlive it while they tear
+        # down their CUDA contexts, and a replacement started on the same GPUs
+        # inside that window fails its startup memory check against the old
+        # allocation. Wait for the group to empty, then for the memory.
+        if pgid is not None:
+            stragglers = wait_for_process_group_exit(pgid, timeout=40.0, kill_after=20.0)
+            if stragglers:
+                logger.error("Worker %s: PIDs %s survived SIGKILL", self.model_id, stragglers)
+        if self._gpu_mem_baseline is not None:
+            held = wait_for_gpu_memory_release(self.gpu_ids, self._gpu_mem_baseline, timeout=60.0)
+            if held:
+                logger.warning(
+                    "Worker %s: GPU memory still held 60s after stop: used %s MiB, baseline %s MiB",
+                    self.model_id,
+                    held,
+                    self._gpu_mem_baseline,
+                )
 
         # Clean up log file
         if self._log_file is not None:

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -57,6 +57,8 @@ class Worker:
     dist_init_port: int | None = None
     log_dir: str | None = None
     extra_engine_args: list[str] | None = None
+    # Overrides the model spec's tp, so a PD pair can run asymmetric legs.
+    tp: int | None = None
     process: subprocess.Popen | None = field(default=None, repr=False)
     _log_file: IO[Any] | None = field(default=None, repr=False)
     # Used memory per GPU just before launch; ``stop`` waits for it to come back.
@@ -248,7 +250,7 @@ class Worker:
         """Build engine-specific launch command using model specs."""
         spec = get_model_spec(self.model_id)
         model_path = spec["model"]
-        tp_size = spec.get("tp", 1)
+        tp_size = self.tp or spec.get("tp", 1)
         features = spec.get("features", [])
 
         if self.engine == "sglang":
@@ -654,6 +656,7 @@ def start_workers(
     wait_ready: bool = True,
     gpus: int | None = None,
     extra_engine_args: list[str] | None = None,
+    tp: int | None = None,
 ) -> list[Worker]:
     """Start N workers for a model. GPU IDs assigned sequentially.
 
@@ -671,6 +674,8 @@ def start_workers(
             If False, spawn processes and return immediately.
         gpus: GPUs per worker; defaults to the model spec's tp (e.g. DP needs dp*tp).
         extra_engine_args: Extra CLI args appended to the engine launch command.
+        tp: Tensor-parallel size for these workers; defaults to the model
+            spec's tp. Also sizes the GPU slice unless ``gpus`` says otherwise.
 
     Returns:
         List of started Worker instances.
@@ -682,7 +687,7 @@ def start_workers(
         engine = get_runtime()
 
     spec = get_model_spec(model_id)
-    gpus_per_worker = gpus or spec.get("tp", 1)
+    gpus_per_worker = gpus or tp or spec.get("tp", 1)
     if gpus is None and mode == ConnectionMode.ZMQ:
         # A grouped ZMQ worker launches get_zmq_engine_count() engines, each
         # tp-wide, in one process — size its GPU slice accordingly. vLLM and
@@ -733,6 +738,7 @@ def start_workers(
                 dist_init_port=dist_init_port,
                 log_dir=log_dir,
                 extra_engine_args=extra_engine_args,
+                tp=tp,
             )
 
             # Stagger launches to avoid resource contention

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -535,6 +535,13 @@ class Worker:
             else:
                 self.nixl_port = get_open_port()
                 env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(self.nixl_port)
+                # Single-host NIXL moves KV over CUDA IPC, and UCX caches the
+                # imported handles on the reader. A decode worker then keeps a
+                # dead prefill's whole KV region mapped (54 GiB stayed
+                # allocated 60 s after every prefill process had exited), and
+                # the prefill restarted on that GPU fails its free-memory
+                # check. Drop the cache so a mapping ends with its transfer.
+                env.setdefault("UCX_CUDA_IPC_CACHE", "n")
 
         if self.engine == "trtllm":
             # TRT-LLM bootstraps workers over Open MPI even at TP=1. On CI pods the

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -208,10 +208,12 @@ class Worker:
             if stragglers:
                 logger.error("Worker %s: PIDs %s survived SIGKILL", self.model_id, stragglers)
         if self._gpu_mem_baseline is not None:
-            held = wait_for_gpu_memory_release(self.gpu_ids, self._gpu_mem_baseline, timeout=60.0)
+            # A region another process still maps (a decode holding a dead
+            # prefill's KV) never frees, so the wait is a bounded courtesy.
+            held = wait_for_gpu_memory_release(self.gpu_ids, self._gpu_mem_baseline, timeout=30.0)
             if held:
                 logger.warning(
-                    "Worker %s: GPU memory still held 60s after stop: used %s MiB, baseline %s MiB",
+                    "Worker %s: GPU memory still held 30s after stop: used %s MiB, baseline %s MiB",
                     self.model_id,
                     held,
                     self._gpu_mem_baseline,

--- a/e2e_test/infra/worker_pool.py
+++ b/e2e_test/infra/worker_pool.py
@@ -69,6 +69,7 @@ class WorkerPool:
         gpu_offset: int = 0,
         gpus: int | None = None,
         extra_engine_args: list[str] | None = None,
+        wait_ready: bool = True,
     ) -> list[Worker]:
         """Return ``count`` healthy workers for the given key.
 
@@ -114,6 +115,7 @@ class WorkerPool:
                     gpu_offset=gpu_offset,
                     gpus=gpus,
                     extra_engine_args=extra_engine_args,
+                    wait_ready=wait_ready,
                 )
 
             # REGULAR workers always start at gpu 0; ``gpu_offset`` is only
@@ -156,6 +158,7 @@ class WorkerPool:
                 log_dir=log_dir,
                 gpus=gpus,
                 extra_engine_args=extra_engine_args,
+                wait_ready=wait_ready,
             )
             self._key = key
             self._workers = new_workers

--- a/e2e_test/infra/worker_pool.py
+++ b/e2e_test/infra/worker_pool.py
@@ -70,6 +70,7 @@ class WorkerPool:
         gpus: int | None = None,
         extra_engine_args: list[str] | None = None,
         wait_ready: bool = True,
+        tp: int | None = None,
     ) -> list[Worker]:
         """Return ``count`` healthy workers for the given key.
 
@@ -116,7 +117,11 @@ class WorkerPool:
                     gpus=gpus,
                     extra_engine_args=extra_engine_args,
                     wait_ready=wait_ready,
+                    tp=tp,
                 )
+
+            if tp is not None:
+                raise ValueError("a per-leg tp is only meaningful for PD prefill/decode workers")
 
             # REGULAR workers always start at gpu 0; ``gpu_offset`` is only
             # meaningful for non-REGULAR (PD decode) callers.

--- a/e2e_test/infra/worker_pool.py
+++ b/e2e_test/infra/worker_pool.py
@@ -71,6 +71,7 @@ class WorkerPool:
         extra_engine_args: list[str] | None = None,
         wait_ready: bool = True,
         tp: int | None = None,
+        kv_backend: str | None = None,
     ) -> list[Worker]:
         """Return ``count`` healthy workers for the given key.
 
@@ -118,10 +119,13 @@ class WorkerPool:
                     extra_engine_args=extra_engine_args,
                     wait_ready=wait_ready,
                     tp=tp,
+                    kv_backend=kv_backend,
                 )
 
-            if tp is not None:
-                raise ValueError("a per-leg tp is only meaningful for PD prefill/decode workers")
+            if tp is not None or kv_backend is not None:
+                raise ValueError(
+                    "a per-leg tp or kv_backend is only meaningful for PD prefill/decode workers"
+                )
 
             # REGULAR workers always start at gpu 0; ``gpu_offset`` is only
             # meaningful for non-REGULAR (PD decode) callers.

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -1,0 +1,562 @@
+"""Prefill/decode disaggregation under every worker topology a 4-GPU node allows.
+
+One class sweeps the topologies 1p1d, 1p2d, 2p1d, 1p3d, 3p1d and 2p2d. The
+counts ride in the ``setup_backend`` param because the fixture is
+class-scoped, and every test runs once per topology. The gateway logs each
+selected pair at debug level, so requests are attributed to workers from the
+router log instead of guessed.
+
+What a user of PD mode hits, in the order they hit it:
+
+- registration: ``/workers`` lists every leg with its role, all healthy
+- placement: every prefill and every decode worker takes traffic
+- transfer: a long prompt's context reaches decode; concurrent requests do
+  not see each other's KV; a second turn still sees the first
+- streaming: a stream completes with usage; an abandoned stream frees the
+  engine slots on both legs instead of generating to its limit
+- failure: a leg loses one worker and traffic keeps flowing; a leg loses its
+  only worker and the client gets a prompt error instead of a hang; the
+  worker comes back and rejoins rotation
+- operations: a PD fleet assembled at runtime through the worker API in IGW
+  mode routes through prefill and decode
+
+TokenSpeed runs Qwen3.5-9B, the model its disaggregation path is proven on;
+SGLang and vLLM run Llama-3.1-8B.
+
+Usage:
+    E2E_RUNTIME=tokenspeed pytest e2e_test/router/test_pd_topologies.py -v -k 2p2d
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import httpx
+import pytest
+from infra import ConnectionMode, Gateway, WorkerType, cleanup_pool, start_workers, stop_workers
+from infra.constants import get_runtime
+from infra.model_specs import get_model_spec
+from infra.pd_logs import LOG_FLUSH_TIMEOUT_S, read_logs
+
+logger = logging.getLogger(__name__)
+
+# Router logs land here via the gateway marker (rolling files named smg.YYYY-MM-DD)
+_LOG_DIR = Path(tempfile.gettempdir()) / f"smg-e2e-pd-topologies-{os.getpid()}"
+PAIR_MARKER = "Selected PD pair"
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_PAIR_RE = re.compile(r"prefill=(\S+)\s+decode=(\S+)")
+
+_MODEL = "meta-llama/Llama-3.1-8B-Instruct"
+_MODEL_BY_ENGINE = {"tokenspeed": "Qwen/Qwen3.5-9B"}
+_HEALTH_ARGS = [
+    "--health-check-interval-secs",
+    "1",
+    "--health-check-timeout-secs",
+    "2",
+    "--health-failure-threshold",
+    "1",
+    "--health-success-threshold",
+    "1",
+]
+_GATEWAY_ARGS = [
+    "--prefill-policy",
+    "round_robin",
+    "--decode-policy",
+    "round_robin",
+    "--load-monitor-interval",
+    "2",
+    *_HEALTH_ARGS,
+]
+_TOPOLOGIES = [
+    pytest.param(("pd_grpc", (p, d)), id=f"{p}p{d}d")
+    for p, d in [(1, 1), (1, 2), (2, 1), (1, 3), (3, 1), (2, 2)]
+]
+_WORDS = [
+    "apricot",
+    "bramble",
+    "cobalt",
+    "dahlia",
+    "ember",
+    "fjord",
+    "glacier",
+    "harbor",
+    "iris",
+    "juniper",
+    "kestrel",
+    "lagoon",
+    "meadow",
+    "nectar",
+    "orchid",
+    "pebble",
+]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _pairs_logged() -> list[tuple[str, str]]:
+    """(prefill, decode) URL pairs the gateway has logged so far, in order."""
+    pairs: list[tuple[str, str]] = []
+    for raw in read_logs(_LOG_DIR, "smg*").splitlines():
+        if PAIR_MARKER not in raw:
+            continue
+        match = _PAIR_RE.search(_ANSI.sub("", raw))
+        if match:
+            pairs.append((match.group(1), match.group(2)))
+    return pairs
+
+
+def _wait_for_pairs(minimum: int, timeout: float = LOG_FLUSH_TIMEOUT_S) -> list[tuple[str, str]]:
+    deadline = time.monotonic() + timeout
+    pairs = _pairs_logged()
+    while len(pairs) < minimum and time.monotonic() < deadline:
+        time.sleep(0.5)
+        pairs = _pairs_logged()
+    assert len(pairs) >= minimum, (
+        f"router logged {len(pairs)} PD pair selections, expected at least {minimum}; "
+        f"is --log-level debug reaching {_LOG_DIR}/smg*?"
+    )
+    return pairs
+
+
+def _workers_by_role(gateway: Gateway) -> dict[str, list]:
+    by_role: dict[str, list] = {}
+    for worker in gateway.list_workers(strict=True):
+        by_role.setdefault(str(worker.metadata.get("worker_type")), []).append(worker)
+    return by_role
+
+
+def _status_of(gateway: Gateway, url: str) -> str | None:
+    for worker in gateway.list_workers(strict=True):
+        if worker.url == url:
+            return worker.status
+    return None
+
+
+def _wait_for_status(gateway: Gateway, url: str, wanted: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    seen: str | None = None
+    while time.monotonic() < deadline:
+        seen = _status_of(gateway, url)
+        if seen == wanted:
+            return
+        time.sleep(0.5)
+    pytest.fail(f"worker {url} never became {wanted} within {timeout:.0f}s (last: {seen})")
+
+
+def _answer_text(message: dict) -> str:
+    """Content plus any reasoning text: thinking models may answer in either."""
+    content = message.get("content") or ""
+    reasoning = message.get("reasoning_content") or message.get("reasoning") or ""
+    return f"{content}\n{reasoning}".strip()
+
+
+def _ask(client, model: str, content: str, *, max_tokens: int = 256, **kwargs) -> dict:
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": content}],
+        temperature=0,
+        max_tokens=max_tokens,
+        timeout=120.0,
+        **kwargs,
+    )
+    return response.choices[0].message.model_dump()
+
+
+def _raw_chat(gateway: Gateway, model: str, content: str, *, timeout: float) -> httpx.Response:
+    return httpx.post(
+        f"{gateway.base_url}/v1/chat/completions",
+        json={
+            "model": model,
+            "messages": [{"role": "user", "content": content}],
+            "max_tokens": 8,
+            "temperature": 0,
+        },
+        timeout=timeout,
+    )
+
+
+def _error_code(resp: httpx.Response) -> str | None:
+    try:
+        body = resp.json()
+    except ValueError:
+        return None
+    error = body.get("error", body)
+    return error.get("code") if isinstance(error, dict) else None
+
+
+def _wait_until_served(gateway: Gateway, model: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last = "no attempt"
+    while time.monotonic() < deadline:
+        try:
+            resp = _raw_chat(gateway, model, "Say hello.", timeout=60.0)
+        except httpx.HTTPError as exc:
+            last = repr(exc)
+        else:
+            if resp.status_code == 200:
+                return
+            last = f"{resp.status_code} {resp.text[:200]}"
+        time.sleep(1.0)
+    pytest.fail(f"gateway did not serve within {timeout:.0f}s; last: {last}")
+
+
+def _fleet_idle(gateway: Gateway) -> tuple[bool, list[dict]]:
+    resp = httpx.get(f"{gateway.base_url}/loads", timeout=5.0)
+    assert resp.status_code == 200, resp.text
+    loads = resp.json().get("loads", [])
+    busy = [e for e in loads if e.get("num_running_reqs", 0) + e.get("num_waiting_reqs", 0) > 0]
+    return (not busy, loads)
+
+
+def _run_all(fns: list[Callable[[], None]], timeout: float) -> list[BaseException]:
+    errors: list[BaseException] = []
+
+    def _wrap(fn: Callable[[], None]) -> None:
+        try:
+            fn()
+        except BaseException as exc:  # collected for the caller's assertion
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_wrap, args=(fn,), daemon=True) for fn in fns]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=timeout)
+    return errors
+
+
+def _long_prompt(secret: str) -> str:
+    filler = (
+        "The harbor office logs every vessel by name, tonnage and berth, and the "
+        "clerk reads the tide tables twice before the evening shift begins. "
+    )
+    # ~3k tokens: enough KV blocks that a transfer that drops blocks shows up.
+    return (
+        f"Instruction: the access code is {secret}. Remember it.\n\n"
+        + filler * 120
+        + "\n\nQuestion: what is the access code? Reply with the number only."
+    )
+
+
+# ---------------------------------------------------------------------------
+# the topology sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.engine("sglang", "vllm", "tokenspeed")
+@pytest.mark.gpu(4)
+@pytest.mark.e2e
+@pytest.mark.model(_MODEL, tokenspeed=_MODEL_BY_ENGINE["tokenspeed"])
+@pytest.mark.workers(parallel_start=True)
+@pytest.mark.gateway(log_level="debug", log_dir=str(_LOG_DIR), extra_args=_GATEWAY_ARGS)
+@pytest.mark.parametrize("setup_backend", _TOPOLOGIES, indirect=True)
+class TestPDTopology:
+    """Every test below runs once per prefill/decode topology."""
+
+    # -- registration ------------------------------------------------------
+
+    def test_workers_registered_by_role(self, setup_backend):
+        _, model, _, gateway = setup_backend
+        expected = {
+            "prefill": {w.base_url for w in gateway.prefill_workers},
+            "decode": {w.base_url for w in gateway.decode_workers},
+        }
+
+        by_role = _workers_by_role(gateway)
+        listed = {role: {w.url for w in workers} for role, workers in by_role.items()}
+
+        assert listed == expected, f"/workers roles {listed} != launched {expected}"
+        unhealthy = [w.url for ws in by_role.values() for w in ws if w.status != "healthy"]
+        assert not unhealthy, f"unhealthy legs after startup: {unhealthy}"
+        assert any(m.get("id") for m in gateway.list_models()), "no model listed"
+
+    # -- placement ---------------------------------------------------------
+
+    def test_every_leg_takes_traffic(self, setup_backend):
+        _, model, client, gateway = setup_backend
+        prefills = {w.base_url for w in gateway.prefill_workers}
+        decodes = {w.base_url for w in gateway.decode_workers}
+        before = len(_pairs_logged())
+        count = 4 * max(len(prefills), len(decodes))
+
+        for i in range(count):
+            _ask(client, model, f"Reply with the number {i}.", max_tokens=8)
+
+        pairs = _wait_for_pairs(before + count)[before:]
+        used_prefill = {p for p, _ in pairs}
+        used_decode = {d for _, d in pairs}
+        assert used_prefill == prefills, f"idle prefill workers: {prefills - used_prefill}"
+        assert used_decode == decodes, f"idle decode workers: {decodes - used_decode}"
+        assert used_prefill.isdisjoint(decodes), "a decode worker served as prefill"
+
+    # -- transfer ----------------------------------------------------------
+
+    def test_concurrent_requests_do_not_alias(self, setup_backend):
+        _, model, client, gateway = setup_backend
+        answers: dict[str, str] = {}
+
+        def _echo(word: str) -> Callable[[], None]:
+            def _run() -> None:
+                message = _ask(
+                    client, model, f"Repeat exactly this one word and nothing else: {word}"
+                )
+                answers[word] = _answer_text(message)
+
+            return _run
+
+        errors = _run_all([_echo(w) for w in _WORDS], timeout=300)
+
+        assert not errors, f"requests failed: {errors[:3]}"
+        assert set(answers) == set(_WORDS), f"missing answers for {set(_WORDS) - set(answers)}"
+        for word, text in answers.items():
+            assert word in text.lower(), f"answer for {word!r} lost it: {text[:120]!r}"
+            content = (text.split("\n", 1)[0]).lower()
+            foreign = [w for w in _WORDS if w != word and w in content]
+            assert not foreign, f"answer for {word!r} carried {foreign}: {content[:120]!r}"
+
+    def test_long_prompt_context_reaches_decode(self, setup_backend):
+        _, model, client, gateway = setup_backend
+        secret = "48213"
+
+        message = _ask(client, model, _long_prompt(secret), max_tokens=128)
+
+        text = _answer_text(message)
+        assert secret in text, f"decode did not see the prefilled context: {text[:200]!r}"
+
+    def test_second_turn_sees_the_first(self, setup_backend):
+        _, model, client, gateway = setup_backend
+        first = {"role": "user", "content": "Remember this: the password is marigold. Reply OK."}
+        reply = client.chat.completions.create(
+            model=model, messages=[first], temperature=0, max_tokens=64, timeout=120.0
+        )
+        assistant = reply.choices[0].message
+
+        follow_up = client.chat.completions.create(
+            model=model,
+            messages=[
+                first,
+                {"role": "assistant", "content": assistant.content or "OK"},
+                {"role": "user", "content": "What is the password? Reply with one word."},
+            ],
+            temperature=0,
+            max_tokens=64,
+            timeout=120.0,
+        )
+
+        text = _answer_text(follow_up.choices[0].message.model_dump())
+        assert "marigold" in text.lower(), f"second turn lost the first: {text[:200]!r}"
+
+    # -- streaming ---------------------------------------------------------
+
+    def test_stream_completes_with_usage(self, setup_backend):
+        _, model, client, gateway = setup_backend
+
+        stream = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Count from one to ten in words."}],
+            temperature=0,
+            max_tokens=64,
+            stream=True,
+            stream_options={"include_usage": True},
+            timeout=120.0,
+        )
+        text, finish, usage = "", None, None
+        for chunk in stream:
+            if chunk.usage:
+                usage = chunk.usage
+            for choice in chunk.choices:
+                text += choice.delta.content or ""
+                finish = choice.finish_reason or finish
+
+        assert text.strip(), "stream carried no content"
+        assert finish in ("stop", "length"), f"stream ended without a finish reason: {finish}"
+        assert usage is not None and usage.completion_tokens > 0, f"no usage on the stream: {usage}"
+
+    def test_abandoned_streams_free_both_legs(self, setup_backend):
+        _, model, client, gateway = setup_backend
+        body = {
+            "model": model,
+            "messages": [{"role": "user", "content": "Write a very long story about the sea."}],
+            "max_tokens": 1500,
+            "temperature": 0,
+            "stream": True,
+            "ignore_eos": True,
+        }
+
+        def _abandon() -> None:
+            with httpx.stream(
+                "POST", f"{gateway.base_url}/v1/chat/completions", json=body, timeout=60.0
+            ) as resp:
+                assert resp.status_code == 200, resp.read()[:200]
+                for line in resp.iter_lines():
+                    if line.startswith("data:"):
+                        break  # first token seen; drop the connection
+
+        errors = _run_all([_abandon for _ in range(4)], timeout=90)
+        assert not errors, f"streams failed before they could be abandoned: {errors[:2]}"
+
+        deadline = time.monotonic() + 30.0
+        idle, loads = _fleet_idle(gateway)
+        while not idle and time.monotonic() < deadline:
+            time.sleep(1.0)
+            idle, loads = _fleet_idle(gateway)
+        assert idle, f"abandoned streams still occupy the engines after 30s: {loads}"
+        _wait_until_served(gateway, model, timeout=60.0)
+
+    # -- failure -----------------------------------------------------------
+
+    def _leg_survives_losing_one(self, setup_backend, role: str) -> None:
+        _, model, client, gateway = setup_backend
+        workers = gateway.prefill_workers if role == "prefill" else gateway.decode_workers
+        if len(workers) < 2:
+            pytest.skip(f"topology has a single {role} worker")
+        victim = workers[-1]
+        peers = {w.base_url for w in workers[:-1]}
+
+        victim.stop()
+        _wait_for_status(gateway, victim.base_url, "unhealthy", timeout=30.0)
+        before = len(_pairs_logged())
+        for i in range(6):
+            _ask(client, model, f"Reply with the number {i}.", max_tokens=8)
+        pairs = _wait_for_pairs(before + 6)[before:]
+        used = {p for p, _ in pairs} if role == "prefill" else {d for _, d in pairs}
+        assert victim.base_url not in used, f"gateway kept routing to the dead {role} worker"
+        assert used <= peers, f"unknown {role} workers in placement: {used - peers}"
+
+        victim.start()
+        _wait_for_status(gateway, victim.base_url, "healthy", timeout=600.0)
+        before = len(_pairs_logged())
+        count = 4 * len(workers)
+        for i in range(count):
+            _ask(client, model, f"Reply with the number {i}.", max_tokens=8)
+        pairs = _wait_for_pairs(before + count)[before:]
+        used = {p for p, _ in pairs} if role == "prefill" else {d for _, d in pairs}
+        assert victim.base_url in used, f"restarted {role} worker never rejoined rotation"
+
+    def test_decode_leg_survives_losing_one_worker(self, setup_backend):
+        self._leg_survives_losing_one(setup_backend, "decode")
+
+    def test_prefill_leg_survives_losing_one_worker(self, setup_backend):
+        self._leg_survives_losing_one(setup_backend, "prefill")
+
+    def test_sole_leg_outage_is_reported_promptly(self, setup_backend):
+        _, model, client, gateway = setup_backend
+        if len(gateway.decode_workers) == 1:
+            role, victim = "decode", gateway.decode_workers[0]
+        elif len(gateway.prefill_workers) == 1:
+            role, victim = "prefill", gateway.prefill_workers[0]
+        else:
+            pytest.skip("both legs have more than one worker")
+
+        victim.stop()
+        _wait_for_status(gateway, victim.base_url, "unhealthy", timeout=30.0)
+        started = time.monotonic()
+        resp = _raw_chat(gateway, model, "Say hello.", timeout=60.0)
+        elapsed = time.monotonic() - started
+        code = _error_code(resp)
+        logger.info(
+            "sole %s down: status=%s code=%s after %.1fs", role, resp.status_code, code, elapsed
+        )
+        assert elapsed < 20.0, f"request hung for {elapsed:.1f}s while the only {role} was down"
+        # The gRPC path answers 404 model_not_found for an unavailable leg today;
+        # the HTTP router answers 503 no_available_workers. Either is prompt and
+        # carries a code; a follow-up aligns the gRPC path with the 503.
+        assert resp.status_code in (404, 503), (
+            f"unexpected outage answer: {resp.status_code} {resp.text[:200]}"
+        )
+        assert code, f"outage answer carried no error code: {resp.text[:200]}"
+
+        victim.start()
+        _wait_for_status(gateway, victim.base_url, "healthy", timeout=600.0)
+        _wait_until_served(gateway, model, timeout=120.0)
+
+
+# ---------------------------------------------------------------------------
+# operations: a PD fleet assembled at runtime
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.engine("sglang", "vllm", "tokenspeed")
+@pytest.mark.gpu(4)
+@pytest.mark.e2e
+@pytest.mark.model(_MODEL, tokenspeed=_MODEL_BY_ENGINE["tokenspeed"])
+class TestPDAssembledAtRuntime:
+    """IGW gateway with no workers; prefill and decode arrive through the API."""
+
+    def test_legs_added_through_the_api_route_as_pd(self):
+        engine = get_runtime()
+        model_id = _MODEL_BY_ENGINE.get(engine, _MODEL)
+        model_path = get_model_spec(model_id)["model"]
+        cleanup_pool()  # the sweep above owns no cached workers, but be explicit about the GPUs
+        log_dir = os.environ.get("E2E_LOG_DIR")
+        prefill = start_workers(
+            model_id,
+            engine,
+            mode=ConnectionMode.GRPC,
+            count=1,
+            worker_type=WorkerType.PREFILL,
+            log_dir=log_dir,
+        )
+        decode = start_workers(
+            model_id,
+            engine,
+            mode=ConnectionMode.GRPC,
+            count=1,
+            worker_type=WorkerType.DECODE,
+            log_dir=log_dir,
+            gpu_offset=1,
+        )
+        gateway = Gateway()
+        try:
+            gateway.start(
+                igw_mode=True, log_level="debug", log_dir=str(_LOG_DIR), extra_args=_HEALTH_ARGS
+            )
+            before = len(_pairs_logged())
+
+            ok, detail = gateway.add_worker(
+                prefill[0].base_url, worker_type="prefill", bootstrap_port=prefill[0].bootstrap_port
+            )
+            assert ok, f"registering the prefill worker failed: {detail}"
+            ok, detail = gateway.add_worker(decode[0].base_url, worker_type="decode")
+            assert ok, f"registering the decode worker failed: {detail}"
+            roles = {r: len(ws) for r, ws in _workers_by_role(gateway).items()}
+            assert roles == {"prefill": 1, "decode": 1}, f"/workers roles: {roles}"
+
+            _wait_until_served(gateway, model_path, timeout=180.0)
+            pairs = _wait_for_pairs(before + 1)[before:]
+            assert (prefill[0].base_url, decode[0].base_url) in pairs, (
+                f"request did not go through the registered pair; pairs={pairs}"
+            )
+
+            ok, detail = gateway.remove_worker(decode[0].base_url)
+            assert ok, f"removing the decode worker failed: {detail}"
+            started = time.monotonic()
+            resp = _raw_chat(gateway, model_path, "Say hello.", timeout=60.0)
+            elapsed = time.monotonic() - started
+            logger.info(
+                "decode removed: status=%s code=%s after %.1fs",
+                resp.status_code,
+                _error_code(resp),
+                elapsed,
+            )
+            assert resp.status_code != 200 and elapsed < 20.0, (
+                f"with no decode worker the gateway answered {resp.status_code} after {elapsed:.1f}s"
+            )
+
+            ok, detail = gateway.add_worker(decode[0].base_url, worker_type="decode")
+            assert ok, f"re-registering the decode worker failed: {detail}"
+            _wait_until_served(gateway, model_path, timeout=120.0)
+        finally:
+            gateway.shutdown()
+            stop_workers(prefill + decode)
+            logger.info("router logs kept at %s", _LOG_DIR)

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -434,7 +434,7 @@ class TestPDTopology:
         assert used <= peers, f"unknown {role} workers in placement: {used - peers}"
 
         victim.start()
-        _wait_for_status(gateway, victim.base_url, "healthy", timeout=600.0)
+        _wait_for_status(gateway, victim.base_url, "healthy", timeout=300.0)
         before = len(_pairs_logged())
         count = 4 * len(workers)
         for i in range(count):
@@ -443,12 +443,15 @@ class TestPDTopology:
         used = {p for p, _ in pairs} if role == "prefill" else {d for _, d in pairs}
         assert victim.base_url in used, f"restarted {role} worker never rejoined rotation"
 
+    @pytest.mark.flaky(reruns=0)  # a restart per attempt; a real failure must surface once
     def test_decode_leg_survives_losing_one_worker(self, setup_backend):
         self._leg_survives_losing_one(setup_backend, "decode")
 
+    @pytest.mark.flaky(reruns=0)  # a restart per attempt; a real failure must surface once
     def test_prefill_leg_survives_losing_one_worker(self, setup_backend):
         self._leg_survives_losing_one(setup_backend, "prefill")
 
+    @pytest.mark.flaky(reruns=0)  # a restart per attempt; a real failure must surface once
     def test_sole_leg_outage_is_reported_promptly(self, setup_backend):
         _, model, client, gateway = setup_backend
         if len(gateway.decode_workers) == 1:
@@ -477,7 +480,7 @@ class TestPDTopology:
         assert code, f"outage answer carried no error code: {resp.text[:200]}"
 
         victim.start()
-        _wait_for_status(gateway, victim.base_url, "healthy", timeout=600.0)
+        _wait_for_status(gateway, victim.base_url, "healthy", timeout=300.0)
         _wait_until_served(gateway, model, timeout=120.0)
 
 
@@ -493,6 +496,7 @@ class TestPDTopology:
 class TestPDAssembledAtRuntime:
     """IGW gateway with no workers; prefill and decode arrive through the API."""
 
+    @pytest.mark.flaky(reruns=0)  # a restart per attempt; a real failure must surface once
     def test_legs_added_through_the_api_route_as_pd(self):
         engine = get_runtime()
         model_id = _MODEL_BY_ENGINE.get(engine, _MODEL)
@@ -530,6 +534,7 @@ class TestPDAssembledAtRuntime:
             ok, detail = gateway.add_worker(decode[0].base_url, worker_type="decode")
             assert ok, f"registering the decode worker failed: {detail}"
             roles = {r: len(ws) for r, ws in _workers_by_role(gateway).items()}
+            logger.info("roles after registration: %s", roles)
             assert roles == {"prefill": 1, "decode": 1}, f"/workers roles: {roles}"
 
             _wait_until_served(gateway, model_path, timeout=180.0)

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -76,19 +76,31 @@ _GATEWAY_ARGS = [
     "2",
     *_HEALTH_ARGS,
 ]
-_TOPOLOGIES = [
-    pytest.param(("pd_grpc", (p, d)), id=f"{p}p{d}d")
-    for p, d in [(1, 1), (1, 2), (2, 1), (1, 3), (3, 1), (2, 2)]
-] + [
-    # The HTTP PD router is its own code path (pairing, KV handoff, error
-    # answers); SGLang is the only engine that serves it.
-    pytest.param(
-        ("pd_http", (p, d)),
-        id=f"{p}p{d}d-http",
-        marks=pytest.mark.skip_for_runtime("vllm", "tokenspeed", reason="HTTP PD is SGLang-only"),
-    )
-    for p, d in [(1, 1), (2, 2)]
-]
+_TOPOLOGIES = (
+    [
+        pytest.param(("pd_grpc", (p, d)), id=f"{p}p{d}d")
+        for p, d in [(1, 1), (1, 2), (2, 1), (1, 3), (3, 1), (2, 2)]
+    ]
+    + [
+        # Asymmetric tensor parallelism: the KV layout changes across the
+        # handoff. A prefill wider than its decodes and the reverse both fit
+        # four GPUs.
+        pytest.param(("pd_grpc", (p, d, ptp, dtp)), id=f"{p}p{d}d-ptp{ptp}-dtp{dtp}")
+        for p, d, ptp, dtp in [(1, 2, 2, 1), (2, 1, 1, 2)]
+    ]
+    + [
+        # The HTTP PD router is its own code path (pairing, KV handoff, error
+        # answers); SGLang is the only engine that serves it.
+        pytest.param(
+            ("pd_http", (p, d)),
+            id=f"{p}p{d}d-http",
+            marks=pytest.mark.skip_for_runtime(
+                "vllm", "tokenspeed", reason="HTTP PD is SGLang-only"
+            ),
+        )
+        for p, d in [(1, 1), (2, 2)]
+    ]
+)
 # A decode window a modest burst overruns. The gateway's admission gate, bounded
 # by the window the engine reports, is what keeps the excess out of the engine,
 # where the prefill's bootstrap deadline would expire on merely queued requests.

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -626,6 +626,57 @@ class TestPDTopology:
 
 
 # ---------------------------------------------------------------------------
+# a fleet that mixes KV transfer backends
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.engine("vllm")
+@pytest.mark.gpu(4)
+@pytest.mark.e2e
+@pytest.mark.model(_MODEL)
+@pytest.mark.workers(parallel_start=True)
+@pytest.mark.gateway(log_level="debug", log_dir=str(_LOG_DIR), extra_args=_GATEWAY_ARGS)
+@pytest.mark.parametrize(
+    "setup_backend",
+    [
+        pytest.param(
+            (
+                "pd_grpc",
+                (2, 2, {"prefill_kv": ["nixl", "mooncake"], "decode_kv": ["nixl", "mooncake"]}),
+            ),
+            id="2p2d-mixed-kv",
+        )
+    ],
+    indirect=True,
+)
+class TestPDMixedTransport:
+    """One NIXL pair and one Mooncake pair share a model.
+
+    Placement pairs a prefill with a decode on runtime and wire alone, so
+    it will hand a NIXL prefill's handoff to a Mooncake decode and the
+    engine fails the request. #2483 adds the pairing protocol that keeps
+    the legs on one transport; until then this is the record of what a
+    mixed fleet does.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="placement pairs across KV transports; pairing protocol pending (#2483)",
+    )
+    def test_every_request_lands_on_a_matching_pair(self, setup_backend):
+        _, model, _, gateway = setup_backend
+        before = len(_pairs_logged())
+        statuses = []
+        for i in range(12):
+            resp = _raw_chat(gateway, model, f"Say hello, {_WORDS[i % len(_WORDS)]}.", timeout=60.0)
+            statuses.append((resp.status_code, _error_code(resp)))
+        pairs = _pairs_logged()[before:]
+        logger.info("mixed fleet: statuses=%s pairs=%s", statuses, pairs)
+        failed = [s for s in statuses if s[0] != 200]
+        assert not failed, f"{len(failed)} of 12 requests failed on a mixed fleet: {failed}"
+
+
+# ---------------------------------------------------------------------------
 # a decode window smaller than the burst
 # ---------------------------------------------------------------------------
 

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -1,8 +1,10 @@
 """Prefill/decode disaggregation under every worker topology a 4-GPU node allows.
 
-One class sweeps the topologies 1p1d, 1p2d, 2p1d, 1p3d, 3p1d and 2p2d. The
-counts ride in the ``setup_backend`` param because the fixture is
-class-scoped, and every test runs once per topology. The gateway logs each
+One class sweeps the topologies 1p1d, 1p2d, 2p1d, 1p3d, 3p1d and 2p2d, two
+asymmetric-tp pairs (1p2d-ptp2-dtp1, 2p1d-ptp1-dtp2) and the HTTP PD router's
+1p1d and 2p2d. The counts, and the per-leg tp when the legs differ, ride in
+the ``setup_backend`` param because the fixture is class-scoped, and every
+test runs once per topology. The gateway logs each
 selected pair at debug level, so requests are attributed to workers from the
 router log instead of guessed.
 
@@ -44,9 +46,14 @@ from pathlib import Path
 import httpx
 import pytest
 from infra import ConnectionMode, Gateway, WorkerType, cleanup_pool, start_workers, stop_workers
-from infra.constants import get_runtime, is_sglang
+from infra.constants import DEFAULT_STARTUP_TIMEOUT, get_runtime, is_sglang
 from infra.model_specs import get_model_spec
-from infra.pd_logs import LOG_FLUSH_TIMEOUT_S, read_logs, worker_log_dir
+from infra.pd_logs import (
+    LOG_FLUSH_TIMEOUT_S,
+    assert_worker_logs_captured,
+    read_logs,
+    worker_log_dir,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +65,11 @@ _PAIR_RE = re.compile(r"prefill=(\S+)\s+decode=(\S+)")
 
 _MODEL = "meta-llama/Llama-3.1-8B-Instruct"
 _MODEL_BY_ENGINE = {"tokenspeed": "Qwen/Qwen3.5-9B"}
+# A restart reloads the model on the same GPUs: give it the budget the model
+# declares for its first load, not Worker.start()'s default.
+_RESTART_TIMEOUT = get_model_spec(_MODEL_BY_ENGINE.get(get_runtime(), _MODEL)).get(
+    "startup_timeout", DEFAULT_STARTUP_TIMEOUT
+)
 _HEALTH_ARGS = [
     "--health-check-interval-secs",
     "1",
@@ -90,9 +102,12 @@ _TOPOLOGIES = (
         for p, d, ptp, dtp in [(1, 2, 2, 1), (2, 1, 1, 2)]
     ]
     + [
-        # The HTTP PD router is its own code path (pairing, KV handoff, error
-        # answers). SGLang and vLLM both serve it; the TokenSpeed e2e worker
-        # has no HTTP frontend.
+        # The HTTP PD router is its own code path: pairing and error answers
+        # on both engines, the KV handoff on SGLang. A vLLM leg registered by
+        # URL carries no kv_connector, so the router passes the request
+        # through and decode recomputes the prompt; vLLM's handoff is covered
+        # by the gRPC rows, where the worker reports its connector. The
+        # TokenSpeed e2e worker has no HTTP frontend.
         pytest.param(
             ("pd_http", (p, d)),
             id=f"{p}p{d}d-http",
@@ -165,12 +180,22 @@ def _wait_for_pairs(minimum: int, timeout: float = LOG_FLUSH_TIMEOUT_S) -> list[
 
 
 def _vllm_transport_installed(*packages: str) -> bool:
-    """Whether every KV transport package is importable in the engine venv."""
+    """Whether every KV transport package is importable from this interpreter."""
     return all(importlib.util.find_spec(package) is not None for package in packages)
 
 
+def _vllm_transports_requested() -> set[str]:
+    """The vLLM transports the lane asked to have installed."""
+    names = [os.environ.get("E2E_VLLM_KV_BACKEND", ""), os.environ.get("E2E_KV_BACKEND", "")]
+    names += os.environ.get("E2E_VLLM_EXTRA_KV_BACKENDS", "").split(",")
+    return {name.strip().lower() for name in names if name.strip()}
+
+
+# Skip only where the lane never asked for both transports; where it did, a
+# missing one fails at worker startup instead of vanishing as a skip.
 _NEEDS_BOTH_VLLM_TRANSPORTS = pytest.mark.skipif(
-    not _vllm_transport_installed("nixl", "mooncake"),
+    not _vllm_transport_installed("nixl", "mooncake")
+    and not {"nixl", "mooncake"} <= _vllm_transports_requested(),
     reason="a fleet that mixes NIXL and Mooncake needs both transfer engines installed",
 )
 
@@ -290,6 +315,12 @@ def _fleet_idle(gateway: Gateway) -> tuple[bool, list[dict]]:
     resp = httpx.get(f"{gateway.base_url}/loads", timeout=5.0)
     assert resp.status_code == 200, resp.text
     loads = resp.json().get("loads", [])
+    # /loads omits workers the monitor has no report for; an unreported leg
+    # is not evidence of idleness.
+    reported = {e.get("worker") for e in loads}
+    expected = {w.base_url for w in gateway.prefill_workers + gateway.decode_workers}
+    if not expected <= reported:
+        return (False, loads)
     busy = [e for e in loads if e.get("num_running_reqs", 0) + e.get("num_waiting_reqs", 0) > 0]
     return (not busy, loads)
 
@@ -307,9 +338,11 @@ def _assert_fleet_idle_within(gateway: Gateway, timeout: float) -> None:
     while not idle and time.monotonic() < deadline:
         time.sleep(1.0)
         idle, loads = _fleet_idle(gateway)
-    # How long the engines keep working after the client is gone is the
-    # abort-propagation latency of the pair; log it so sweeps can compare.
-    logger.info("fleet idle after %.1fs (idle=%s)", time.monotonic() - started, idle)
+    # A floor on how long the engines kept working after the clients left:
+    # the clock starts once the callers joined their threads, and /loads is
+    # a 2 s-interval report, so only differences well above that mean much.
+    if idle:
+        logger.info("fleet idle within %.1fs of the clients leaving", time.monotonic() - started)
     assert idle, f"engines still hold work after {timeout:.0f}s: {loads}"
 
 
@@ -325,8 +358,11 @@ def _run_all(fns: list[Callable[[], None]], timeout: float) -> list[BaseExceptio
     threads = [threading.Thread(target=_wrap, args=(fn,), daemon=True) for fn in fns]
     for t in threads:
         t.start()
+    deadline = time.monotonic() + timeout
     for t in threads:
-        t.join(timeout=timeout)
+        t.join(timeout=max(0.0, deadline - time.monotonic()))
+        if t.is_alive():
+            errors.append(TimeoutError(f"a request was still running {timeout:.0f}s in"))
     return errors
 
 
@@ -543,13 +579,15 @@ class TestPDTopology:
     def test_batched_completion_serves_every_choice(self, setup_backend, request):
         """Every choice of an ``n>1`` request must come back through the PD pair.
 
-        Over gRPC the gateway fans the request out into one single-sample
-        pair per choice, each with its own bootstrap room (#2482).
+        On the room-based engines (SGLang, TokenSpeed) the gRPC router fans
+        the request out into one single-sample pair per choice, each with its
+        own bootstrap room (#2482); vLLM dispatches sequentially and skips the
+        handoff for ``n>1``, leaving decode to recompute the prompt.
         """
         mode, model, _, gateway = setup_backend
         if mode == "pd_http" and is_sglang():
-            # Same shape as the TokenSpeed gRPC case: the HTTP PD router mints
-            # one room for a single-prompt request whatever ``n`` is, the engine
+            # The shape the gRPC fan-out fixed: the HTTP PD router mints one
+            # room for a single-prompt request whatever ``n`` is, the engine
             # broadcasts it to every sample, and the decode's children wait on
             # a transfer that never comes until the decode aborts them. vLLM
             # over HTTP skips the handoff for n>1 and lets decode own the prompt.
@@ -597,8 +635,10 @@ class TestPDTopology:
         assert victim.base_url not in used, f"gateway kept routing to the dead {role} worker"
         assert used <= peers, f"unknown {role} workers in placement: {used - peers}"
 
-        victim.start()
-        _wait_for_status(gateway, victim.base_url, "healthy", timeout=300.0)
+        victim.start(timeout=_RESTART_TIMEOUT)
+        # start() blocked on the worker's own health; the gateway's monitor
+        # notices within a few of its 1 s intervals.
+        _wait_for_status(gateway, victim.base_url, "healthy", timeout=60.0)
         before = len(_pairs_logged())
         count = 4 * len(workers)
         for i in range(count):
@@ -637,22 +677,21 @@ class TestPDTopology:
             )
             assert elapsed < 20.0, f"request hung for {elapsed:.1f}s while the only {role} was down"
             # The model exists and its leg is merely down: a 503 the client can
-            # retry, never a 404 that says the model is gone (#2465). The gRPC
-            # router answers no_available_workers; the HTTP PD router answers
-            # server_selection_failed with the leg named in the message.
+            # retry, never a 404 that says the model is gone (#2465). Every
+            # router answers no_available_workers (#2479); the HTTP PD router
+            # may name the leg instead.
             assert resp.status_code == 503, (
                 f"unexpected outage answer: {resp.status_code} {resp.text[:200]}"
             )
             assert code in (
                 "no_available_workers",
-                "server_selection_failed",
                 f"no_{role}_servers",
                 f"{role}_unavailable",
             ), f"outage answer carried an unexpected code: {code!r} {resp.text[:200]}"
         finally:
             # Whatever the verdict, the class's later tests need the leg back.
-            victim.start()
-            _wait_for_status(gateway, victim.base_url, "healthy", timeout=300.0)
+            victim.start(timeout=_RESTART_TIMEOUT)
+            _wait_for_status(gateway, victim.base_url, "healthy", timeout=60.0)
         _wait_until_served(gateway, model, timeout=120.0)
 
 
@@ -782,6 +821,20 @@ class TestPDSmallWindow:
     def test_burst_beyond_decode_window_is_shed_not_stalled(self, setup_backend):
         _, model, _, gateway = setup_backend
         _wait_until_served(gateway, model, timeout=60.0)
+        # The window must have reached the engine, or the burst fits and the
+        # gate is never crossed. Engines that report their window on /loads
+        # (SGLang, TokenSpeed) are checked; vLLM reports none.
+        _, loads = _fleet_idle(gateway)
+        decode_urls = {w.base_url for w in gateway.decode_workers}
+        windows = {
+            e["worker"]: e["max_running_requests"]
+            for e in loads
+            if e.get("worker") in decode_urls and e.get("max_running_requests", 0) > 0
+        }
+        assert all(w == _WINDOW for w in windows.values()), f"decode window not applied: {windows}"
+        logger.info("decode windows reported: %s", windows or "none (engine reports no window)")
+        worker_dir = worker_log_dir(_LOG_DIR)
+        before = len(read_logs(worker_dir, "worker-*.log"))
         results: list[httpx.Response] = []
 
         def _one(i: int) -> None:
@@ -824,9 +877,12 @@ class TestPDSmallWindow:
                 assert resp.headers.get("retry-after"), "a shed must say when to retry"
         assert elapsed < 90.0, f"the burst took {elapsed:.0f}s; queued rooms are timing out"
 
-        logs = read_logs(worker_log_dir(_LOG_DIR), "worker-*.log")
+        # Only this burst's lines: earlier classes kill workers out from under
+        # their peers, and an empty capture must fail rather than pass.
+        logs = read_logs(worker_dir, "worker-*.log")
+        assert_worker_logs_captured(logs, "prefill bootstrap timeouts")
         for marker in _BOOTSTRAP_TIMEOUT_MARKERS:
-            assert marker not in logs, f"an engine leg timed out a bootstrap: {marker!r}"
+            assert marker not in logs[before:], f"an engine leg timed out a bootstrap: {marker!r}"
         _wait_until_served(gateway, model, timeout=60.0)
 
 
@@ -849,25 +905,27 @@ class TestPDAssembledAtRuntime:
         model_path = get_model_spec(model_id)["model"]
         cleanup_pool()  # the sweep above owns no cached workers, but be explicit about the GPUs
         log_dir = os.environ.get("E2E_LOG_DIR")
-        prefill = start_workers(
-            model_id,
-            engine,
-            mode=ConnectionMode.GRPC,
-            count=1,
-            worker_type=WorkerType.PREFILL,
-            log_dir=log_dir,
-        )
-        decode = start_workers(
-            model_id,
-            engine,
-            mode=ConnectionMode.GRPC,
-            count=1,
-            worker_type=WorkerType.DECODE,
-            log_dir=log_dir,
-            gpu_offset=1,
-        )
+        prefill: list = []
+        decode: list = []
         gateway = Gateway()
         try:
+            prefill = start_workers(
+                model_id,
+                engine,
+                mode=ConnectionMode.GRPC,
+                count=1,
+                worker_type=WorkerType.PREFILL,
+                log_dir=log_dir,
+            )
+            decode = start_workers(
+                model_id,
+                engine,
+                mode=ConnectionMode.GRPC,
+                count=1,
+                worker_type=WorkerType.DECODE,
+                log_dir=log_dir,
+                gpu_offset=1,
+            )
             gateway.start(
                 igw_mode=True, log_level="debug", log_dir=str(_LOG_DIR), extra_args=_HEALTH_ARGS
             )
@@ -891,6 +949,9 @@ class TestPDAssembledAtRuntime:
 
             ok, detail = gateway.remove_worker(decode[0].base_url)
             assert ok, f"removing the decode worker failed: {detail}"
+            # The removal is accepted (202) and drained in the background; the
+            # outage exists once the worker has left /workers.
+            _wait_for_removal(gateway, decode[0].base_url, timeout=60.0)
             started = time.monotonic()
             resp = _raw_chat(gateway, model_path, "Say hello.", timeout=60.0)
             elapsed = time.monotonic() - started
@@ -904,9 +965,6 @@ class TestPDAssembledAtRuntime:
                 f"with no decode worker the gateway answered {resp.status_code} after {elapsed:.1f}s"
             )
 
-            # Re-adding the same URL while the removal is still draining is
-            # refused as a duplicate, so wait for the worker to actually leave.
-            _wait_for_removal(gateway, decode[0].base_url, timeout=60.0)
             ok, detail = gateway.add_worker(decode[0].base_url, worker_type="decode")
             assert ok, f"re-registering the decode worker failed: {detail}"
             _wait_until_served(gateway, model_path, timeout=120.0)

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -422,7 +422,15 @@ class TestPDTopology:
             if chunk.usage:
                 usage = chunk.usage
             for choice in chunk.choices:
-                text += choice.delta.content or ""
+                # Thinking models may spend the whole budget in the reasoning
+                # channel; either channel proves the decode leg streamed.
+                delta = choice.delta
+                text += delta.content or ""
+                text += (
+                    getattr(delta, "reasoning_content", None)
+                    or getattr(delta, "reasoning", None)
+                    or ""
+                )
                 finish = choice.finish_reason or finish
 
         assert text.strip(), "stream carried no content"

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -43,7 +43,7 @@ from pathlib import Path
 import httpx
 import pytest
 from infra import ConnectionMode, Gateway, WorkerType, cleanup_pool, start_workers, stop_workers
-from infra.constants import get_runtime
+from infra.constants import get_runtime, is_tokenspeed
 from infra.model_specs import get_model_spec
 from infra.pd_logs import LOG_FLUSH_TIMEOUT_S, read_logs, worker_log_dir
 
@@ -492,8 +492,15 @@ class TestPDTopology:
         _assert_fleet_idle_within(gateway, 30.0)
         _wait_until_served(gateway, model, timeout=60.0)
 
+    @pytest.mark.xfail(
+        is_tokenspeed(),
+        strict=True,
+        reason="the gateway mints one bootstrap room per request and TokenSpeed broadcasts "
+        "it to every sample of an n>1 request; the prefill rejects the decode's repeated "
+        "pre-allocations as duplicates and the request fails with decode_worker_failed_to_start",
+    )
     def test_batched_completion_serves_every_choice(self, setup_backend):
-        """``n`` choices fan out one bootstrap room each; every choice must come back."""
+        """Every choice of an ``n>1`` request must come back through the PD pair."""
         _, model, _, gateway = setup_backend
 
         resp = httpx.post(

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -175,6 +175,16 @@ def _wait_for_status(gateway: Gateway, url: str, wanted: str, timeout: float) ->
     pytest.fail(f"worker {url} never became {wanted} within {timeout:.0f}s (last: {seen})")
 
 
+def _wait_for_removal(gateway: Gateway, url: str, timeout: float) -> None:
+    """A removal drains in-flight work first; the worker leaves /workers after that."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _status_of(gateway, url) is None:
+            return
+        time.sleep(0.5)
+    pytest.fail(f"worker {url} still listed {timeout:.0f}s after its removal was accepted")
+
+
 def _answer_text(message: dict) -> str:
     """Content plus any reasoning text: thinking models may answer in either."""
     content = message.get("content") or ""
@@ -721,6 +731,9 @@ class TestPDAssembledAtRuntime:
                 f"with no decode worker the gateway answered {resp.status_code} after {elapsed:.1f}s"
             )
 
+            # Re-adding the same URL while the removal is still draining is
+            # refused as a duplicate, so wait for the worker to actually leave.
+            _wait_for_removal(gateway, decode[0].base_url, timeout=60.0)
             ok, detail = gateway.add_worker(decode[0].base_url, worker_type="decode")
             assert ok, f"re-registering the decode worker failed: {detail}"
             _wait_until_served(gateway, model_path, timeout=120.0)

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -163,6 +163,25 @@ def _wait_for_pairs(minimum: int, timeout: float = LOG_FLUSH_TIMEOUT_S) -> list[
     return pairs
 
 
+def _pairing_keys(gateway: Gateway) -> dict[str, str]:
+    """Each PD worker's `pd_pairing` key as the gateway reports it on /workers."""
+    return {
+        worker.url: worker.metadata["pd_pairing"]
+        for worker in gateway.list_workers(strict=True)
+        if worker.metadata.get("pd_pairing")
+    }
+
+
+def _wait_for_healthy_workers(gateway: Gateway, count: int, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        healthy = [w for w in gateway.list_workers() if w.status == "healthy"]
+        if len(healthy) >= count:
+            return
+        time.sleep(1.0)
+    raise AssertionError(f"fewer than {count} healthy workers after {timeout}s")
+
+
 def _workers_by_role(gateway: Gateway) -> dict[str, list]:
     by_role: dict[str, list] = {}
     for worker in gateway.list_workers(strict=True):
@@ -652,28 +671,70 @@ class TestPDTopology:
 class TestPDMixedTransport:
     """One NIXL pair and one Mooncake pair share a model.
 
-    Placement pairs a prefill with a decode on runtime and wire alone, so
-    it will hand a NIXL prefill's handoff to a Mooncake decode and the
-    engine fails the request. #2483 adds the pairing protocol that keeps
-    the legs on one transport; until then this is the record of what a
-    mixed fleet does.
+    Placement pairs a prefill with a decode on their KV transfer protocol
+    (#2483): a NIXL prefill's handoff never lands on a Mooncake decode, and
+    the gateway reports which protocol each leg speaks.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="placement pairs across KV transports; pairing protocol pending (#2483)",
-    )
     def test_every_request_lands_on_a_matching_pair(self, setup_backend):
         _, model, _, gateway = setup_backend
+        _wait_for_healthy_workers(gateway, 4, timeout=120.0)
+        keys = _pairing_keys(gateway)
+        logger.info("mixed fleet pairing keys: %s", keys)
+        assert len(keys) == 4, keys
+        transports = {key.split("/")[1] for key in keys.values()}
+        assert transports == {"nixl", "mooncake"}, keys
+
         before = len(_pairs_logged())
         statuses = []
         for i in range(12):
             resp = _raw_chat(gateway, model, f"Say hello, {_WORDS[i % len(_WORDS)]}.", timeout=60.0)
             statuses.append((resp.status_code, _error_code(resp)))
-        pairs = _pairs_logged()[before:]
+        pairs = _wait_for_pairs(before + 12)[before:]
         logger.info("mixed fleet: statuses=%s pairs=%s", statuses, pairs)
         failed = [s for s in statuses if s[0] != 200]
         assert not failed, f"{len(failed)} of 12 requests failed on a mixed fleet: {failed}"
+        crossed = [(p, d) for p, d in pairs if keys.get(p) != keys.get(d)]
+        assert not crossed, f"pairs crossed KV transports: {crossed}"
+        logger.info(
+            "mixed fleet transports served: %s",
+            sorted({keys[p].split("/")[1] for p, _ in pairs if p in keys}),
+        )
+
+
+@pytest.mark.engine("vllm")
+@pytest.mark.gpu(4)
+@pytest.mark.e2e
+@pytest.mark.model(_MODEL)
+@pytest.mark.workers(parallel_start=True)
+@pytest.mark.gateway(log_level="debug", log_dir=str(_LOG_DIR), extra_args=_GATEWAY_ARGS)
+@pytest.mark.parametrize(
+    "setup_backend",
+    [
+        pytest.param(
+            ("pd_grpc", (1, 1, {"prefill_kv": ["nixl"], "decode_kv": ["mooncake"]})),
+            id="1p1d-kv-mismatch",
+        )
+    ],
+    indirect=True,
+)
+class TestPDMismatchedTransport:
+    """A NIXL prefill and a Mooncake decode can never complete a handoff.
+
+    Placement refuses the pair up front with `no_compatible_pd_pair`
+    (#2483) instead of letting the engine time out on the rendezvous.
+    """
+
+    def test_request_is_refused_at_placement(self, setup_backend):
+        _, model, _, gateway = setup_backend
+        _wait_for_healthy_workers(gateway, 2, timeout=120.0)
+        keys = _pairing_keys(gateway)
+        logger.info("mismatched fleet pairing keys: %s", keys)
+        assert len(keys) == 2, keys
+
+        resp = _raw_chat(gateway, model, "Say hello.", timeout=60.0)
+        assert resp.status_code == 503, resp.text
+        assert _error_code(resp) == "no_compatible_pd_pair", resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -43,7 +43,7 @@ from pathlib import Path
 import httpx
 import pytest
 from infra import ConnectionMode, Gateway, WorkerType, cleanup_pool, start_workers, stop_workers
-from infra.constants import get_runtime, is_sglang, is_tokenspeed
+from infra.constants import get_runtime, is_sglang
 from infra.model_specs import get_model_spec
 from infra.pd_logs import LOG_FLUSH_TIMEOUT_S, read_logs, worker_log_dir
 
@@ -509,15 +509,12 @@ class TestPDTopology:
         _assert_fleet_idle_within(gateway, 30.0)
         _wait_until_served(gateway, model, timeout=60.0)
 
-    @pytest.mark.xfail(
-        is_tokenspeed(),
-        strict=True,
-        reason="the gateway mints one bootstrap room per request and TokenSpeed broadcasts "
-        "it to every sample of an n>1 request; the prefill rejects the decode's repeated "
-        "pre-allocations as duplicates and the request fails with decode_worker_failed_to_start",
-    )
     def test_batched_completion_serves_every_choice(self, setup_backend, request):
-        """Every choice of an ``n>1`` request must come back through the PD pair."""
+        """Every choice of an ``n>1`` request must come back through the PD pair.
+
+        Over gRPC the gateway fans the request out into one single-sample
+        pair per choice, each with its own bootstrap room (#2482).
+        """
         mode, model, _, gateway = setup_backend
         if mode == "pd_http" and is_sglang():
             # Same shape as the TokenSpeed gRPC case: the HTTP PD router mints

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -29,6 +29,7 @@ Usage:
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 import os
 import re
@@ -161,6 +162,17 @@ def _wait_for_pairs(minimum: int, timeout: float = LOG_FLUSH_TIMEOUT_S) -> list[
         f"is --log-level debug reaching {_LOG_DIR}/smg*?"
     )
     return pairs
+
+
+def _vllm_transport_installed(*packages: str) -> bool:
+    """Whether every KV transport package is importable in the engine venv."""
+    return all(importlib.util.find_spec(package) is not None for package in packages)
+
+
+_NEEDS_BOTH_VLLM_TRANSPORTS = pytest.mark.skipif(
+    not _vllm_transport_installed("nixl", "mooncake"),
+    reason="a fleet that mixes NIXL and Mooncake needs both transfer engines installed",
+)
 
 
 def _pairing_keys(gateway: Gateway) -> dict[str, str]:
@@ -668,6 +680,7 @@ class TestPDTopology:
     ],
     indirect=True,
 )
+@_NEEDS_BOTH_VLLM_TRANSPORTS
 class TestPDMixedTransport:
     """One NIXL pair and one Mooncake pair share a model.
 
@@ -718,6 +731,7 @@ class TestPDMixedTransport:
     ],
     indirect=True,
 )
+@_NEEDS_BOTH_VLLM_TRANSPORTS
 class TestPDMismatchedTransport:
     """A NIXL prefill and a Mooncake decode can never complete a handoff.
 

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -35,7 +35,9 @@ import re
 import tempfile
 import threading
 import time
+from collections import Counter
 from collections.abc import Callable
+from functools import partial
 from pathlib import Path
 
 import httpx
@@ -43,7 +45,7 @@ import pytest
 from infra import ConnectionMode, Gateway, WorkerType, cleanup_pool, start_workers, stop_workers
 from infra.constants import get_runtime
 from infra.model_specs import get_model_spec
-from infra.pd_logs import LOG_FLUSH_TIMEOUT_S, read_logs
+from infra.pd_logs import LOG_FLUSH_TIMEOUT_S, read_logs, worker_log_dir
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +79,27 @@ _GATEWAY_ARGS = [
 _TOPOLOGIES = [
     pytest.param(("pd_grpc", (p, d)), id=f"{p}p{d}d")
     for p, d in [(1, 1), (1, 2), (2, 1), (1, 3), (3, 1), (2, 2)]
+] + [
+    # The HTTP PD router is its own code path (pairing, KV handoff, error
+    # answers); SGLang is the only engine that serves it.
+    pytest.param(
+        ("pd_http", (p, d)),
+        id=f"{p}p{d}d-http",
+        marks=pytest.mark.skip_for_runtime("vllm", "tokenspeed", reason="HTTP PD is SGLang-only"),
+    )
+    for p, d in [(1, 1), (2, 2)]
 ]
+# A decode window a modest burst overruns. The gateway's admission gate, bounded
+# by the window the engine reports, is what keeps the excess out of the engine,
+# where the prefill's bootstrap deadline would expire on merely queued requests.
+_WINDOW = 4
+_WINDOW_ARGS = {
+    "sglang": ["--max-running-requests", str(_WINDOW)],
+    "vllm": ["--max-num-seqs", str(_WINDOW)],
+    "tokenspeed": ["--max-num-seqs", str(_WINDOW)],
+}.get(get_runtime(), [])
+# What an SGLang-lineage prefill logs when it gave up waiting for the decode.
+_BOOTSTRAP_TIMEOUT_MARKERS = ("timed out when bootstrapping",)
 _WORDS = [
     "apricot",
     "bramble",
@@ -216,6 +238,21 @@ def _fleet_idle(gateway: Gateway) -> tuple[bool, list[dict]]:
     loads = resp.json().get("loads", [])
     busy = [e for e in loads if e.get("num_running_reqs", 0) + e.get("num_waiting_reqs", 0) > 0]
     return (not busy, loads)
+
+
+def _require_load_reports(backend: str) -> None:
+    """The idle check reads /loads; HTTP SGLang workers report none without metrics."""
+    if backend == "pd_http":
+        pytest.skip("load reports need gRPC workers")
+
+
+def _assert_fleet_idle_within(gateway: Gateway, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    idle, loads = _fleet_idle(gateway)
+    while not idle and time.monotonic() < deadline:
+        time.sleep(1.0)
+        idle, loads = _fleet_idle(gateway)
+    assert idle, f"engines still hold work after {timeout:.0f}s: {loads}"
 
 
 def _run_all(fns: list[Callable[[], None]], timeout: float) -> list[BaseException]:
@@ -383,7 +420,8 @@ class TestPDTopology:
         assert usage is not None and usage.completion_tokens > 0, f"no usage on the stream: {usage}"
 
     def test_abandoned_streams_free_both_legs(self, setup_backend):
-        _, model, client, gateway = setup_backend
+        backend, model, client, gateway = setup_backend
+        _require_load_reports(backend)
         body = {
             "model": model,
             "messages": [{"role": "user", "content": "Write a very long story about the sea."}],
@@ -405,13 +443,57 @@ class TestPDTopology:
         errors = _run_all([_abandon for _ in range(4)], timeout=90)
         assert not errors, f"streams failed before they could be abandoned: {errors[:2]}"
 
-        deadline = time.monotonic() + 30.0
-        idle, loads = _fleet_idle(gateway)
-        while not idle and time.monotonic() < deadline:
-            time.sleep(1.0)
-            idle, loads = _fleet_idle(gateway)
-        assert idle, f"abandoned streams still occupy the engines after 30s: {loads}"
+        _assert_fleet_idle_within(gateway, 30.0)
         _wait_until_served(gateway, model, timeout=60.0)
+
+    def test_aborts_during_prefill_free_both_legs(self, setup_backend):
+        """Clients that give up before the first token leave no room behind."""
+        backend, model, _, gateway = setup_backend
+        _require_load_reports(backend)
+        body = {
+            "model": model,
+            "messages": [{"role": "user", "content": _long_prompt("22222")}],
+            "max_tokens": 64,
+            "temperature": 0,
+            "stream": True,
+        }
+
+        def _give_up_early() -> None:
+            try:
+                httpx.post(
+                    f"{gateway.base_url}/v1/chat/completions",
+                    json=body,
+                    timeout=httpx.Timeout(10.0, read=0.3),
+                )
+            except httpx.ReadTimeout:
+                return  # dropped while the prompt was still being prefilled
+            # An answer inside the read window is not a failure of this test.
+
+        errors = _run_all([_give_up_early for _ in range(8)], timeout=60)
+        assert not errors, f"requests failed before they could be abandoned: {errors[:2]}"
+        _assert_fleet_idle_within(gateway, 30.0)
+        _wait_until_served(gateway, model, timeout=60.0)
+
+    def test_batched_completion_serves_every_choice(self, setup_backend):
+        """``n`` choices fan out one bootstrap room each; every choice must come back."""
+        _, model, _, gateway = setup_backend
+
+        resp = httpx.post(
+            f"{gateway.base_url}/v1/completions",
+            json={
+                "model": model,
+                "prompt": "The three primary colors are",
+                "n": 4,
+                "max_tokens": 16,
+                "temperature": 0.8,
+            },
+            timeout=120.0,
+        )
+
+        assert resp.status_code == 200, f"{resp.status_code} {resp.text[:300]}"
+        choices = resp.json().get("choices", [])
+        assert len(choices) == 4, f"expected 4 choices, got {len(choices)}"
+        assert all(c.get("text", "").strip() for c in choices), f"empty choice in {choices}"
 
     # -- failure -----------------------------------------------------------
 
@@ -471,17 +553,98 @@ class TestPDTopology:
             "sole %s down: status=%s code=%s after %.1fs", role, resp.status_code, code, elapsed
         )
         assert elapsed < 20.0, f"request hung for {elapsed:.1f}s while the only {role} was down"
-        # The gRPC path answers 404 model_not_found for an unavailable leg today;
-        # the HTTP router answers 503 no_available_workers. Either is prompt and
-        # carries a code; a follow-up aligns the gRPC path with the 503.
-        assert resp.status_code in (404, 503), (
+        # The model exists and its leg is merely down: a 503 the client can
+        # retry, never a 404 that says the model is gone (#2465). The HTTP PD
+        # router names the leg in its code.
+        assert resp.status_code == 503, (
             f"unexpected outage answer: {resp.status_code} {resp.text[:200]}"
         )
-        assert code, f"outage answer carried no error code: {resp.text[:200]}"
+        assert code in ("no_available_workers", f"no_{role}_servers", f"{role}_unavailable"), (
+            f"outage answer carried an unexpected code: {code!r} {resp.text[:200]}"
+        )
 
         victim.start()
         _wait_for_status(gateway, victim.base_url, "healthy", timeout=300.0)
         _wait_until_served(gateway, model, timeout=120.0)
+
+
+# ---------------------------------------------------------------------------
+# a decode window smaller than the burst
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.engine("sglang", "vllm", "tokenspeed")
+@pytest.mark.gpu(4)
+@pytest.mark.e2e
+@pytest.mark.model(_MODEL, tokenspeed=_MODEL_BY_ENGINE["tokenspeed"])
+@pytest.mark.workers(parallel_start=True, extra_engine_args=_WINDOW_ARGS)
+@pytest.mark.gateway(
+    log_level="debug",
+    log_dir=str(_LOG_DIR),
+    extra_args=[*_GATEWAY_ARGS, "--pd-admission-wait-secs", "2"],
+)
+@pytest.mark.parametrize(
+    "setup_backend", [pytest.param(("pd_grpc", (1, 1)), id="1p1d-window4")], indirect=True
+)
+class TestPDSmallWindow:
+    """A burst wider than the decode window is held or shed at the gateway.
+
+    Without the admission gate the excess reached the engine, where the
+    prefill's bootstrap deadline expired on requests that were merely queued
+    behind the decode's admission, and every such room then held a decode slot
+    for the whole transfer timeout (run 34173426995: 14 of 64 requests lost,
+    1392 s for an eval that takes 35 s).
+    """
+
+    def test_burst_beyond_decode_window_is_shed_not_stalled(self, setup_backend):
+        _, model, _, gateway = setup_backend
+        _wait_until_served(gateway, model, timeout=60.0)
+        results: list[httpx.Response] = []
+
+        def _one(i: int) -> None:
+            results.append(
+                httpx.post(
+                    f"{gateway.base_url}/v1/chat/completions",
+                    json={
+                        "model": model,
+                        "messages": [
+                            {"role": "user", "content": f"Write {i} sentences about the sea."}
+                        ],
+                        "max_tokens": 96,
+                        "temperature": 0,
+                        "ignore_eos": True,
+                    },
+                    timeout=120.0,
+                )
+            )
+
+        started = time.monotonic()
+        errors = _run_all([partial(_one, i) for i in range(6 * _WINDOW)], timeout=180)
+        elapsed = time.monotonic() - started
+
+        assert not errors, f"requests failed at the transport: {errors[:2]}"
+        statuses = Counter(r.status_code for r in results)
+        logger.info(
+            "burst of %d against a window of %d: %s in %.1fs",
+            6 * _WINDOW,
+            _WINDOW,
+            dict(statuses),
+            elapsed,
+        )
+        assert set(statuses) <= {200, 503}, (
+            f"a burst must be served or shed, never errored: {dict(statuses)}"
+        )
+        assert statuses[200] >= _WINDOW, f"too few requests served: {dict(statuses)}"
+        for resp in results:
+            if resp.status_code == 503:
+                assert _error_code(resp) == "worker_overload_protection_shed", resp.text[:200]
+                assert resp.headers.get("retry-after"), "a shed must say when to retry"
+        assert elapsed < 90.0, f"the burst took {elapsed:.0f}s; queued rooms are timing out"
+
+        logs = read_logs(worker_log_dir(_LOG_DIR), "worker-*.log")
+        for marker in _BOOTSTRAP_TIMEOUT_MARKERS:
+            assert marker not in logs, f"an engine leg timed out a bootstrap: {marker!r}"
+        _wait_until_served(gateway, model, timeout=60.0)
 
 
 # ---------------------------------------------------------------------------

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -499,9 +499,20 @@ class TestPDTopology:
         "it to every sample of an n>1 request; the prefill rejects the decode's repeated "
         "pre-allocations as duplicates and the request fails with decode_worker_failed_to_start",
     )
-    def test_batched_completion_serves_every_choice(self, setup_backend):
+    def test_batched_completion_serves_every_choice(self, setup_backend, request):
         """Every choice of an ``n>1`` request must come back through the PD pair."""
-        _, model, _, gateway = setup_backend
+        mode, model, _, gateway = setup_backend
+        if mode == "pd_http":
+            # Same shape as the TokenSpeed gRPC case: the HTTP PD router mints
+            # one room for a single-prompt request whatever ``n`` is, the engine
+            # broadcasts it to every sample, and the decode's children wait on
+            # a transfer that never comes until the decode aborts them.
+            request.node.add_marker(
+                pytest.mark.xfail(
+                    strict=True,
+                    reason="n>1 over HTTP PD shares one bootstrap room across samples and hangs",
+                )
+            )
 
         resp = httpx.post(
             f"{gateway.base_url}/v1/completions",
@@ -512,7 +523,7 @@ class TestPDTopology:
                 "max_tokens": 16,
                 "temperature": 0.8,
             },
-            timeout=120.0,
+            timeout=60.0,
         )
 
         assert resp.status_code == 200, f"{resp.status_code} {resp.text[:300]}"
@@ -569,27 +580,33 @@ class TestPDTopology:
             pytest.skip("both legs have more than one worker")
 
         victim.stop()
-        _wait_for_status(gateway, victim.base_url, "unhealthy", timeout=30.0)
-        started = time.monotonic()
-        resp = _raw_chat(gateway, model, "Say hello.", timeout=60.0)
-        elapsed = time.monotonic() - started
-        code = _error_code(resp)
-        logger.info(
-            "sole %s down: status=%s code=%s after %.1fs", role, resp.status_code, code, elapsed
-        )
-        assert elapsed < 20.0, f"request hung for {elapsed:.1f}s while the only {role} was down"
-        # The model exists and its leg is merely down: a 503 the client can
-        # retry, never a 404 that says the model is gone (#2465). The HTTP PD
-        # router names the leg in its code.
-        assert resp.status_code == 503, (
-            f"unexpected outage answer: {resp.status_code} {resp.text[:200]}"
-        )
-        assert code in ("no_available_workers", f"no_{role}_servers", f"{role}_unavailable"), (
-            f"outage answer carried an unexpected code: {code!r} {resp.text[:200]}"
-        )
-
-        victim.start()
-        _wait_for_status(gateway, victim.base_url, "healthy", timeout=300.0)
+        try:
+            _wait_for_status(gateway, victim.base_url, "unhealthy", timeout=30.0)
+            started = time.monotonic()
+            resp = _raw_chat(gateway, model, "Say hello.", timeout=60.0)
+            elapsed = time.monotonic() - started
+            code = _error_code(resp)
+            logger.info(
+                "sole %s down: status=%s code=%s after %.1fs", role, resp.status_code, code, elapsed
+            )
+            assert elapsed < 20.0, f"request hung for {elapsed:.1f}s while the only {role} was down"
+            # The model exists and its leg is merely down: a 503 the client can
+            # retry, never a 404 that says the model is gone (#2465). The gRPC
+            # router answers no_available_workers; the HTTP PD router answers
+            # server_selection_failed with the leg named in the message.
+            assert resp.status_code == 503, (
+                f"unexpected outage answer: {resp.status_code} {resp.text[:200]}"
+            )
+            assert code in (
+                "no_available_workers",
+                "server_selection_failed",
+                f"no_{role}_servers",
+                f"{role}_unavailable",
+            ), f"outage answer carried an unexpected code: {code!r} {resp.text[:200]}"
+        finally:
+            # Whatever the verdict, the class's later tests need the leg back.
+            victim.start()
+            _wait_for_status(gateway, victim.base_url, "healthy", timeout=300.0)
         _wait_until_served(gateway, model, timeout=120.0)
 
 

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -179,6 +179,23 @@ def _wait_for_pairs(minimum: int, timeout: float = LOG_FLUSH_TIMEOUT_S) -> list[
     return pairs
 
 
+def _log_sizes(log_dir: Path) -> dict[Path, int]:
+    """Byte size of every worker log now, to read only what is appended later."""
+    return {p: p.stat().st_size for p in log_dir.glob("worker-*.log") if p.is_file()}
+
+
+def _logs_since(log_dir: Path, sizes: dict[Path, int]) -> str:
+    """What each worker log gained since ``sizes`` was taken, per file."""
+    parts: list[str] = []
+    for path in sorted(log_dir.glob("worker-*.log")):
+        if not path.is_file():
+            continue
+        with path.open("rb") as fh:
+            fh.seek(sizes.get(path, 0))
+            parts.append(fh.read().decode("utf-8", errors="replace"))
+    return "\n".join(parts)
+
+
 def _vllm_transport_installed(*packages: str) -> bool:
     """Whether every KV transport package is importable from this interpreter."""
     return all(importlib.util.find_spec(package) is not None for package in packages)
@@ -823,8 +840,14 @@ class TestPDSmallWindow:
         _wait_until_served(gateway, model, timeout=60.0)
         # The window must have reached the engine, or the burst fits and the
         # gate is never crossed. Engines that report their window on /loads
-        # (SGLang, TokenSpeed) are checked; vLLM reports none.
-        _, loads = _fleet_idle(gateway)
+        # (SGLang, TokenSpeed) are checked; vLLM reports none. Every leg has
+        # to appear in /loads first, which takes the monitor an interval.
+        deadline = time.monotonic() + 30.0
+        reported, loads = _fleet_idle(gateway)
+        while not reported and time.monotonic() < deadline:
+            time.sleep(1.0)
+            reported, loads = _fleet_idle(gateway)
+        assert reported, f"a leg never reported a load: {loads}"
         decode_urls = {w.base_url for w in gateway.decode_workers}
         windows = {
             e["worker"]: e["max_running_requests"]
@@ -834,7 +857,7 @@ class TestPDSmallWindow:
         assert all(w == _WINDOW for w in windows.values()), f"decode window not applied: {windows}"
         logger.info("decode windows reported: %s", windows or "none (engine reports no window)")
         worker_dir = worker_log_dir(_LOG_DIR)
-        before = len(read_logs(worker_dir, "worker-*.log"))
+        before = _log_sizes(worker_dir)
         results: list[httpx.Response] = []
 
         def _one(i: int) -> None:
@@ -877,12 +900,13 @@ class TestPDSmallWindow:
                 assert resp.headers.get("retry-after"), "a shed must say when to retry"
         assert elapsed < 90.0, f"the burst took {elapsed:.0f}s; queued rooms are timing out"
 
-        # Only this burst's lines: earlier classes kill workers out from under
-        # their peers, and an empty capture must fail rather than pass.
-        logs = read_logs(worker_dir, "worker-*.log")
-        assert_worker_logs_captured(logs, "prefill bootstrap timeouts")
+        # Only what this burst appended, per file: earlier classes kill workers
+        # out from under their peers, and an empty capture must fail rather
+        # than pass.
+        assert_worker_logs_captured(read_logs(worker_dir, "worker-*.log"), "bootstrap timeouts")
+        new_lines = _logs_since(worker_dir, before)
         for marker in _BOOTSTRAP_TIMEOUT_MARKERS:
-            assert marker not in logs[before:], f"an engine leg timed out a bootstrap: {marker!r}"
+            assert marker not in new_lines, f"an engine leg timed out a bootstrap: {marker!r}"
         _wait_until_served(gateway, model, timeout=60.0)
 
 

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -43,7 +43,7 @@ from pathlib import Path
 import httpx
 import pytest
 from infra import ConnectionMode, Gateway, WorkerType, cleanup_pool, start_workers, stop_workers
-from infra.constants import get_runtime, is_tokenspeed
+from infra.constants import get_runtime, is_sglang, is_tokenspeed
 from infra.model_specs import get_model_spec
 from infra.pd_logs import LOG_FLUSH_TIMEOUT_S, read_logs, worker_log_dir
 
@@ -90,12 +90,13 @@ _TOPOLOGIES = (
     ]
     + [
         # The HTTP PD router is its own code path (pairing, KV handoff, error
-        # answers); SGLang is the only engine that serves it.
+        # answers). SGLang and vLLM both serve it; the TokenSpeed e2e worker
+        # has no HTTP frontend.
         pytest.param(
             ("pd_http", (p, d)),
             id=f"{p}p{d}d-http",
             marks=pytest.mark.skip_for_runtime(
-                "vllm", "tokenspeed", reason="HTTP PD is SGLang-only"
+                "tokenspeed", reason="the TokenSpeed e2e worker has no HTTP frontend"
             ),
         )
         for p, d in [(1, 1), (2, 2)]
@@ -514,11 +515,12 @@ class TestPDTopology:
     def test_batched_completion_serves_every_choice(self, setup_backend, request):
         """Every choice of an ``n>1`` request must come back through the PD pair."""
         mode, model, _, gateway = setup_backend
-        if mode == "pd_http":
+        if mode == "pd_http" and is_sglang():
             # Same shape as the TokenSpeed gRPC case: the HTTP PD router mints
             # one room for a single-prompt request whatever ``n`` is, the engine
             # broadcasts it to every sample, and the decode's children wait on
-            # a transfer that never comes until the decode aborts them.
+            # a transfer that never comes until the decode aborts them. vLLM
+            # over HTTP skips the handoff for n>1 and lets decode own the prompt.
             request.node.add_marker(
                 pytest.mark.xfail(
                     strict=True,

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -270,11 +270,15 @@ def _require_load_reports(backend: str) -> None:
 
 
 def _assert_fleet_idle_within(gateway: Gateway, timeout: float) -> None:
-    deadline = time.monotonic() + timeout
+    started = time.monotonic()
+    deadline = started + timeout
     idle, loads = _fleet_idle(gateway)
     while not idle and time.monotonic() < deadline:
         time.sleep(1.0)
         idle, loads = _fleet_idle(gateway)
+    # How long the engines keep working after the client is gone is the
+    # abort-propagation latency of the pair; log it so sweeps can compare.
+    logger.info("fleet idle after %.1fs (idle=%s)", time.monotonic() - started, idle)
     assert idle, f"engines still hold work after {timeout:.0f}s: {loads}"
 
 

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -42,6 +42,7 @@ from collections import Counter
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
+from urllib.parse import urlparse
 
 import httpx
 import pytest
@@ -191,9 +192,19 @@ def _logs_since(log_dir: Path, sizes: dict[Path, int]) -> str:
         if not path.is_file():
             continue
         with path.open("rb") as fh:
-            fh.seek(sizes.get(path, 0))
+            # A restart truncates the log (mode "w"): a stale offset past EOF
+            # would silently read nothing, so fall back to the whole file.
+            start = sizes.get(path, 0)
+            fh.seek(start if start <= path.stat().st_size else 0)
             parts.append(fh.read().decode("utf-8", errors="replace"))
     return "\n".join(parts)
+
+
+def _fleet_logs(sizes: dict[Path, int], gateway: Gateway) -> str:
+    """The captured log files of this gateway's own legs, named by port."""
+    legs = gateway.prefill_workers + gateway.decode_workers
+    ports = {str(urlparse(w.base_url).port) for w in legs}
+    return "\n".join(str(p) for p in sorted(sizes) if p.stem.rsplit("_", 1)[-1] in ports)
 
 
 def _vllm_transport_installed(*packages: str) -> bool:
@@ -901,9 +912,9 @@ class TestPDSmallWindow:
         assert elapsed < 90.0, f"the burst took {elapsed:.0f}s; queued rooms are timing out"
 
         # Only what this burst appended, per file: earlier classes kill workers
-        # out from under their peers, and an empty capture must fail rather
-        # than pass.
-        assert_worker_logs_captured(read_logs(worker_dir, "worker-*.log"), "bootstrap timeouts")
+        # out from under their peers. The capture guard checks this fleet's own
+        # files exist, so an uncaptured leg cannot pass as a quiet one.
+        assert_worker_logs_captured(_fleet_logs(before, gateway), "bootstrap timeouts")
         new_lines = _logs_since(worker_dir, before)
         for marker in _BOOTSTRAP_TIMEOUT_MARKERS:
             assert marker not in new_lines, f"an engine leg timed out a bootstrap: {marker!r}"

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -419,6 +419,11 @@ pub(crate) fn select_pair(
         decode_policy.name(),
     );
 
+    debug!(
+        prefill = %selected_prefill.url(),
+        decode = %selected_decode.url(),
+        "Selected PD pair"
+    );
     Ok(Pair {
         prefill: selected_prefill,
         decode: selected_decode,

--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -65,9 +65,13 @@ echo "nixl import canary OK"
 python3 -c "import torch, torchcodec, vllm"
 echo "vllm/torchcodec import canary OK"
 
-# Mooncake transfer engine, only on the MooncakeConnector PD leg so a broken
-# wheel cannot fail the unrelated vLLM jobs
-if [ "${E2E_VLLM_KV_BACKEND:-nixl}" = "mooncake" ]; then
+# Mooncake transfer engine, only where a lane runs MooncakeConnector PD
+# workers (its own backend, the lane-wide E2E_KV_BACKEND, or an extra backend
+# for a fleet that mixes transports) so a broken wheel cannot fail the
+# unrelated vLLM jobs
+if [ "${E2E_VLLM_KV_BACKEND:-nixl}" = "mooncake" ] \
+    || [ "${E2E_KV_BACKEND:-}" = "mooncake" ] \
+    || [[ ",${E2E_VLLM_EXTRA_KV_BACKENDS:-}," == *",mooncake,"* ]]; then
     # Mooncake's native extension links libibverbs/libnuma at load time even
     # when the transfer protocol is tcp — without these the import fails with
     # "libibverbs.so.1: cannot open shared object file".


### PR DESCRIPTION
## Description

### Problem

Users say PD mode is hard to run, and TokenSpeed PD in particular, but the e2e suite has only ever exercised one prefill and one decode worker with a handful of happy-path requests. Nothing checks that every leg takes traffic, that KV actually reaches decode for a long prompt, that concurrent requests keep their own context, that an abandoned stream frees the engines, that a leg survives losing a worker, or what a client sees when a whole leg is gone. Nothing assembles a PD fleet through the worker API the way discovery does.

### Solution

`e2e_test/router/test_pd_topologies.py` runs the same checks under six topologies (1p1d, 1p2d, 2p1d, 1p3d, 3p1d, 2p2d) on sglang, vllm and tokenspeed. Per topology:

- registration: `/workers` lists every leg with its role, all healthy
- placement: every prefill and every decode worker takes traffic (attributed from the router log, not guessed)
- transfer: a ~3k-token prompt's secret reaches decode; 16 concurrent echo requests never carry each other's word; a second turn sees the first
- streaming: a stream completes with usage; four abandoned streams leave every engine idle within 30 s
- failure: a leg with two workers keeps serving after one dies and the restarted worker rejoins rotation; a sole leg's outage is answered within 20 s with an error code, and service resumes after restart

Plus `TestPDAssembledAtRuntime`: an IGW gateway with no workers gets a prefill (with bootstrap port) and a decode through `POST /workers`, must route through that pair, must fail promptly when the decode is removed, and must serve again when it is re-added.

Infrastructure needed for this:

- `setup_backend`: `("pd_grpc", (n_prefill, n_decode))` params carry the topology; `@pytest.mark.workers(parallel_start=True)` spawns every leg first and waits afterwards, so a topology costs one model load and the legs come up in no particular order, as a user's fleet does.
- `Worker.wait_ready()`; `WorkerPool.acquire(wait_ready=...)`.
- `Gateway` keeps `prefill_workers` / `decode_workers` / `encode_workers`; `add_worker(worker_type=..., bootstrap_port=...)`.
- `placement::select_pair` logs `Selected PD pair prefill=<url> decode=<url>` at debug level. One line, useful to anyone debugging PD placement.

Lanes:

- `e2e-4gpu-pd (sglang|vllm|tokenspeed)` on every PR: the 2p2d topology plus the runtime-assembled fleet (11 cases), gated like `e2e-2gpu-pd`, added to the `finish` gate.
- `nightly-pd.yml`: the full sweep per engine, daily and on dispatch (`engines`, `filter` inputs), watched by `nightly-triage.yml`.

Stacked on #2463 (the engine-aware model marker; TokenSpeed runs Qwen3.5-9B, the model its PD path is proven on).

### Transport coverage (added while iterating)

- Per-worker KV backend in the e2e infra: `("pd_grpc", (p, d, {"prefill_kv": [...], "decode_kv": [...]}))` and `E2E_KV_BACKEND` lane-wide; TokenSpeed always runs Mooncake (its only transport).
- A sweep row for vLLM's other transport: `vllm` + `kv_backend: mooncake` (the PR slice; the full sweep nightly). The vLLM rows install Mooncake beside NIXL (`vllm_extra_kv_backends`), which `ci_install_vllm.sh` now honours along with the lane-wide backend. The SGLang PD worker now passes `--disaggregation-transfer-backend`; an SGLang-over-NIXL row waits on a NIXL install for its venv (#2498).
- `TestPDMixedTransport` (vLLM 2p2d, one NIXL pair and one Mooncake pair): every request succeeds and every logged pair shares the `pd_pairing` key `/workers` reports. `TestPDMismatchedTransport` (NIXL prefill, Mooncake decode): placement refuses with `503 no_compatible_pd_pair`. Both need #2484 and #2486 (the pairing protocol, #2483); this branch is rebased onto that stack while they are open.

### Findings so far, before a single GPU run

- The gRPC path answers **404 `model_not_found`** when a leg's workers are all unavailable (`pair_failure` and the regular-leg fallback both map `Unavailable` to not-found). The HTTP router answers **503 `no_available_workers`** for the same situation. A client of the gRPC path is told the model does not exist while its workers restart. The sole-leg test accepts both today and logs the code; a follow-up aligns the gRPC path with the 503.
- IGW picks the PD router automatically once both legs are registered, so a fleet can be assembled through the API without `--pd-disaggregation`. The runtime-assembly test pins that.

## Changes

- `e2e_test/router/test_pd_topologies.py`: new (61 cases per engine).
- `e2e_test/fixtures/setup_backend.py`, `e2e_test/infra/worker.py`, `worker_pool.py`, `gateway.py`: fixture and infra support above.
- `model_gateway/src/routers/common/placement.rs`: debug line per selected pair.
- `.github/workflows/pr-test-rust.yml`: `e2e-4gpu-pd` lane and gate; `nightly-pd.yml`: new; `nightly-triage.yml`: watches it.
- `.github/workflows/e2e-gpu-job.yml`, `scripts/ci_install_vllm.sh`: `kv_backend` / `vllm_extra_kv_backends` inputs and the Mooncake install gating.

## Test Plan

- `cargo +nightly fmt --all -- --check`, `cargo clippy -p smg --all-targets -- -D warnings`, `cargo test -p smg --lib placement`: clean.
- `ruff check` / `ruff format --check` / `mypy --config-file mypy.ini` on the new and touched Python: clean; `pytest e2e_test/fixtures e2e_test/infra`: 63 passed.
- Collection with `E2E_GPU_TIER=4`: 61 selected per engine; the PR lane's `-k "2p2d or AssembledAtRuntime"` keeps 11. The gate-integrity lint passes with the new lane.
- The `e2e-4gpu-pd` jobs on this PR are the first real runs. Expect findings; each failure will be triaged into an engine bug, a gateway bug, or a test assumption, and reported on this PR.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (`-p smg --all-targets`; the all-features build needs OpenCV locally)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


