### PR TITLE
test(e2e): size the in-flight load burst to outlast the poll, and widen the gateway lane budget

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -848,11 +848,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # The router suite grew (load reports, overload, restart); the sglang
+          # lane also switches models between classes, which restarts a worker.
           - engine: sglang
-            timeout: 20
+            timeout: 30
             min_selected: 23 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: vllm
-            timeout: 20
+            timeout: 30
             min_selected: 3 # vllm gateway lane selects only 3 tests; floor covers all of them (e2e audit 2026-08-21)
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:

--- a/e2e_test/router/test_loads.py
+++ b/e2e_test/router/test_loads.py
@@ -25,7 +25,9 @@ import pytest
 logger = logging.getLogger(__name__)
 
 # Short poll interval so a report lands within seconds; the gateway default is 10s.
-LOAD_MONITOR_INTERVAL_SECS = 2
+# One second also keeps a burst observable: a small model on an H100 finishes
+# sixteen 512-token generations in about a second, inside a single wider poll.
+LOAD_MONITOR_INTERVAL_SECS = 1
 _GATEWAY_ARGS = ["--load-monitor-interval", str(LOAD_MONITOR_INTERVAL_SECS)]
 _REPORT_TIMEOUT_SECS = 8 * LOAD_MONITOR_INTERVAL_SECS
 
@@ -75,7 +77,6 @@ def _assert_report_is_sane(entry: dict) -> None:
 @pytest.mark.engine("sglang", "vllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.e2e
-@pytest.mark.model("meta-llama/Llama-3.2-1B-Instruct")
 @pytest.mark.gateway(extra_args=_GATEWAY_ARGS)
 @pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
 class TestWorkerLoadReports:
@@ -96,6 +97,7 @@ class TestWorkerLoadReports:
 
         A report that never moves off zero would still pass the presence check
         above; this proves the counters come from the engine, not a default.
+        The burst is sized to outlast several poll intervals on a fast engine.
         """
         _, model, client, gateway = setup_backend
         expected = _worker_urls(gateway)
@@ -110,14 +112,14 @@ class TestWorkerLoadReports:
                     messages=[
                         {"role": "user", "content": "Write a long story about a lighthouse."}
                     ],
-                    max_tokens=512,
+                    max_tokens=1536,
                     temperature=0.0,
                     extra_body={"ignore_eos": True},
                 )
             except BaseException as exc:  # surfaced below; never swallow silently
                 errors.append(exc)
 
-        threads = [threading.Thread(target=_long_request, daemon=True) for _ in range(16)]
+        threads = [threading.Thread(target=_long_request, daemon=True) for _ in range(32)]
         for t in threads:
             t.start()
 
@@ -133,10 +135,10 @@ class TestWorkerLoadReports:
                 time.sleep(0.25)
         finally:
             for t in threads:
-                t.join(timeout=120)
+                t.join(timeout=300)
 
         assert not errors, f"burst requests failed: {errors[:3]}"
-        assert observed, "no load report showed running or waiting work during a 16-request burst"
+        assert observed, "no load report showed running or waiting work during a 32-request burst"
 
 
 @pytest.mark.engine("sglang", "vllm", "tokenspeed")


### PR DESCRIPTION
## Description

### Problem

`test_report_reflects_in_flight_requests` (merged in #2460) sends sixteen 512-token requests and expects at least one load poll to show running or waiting work. On vLLM a 1B model on an H100 finishes that whole burst in about 1.3 s (run 34277963919: requests sent at 21:52:57.4, all answered by 21:52:58.7), inside a single 2-second poll interval, so the check fails on every attempt there while passing on the slower SGLang. That failure blocks every PR's `e2e-1gpu-gateway (vllm)` lane, and since the PD lanes depend on the gateway lane, it also skips them.

Separately, the sglang gateway lane was cancelled at its 20-minute job budget on the same run: the router suite gained the load-report class (and #2462 adds overload and restart classes), and the load-report class used a different model than the other router tests, which made the worker pool restart a worker for it.

### Solution

- The gateway polls loads every second in this test, and the burst is thirty-two 1536-token requests, which outlasts several polls on any engine in CI.
- `TestWorkerLoadReports` drops its private model marker so it reuses the pooled worker the other router tests run on, instead of restarting a worker for one class. The PD class keeps the small model because PD workers are not pooled.
- The `e2e-1gpu-gateway` lanes get a 30-minute budget.

## Changes

- `e2e_test/router/test_loads.py`: poll interval, burst size, thread join timeout, model marker.
- `.github/workflows/pr-test-rust.yml`: gateway lane budget.

## Test Plan

- `ruff check` / `ruff format --check` and `mypy --config-file mypy.ini` clean.
- The `e2e-1gpu-gateway (sglang, vllm)` lanes on this PR are the check; the vLLM one failed three attempts in a row before this change.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
