### PR TITLE
ci: widen the vLLM 1-GPU chat lane budget

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -627,9 +627,12 @@ jobs:
             timeout: 36
             test_timeout: 28
             min_selected: 204 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
+          # 21 min end to end on a quiet host (setup ~6 min, tests ~15 min);
+          # under runner contention setup alone reached 9 min and the 24 min
+          # budget cut the run short. Keep ~30% headroom like the other rows.
           - engine: vllm
-            timeout: 24
-            test_timeout: 18
+            timeout: 32
+            test_timeout: 24
             min_selected: 202 # floor ≈ 95% of measured effective (e2e audit 2026-08-21)
           - engine: trtllm
             timeout: 36


### PR DESCRIPTION
## Description

### Problem

The vLLM row of `e2e-1gpu-chat` runs about 21 minutes end to end on a quiet host (setup ~6 min, tests ~15 min) against a 24-minute job budget and an 18-minute test-step budget. Under runner contention tonight the setup step alone took 9 minutes and the job was cancelled at the deadline while the tests were still passing (run 34292895837: "The job has exceeded the maximum execution time of 24m0s"). The sglang and trtllm rows carry ~30% headroom; this row carries ~12%.

### Solution

Give the vLLM row the same headroom as its siblings: job budget 32 minutes, test step 24 minutes. Nothing else changes; the lane's selection floor stays as measured.

## Changes

- `.github/workflows/pr-test-rust.yml`: `e2e-1gpu-chat` vLLM row `timeout: 24 -> 32`, `test_timeout: 18 -> 24`, with a comment recording the measured durations.

## Test Plan

Measured durations of `e2e-1gpu-chat (vllm)` today:

| Run | Setup vLLM backend | Run E2E tests | Total | Outcome |
|---|---|---|---|---|
| 34284571367 (quiet) | 6 min | 13 min | 20.6 min | pass |
| 34287889516 (main, busy) | 5.7 min | 15 min | 21.7 min | pass |
| 34292895837 (busy) | 9 min | >14 min, cut | 24 min | cancelled at the job deadline |

After: the lane's own CI run on this PR completes inside the new budget.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
