### PR TITLE
fix(pd): name an unavailable PD leg with the same 503 code as the other routers

### DIFF
--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -209,8 +209,12 @@ impl PDRouter {
             PdSelectionFailure::Shed(shed) => shed,
             PdSelectionFailure::Unavailable(error) => {
                 error!("Failed to select PD pair error={}", error);
+                // Same code the regular HTTP router and the gRPC routers use
+                // for a leg that is merely down, so a client can key its
+                // retry on one code whatever the transport; the message
+                // still names the leg.
                 error::service_unavailable(
-                    "server_selection_failed",
+                    "no_available_workers",
                     format!("No available servers: {error}"),
                 )
             }


### PR DESCRIPTION
## Description

### Problem

With a PD pair's only decode worker down, the HTTP PD router answers `503 {"code": "server_selection_failed", "message": "No available servers: No available decode workers"}`, while the regular HTTP router and the gRPC routers answer the same condition with `503 no_available_workers` (#2465 unified the gRPC side). A client that keys its retry on the error code has to know which transport it is talking to. Found by the PD topology sweep in #2464 (`test_sole_leg_outage_is_reported_promptly[1p1d-http]`).

### Solution

Use `no_available_workers` in the HTTP PD router's selection-failure path as well. The status stays 503 and the message still names the missing leg. Overload sheds keep their own code.

## Changes

- `model_gateway/src/routers/http/pd_router.rs`: `handle_server_selection_error` emits `no_available_workers` instead of `server_selection_failed` for `PdSelectionFailure::Unavailable`.

## Test Plan

- `cargo +nightly fmt --all`, `cargo clippy -p smg --all-targets -- -D warnings`, `cargo test -p smg --lib pd_router` pass locally.
- The sweep's sole-leg outage test accepts both codes for now; once this lands it can drop `server_selection_failed`.

Before (HTTP PD, sole decode down): `503 server_selection_failed`. After: `503 no_available_workers`, same message.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
