### PR TITLE
fix(pd): fan an n>1 request out into one PD pair per sample on room-based engines

### DIFF
--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -6,7 +6,10 @@ use axum::response::Response;
 use futures::future::{join_all, try_join_all};
 use tracing::{debug, error, info_span, Instrument};
 
-use super::pd_protocol::{DpPlacement, PdDispatch, PdProtocol};
+use super::{
+    helpers::{maybe_inject_pd_metadata, maybe_inject_pd_rendezvous},
+    pd_protocol::{DpPlacement, PdDispatch, PdProtocol},
+};
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
@@ -25,8 +28,8 @@ use crate::{
                 ExecutionResult, LoadGuards, PdTiming, WorkerSelection,
             },
             proto_wrapper::{
-                ProtoEmbedRequest, ProtoGenerateRequest, ProtoRequest, ProtoResponseVariant,
-                ProtoStream,
+                FanoutStream, ProtoEmbedRequest, ProtoGenerateRequest, ProtoRequest,
+                ProtoResponseVariant, ProtoStream,
             },
             utils::tonic_ext::{TonicResultExt, TonicStatusExt},
         },
@@ -97,15 +100,74 @@ enum PdDispatchOutcome {
     },
 }
 
-/// Backend requests one plan dispatches — one per batched prompt, else one.
+/// Backend requests one plan dispatches — one per batched prompt, times the
+/// PD fan-out width where a parallel PD request asks for n>1 samples.
 ///
 /// This is both the load-guard scale and the number of PD bootstrap rooms the
 /// plan will post, which is why admission and the guards read the same count.
