### PR TITLE
fix(worker): keep probing a failed worker so a restart on the same address rejoins

### DIFF
--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -931,8 +931,9 @@ pub struct HealthCheckConfig {
     pub check_interval_secs: u64,
     pub endpoint: String,
     pub disable_health_check: bool,
-    /// Let workers recover after prolonged failure: removal re-enters them
-    /// through service discovery once their engine returns.
+    /// Recover failed workers by removal: they re-enter through service
+    /// discovery once their engine returns. Off, a Failed worker stays
+    /// registered and probed, and rejoins in place when it answers again.
     #[serde(default, alias = "worker_auto_recovery")]
     pub remove_unhealthy_workers: bool,
     /// Seconds to keep a Ready worker in `Draining` after `RemoveWorker`

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -845,16 +845,16 @@ struct CliArgs {
     #[arg(long, default_value_t = false, help_heading = "Health Checks")]
     disable_health_check: bool,
 
-    /// Let workers recover after prolonged failure: a worker that stays
-    /// unhealthy long enough is removed from the registry so service
-    /// discovery re-registers and re-probes it once its engine returns
-    /// (without this, a worker unreachable for ~12 minutes reaches a
-    /// terminal Failed state and is never probed again). Defaults to the
-    /// --service-discovery setting: recovery works by removal plus
-    /// discovery re-registration, so discovery-managed fleets get it for
-    /// free, while without discovery nothing would re-add the worker and
-    /// removal would permanently shrink a static fleet. Pass =false to
-    /// keep it off under discovery.
+    /// Recover failed workers by removal: a worker that stays unhealthy
+    /// long enough (Failed, ~12 minutes at the default thresholds) is
+    /// removed from the registry so service discovery re-registers and
+    /// re-probes it once its engine returns. Without this a Failed worker
+    /// stays registered, out of rotation, and keeps being probed, so it
+    /// rejoins in place as soon as it answers again. Defaults to the
+    /// --service-discovery setting: discovery-managed fleets recover by
+    /// removal plus re-registration, while a static fleet has nothing to
+    /// re-add a removed worker and recovers in place instead. Pass =false
+    /// to keep it off under discovery.
     #[arg(
         long,
         visible_alias = "worker-auto-recovery",

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -344,7 +344,10 @@ async fn run_health_loop(
                 if matches!(
                     apply_probe_completion(&registry, completion, job_queue.as_ref()).await,
                     ProbeApplyResult::Applied(Some((_, WorkerStatus::Failed)))
-                ) {
+                ) && config.remove_unhealthy
+                {
+                    // Removal is in flight; stop probing. Without removal the
+                    // worker stays scheduled so a restart rejoins.
                     next_check.remove(&worker_id);
                 }
             }
@@ -459,15 +462,16 @@ fn queue_due_probes(
 
         let launched_status = worker.status();
         let expected_revision = worker.revision();
-        if launched_status == WorkerStatus::Failed {
+        if launched_status == WorkerStatus::Failed && config.remove_unhealthy {
+            // Removal takes it from here. A Failed worker that is not being
+            // removed keeps its probe slot below, so an engine that comes back
+            // on the same address is noticed and promoted.
             next_check.remove(&worker_id);
-            if config.remove_unhealthy {
-                removals.push(RemovalCandidate {
-                    worker_id: worker_id.clone(),
-                    url: worker.base_url().to_string(),
-                    expected_revision,
-                });
-            }
+            removals.push(RemovalCandidate {
+                worker_id: worker_id.clone(),
+                url: worker.base_url().to_string(),
+                expected_revision,
+            });
             continue;
         }
         if launched_status == WorkerStatus::Draining {
@@ -609,8 +613,9 @@ fn apply_connect_signal(
     match registry.transition_status_if_revision(&worker_id, revision, WorkerStatus::Ready) {
         Some((old, new)) => {
             debug!(worker_url = %url, ?old, ?new, "Promoted worker on connect signal");
-            // A Failed worker was dropped from the schedule; a promoted one is
-            // serving traffic, so it must be probed again — otherwise a later
+            // A Failed worker may have been dropped from the schedule (removal
+            // enabled); a promoted one is serving traffic, so it must be probed
+            // again — otherwise a later
             // engine death would leave it Ready with a dead client forever.
             if let Some(worker) = registry.get(&worker_id) {
                 schedule_worker_at(
@@ -651,9 +656,11 @@ fn schedule_descriptor_at(
         next_check.remove(&descriptor.worker_id);
         return;
     }
-    if descriptor.status == WorkerStatus::Failed {
-        // Startup reconcile and lagged rebuild must be side-effect-free:
-        // do not reschedule already-failed workers for probing or removal.
+    if descriptor.status == WorkerStatus::Failed && config.remove_unhealthy {
+        // Startup reconcile and lagged rebuild must be side-effect-free, and
+        // scheduling a Failed worker under removal would queue its removal.
+        // Without removal the probe is the only effect, and it is how a
+        // restarted engine rejoins.
         next_check.remove(&descriptor.worker_id);
         return;
     }
@@ -702,7 +709,10 @@ fn schedule_worker_at(
 ///   - NotReady → Ready on `success_threshold` consecutive successes
 ///   - NotReady → Failed on `liveness_failure_threshold` (3 × failure_threshold)
 ///   - Ready → NotReady on `failure_threshold` consecutive failures
-///   - Failed: terminal (handled outside this function — no transitions)
+///   - Failed → Ready on `success_threshold` consecutive successes: the engine
+///     came back on the same address (a restart), and without
+///     `--remove-unhealthy-workers` this is the only way it rejoins
+///   - Failed stays Failed on failure; Draining never transitions here
 fn compute_next_status(
     worker: &Arc<dyn Worker>,
     probe_ok: bool,
@@ -723,7 +733,7 @@ fn compute_next_status(
 
         if matches!(
             current_status,
-            WorkerStatus::Pending | WorkerStatus::NotReady
+            WorkerStatus::Pending | WorkerStatus::NotReady | WorkerStatus::Failed
         ) && successes >= success_threshold
         {
             worker.consecutive_successes_reset();
@@ -767,9 +777,10 @@ fn compute_next_status(
                 }
             }
             WorkerStatus::Failed | WorkerStatus::Draining => {
-                // Terminal for the health-state machine. Failed is removed
-                // by `--remove-unhealthy-workers`; Draining is removed by
-                // the discovery drain timer once in-flight requests settle.
+                // Nowhere further down to go. Failed is removed by
+                // `--remove-unhealthy-workers` and otherwise stays probed so
+                // a restart is noticed; Draining is removed by the discovery
+                // drain timer once in-flight requests settle.
             }
         }
 
@@ -1644,17 +1655,22 @@ mod tests {
     }
 
     #[test]
-    fn test_state_machine_failed_is_terminal() {
+    fn test_state_machine_failed_recovers_after_success_threshold() {
         let worker = make_worker("http://w:1", 2, 3);
         worker.set_status(WorkerStatus::Failed);
 
-        // Successful probes don't recover Failed.
-        assert_eq!(compute_next_status(&worker, true, &cfg(2, 3)), None);
-        assert_eq!(compute_next_status(&worker, true, &cfg(2, 3)), None);
+        // Failures keep it Failed.
+        assert_eq!(compute_next_status(&worker, false, &cfg(2, 3)), None);
         assert_eq!(worker.status(), WorkerStatus::Failed);
 
-        // Failed probes don't transition Failed anywhere either.
-        assert_eq!(compute_next_status(&worker, false, &cfg(2, 3)), None);
+        // The engine came back on the same address: success_threshold
+        // consecutive successes promote it exactly like NotReady, because a
+        // static fleet has no other way to rejoin.
+        assert_eq!(compute_next_status(&worker, true, &cfg(2, 3)), None);
+        assert_eq!(
+            compute_next_status(&worker, true, &cfg(2, 3)),
+            Some(WorkerStatus::Ready)
+        );
     }
 
     #[test]
@@ -1753,6 +1769,29 @@ mod tests {
         assert!(
             !next_check.contains_key(&failed_id),
             "bootstrap reconcile must not reschedule failed workers"
+        );
+    }
+
+    #[test]
+    fn test_reconcile_from_registry_keeps_failed_workers_probed_without_removal() {
+        // Without --remove-unhealthy-workers a Failed worker is kept on the
+        // schedule: the probe is how a restart on the same address rejoins.
+        let registry = Arc::new(WorkerRegistry::new());
+        let failed_worker = make_worker("http://failed:1", 2, 3);
+        failed_worker.set_status(WorkerStatus::Failed);
+        let failed_id = registry.register(failed_worker).unwrap();
+        let mut next_check = HashMap::new();
+        reconcile_from_registry(
+            &registry,
+            &mut next_check,
+            &WorkerManagerConfig {
+                default_check_interval_secs: 5,
+                remove_unhealthy: false,
+            },
+        );
+        assert!(
+            next_check.contains_key(&failed_id),
+            "a failed worker that is not being removed must keep being probed"
         );
     }
 


### PR DESCRIPTION
## Description

### Problem

The health state machine in `model_gateway/src/worker/manager.rs` treats `Failed` as terminal. A worker that misses `failure_threshold` probes goes `NotReady`, after the liveness threshold it goes `Failed`, and at that point it is dropped from the probe schedule. The only transition out of `Failed` is the connect signal in `apply_connect_signal`, which only ZMQ engines emit. A gRPC or HTTP worker that dies and comes back on the same address, which is exactly what restarting a worker in a static fleet looks like, is never probed again and stays out of rotation until the gateway restarts or the worker is re-added through the API.

The PD topology suite (#2464) hit this on every engine. In run 34189838383, decode worker `grpc://127.0.0.1:46287` was stopped at 06:23:30, went `Ready → NotReady → Failed` by 06:23:33, was restarted and healthy on its own port at 06:25:19, and the gateway logged no further probe for it for the next ten minutes while the test polled `/workers`; the other three workers were probed every second throughout. The same sequence appears on vLLM and TokenSpeed, and the worker-restart test in #2462 fails the same way on the 1-GPU lanes.

### Solution

- `compute_next_status`: `Failed → Ready` on `success_threshold` consecutive successes, the same rule as `NotReady`. Failures keep it `Failed`.
- `queue_due_probes` and the probe-completion handler: a `Failed` worker is dropped from the schedule only when `--remove-unhealthy-workers` is set, where removal takes over as before. Without removal it keeps its probe slot, so a restart is noticed and it rejoins.
- `schedule_descriptor_at`: the startup reconcile is unchanged under removal (it must not queue removals) and schedules the probe without it.
- Docs updated on the state machine and the connect-signal path.

## Changes

- `model_gateway/src/worker/manager.rs`: state machine, scheduling, and comments as above; `test_state_machine_failed_is_terminal` becomes `test_state_machine_failed_recovers_after_success_threshold`; new `test_reconcile_from_registry_keeps_failed_workers_probed_without_removal`.

## Test Plan

- `cargo +nightly fmt --all`, `cargo clippy -p smg --all-targets -- -D warnings`: clean.
- `cargo test -p smg --lib`: passes (34 manager tests including the two above; full lib count in the job log).
- End-to-end: the worker-restart test in #2462 (1-GPU gateway lanes) and the decode/prefill failover tests in #2464 (4-GPU PD lanes) exercise the restart path against real engines; they should go from timing out to passing once this lands.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (`-p smg --all-targets`; the all-features build needs OpenCV locally)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
