### PR TITLE
ci(e2e): stop pinning TokenSpeed's sequence window in the Qwen3.5-9B spec

### DIFF
--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -187,13 +187,6 @@ MODEL_SPECS: dict[str, dict] = {
             "fa3",
             "--max-model-len",
             "8192",
-            # PD legs admit requests independently: a window smaller than the
-            # number of requests in flight lets prefill and decode admit
-            # disjoint subsets and wait on each other until the transfer
-            # timeout (run 34173426995 deadlocked at 4 under 32 concurrent).
-            # 32 covers every burst the PD suites drive.
-            "--max-num-seqs",
-            "32",
             "--gpu-memory-utilization",
             "0.8",
             # This model's hybrid-attention KV pool opts into tokenspeed's


### PR DESCRIPTION
## Description

### Problem

`e2e_test/infra/model_specs.py` pins `--max-num-seqs` for Qwen3.5-9B on TokenSpeed. The pin arrived with the EPD multimodal smoke lane (#1924) at 4, without a stated reason, and #2463 raised it to 32 after the first TokenSpeed PD run deadlocked: with a 4-wide decode window and 32 concurrent requests, the prefill's bootstrap deadline expired on requests that were merely queued behind the decode's admission. A small pinned window is not a property of the model, and it is exactly the configuration that turns a burst into bootstrap timeouts in PD. Nobody runs the engine that way outside this spec.

### Solution

Remove the pin and let the engine's default window apply, as it does for every other model in the suite. The `e2e-2gpu-pd (tokenspeed)`, `e2e-4gpu-epd (tokenspeed)` and, once #2464 lands, `e2e-4gpu-pd (tokenspeed)` lanes on this PR are the check that nothing relied on it. If the EPD lane turns out to need a bound for the encode worker, it should be scoped to that role in `worker.py`, not applied to every TokenSpeed worker of the model.

The burst-versus-window behaviour itself gets its own coverage: a topology-suite test that sets a deliberately small window and asserts the gateway's admission sheds instead of the engine timing out (follow-up on #2464), alongside the gateway admission fix in #2466 and the engine fix in TokenSpeed.

## Changes

- `e2e_test/infra/model_specs.py`: drop `--max-num-seqs` and its comment from the Qwen3.5-9B TokenSpeed args.

## Test Plan

- `ruff check` / `ruff format --check` clean.
- Lanes exercising the change on this PR: `e2e-2gpu-pd (tokenspeed)` (11 cases, MMLU floor marked expected-fail), `e2e-4gpu-epd (tokenspeed)`, `e2e-1gpu-chat (tokenspeed)`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
