### PR TITLE
feat(protocols): pass through unknown chat content parts

### DIFF
--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -262,6 +262,10 @@ pub enum ContentPart {
     InputAudio { input_audio: InputAudio },
     #[serde(rename = "video_url")]
     VideoUrl { video_url: VideoUrl },
+    /// Pass through unknown content objects to HTTP backends.
+    /// Also matches malformed known types; gRPC backends reject this variant.
+    #[serde(untagged)]
+    Unknown(Map<String, Value>),
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, schemars::JsonSchema)]
@@ -1072,6 +1076,49 @@ mod tests {
                 },
             }
         );
+    }
+
+    #[test]
+    fn content_part_round_trips_unknown_type() {
+        let value = json!({
+            "type": "vendor_special",
+            "payload": {"items": [1, "two", null], "enabled": true},
+            "vendor_option": "keep"
+        });
+        let part: ContentPart = serde_json::from_value(value.clone()).unwrap();
+
+        assert!(
+            matches!(&part, ContentPart::Unknown(fields) if fields["type"] == "vendor_special")
+        );
+        assert_eq!(serde_json::to_value(&part).unwrap(), value);
+    }
+
+    #[test]
+    fn content_part_rejects_non_objects() {
+        for value in [
+            json!(null),
+            json!(true),
+            json!(42),
+            json!("text"),
+            json!([]),
+        ] {
+            assert!(serde_json::from_value::<ContentPart>(value).is_err());
+        }
+    }
+
+    #[test]
+    fn content_part_known_types_take_precedence_over_fallback() {
+        for value in [
+            json!({"type": "text", "text": "hello"}),
+            json!({"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}),
+            json!({"type": "audio_url", "audio_url": {"url": "https://example.com/audio.wav"}}),
+            json!({"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}}),
+            json!({"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}),
+        ] {
+            let part: ContentPart = serde_json::from_value(value.clone()).unwrap();
+            assert!(!matches!(&part, ContentPart::Unknown(_)));
+            assert_eq!(serde_json::to_value(&part).unwrap(), value);
+        }
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -346,6 +346,7 @@ impl HarmonyBuilder {
         &self,
         request: &ChatCompletionRequest,
     ) -> Result<HarmonyBuildOutput, String> {
+        utils::validate_chat_content_parts(&request.messages)?;
         reject_chat_audio(&request.messages)?;
         let encoding = try_harmony_encoding()?;
 
@@ -1250,6 +1251,21 @@ mod tests {
 
     use super::*;
     use crate::routers::grpc::common::responses::utils::namespace_test_request;
+
+    #[test]
+    fn build_from_chat_rejects_unknown_content_parts_before_loading_encoding() {
+        let request: ChatCompletionRequest = serde_json::from_value(json!({
+            "model": "gpt-oss-120b",
+            "messages": [{
+                "role": "user",
+                "content": [{"type": "vendor_media", "payload": "media_1"}]
+            }]
+        }))
+        .unwrap();
+        let error = HarmonyBuilder::new().build_from_chat(&request).unwrap_err();
+        assert!(error.contains("vendor_media"));
+        assert!(error.contains("gRPC"));
+    }
 
     #[test]
     fn chat_audio_is_explicitly_rejected() {

--- a/model_gateway/src/routers/grpc/multimodal/detect.rs
+++ b/model_gateway/src/routers/grpc/multimodal/detect.rs
@@ -39,7 +39,6 @@ fn extract_media_parts(messages: &[ChatMessage]) -> Vec<MediaContentPart> {
                             max_long_side_pixel: image_url.max_long_side_pixel,
                         });
                     }
-                    ContentPart::Text { .. } => {}
                     ContentPart::AudioUrl { audio_url } => {
                         parts.push(MediaContentPart::AudioUrl {
                             url: audio_url.url.clone(),
@@ -63,6 +62,9 @@ fn extract_media_parts(messages: &[ChatMessage]) -> Vec<MediaContentPart> {
                             max_long_side_pixel: video_url.max_long_side_pixel,
                         });
                     }
+                    ContentPart::Text { .. } => {}
+                    // Chat preparation rejects unknown parts before building the media plan.
+                    ContentPart::Unknown(_) => {}
                 }
             }
         }

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -65,6 +65,8 @@ pub(crate) async fn prepare_chat_like(
     ctx: &mut RequestContext,
     request: &ChatCompletionRequest,
 ) -> Result<(Vec<u32>, ProcessedMessages, Option<(String, String)>), Response> {
+    utils::validate_chat_content_parts(&request.messages)
+        .map_err(|e| error::bad_request("unsupported_content_part", e))?;
     {
         // Step 0: Resolve tokenizer from registry (cached for reuse in response processing)
         let tokenizer =

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -16,8 +16,11 @@ use llm_tokenizer::{
     StopSequenceDecoder,
 };
 use openai_protocol::{
-    chat::{ChatCompletionRequest, ChatMessage},
-    common::{FunctionCallResponse, StringOrArray, Tool, ToolCall, ToolChoice, ToolChoiceValue},
+    chat::{ChatCompletionRequest, ChatMessage, MessageContent},
+    common::{
+        ContentPart, FunctionCallResponse, StringOrArray, Tool, ToolCall, ToolChoice,
+        ToolChoiceValue,
+    },
     generate::GenerateFinishReason,
 };
 use serde_json::{json, Value};
@@ -245,6 +248,34 @@ fn build_chat_template_kwargs(request: &ChatCompletionRequest) -> HashMap<String
         combined.extend(template_kwargs.clone());
     }
     combined
+}
+
+/// gRPC backends require content parts the gateway knows how to render.
+pub(crate) fn validate_chat_content_parts(messages: &[ChatMessage]) -> Result<(), String> {
+    for message in messages {
+        let content = match message {
+            ChatMessage::System { content, .. }
+            | ChatMessage::User { content, .. }
+            | ChatMessage::Tool { content, .. }
+            | ChatMessage::Developer { content, .. } => Some(content),
+            ChatMessage::Assistant { content, .. } => content.as_ref(),
+            ChatMessage::Function { .. } => None,
+        };
+        if let Some(MessageContent::Parts(parts)) = content {
+            for part in parts {
+                if let ContentPart::Unknown(fields) = part {
+                    let type_name = fields
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .unwrap_or("<missing>");
+                    return Err(format!(
+                        "Unsupported chat content part type {type_name:?} for gRPC backends"
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 fn process_content_format_with_order(
@@ -476,6 +507,8 @@ pub fn process_chat_messages(
     tokenizer: &dyn Tokenizer,
     image_placeholder: Option<&str>,
 ) -> Result<ProcessedMessages, String> {
+    // Bindings call this entry point without the gRPC preparation stage.
+    validate_chat_content_parts(&request.messages)?;
     let placeholder_tokens = image_placeholder.map(|token| {
         let mut placeholders = PlaceholderTokens::default();
         placeholders.insert(Modality::Image, token.to_string());
@@ -854,6 +887,57 @@ mod tests {
             tokens.insert(*modality, (*token).to_string());
         }
         tokens
+    }
+
+    #[test]
+    fn unknown_chat_content_parts_are_rejected_in_every_role() {
+        for role in ["system", "user", "assistant", "tool", "developer"] {
+            let message: ChatMessage = serde_json::from_value(json!({
+                "role": role,
+                "tool_call_id": "call_1",
+                "content": [
+                    {"type": "text", "text": "hello"},
+                    {"type": "vendor_media", "payload": {"id": "media_1"}}
+                ]
+            }))
+            .unwrap();
+            let error = validate_chat_content_parts(&[message]).unwrap_err();
+            assert!(error.contains("vendor_media"), "{role}: {error}");
+            assert!(error.contains("gRPC"), "{role}: {error}");
+        }
+    }
+
+    #[test]
+    fn process_chat_messages_rejects_unknown_content_parts() {
+        let request: ChatCompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "Describe this attachment"},
+                {"type": "vendor_media", "payload": "media_1"}
+            ]}]
+        }))
+        .unwrap();
+        let tokenizer = llm_tokenizer::MockTokenizer::new();
+        let error = process_chat_messages(&request, &tokenizer, None).unwrap_err();
+        assert!(error.contains("vendor_media"));
+    }
+
+    #[test]
+    fn known_chat_content_parts_are_accepted() {
+        let messages: Vec<ChatMessage> = serde_json::from_value(json!([
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": [
+                {"type": "text", "text": "hello"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+                {"type": "audio_url", "audio_url": {"url": "https://example.com/audio.wav"}},
+                {"type": "input_audio", "input_audio": {"data": "UklGRg==", "format": "wav"}},
+                {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}
+            ]},
+            {"role": "assistant", "content": null},
+            {"role": "function", "name": "lookup", "content": "result"}
+        ]))
+        .unwrap();
+        assert!(validate_chat_content_parts(&messages).is_ok());
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use chat_utils::{
     encode_blocking, encode_prompt_blocking, filter_chat_request_by_tool_choice,
     filter_tools_by_tool_choice, generate_tool_call_id, get_history_tool_calls_count,
     parse_finish_reason, parse_json_schema_response, process_chat_messages_with_placeholders,
-    resolve_tokenizer, send_error_sse,
+    resolve_tokenizer, send_error_sse, validate_chat_content_parts,
 };
 pub(crate) use logprobs::{
     convert_generate_input_logprobs, convert_generate_output_logprobs, convert_proto_logprobs,

--- a/model_gateway/src/routers/http/request_body.rs
+++ b/model_gateway/src/routers/http/request_body.rs
@@ -378,6 +378,31 @@ mod tests {
     }
 
     #[test]
+    fn chat_completion_body_preserves_unknown_content_parts() {
+        let content = json!([
+            {"type": "text", "text": "Describe this attachment"},
+            {"type": "vendor_special", "payload": {"items": [1, null, true]}, "option": "keep"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
+        ]);
+        let req: ChatCompletionRequest = serde_json::from_value(json!({
+            "model": "alias-model",
+            "messages": [{"role": "user", "content": content}]
+        }))
+        .unwrap();
+
+        // Exercise both direct serialization and the worker's Value-based
+        // prepare_request path, with and without a model rewrite.
+        for worker in [worker(), dp_worker()] {
+            for canonical_model in [None, Some("canonical-model")] {
+                let body = serialize_request_body(&req, canonical_model, &worker, None).unwrap();
+                let parsed: Value = serde_json::from_slice(&body).unwrap();
+                assert_eq!(parsed["messages"][0]["content"], content);
+                assert_eq!(parsed["model"], canonical_model.unwrap_or("alias-model"));
+            }
+        }
+    }
+
+    #[test]
     fn default_completion_body_reuses_the_direct_serialization() {
         let worker = worker();
         let req: openai_protocol::completion::CompletionRequest = serde_json::from_value(json!({


### PR DESCRIPTION
## Description

### Problem

With the HTTP backend API, we often will send extensions or specific variants of the /v1/chat/completions in SGLang (via private fork) that may not be widely supported. Rather than diverge from SMG, I think it would be useful to have a drop-in code path to improve compatibility.

### Solution

<!-- How does this PR solve the problem? -->
Add a new catch-all `ContentPart::Unknown`. This is forwarded through the HTTP API as-is, so SMG can route requests with a content part like:

```json
{
    "type": "vendor_special",
    "payload": {"items": [1, "two", null], "enabled": true},
    "vendor_option": "keep"
}
```

## Changes

<!-- - Describe your changes here. -->
- Add new unknown content part with passthrough serialization
- Add checks to the gRPC and Harmony request renderers to make sure they don't accept `Unknown`

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->
- Test was added for passthrough as well as gRPC APIs.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- (Optional) Documentation updated
- (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
