### PR TITLE
ci: widen the Go bindings e2e job budget

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1182,7 +1182,10 @@ jobs:
                   || needs.detect-changes.outputs.go-bindings == 'true')))
     runs-on: ${{ vars.SMG_RUNNER_GPU_1 || '1-gpu-h100' }}
     container: ${{ vars.SMG_CI_GPU_CONTAINER_IMAGE }}
-    timeout-minutes: 20
+    # 19 min on a quiet host (SGLang setup ~6.5 min, Go ~4 min, tests ~6.5
+    # min); under runner contention the setup step reached 10 min and the
+    # job was cancelled as the last test passed. Keep ~35% headroom.
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Description

### Problem

`go-bindings-e2e` runs about 19 minutes on a quiet host (SGLang setup ~6.5 min, Go setup ~4 min, tests ~6.5 min) against a 20-minute job budget. On the main run for a668ad3e (34297830861) the SGLang setup step took 10 minutes under runner contention and the job was cancelled at the deadline as its last test passed:

```
============== 19 passed, 4 xfailed, 1 rerun in 390.59s (0:06:30) ==============
##[error]The operation was canceled.
The job has exceeded the maximum execution time of 20m0s
```

That is the second lane today to go red on a budget with under 10% headroom while every test passed (#2477 was the vLLM 1-GPU chat lane).

### Solution

Give the job 30 minutes, the same ~35% headroom the other lanes carry. No test or setup change.

## Changes

- `.github/workflows/pr-test-rust.yml`: `go-bindings-e2e` `timeout-minutes: 20 -> 30`, with a comment recording the measured step durations.

## Test Plan

Measured durations of `go-bindings-e2e` on main today:

| Run | Setup SGLang | Setup Go | Tests | Total | Outcome |
|---|---|---|---|---|---|
| 34287889516 (22d0d0f4) | 6.5 min | 4.2 min | 7.2 min | 18.8 min | pass |
| 34297830861 (a668ad3e) | 10.1 min | 2.8 min | 6.7 min | 20.0 min | cancelled at the deadline, 19 passed |

After: the job on this PR completes inside the new budget.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