-fn plan_sub_requests(plan: &ExecutionPlan) -> usize {
+fn plan_sub_requests(plan: &ExecutionPlan, workers: Option<&WorkerSelection>) -> usize {
+    let protocol = workers
+        .and_then(WorkerSelection::disaggregated_runtime_type)
+        .and_then(|runtime| PdProtocol::for_runtime(*runtime));
+    let width = |request: &ProtoGenerateRequest| {
+        protocol
+            .and_then(|protocol| pd_fanout_width(request, protocol))
+            .map_or(1, |n| n as usize)
+    };
     match plan {
-        ExecutionPlan::Batch { requests, .. } => requests.len(),
-        _ => 1,
+        ExecutionPlan::Batch {
+            kind: ExecutionPlanKind::Single,
+            requests,
+            ..
+        } => requests.len(),
+        ExecutionPlan::Batch { requests, .. } => requests.iter().map(width).sum(),
+        ExecutionPlan::PrefillDecode(request) | ExecutionPlan::EncodePrefillDecode { request } => {
+            width(request)
+        }
+        ExecutionPlan::Single(_) => 1,
     }
+}
+
+/// Fan-out width for a parallel PD dispatch: `n` when the request asks for
+/// more than one sample of a text-only prompt, else `None`.
+///
+/// A rendezvous room serves one sample. The engines that rendezvous on a
+/// room broadcast the request's single room to every sample of an n>1
+/// request: each of the decode's children then pre-allocates against the
+/// same room, and the prefill either rejects the repeats (TokenSpeed) or
+/// serves one child while the rest wait on KV that never comes. So each
+/// sample becomes its own single-sample PD dispatch with its own room, and
+/// the merged streams stamp every child's position as the choice index. A
+/// multimodal payload travels as one SHM segment that the prefill unlinks on
+/// read, so it cannot be handed to n prefills; those requests keep the
+/// single dispatch.
+fn pd_fanout_width(request: &ProtoGenerateRequest, protocol: PdProtocol) -> Option<u32> {
+    if protocol.dispatch != PdDispatch::Parallel || request.has_mm_inputs() {
+        return None;
+    }
+    let n = request.sampling_n();
+    (n > 1).then_some(n)
+}
+
+/// Split an n>1 request into `n` single-sample sub-requests. Sub `i` carries
+/// engine id `{id}-{i}`, `n = 1`, a seed offset of `i` when the request
+/// pinned a seed, and whatever rendezvous `remint` stamps on it.
+fn fan_out_pd_request(
+    request: &ProtoGenerateRequest,
+    n: u32,
+    mut remint: impl FnMut(&mut ProtoGenerateRequest),
+) -> Vec<ProtoGenerateRequest> {
+    let base_id = request.request_id().to_string();
+    (0..n)
+        .map(|i| {
+            let mut sub = request.clone();
+            sub.set_request_id(format!("{base_id}-{i}"));
+            sub.set_sampling_n(1);
+            sub.offset_sampling_seed(i);
+            remint(&mut sub);
+            sub
+        })
+        .collect()
 }
 
 /// Metric connection labels for the PD legs (a leg can be gRPC or ZMQ).
@@ -135,7 +197,7 @@ pub(crate) async fn execute_plan(
     // completion fans out one PD dispatch per sub-request, so admission has
     // to claim for all of them or the siblings walk past a gate that only
     // ever asked about one.
-    let sub_requests = plan_sub_requests(&execution_plan);
+    let sub_requests = plan_sub_requests(&execution_plan, ctx.workers.as_ref());
 
     // Admission runs before this attempt claims anything else. The decode
     // leg's engine window is what clears the prefill's bootstrap deadline, so
@@ -271,10 +333,77 @@ async fn execute_pd_dispatch(
         PdDispatch::Sequential => {
             execute_sequential_pd(proto_request, clients, workers, model).await
         }
-        PdDispatch::Parallel => {
-            execute_parallel_pd(proto_request, clients, workers, protocol).await
-        }
+        PdDispatch::Parallel => match pd_fanout_width(&proto_request, protocol) {
+            Some(n) => execute_fanout_pd(proto_request, n, clients, workers, protocol).await,
+            None => execute_parallel_pd(proto_request, clients, workers, protocol).await,
+        },
     }
+}
+
+/// Dispatch an n>1 request as `n` concurrent single-sample PD pairs, each
+/// with its own rendezvous room, and merge their legs into one PD result
+/// whose responses carry the sample index. Fail-fast: the first pair that
+/// fails to start fails the request, and dropping the others aborts them.
+async fn execute_fanout_pd(
+    proto_request: ProtoGenerateRequest,
+    n: u32,
+    clients: &mut ClientSelection,
+    workers: &WorkerSelection,
+    protocol: PdProtocol,
+) -> Result<ExecutionResult, Response> {
+    let subs = fan_out_pd_request(&proto_request, n, |sub| {
+        maybe_inject_pd_metadata(sub, workers);
+        maybe_inject_pd_rendezvous(sub, workers);
+    });
+    debug!(
+        request_id = proto_request.request_id(),
+        samples = n,
+        "PD fan-out: one single-sample pair per sample, each with its own room"
+    );
+    let dispatches = subs.into_iter().map(|sub| {
+        let mut clients = clients.clone();
+        async move { execute_parallel_pd(sub, &mut clients, workers, protocol).await }
+    });
+    let results = try_join_all(dispatches).await?;
+
+    let mut prefills = Vec::with_capacity(results.len());
+    let mut decodes = Vec::with_capacity(results.len());
+    let mut timing: Option<PdTiming> = None;
+    for result in results {
+        let ExecutionResult::PrefillDecode {
+            prefill,
+            decode,
+            pd_timing,
+        } = result
+        else {
+            error!(
+                function = "execute_fanout_pd",
+                "PD fan-out child returned a non-PD result"
+            );
+            return Err(error::internal_error(
+                "pd_fanout_unexpected_result",
+                "PD fan-out child returned a non-PD result",
+            ));
+        };
+        prefills.push(prefill);
+        decodes.push(*decode);
+        // The earliest prefill start anchors the merged request's TTFT.
+        timing = Some(match timing {
+            Some(earliest) if earliest.prefill_start <= pd_timing.prefill_start => earliest,
+            _ => pd_timing,
+        });
+    }
+    let Some(pd_timing) = timing else {
+        return Err(error::internal_error(
+            "pd_fanout_empty",
+            "PD fan-out produced no dispatch",
+        ));
+    };
+    Ok(ExecutionResult::PrefillDecode {
+        prefill: ProtoStream::Fanout(FanoutStream::new(prefills)),
+        decode: Box::new(ProtoStream::Fanout(FanoutStream::new(decodes))),
+        pd_timing,
+    })
 }
 
 async fn execute_epd_dispatch(
@@ -954,10 +1083,149 @@ async fn execute_sequential_pd(
 mod tests {
     use std::{sync::Arc, time::Duration};
 
-    use smg_grpc_client::{tokenspeed_proto as ts, vllm_proto as vllm};
+    use smg_grpc_client::{sglang_proto as sglang, tokenspeed_proto as ts, vllm_proto as vllm};
 
     use super::*;
     use crate::worker::{BasicWorkerBuilder, ConnectionMode, RuntimeType, Worker, WorkerType};
+
+    fn tokenspeed_request(n: u32, seed: Option<u64>) -> ProtoGenerateRequest {
+        ProtoGenerateRequest::TokenSpeed(Box::new(ts::GenerateRequest {
+            request_id: "req".to_string(),
+            sampling_params: Some(ts::SamplingParams {
+                n,
+                sampling_seed: seed,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+    }
+
+    fn tokenspeed_pair() -> WorkerSelection {
+        let leg = |url: &str, worker_type: WorkerType| -> Arc<dyn Worker> {
+            Arc::new(
+                BasicWorkerBuilder::new(url)
+                    .worker_type(worker_type)
+                    .runtime_type(RuntimeType::TokenSpeed)
+                    .connection_mode(ConnectionMode::Grpc)
+                    .build(),
+            )
+        };
+        WorkerSelection::Disaggregated {
+            encode_assignments: None,
+            prefill: leg("grpc://prefill:30000", WorkerType::Prefill),
+            decode: leg("grpc://decode:30000", WorkerType::Decode),
+            runtime_type: RuntimeType::TokenSpeed,
+        }
+    }
+
+    #[test]
+    fn pd_fanout_width_applies_to_multi_sample_text_requests_on_parallel_pd() {
+        let tokenspeed = PdProtocol::for_runtime(RuntimeType::TokenSpeed).unwrap();
+        assert_eq!(
+            pd_fanout_width(&tokenspeed_request(3, None), tokenspeed),
+            Some(3)
+        );
+        assert_eq!(
+            pd_fanout_width(&tokenspeed_request(1, None), tokenspeed),
+            None
+        );
+        assert_eq!(
+            pd_fanout_width(&tokenspeed_request(0, None), tokenspeed),
+            None
+        );
+
+        let sglang = ProtoGenerateRequest::Sglang(Box::new(sglang::GenerateRequest {
+            request_id: "req".to_string(),
+            sampling_params: Some(sglang::SamplingParams {
+                n: 2,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+        assert_eq!(
+            pd_fanout_width(
+                &sglang,
+                PdProtocol::for_runtime(RuntimeType::Sglang).unwrap()
+            ),
+            Some(2)
+        );
+
+        // A multimodal payload cannot be handed to n prefills.
+        let mut multimodal = tokenspeed_request(3, None);
+        if let ProtoGenerateRequest::TokenSpeed(req) = &mut multimodal {
+            req.mm_inputs = Some(ts::MultimodalInputs::default());
+        }
+        assert_eq!(pd_fanout_width(&multimodal, tokenspeed), None);
+
+        // The sequential (vLLM) path relays one KV handoff and already
+        // skips it for n>1; no fan-out there.
+        let vllm = ProtoGenerateRequest::Vllm(Box::new(vllm::GenerateRequest {
+            request_id: "req".to_string(),
+            sampling_params: Some(vllm::SamplingParams {
+                n: 3,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+        assert_eq!(
+            pd_fanout_width(&vllm, PdProtocol::for_runtime(RuntimeType::Vllm).unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn fan_out_pd_request_gives_each_sample_its_own_id_seed_and_room() {
+        let request = tokenspeed_request(3, Some(7));
+        let mut next_room = 100;
+        let subs = fan_out_pd_request(&request, 3, |sub| {
+            sub.set_kv_bootstrap_info("prefill".to_string(), 8998, next_room);
+            next_room += 1;
+        });
+        assert_eq!(subs.len(), 3);
+        let mut rooms = Vec::new();
+        for (i, sub) in subs.iter().enumerate() {
+            assert_eq!(sub.request_id(), format!("req-{i}"));
+            assert_eq!(sub.sampling_n(), 1);
+            let ProtoGenerateRequest::TokenSpeed(req) = sub else {
+                panic!("sub-request changed runtime");
+            };
+            let params = req.sampling_params.as_ref().unwrap();
+            assert_eq!(params.sampling_seed, Some(7 + i as u64));
+            rooms.push(req.kv_bootstrap_info.as_ref().unwrap().bootstrap_room);
+        }
+        assert_eq!(rooms, vec![100, 101, 102]);
+        // The original still asks for its three samples.
+        assert_eq!(request.sampling_n(), 3);
+    }
+
+    #[test]
+    fn fan_out_pd_request_leaves_an_unset_seed_unset() {
+        for sub in &fan_out_pd_request(&tokenspeed_request(2, None), 2, |_| {}) {
+            let ProtoGenerateRequest::TokenSpeed(req) = sub else {
+                panic!("sub-request changed runtime");
+            };
+            assert_eq!(req.sampling_params.as_ref().unwrap().sampling_seed, None);
+        }
+    }
+
+    #[test]
+    fn plan_sub_requests_counts_fanned_out_samples() {
+        let workers = tokenspeed_pair();
+        let fanned = ExecutionPlan::PrefillDecode(tokenspeed_request(4, None));
+        assert_eq!(plan_sub_requests(&fanned, Some(&workers)), 4);
+        // Without a disaggregated selection there is no PD protocol to fan out on.
+        assert_eq!(plan_sub_requests(&fanned, None), 1);
+
+        let plain = ExecutionPlan::PrefillDecode(tokenspeed_request(1, None));
+        assert_eq!(plan_sub_requests(&plain, Some(&workers)), 1);
+
+        let batch = ExecutionPlan::Batch {
+            kind: ExecutionPlanKind::PrefillDecode,
+            shared_request_id: "cmpl-1".to_string(),
+            requests: vec![tokenspeed_request(2, None), tokenspeed_request(1, None)],
+        };
+        assert_eq!(plan_sub_requests(&batch, Some(&workers)), 3);
+    }
 
     /// A leg that never answers — the decode leg stuck behind the engine's
     /// transfer deadline while the prefill leg has already given up.
@@ -1023,7 +1291,7 @@ mod tests {
     #[test]
     fn plan_sub_requests_counts_every_batched_prompt() {
         let single = ExecutionPlan::PrefillDecode(ProtoGenerateRequest::Vllm(Box::default()));
-        assert_eq!(plan_sub_requests(&single), 1);
+        assert_eq!(plan_sub_requests(&single, None), 1);
 
         let batch = ExecutionPlan::Batch {
             kind: ExecutionPlanKind::PrefillDecode,
@@ -1032,7 +1300,7 @@ mod tests {
                 .map(|_| ProtoGenerateRequest::Vllm(Box::default()))
                 .collect(),
         };
-        assert_eq!(plan_sub_requests(&batch), 4);
+        assert_eq!(plan_sub_requests(&batch, None), 4);
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -7,8 +7,10 @@
 use std::{
     collections::HashMap,
     fs::{read_dir, remove_file, OpenOptions},
+    future::Future,
     io::Write,
     path::{Path, PathBuf},
+    pin::Pin,
     process,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -17,6 +19,7 @@ use std::{
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
+use futures::future::select_all;
 use futures_util::StreamExt;
 use memmap2::MmapOptions;
 use rand::RngExt;
@@ -1502,16 +1505,70 @@ impl ProtoGenerateRequest {
         }
     }
 
-    /// Number of parallel samples requested (vLLM only; 1 when unset).
+    /// Number of parallel samples requested (1 when unset). vLLM, SGLang
+    /// and TokenSpeed carry it in their sampling params; the others have no
+    /// per-request sample count.
     pub fn sampling_n(&self) -> u32 {
+        let n = match self {
+            Self::Vllm(req) => req.sampling_params.as_ref().map(|p| p.n),
+            Self::Sglang(req) => req.sampling_params.as_ref().map(|p| p.n),
+            Self::TokenSpeed(req) => req.sampling_params.as_ref().map(|p| p.n),
+            Self::Trtllm(_) | Self::Mlx(_) => None,
+        };
+        n.filter(|&n| n > 0).unwrap_or(1)
+    }
+
+    /// Set the number of parallel samples (engines without the field ignore it).
+    pub fn set_sampling_n(&mut self, n: u32) {
         match self {
-            Self::Vllm(req) => req
-                .sampling_params
-                .as_ref()
-                .map(|p| p.n)
-                .filter(|&n| n > 0)
-                .unwrap_or(1),
-            Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => 1,
+            Self::Vllm(req) => {
+                if let Some(params) = req.sampling_params.as_mut() {
+                    params.n = n;
+                }
+            }
+            Self::Sglang(req) => {
+                if let Some(params) = req.sampling_params.as_mut() {
+                    params.n = n;
+                }
+            }
+            Self::TokenSpeed(req) => {
+                if let Some(params) = req.sampling_params.as_mut() {
+                    params.n = n;
+                }
+            }
+            Self::Trtllm(_) | Self::Mlx(_) => {}
+        }
+    }
+
+    /// Offset an explicit sampling seed so fanned-out samples stay distinct
+    /// yet deterministic; an unset seed stays unset (the engine then seeds
+    /// each request on its own). Engines without a seed field ignore it.
+    pub fn offset_sampling_seed(&mut self, offset: u32) {
+        match self {
+            Self::Vllm(req) => {
+                if let Some(params) = req.sampling_params.as_mut() {
+                    let offset = i32::try_from(offset).unwrap_or(i32::MAX);
+                    params.seed = params.seed.map(|seed| seed.wrapping_add(offset));
+                }
+            }
+            Self::TokenSpeed(req) => {
+                if let Some(params) = req.sampling_params.as_mut() {
+                    params.sampling_seed = params
+                        .sampling_seed
+                        .map(|seed| seed.wrapping_add(u64::from(offset)));
+                }
+            }
+            Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) => {}
+        }
+    }
+
+    /// Whether the request carries multimodal inputs.
+    pub fn has_mm_inputs(&self) -> bool {
+        match self {
+            Self::Sglang(req) => req.mm_inputs.is_some(),
+            Self::Vllm(req) => req.mm_inputs.is_some(),
+            Self::TokenSpeed(req) => req.mm_inputs.is_some(),
+            Self::Trtllm(_) | Self::Mlx(_) => false,
         }
     }
 
@@ -1595,6 +1652,53 @@ pub enum ProtoGenerateResponse {
 }
 
 impl ProtoGenerateResponse {
+    /// Stamp the choice index on a chunk or complete. A fanned-out n>1
+    /// sample reports index 0 from its own engine request; the fan-out
+    /// restamps it with the sample's position.
+    pub fn set_index(&mut self, index: u32) {
+        match self {
+            Self::Sglang(resp) => match resp.response.as_mut() {
+                Some(sglang::generate_response::Response::Chunk(chunk)) => chunk.index = index,
+                Some(sglang::generate_response::Response::Complete(complete)) => {
+                    complete.index = index;
+                }
+                None => {}
+            },
+            Self::Vllm(resp) => match resp.response.as_mut() {
+                Some(vllm::generate_response::Response::Chunk(chunk)) => chunk.index = index,
+                Some(vllm::generate_response::Response::Complete(complete)) => {
+                    complete.index = index;
+                }
+                None => {}
+            },
+            Self::Trtllm(resp) => match resp.response.as_mut() {
+                Some(trtllm::generate_response::Response::Chunk(chunk)) => {
+                    chunk.sequence_index = index;
+                }
+                Some(trtllm::generate_response::Response::Complete(complete)) => {
+                    complete.sequence_index = index;
+                }
+                None => {}
+            },
+            Self::Mlx(resp) => match resp.response.as_mut() {
+                Some(mlx::generate_response::Response::Chunk(chunk)) => chunk.index = index,
+                Some(mlx::generate_response::Response::Complete(complete)) => {
+                    complete.index = index;
+                }
+                None => {}
+            },
+            Self::TokenSpeed(resp) => match resp.response.as_mut() {
+                Some(tokenspeed::generate_response::Response::Chunk(chunk)) => {
+                    chunk.index = index;
+                }
+                Some(tokenspeed::generate_response::Response::Complete(complete)) => {
+                    complete.index = index;
+                }
+                None => {}
+            },
+        }
+    }
+
     /// Get the response variant (chunk, complete, or error)
     ///
     /// Consumes self to avoid cloning large proto messages in hot streaming path
@@ -2158,6 +2262,9 @@ pub enum ProtoStream {
     /// ZMQ backend: a custom stream yielding vLLM-proto responses built from
     /// EngineCore outputs. Auto-aborts on drop, so `mark_completed` is a no-op.
     Zmq(ZmqGenerateStream),
+    /// An n>1 fan-out over rendezvous-room PD pairs: one child per sample,
+    /// each response stamped with its sample's index (see [`FanoutStream`]).
+    Fanout(FanoutStream),
 }
 
 impl ProtoStream {
@@ -2196,6 +2303,7 @@ impl ProtoStream {
                 .next()
                 .await
                 .map(|result| result.map(|r| ProtoGenerateResponse::Vllm(Box::new(r)))),
+            Self::Fanout(stream) => stream.next().await,
         }
     }
 
@@ -2208,6 +2316,7 @@ impl ProtoStream {
             Self::Mlx(stream) => stream.mark_completed(),
             Self::TokenSpeed(stream) => stream.mark_completed(),
             Self::Zmq(stream) => stream.mark_completed(),
+            Self::Fanout(stream) => stream.mark_completed(),
         }
     }
 
@@ -2228,6 +2337,133 @@ impl ProtoStream {
             Self::Mlx(stream) => Self::Mlx(stream.defer_abort_until_first_item()),
             Self::TokenSpeed(stream) => Self::TokenSpeed(stream.defer_abort_until_first_item()),
             Self::Zmq(stream) => Self::Zmq(stream),
+            Self::Fanout(stream) => Self::Fanout(stream.defer_abort_until_first_item()),
+        }
+    }
+}
+
+impl FanoutChild for ProtoStream {
+    fn next_item(
+        &mut self,
+    ) -> impl Future<Output = Option<Result<ProtoGenerateResponse, tonic::Status>>> + Send {
+        self.next()
+    }
+
+    fn mark_completed(&mut self) {
+        Self::mark_completed(self);
+    }
+
+    fn defer_abort_until_first_item(self) -> Self {
+        Self::defer_abort_until_first_item(self)
+    }
+}
+
+/// What a fan-out needs from a child stream. Implemented by [`ProtoStream`];
+/// tests implement it on a scripted child.
+pub trait FanoutChild: Send {
+    /// The child's next response, or `None` once it has ended.
+    fn next_item(
+        &mut self,
+    ) -> impl Future<Output = Option<Result<ProtoGenerateResponse, tonic::Status>>> + Send;
+
+    /// Mark the child completed so dropping it sends no abort.
+    fn mark_completed(&mut self);
+
+    /// Defer the child's abort-on-drop until its first response.
+    #[must_use]
+    fn defer_abort_until_first_item(self) -> Self;
+}
+
+/// One child per sample of an n>1 fan-out over rendezvous-room PD pairs.
+///
+/// Each child is a single-sample dispatch whose responses report choice
+/// index 0; the fan-out restamps them with the child's position, so the
+/// pipeline demuxes the merged stream exactly like an engine-native n>1
+/// stream. Children are polled together, starting from a rotating cursor so
+/// a chatty child cannot starve its siblings, and are retired as they end;
+/// the fan-out ends with the last child. Dropping it drops every child, so
+/// each leg keeps its abort-on-drop, and `mark_completed` reaches every
+/// child.
+pub struct FanoutStream<C = ProtoStream> {
+    children: Vec<Option<C>>,
+    cursor: usize,
+}
+
+type FanoutItem = Option<Result<ProtoGenerateResponse, tonic::Status>>;
+/// One child's pending `next_item`, tagged with the child's position.
+type FanoutPoll<'a> = Pin<Box<dyn Future<Output = (usize, FanoutItem)> + Send + 'a>>;
+
+impl<C: FanoutChild> FanoutStream<C> {
+    pub fn new(children: Vec<C>) -> Self {
+        Self {
+            children: children.into_iter().map(Some).collect(),
+            cursor: 0,
+        }
+    }
+
+    /// Children that have not ended yet.
+    pub fn open_children(&self) -> usize {
+        self.children.iter().flatten().count()
+    }
+
+    /// Next response from any open child, stamped with that child's index.
+    pub async fn next(&mut self) -> FanoutItem {
+        loop {
+            let len = self.children.len();
+            if len == 0 {
+                return None;
+            }
+            let start = self.cursor % len;
+            self.cursor = (start + 1) % len;
+            // Open children before the cursor go to the back of the poll
+            // order, so the cursor rotates which child gets the first look.
+            let skip = self.children[..start].iter().flatten().count();
+            let mut polls: Vec<FanoutPoll<'_>> = self
+                .children
+                .iter_mut()
+                .enumerate()
+                .filter_map(|(position, child)| {
+                    child.as_mut().map(|child| {
+                        let poll: FanoutPoll<'_> =
+                            Box::pin(async move { (position, child.next_item().await) });
+                        poll
+                    })
+                })
+                .collect();
+            if polls.is_empty() {
+                return None;
+            }
+            let rotate = skip % polls.len();
+            polls.rotate_left(rotate);
+            let ((position, item), _, _) = select_all(polls).await;
+            match item {
+                Some(Ok(mut response)) => {
+                    response.set_index(u32::try_from(position).unwrap_or(u32::MAX));
+                    return Some(Ok(response));
+                }
+                Some(Err(status)) => return Some(Err(status)),
+                None => self.children[position] = None,
+            }
+        }
+    }
+
+    /// Mark every open child completed.
+    pub fn mark_completed(&mut self) {
+        for child in self.children.iter_mut().flatten() {
+            child.mark_completed();
+        }
+    }
+
+    /// Defer every open child's abort-on-drop until its first response.
+    #[must_use]
+    pub fn defer_abort_until_first_item(self) -> Self {
+        Self {
+            children: self
+                .children
+                .into_iter()
+                .map(|child| child.map(FanoutChild::defer_abort_until_first_item))
+                .collect(),
+            cursor: self.cursor,
         }
     }
 }
@@ -2332,6 +2568,172 @@ impl ProtoEmbedComplete {
             Self::Sglang(r) => r.embedding_dim,
             Self::Vllm(r) => r.embedding_dim,
         }
+    }
+}
+
+#[cfg(test)]
+mod fanout_tests {
+    use std::{
+        collections::VecDeque,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+    };
+
+    use super::*;
+
+    /// A child that yields a script, then ends.
+    struct Scripted {
+        items: VecDeque<Result<ProtoGenerateResponse, tonic::Status>>,
+        completed: Arc<AtomicBool>,
+    }
+
+    impl FanoutChild for Scripted {
+        fn next_item(
+            &mut self,
+        ) -> impl Future<Output = Option<Result<ProtoGenerateResponse, tonic::Status>>> + Send
+        {
+            let item = self.items.pop_front();
+            async move { item }
+        }
+
+        fn mark_completed(&mut self) {
+            self.completed.store(true, Ordering::SeqCst);
+        }
+
+        fn defer_abort_until_first_item(self) -> Self {
+            self
+        }
+    }
+
+    fn chunk(text: &str) -> ProtoGenerateResponse {
+        ProtoGenerateResponse::Sglang(Box::new(sglang::GenerateResponse {
+            response: Some(sglang::generate_response::Response::Chunk(
+                sglang::GenerateStreamChunk {
+                    token_ids: vec![text.len() as u32],
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        }))
+    }
+
+    fn complete() -> ProtoGenerateResponse {
+        ProtoGenerateResponse::Sglang(Box::new(sglang::GenerateResponse {
+            response: Some(sglang::generate_response::Response::Complete(
+                sglang::GenerateComplete::default(),
+            )),
+            ..Default::default()
+        }))
+    }
+
+    fn child(items: Vec<ProtoGenerateResponse>) -> (Scripted, Arc<AtomicBool>) {
+        let completed = Arc::new(AtomicBool::new(false));
+        let child = Scripted {
+            items: items.into_iter().map(Ok).collect(),
+            completed: Arc::clone(&completed),
+        };
+        (child, completed)
+    }
+
+    fn index_of(response: ProtoGenerateResponse) -> u32 {
+        match response.into_response() {
+            ProtoResponseVariant::Chunk(chunk) => chunk.index(),
+            ProtoResponseVariant::Complete(complete) => complete.index(),
+            ProtoResponseVariant::None => u32::MAX,
+        }
+    }
+
+    #[tokio::test]
+    async fn fanout_stamps_each_childs_position_and_ends_with_the_last_child() {
+        let (first, first_done) = child(vec![chunk("a"), chunk("aa"), complete()]);
+        let (second, second_done) = child(vec![chunk("b"), complete()]);
+        let mut fanout = FanoutStream::new(vec![first, second]);
+
+        let mut indices = Vec::new();
+        while let Some(item) = fanout.next().await {
+            indices.push(index_of(item.unwrap()));
+        }
+        assert_eq!(indices.len(), 5);
+        assert_eq!(indices.iter().filter(|&&i| i == 0).count(), 3);
+        assert_eq!(indices.iter().filter(|&&i| i == 1).count(), 2);
+        // The rotating cursor lets the second child in before the first drains.
+        assert_ne!(indices[0], indices[1]);
+        assert_eq!(fanout.open_children(), 0);
+        assert!(fanout.next().await.is_none());
+
+        assert!(!first_done.load(Ordering::SeqCst));
+        fanout.mark_completed();
+        // Ended children were retired; only open children get marked.
+        assert!(!first_done.load(Ordering::SeqCst));
+        assert!(!second_done.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn fanout_mark_completed_reaches_every_open_child() {
+        let (first, first_done) = child(vec![chunk("a")]);
+        let (second, second_done) = child(vec![chunk("b")]);
+        let mut fanout = FanoutStream::new(vec![first, second]);
+        assert_eq!(fanout.open_children(), 2);
+        fanout.mark_completed();
+        assert!(first_done.load(Ordering::SeqCst));
+        assert!(second_done.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn fanout_passes_a_child_error_through() {
+        let (first, _) = child(vec![chunk("a")]);
+        let second = Scripted {
+            items: VecDeque::from([Err(tonic::Status::internal("leg died"))]),
+            completed: Arc::new(AtomicBool::new(false)),
+        };
+        let mut fanout = FanoutStream::new(vec![second, first]);
+        let first_item = fanout.next().await.unwrap();
+        assert!(matches!(first_item, Err(status) if status.message() == "leg died"));
+    }
+
+    #[test]
+    fn set_index_restamps_chunks_and_completes() {
+        let mut response = chunk("x");
+        response.set_index(3);
+        assert_eq!(index_of(response), 3);
+        let mut response = complete();
+        response.set_index(2);
+        assert_eq!(index_of(response), 2);
+    }
+
+    #[test]
+    fn sampling_n_reads_and_writes_the_room_based_engines() {
+        let mut sglang_req = ProtoGenerateRequest::Sglang(Box::new(sglang::GenerateRequest {
+            sampling_params: Some(sglang::SamplingParams {
+                n: 4,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+        assert_eq!(sglang_req.sampling_n(), 4);
+        sglang_req.set_sampling_n(1);
+        assert_eq!(sglang_req.sampling_n(), 1);
+        assert!(!sglang_req.has_mm_inputs());
+
+        let mut tokenspeed_req =
+            ProtoGenerateRequest::TokenSpeed(Box::new(tokenspeed::GenerateRequest {
+                sampling_params: Some(tokenspeed::SamplingParams {
+                    n: 0,
+                    sampling_seed: Some(5),
+                    ..Default::default()
+                }),
+                mm_inputs: Some(tokenspeed::MultimodalInputs::default()),
+                ..Default::default()
+            }));
+        assert_eq!(tokenspeed_req.sampling_n(), 1, "0 means unset");
+        assert!(tokenspeed_req.has_mm_inputs());
+        tokenspeed_req.offset_sampling_seed(2);
+        let ProtoGenerateRequest::TokenSpeed(req) = &tokenspeed_req else {
+            panic!("runtime changed");
+        };
+        assert_eq!(req.sampling_params.as_ref().unwrap().sampling_seed, Some(7));
     }
 }
 

--- a/model_gateway/tests/grpc_pd_fanout_test.rs
+++ b/model_gateway/tests/grpc_pd_fanout_test.rs
@@ -1,0 +1,253 @@
+//! End-to-end check of the gRPC PD n>1 fan-out against a mock TokenSpeed
+//! prefill/decode pair.
+//!
+//! The mock worker in canned mode answers every generate request with one
+//! index-0 completion whatever `n` says, which is what a rendezvous-room
+//! engine effectively does with a sample count it cannot serve from a single
+//! room. So `n` choices can only come back if the gateway fans the request
+//! out into `n` single-sample pairs and restamps each pair's index, which is
+//! what these tests pin, non-streaming and streaming.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+
+use llm_tokenizer::{traits::Tokenizer, MockTokenizer, TokenizerRegistry};
+use openai_protocol::{
+    completion::CompletionRequest, model_card::ModelCard, worker::HealthCheckConfig,
+};
+use smg::{
+    config::{RouterConfig, RoutingMode},
+    middleware::TenantRequestMeta,
+    routers::{RouterFactory, RouterTrait},
+    tenant::TenantKey,
+    worker::{BasicWorkerBuilder, ConnectionMode, RuntimeType, WorkerType},
+};
+use tokio::net::TcpListener;
+
+const MODEL: &str = "pd-fanout-test-model";
+/// Tokens the canned mock emits per request; every sample reports exactly this.
+const OUTPUT_TOKENS: u32 = 3;
+
+/// Spawn a canned mock gRPC worker in-process: one index-0 completion of
+/// `OUTPUT_TOKENS` tokens per request, `n` ignored.
+#[expect(
+    clippy::expect_used,
+    clippy::disallowed_methods,
+    reason = "test helper - panicking on failure is intentional; the spawned \
+              mock server task is fire-and-forget for the test process's lifetime"
+)]
+async fn start_mock_grpc_worker() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock gRPC worker");
+    let port = listener
+        .local_addr()
+        .expect("mock gRPC worker address")
+        .port();
+    let cfg = Arc::new(mock_worker::config::Config {
+        host: "127.0.0.1".to_string(),
+        http_base_port: 0,
+        http_count: 0,
+        grpc_base_port: port,
+        grpc_count: 1,
+        zmq_handshake: None,
+        zmq_count: 0,
+        zmq_start_index: 0,
+        model_id: MODEL.to_string(),
+        tokenizer_path: MODEL.to_string(),
+        gen_delay: Duration::ZERO,
+        output_tokens: OUTPUT_TOKENS,
+        realistic: false,
+        engine: mock_worker::engine::EngineParams::default(),
+    });
+    tokio::spawn(mock_worker::grpc::serve_with_listener(cfg, listener));
+    port
+}
+
+/// A PD gRPC router over one mock prefill and one mock decode worker, both
+/// registered as TokenSpeed so the dispatch takes the rendezvous-room path.
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+async fn build_pd_router(prefill_port: u16, decode_port: u16) -> Box<dyn RouterTrait> {
+    let mut config = RouterConfig::builder()
+        .mode(RoutingMode::PrefillDecode {
+            prefill_urls: vec![],
+            decode_urls: vec![],
+            prefill_policy: None,
+            decode_policy: None,
+        })
+        .grpc_connection()
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(1024 * 1024)
+        .build_unchecked();
+    config.health_check.disable_health_check = true;
+
+    let tokenizer_registry = Arc::new(TokenizerRegistry::new());
+    let tokenizer = Arc::new(MockTokenizer::new()) as Arc<dyn Tokenizer>;
+    tokenizer_registry
+        .load(
+            "tokenizer-id",
+            MODEL,
+            "test",
+            || async move { Ok(tokenizer) },
+        )
+        .await
+        .unwrap();
+    let app_context =
+        common::create_test_context_with_tokenizer_registry(config, tokenizer_registry).await;
+    for (port, worker_type) in [
+        (prefill_port, WorkerType::Prefill),
+        (decode_port, WorkerType::Decode),
+    ] {
+        let worker = BasicWorkerBuilder::new(format!("grpc://127.0.0.1:{port}"))
+            .worker_type(worker_type)
+            .connection_mode(ConnectionMode::Grpc)
+            .runtime_type(RuntimeType::TokenSpeed)
+            .model(ModelCard::new(MODEL))
+            .health_config(HealthCheckConfig {
+                disable_health_check: true,
+                ..Default::default()
+            })
+            .build();
+        app_context
+            .worker_registry
+            .register(Arc::new(worker))
+            .unwrap();
+    }
+    RouterFactory::create_router(&app_context)
+        .await
+        .expect("PD gRPC router should build")
+}
+
+#[expect(
+    clippy::unwrap_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+fn completion_request(n: u32, stream: bool) -> CompletionRequest {
+    serde_json::from_value(serde_json::json!({
+        "model": MODEL,
+        "prompt": "Hello world",
+        "n": n,
+        "max_tokens": 8,
+        "stream": stream,
+    }))
+    .unwrap()
+}
+
+fn tenant() -> TenantRequestMeta {
+    TenantRequestMeta::new(TenantKey::new("pd-fanout-test-tenant"))
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+async fn read_body(response: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+        .await
+        .expect("response body");
+    String::from_utf8(bytes.to_vec()).expect("utf-8 body")
+}
+
+/// Three samples through one rendezvous-room PD pair: the fan-out runs three
+/// single-sample pairs and the merged stream carries choices 0, 1 and 2.
+#[tokio::test]
+async fn n_samples_come_back_as_n_choices_through_a_room_based_pd_pair() {
+    let (prefill, decode) = (
+        start_mock_grpc_worker().await,
+        start_mock_grpc_worker().await,
+    );
+    let router = build_pd_router(prefill, decode).await;
+
+    let response = router
+        .route_completion(None, &tenant(), completion_request(3, false), MODEL)
+        .await;
+    let status = response.status();
+    let body = read_body(response).await;
+    assert_eq!(status, http::StatusCode::OK, "{body}");
+
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let choices = json["choices"].as_array().unwrap();
+    let indices: BTreeSet<u64> = choices
+        .iter()
+        .map(|choice| choice["index"].as_u64().unwrap())
+        .collect();
+    assert_eq!(indices, BTreeSet::from([0, 1, 2]), "{body}");
+    assert_eq!(choices.len(), 3, "{body}");
+    // Every sample reports the full prompt once and its own completion:
+    // prompt tokens are counted once, completion tokens add up.
+    let usage = &json["usage"];
+    assert_eq!(usage["prompt_tokens"].as_u64().unwrap(), 1, "{body}");
+    assert_eq!(
+        usage["completion_tokens"].as_u64().unwrap(),
+        u64::from(OUTPUT_TOKENS) * 3,
+        "{body}"
+    );
+}
+
+/// The same request streamed: every choice index shows up in the SSE events
+/// and the stream still terminates with `[DONE]`.
+#[tokio::test]
+async fn streamed_samples_carry_every_choice_index() {
+    let (prefill, decode) = (
+        start_mock_grpc_worker().await,
+        start_mock_grpc_worker().await,
+    );
+    let router = build_pd_router(prefill, decode).await;
+
+    let response = router
+        .route_completion(None, &tenant(), completion_request(2, true), MODEL)
+        .await;
+    let status = response.status();
+    let body = read_body(response).await;
+    assert_eq!(status, http::StatusCode::OK, "{body}");
+
+    let mut indices = BTreeSet::new();
+    let mut done = false;
+    for line in body.lines() {
+        let Some(payload) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        if payload.trim() == "[DONE]" {
+            done = true;
+            continue;
+        }
+        let event: serde_json::Value = serde_json::from_str(payload).unwrap();
+        for choice in event["choices"].as_array().into_iter().flatten() {
+            indices.insert(choice["index"].as_u64().unwrap());
+        }
+    }
+    assert_eq!(indices, BTreeSet::from([0, 1]), "{body}");
+    assert!(done, "stream did not terminate with [DONE]: {body}");
+}
+
+/// A single sample takes the plain single-pair path unchanged.
+#[tokio::test]
+async fn a_single_sample_is_one_choice() {
+    let (prefill, decode) = (
+        start_mock_grpc_worker().await,
+        start_mock_grpc_worker().await,
+    );
+    let router = build_pd_router(prefill, decode).await;
+
+    let response = router
+        .route_completion(None, &tenant(), completion_request(1, false), MODEL)
+        .await;
+    let status = response.status();
+    let body = read_body(response).await;
+    assert_eq!(status, http::StatusCode::OK, "{body}");
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(json["choices"].as_array().unwrap().len(), 1, "{body}");
+    assert_eq!(
+        json["usage"]["completion_tokens"].as_u64().unwrap(),
+        u64::from(OUTPUT_TOKENS),
+        "{body}"
+    );
+}


### PR DESCRIPTION
## Description

### Problem

An `n>1` request through a PD pair on a rendezvous-room engine fails or hangs. The gateway mints one bootstrap room per request, and SGLang and TokenSpeed broadcast that room to every sample of an `n>1` request, so the decode's children all pre-allocate against the same room:

- **TokenSpeed over gRPC**: the prefill rejects the repeats (`Rejecting malformed pre-allocation metadata ... duplicate CachePD pre-allocation for Decode session`) and the request fails with `500 decode_worker_failed_to_start` on every attempt.
- **SGLang over HTTP**: one child gets the KV and the rest wait on a transfer that never comes until the decode aborts them (`KVTransferError ... Aborted by AbortReq` after 120 s); SGLang over gRPC passes the same case only by timing and flaked once in four sweeps.

Found by the PD topology sweep in #2464 (`test_batched_completion_serves_every_choice`, kept there as strict xfails).

### Solution

On the parallel PD path, split a text-only `n>1` request into `n` single-sample sub-requests, each with its own engine id (`{id}-{i}`), a seed offset of `i` when the request pinned a seed, and a freshly minted room. The `n` pairs dispatch concurrently and fail fast together. Their prefill legs and decode legs merge into one PD result through a `FanoutStream` that restamps each child's responses with the child's position, so the response pipeline demuxes choices exactly as it does for an engine-native `n>1` stream, no per-endpoint changes. Admission and the load guards count the `n` rooms the plan posts.

Out of scope, on purpose: multimodal payloads (one SHM segment the prefill unlinks on read, so they cannot be handed to `n` prefills; they keep the single dispatch), the sequential vLLM path (already skips the handoff for `n>1`), and the HTTP PD router, which needs its own fan-out and gets a follow-up.

## Changes

- `model_gateway/src/routers/grpc/proto_wrapper.rs`: `sampling_n` now reads SGLang and TokenSpeed too; `set_sampling_n`, `offset_sampling_seed`, `has_mm_inputs` on the request; `set_index` on the response; `FanoutChild` + `FanoutStream` (rotating-cursor merge, restamped indices, retirement of ended children, `mark_completed` and deferred abort reaching every child); `ProtoStream::Fanout`.
- `model_gateway/src/routers/grpc/common/stages/request_execution.rs`: `pd_fanout_width`, `fan_out_pd_request`, `execute_fanout_pd`; the parallel PD dispatch fans out; `plan_sub_requests` counts fanned-out samples for admission and load guards.
- `model_gateway/tests/grpc_pd_fanout_test.rs`: end-to-end through a mock TokenSpeed prefill/decode pair that answers every request with one index-0 completion, so three choices can only come back through the fan-out.

## Test Plan

- `cargo +nightly fmt --all`, `cargo clippy -p smg --all-targets -- -D warnings`, `cargo test -p smg --lib` (1722 passed), `cargo test -p smg --test grpc_pd_fanout_test`, `cargo check -p smg-golang`, `cargo check --manifest-path bindings/python/Cargo.toml`: all green locally.
- Unit tests: fan-out width (n>1 text on parallel PD only; not for n=1, multimodal, or the sequential path), sub-request ids/seeds/rooms, admission count, merged-stream index restamping, fairness, error passthrough, completion marking.
- End-to-end (mock PD pair, `n` ignored by the engine): `n=3` non-streaming returns choices 0, 1, 2 with `prompt_tokens=1` and `completion_tokens=9`; `n=2` streaming carries both indices and ends with `[DONE]`; `n=1` is unchanged.
- Real engines: #2464 will be rebased onto this branch with its strict xfails removed, so the TokenSpeed and SGLang sweeps prove it on hardware.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
