### PR TITLE
feat(pd): surface each engine's KV transfer protocol facts as worker labels

### DIFF
--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -360,6 +360,15 @@ message GetServerInfoResponse {
   // the router can verify a shared /dev/shm before using the SHM tensor
   // transport under `auto`. Empty when it can't be determined.
   string shm_namespace_id = 10;
+
+  // PD pairing protocol: what a prefill and a decode must agree on for a KV
+  // handoff to work. These mirror the factors vLLM's NIXL compatibility hash
+  // is built from, so the router can keep incompatible legs apart before the
+  // engines reject each other at handshake.
+  string kv_cache_dtype = 11;     // cache_config.cache_dtype ("auto", "fp8", ...)
+  int32 block_size = 12;          // cache_config.block_size (0 until the engine resolves it)
+  string attention_backend = 13;  // attention_config.backend name, "" when auto-selected
+  string model_dtype = 14;        // model_config.dtype ("torch.bfloat16", ...)
 }
 
 // =====================

--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.4.16"
+version = "0.4.17"
 description = "SMG gRPC proto definitions for vLLM, TRT-LLM, MLX, TokenSpeed, and SGLang"
 requires-python = ">=3.10"
 dependencies = [

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.9.1"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, MLX, TokenSpeed, SGLang)"
 requires-python = ">=3.10"
 dependencies = [
-    "smg-grpc-proto>=0.4.16",  # 0.4.16: first release with GenerateRequest.data_parallel_rank (field 12)
+    "smg-grpc-proto>=0.4.17",  # 0.4.17: first release with the vLLM GetServerInfoResponse pairing fields (11-14)
     "grpcio>=1.81.1",
     "grpcio-reflection>=1.81.1",
     "grpcio-health-checking>=1.81.1",

--- a/grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py
@@ -14,11 +14,12 @@ _SUPPORTED_PD_CONNECTORS = frozenset({"MooncakeConnector", "NixlConnector"})
 def pairing_fields(vllm_config: object) -> dict:
     """The KV-layout facts a PD peer must share, read off the engine config.
 
-    They mirror the factors vLLM folds into its NIXL compatibility hash
-    (model dtype, KV cache dtype, attention backend) plus the block size the
-    handshake negotiates, so the router can keep incompatible prefill and
-    decode workers apart before the engines reject each other. Every field
-    degrades to its proto default when the config does not carry it.
+    Model dtype, KV cache dtype and block size are the config-level factors
+    vLLM folds into its NIXL compatibility hash. The attention backend is the
+    *requested* one (`--attention-backend`): the resolved backend is picked
+    inside the worker process, so on the common auto path this field is
+    absent and the router treats it as unknown rather than as a match. Every
+    field degrades to its proto default when the config does not carry it.
     """
     fields: dict = {}
     cache = getattr(vllm_config, "cache_config", None)

--- a/grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py
@@ -11,6 +11,35 @@ _MULTI_CONNECTOR = "MultiConnector"
 _SUPPORTED_PD_CONNECTORS = frozenset({"MooncakeConnector", "NixlConnector"})
 
 
+def pairing_fields(vllm_config: object) -> dict:
+    """The KV-layout facts a PD peer must share, read off the engine config.
+
+    They mirror the factors vLLM folds into its NIXL compatibility hash
+    (model dtype, KV cache dtype, attention backend) plus the block size the
+    handshake negotiates, so the router can keep incompatible prefill and
+    decode workers apart before the engines reject each other. Every field
+    degrades to its proto default when the config does not carry it.
+    """
+    fields: dict = {}
+    cache = getattr(vllm_config, "cache_config", None)
+    if cache is not None:
+        dtype = getattr(cache, "cache_dtype", None)
+        if dtype:
+            fields["kv_cache_dtype"] = str(dtype)
+        block_size = getattr(cache, "block_size", None)
+        if isinstance(block_size, int) and block_size > 0:
+            fields["block_size"] = block_size
+    attention = getattr(vllm_config, "attention_config", None)
+    backend = getattr(attention, "backend", None) if attention is not None else None
+    if backend is not None:
+        fields["attention_backend"] = str(getattr(backend, "name", backend))
+    model = getattr(vllm_config, "model_config", None)
+    dtype = getattr(model, "dtype", None) if model is not None else None
+    if dtype is not None:
+        fields["model_dtype"] = str(dtype)
+    return fields
+
+
 def resolve_pd_connector(config: object) -> tuple[str, str]:
     """Resolve the connector and engine id that SMG should report for PD.
 

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -45,6 +45,7 @@ from smg_grpc_servicer.vllm.kv_events import (
     stream_kv_events,
 )
 from smg_grpc_servicer.vllm.kv_transfer import (
+    pairing_fields,
     params_from_request,
     params_to_response_fields,
     resolve_pd_connector,
@@ -524,6 +525,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             kv_engine_id=kv_engine_id,
             data_parallel_size=parallel.data_parallel_size,
             shm_namespace_id=mm_shm.shm_namespace_id(),
+            **pairing_fields(self.engine.vllm_config),
         )
 
     async def GetLoads(

--- a/grpc_servicer/tests/test_pd_pairing_fields.py
+++ b/grpc_servicer/tests/test_pd_pairing_fields.py
@@ -1,0 +1,62 @@
+"""The KV-layout facts the vLLM servicer reports for PD pairing (engine-free, no vLLM required).
+
+Run with: pytest grpc_servicer/tests/test_pd_pairing_fields.py
+"""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("smg_grpc_proto")
+
+# Import the module directly to avoid pulling vllm via the package __init__
+_MODULE_PATH = Path(__file__).parents[1] / "smg_grpc_servicer" / "vllm" / "kv_transfer.py"
+_spec = importlib.util.spec_from_file_location("kv_transfer", _MODULE_PATH)
+kv_transfer = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(kv_transfer)
+pairing_fields = kv_transfer.pairing_fields
+
+
+def _config(**overrides):
+    base = {
+        "cache_config": SimpleNamespace(cache_dtype="fp8", block_size=16),
+        "attention_config": SimpleNamespace(backend=SimpleNamespace(name="FLASH_ATTN")),
+        "model_config": SimpleNamespace(dtype="torch.bfloat16"),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_pairing_fields_reads_every_layout_fact():
+    assert pairing_fields(_config()) == {
+        "kv_cache_dtype": "fp8",
+        "block_size": 16,
+        "attention_backend": "FLASH_ATTN",
+        "model_dtype": "torch.bfloat16",
+    }
+
+
+def test_pairing_fields_omits_what_the_config_does_not_carry():
+    # An auto-selected attention backend is None until the worker resolves
+    # it; an unresolved block size is None too. Neither becomes a field.
+    config = _config(
+        cache_config=SimpleNamespace(cache_dtype="auto", block_size=None),
+        attention_config=SimpleNamespace(backend=None),
+    )
+    assert pairing_fields(config) == {"kv_cache_dtype": "auto", "model_dtype": "torch.bfloat16"}
+    assert pairing_fields(SimpleNamespace()) == {}
+
+
+def test_pairing_fields_round_trip_the_proto():
+    from smg_grpc_proto import vllm_engine_pb2 as pb2
+
+    if not hasattr(pb2.GetServerInfoResponse, "kv_cache_dtype"):
+        pytest.skip("installed smg_grpc_proto predates the pairing fields")
+    info = pb2.GetServerInfoResponse(**pairing_fields(_config()))
+    parsed = pb2.GetServerInfoResponse.FromString(info.SerializeToString())
+    assert parsed.kv_cache_dtype == "fp8"
+    assert parsed.block_size == 16
+    assert parsed.attention_backend == "FLASH_ATTN"
+    assert parsed.model_dtype == "torch.bfloat16"

--- a/grpc_servicer/tests/test_pd_pairing_fields.py
+++ b/grpc_servicer/tests/test_pd_pairing_fields.py
@@ -52,8 +52,15 @@ def test_pairing_fields_omits_what_the_config_does_not_carry():
 def test_pairing_fields_round_trip_the_proto():
     from smg_grpc_proto import vllm_engine_pb2 as pb2
 
-    if not hasattr(pb2.GetServerInfoResponse, "kv_cache_dtype"):
-        pytest.skip("installed smg_grpc_proto predates the pairing fields")
+    # Field presence is a descriptor fact; `hasattr` on the generated class
+    # only holds under the pure-Python protobuf runtime.
+    fields = pb2.GetServerInfoResponse.DESCRIPTOR.fields_by_name
+    if "kv_cache_dtype" not in fields:
+        pytest.skip(
+            "smg_grpc_proto stubs predate the GetServerInfoResponse pairing fields; "
+            "regenerate from crates/grpc_client/proto"
+        )
+    assert {"kv_cache_dtype", "block_size", "attention_backend", "model_dtype"} <= set(fields)
     info = pb2.GetServerInfoResponse(**pairing_fields(_config()))
     parsed = pb2.GetServerInfoResponse.FromString(info.SerializeToString())
     assert parsed.kv_cache_dtype == "fp8"

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -852,17 +852,30 @@ const SGLANG_GRPC_KEYS: &[&str] = &[
     "is_embedding",
     "vocab_size",
     "weight_version",
+    // PD pairing protocol: the transport and KV layout a prefill and a decode
+    // must share for a handoff to work (the engines validate TP themselves).
+    "disaggregation_transfer_backend",
+    "disaggregation_bootstrap_port",
+    "kv_cache_dtype",
+    "page_size",
+    "attention_backend",
 ];
 
 /// Keys worth extracting from TokenSpeed gRPC `server_args` (post-rename: bare
 /// names, not `_path` variants — TokenSpeed dropped the legacy suffixes).
+/// TokenSpeed spells its parallelism `attn_tp_size` / `pipeline_parallel_size`
+/// / `data_parallel_size`; `normalize_grpc_keys` folds those into the
+/// canonical `tp_size` / `pp_size` / `dp_size`.
 const TOKENSPEED_GRPC_KEYS: &[&str] = &[
     "model",
     "served_model_name",
     "tokenizer",
     "tp_size",
+    "attn_tp_size",
     "dp_size",
+    "data_parallel_size",
     "pp_size",
+    "pipeline_parallel_size",
     "context_length",
     "max_total_tokens",
     // TokenSpeed's spelling of the scheduler's running window; the fleet
@@ -873,6 +886,13 @@ const TOKENSPEED_GRPC_KEYS: &[&str] = &[
     "is_embedding",
     "vocab_size",
     "weight_version",
+    // PD pairing protocol (see SGLANG_GRPC_KEYS). TokenSpeed has no page
+    // size: its KV layout is the cache contract exchanged at rendezvous.
+    "disaggregation_mode",
+    "disaggregation_transfer_backend",
+    "disaggregation_bootstrap_port",
+    "kv_cache_dtype",
+    "attention_backend",
 ];
 
 // ---------------------------------------------------------------------------
@@ -985,6 +1005,18 @@ mod tests {
                     ("tokenizer".to_string(), string_value("Qwen/Qwen3-8B")),
                     ("tp_size".to_string(), number_value(2.0)),
                     ("max_total_tokens".to_string(), number_value(8192.0)),
+                    ("disaggregation_mode".to_string(), string_value("prefill")),
+                    (
+                        "disaggregation_transfer_backend".to_string(),
+                        string_value("mooncake"),
+                    ),
+                    (
+                        "disaggregation_bootstrap_port".to_string(),
+                        number_value(8998.0),
+                    ),
+                    ("kv_cache_dtype".to_string(), string_value("auto")),
+                    ("attention_backend".to_string(), string_value("flashinfer")),
+                    ("pipeline_parallel_size".to_string(), number_value(2.0)),
                     // Not in TOKENSPEED_GRPC_KEYS — must not become a label.
                     ("host".to_string(), string_value("127.0.0.1")),
                 ]),
@@ -1017,6 +1049,36 @@ mod tests {
         );
         assert_eq!(labels.get("version").map(String::as_str), Some("0.1.0"));
         assert!(!labels.contains_key("host"));
+        // The pairing-protocol facts survive, under the engine's own names;
+        // the discovery step canonicalises the parallelism spellings.
+        assert_eq!(
+            labels.get("disaggregation_mode").map(String::as_str),
+            Some("prefill")
+        );
+        assert_eq!(
+            labels
+                .get("disaggregation_transfer_backend")
+                .map(String::as_str),
+            Some("mooncake")
+        );
+        assert_eq!(
+            labels
+                .get("disaggregation_bootstrap_port")
+                .map(String::as_str),
+            Some("8998")
+        );
+        assert_eq!(
+            labels.get("kv_cache_dtype").map(String::as_str),
+            Some("auto")
+        );
+        assert_eq!(
+            labels.get("attention_backend").map(String::as_str),
+            Some("flashinfer")
+        );
+        assert_eq!(
+            labels.get("pipeline_parallel_size").map(String::as_str),
+            Some("2")
+        );
         // scheduler_info and transient runtime state never become labels.
         assert!(!labels.contains_key("status"));
         assert!(!labels.contains_key("active_requests"));
@@ -1036,6 +1098,17 @@ mod tests {
                             kind: Some(prost_types::value::Kind::BoolValue(false)),
                         },
                     ),
+                    (
+                        "disaggregation_transfer_backend".to_string(),
+                        string_value("nixl"),
+                    ),
+                    (
+                        "disaggregation_bootstrap_port".to_string(),
+                        number_value(8998.0),
+                    ),
+                    ("kv_cache_dtype".to_string(), string_value("fp8_e5m2")),
+                    ("page_size".to_string(), number_value(64.0)),
+                    ("attention_backend".to_string(), string_value("fa3")),
                     // Not in SGLANG_GRPC_KEYS — must not become a label.
                     ("api_key".to_string(), string_value("secret")),
                 ]),
@@ -1058,6 +1131,28 @@ mod tests {
         );
         assert_eq!(labels.get("version").map(String::as_str), Some("0.4.0"));
         assert!(!labels.contains_key("api_key"));
+        // The pairing-protocol facts survive: transport, bootstrap port, KV layout.
+        assert_eq!(
+            labels
+                .get("disaggregation_transfer_backend")
+                .map(String::as_str),
+            Some("nixl")
+        );
+        assert_eq!(
+            labels
+                .get("disaggregation_bootstrap_port")
+                .map(String::as_str),
+            Some("8998")
+        );
+        assert_eq!(
+            labels.get("kv_cache_dtype").map(String::as_str),
+            Some("fp8_e5m2")
+        );
+        assert_eq!(labels.get("page_size").map(String::as_str), Some("64"));
+        assert_eq!(
+            labels.get("attention_backend").map(String::as_str),
+            Some("fa3")
+        );
     }
 
     /// `GetModelInfoResponse` is flat for every backend, so it serializes via

--- a/model_gateway/src/workflow/steps/local/discover_metadata.rs
+++ b/model_gateway/src/workflow/steps/local/discover_metadata.rs
@@ -285,11 +285,16 @@ async fn fetch_grpc_metadata(
 fn normalize_grpc_keys(labels: &mut HashMap<String, String>) {
     for &(from, to) in &[
         ("tensor_parallel_size", "tp_size"),
-        // TokenSpeed's spelling of the attention TP width.
+        // TokenSpeed reports no `tp_size`: `attn_tp_size` is its attention
+        // TP width, the full width for a dense model and narrower than
+        // `world_size` only under attention DP or CP. A `tp_size` the engine
+        // does report wins, as for every canonical label below.
         ("attn_tp_size", "tp_size"),
         ("pipeline_parallel_size", "pp_size"),
         ("context_parallel_size", "cp_size"),
         ("data_parallel_size", "dp_size"),
+        // vLLM's name for the KV page granularity SGLang calls `page_size`.
+        ("block_size", "page_size"),
     ] {
         if let Some(val) = labels.remove(from) {
             labels.entry(to.to_string()).or_insert(val);
@@ -430,6 +435,7 @@ mod tests {
             ("pipeline_parallel_size", "1"),
             ("data_parallel_size", "4"),
             ("context_parallel_size", "1"),
+            ("block_size", "16"),
             ("uptime_seconds", "12.5"),
         ]
         .into_iter()
@@ -441,7 +447,18 @@ mod tests {
         assert_eq!(labels.get("dp_size").map(String::as_str), Some("4"));
         assert_eq!(labels.get("cp_size").map(String::as_str), Some("1"));
         assert!(!labels.contains_key("attn_tp_size"));
+        assert_eq!(labels.get("page_size").map(String::as_str), Some("16"));
+        assert!(!labels.contains_key("block_size"));
         assert!(!labels.contains_key("uptime_seconds"));
+
+        // An engine that reports both keeps its own `tp_size`.
+        let mut attn: HashMap<String, String> = [("tp_size", "8"), ("attn_tp_size", "2")]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        normalize_grpc_keys(&mut attn);
+        assert_eq!(attn.get("tp_size").map(String::as_str), Some("8"));
+        assert!(!attn.contains_key("attn_tp_size"));
 
         let mut both: HashMap<String, String> = [("tp_size", "8"), ("tensor_parallel_size", "2")]
             .into_iter()

--- a/model_gateway/src/workflow/steps/local/discover_metadata.rs
+++ b/model_gateway/src/workflow/steps/local/discover_metadata.rs
@@ -285,6 +285,8 @@ async fn fetch_grpc_metadata(
 fn normalize_grpc_keys(labels: &mut HashMap<String, String>) {
     for &(from, to) in &[
         ("tensor_parallel_size", "tp_size"),
+        // TokenSpeed's spelling of the attention TP width.
+        ("attn_tp_size", "tp_size"),
         ("pipeline_parallel_size", "pp_size"),
         ("context_parallel_size", "cp_size"),
         ("data_parallel_size", "dp_size"),
@@ -418,6 +420,36 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverMetadataStep {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every engine's spelling of the parallelism widths folds into the
+    /// canonical labels, and an existing canonical label is never overwritten.
+    #[test]
+    fn normalize_grpc_keys_canonicalises_every_parallelism_spelling() {
+        let mut labels: HashMap<String, String> = [
+            ("attn_tp_size", "2"),
+            ("pipeline_parallel_size", "1"),
+            ("data_parallel_size", "4"),
+            ("context_parallel_size", "1"),
+            ("uptime_seconds", "12.5"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+        normalize_grpc_keys(&mut labels);
+        assert_eq!(labels.get("tp_size").map(String::as_str), Some("2"));
+        assert_eq!(labels.get("pp_size").map(String::as_str), Some("1"));
+        assert_eq!(labels.get("dp_size").map(String::as_str), Some("4"));
+        assert_eq!(labels.get("cp_size").map(String::as_str), Some("1"));
+        assert!(!labels.contains_key("attn_tp_size"));
+        assert!(!labels.contains_key("uptime_seconds"));
+
+        let mut both: HashMap<String, String> = [("tp_size", "8"), ("tensor_parallel_size", "2")]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        normalize_grpc_keys(&mut both);
+        assert_eq!(both.get("tp_size").map(String::as_str), Some("8"));
+    }
 
     #[expect(clippy::print_stderr)]
     fn dump_labels(title: &str, labels: &HashMap<String, String>) {


### PR DESCRIPTION
## Description

### Problem

A prefill and a decode can only hand KV over when they share a transport (NIXL vs Mooncake), a compatible engine version and a compatible KV layout. Placement pairs them today on availability, wire and runtime type alone, so a mixed fleet or a rolling upgrade produces pairs that fail inside the engine on every request (#2483). The engines already report what is needed; the gateway drops it:

- SGLang and TokenSpeed serialise their whole `ServerArgs` into `server_args`, but the gateway's allowlists keep neither the transport (`disaggregation_transfer_backend`) nor the KV layout (`kv_cache_dtype`, `page_size`, `attention_backend`).
- TokenSpeed spells its parallelism `attn_tp_size` / `pipeline_parallel_size` / `data_parallel_size`; the allowlist asked for `tp_size` / `pp_size`, so TokenSpeed workers have carried no TP or PP label at all.
- vLLM's `GetServerInfo` reports the connector but nothing about the KV layout.

### Solution

First step of #2483: make every pairing-relevant fact a worker label, without changing placement yet.

- Gateway allowlists (`client.rs`) keep `disaggregation_transfer_backend`, `disaggregation_bootstrap_port`, `kv_cache_dtype`, `page_size` and `attention_backend` for SGLang; the same plus `disaggregation_mode` for TokenSpeed, whose parallelism names are kept and canonicalised by `normalize_grpc_keys` (`attn_tp_size` -> `tp_size`).
- `GetServerInfoResponse` for vLLM gains `kv_cache_dtype`, `block_size`, `attention_backend` and `model_dtype`: the factors vLLM folds into its NIXL compatibility hash (`compute_nixl_compatibility_hash` at v0.27.1) plus the block size the handshake negotiates. The servicer fills them from `vllm_config` and leaves each at its proto default when the config does not carry it.

The pairing key, the placement filter and the pair quarantine follow in separate PRs.

## Changes

- `crates/grpc_client/proto/vllm_engine.proto`: four new `GetServerInfoResponse` fields (11-14); the Rust and Python bindings regenerate from the proto.
- `grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py`: `pairing_fields(vllm_config)`; `vllm/servicer.py` reports them.
- `model_gateway/src/routers/grpc/client.rs`: allowlists for SGLang and TokenSpeed.
- `model_gateway/src/workflow/steps/local/discover_metadata.rs`: `attn_tp_size` canonicalisation.

## Review follow-up

- `smg-grpc-proto` is bumped to 0.4.17 and the servicer floor raised to match, since `GetServerInfo` now passes the four pairing fields to `GetServerInfoResponse` (the same move 0.4.16 made for `data_parallel_rank`).
- vLLM's `block_size` folds into the canonical `page_size` label in `normalize_grpc_keys`, so the KV page granularity reads the same across engines; a comment records why TokenSpeed's `attn_tp_size` stands in for `tp_size`, with a both-present test.
- The proto round-trip test checks field presence through the descriptor and asserts all four fields once the bindings are current; the servicer docstring says the attention backend it reports is the requested one (absent on the auto path).

## Test Plan

- `cargo +nightly fmt --all`, `cargo clippy -p smg --all-targets -- -D warnings`, `cargo test -p smg --lib -- server_info_to_labels normalize_grpc_keys model_info_to_labels`: green.
- `pytest grpc_servicer/tests/test_pd_pairing_fields.py tests/test_kv_transfer_params.py`: green (the proto round-trip case runs in CI, where `smg-grpc-proto` is built from the updated proto).
- Curated-key tests now assert the transport, bootstrap port and layout labels survive for SGLang and TokenSpeed; a new test pins every parallelism spelling folding into `tp_size` / `pp_size` / `dp_size` / `cp_size` without overwriting a canonical label.
- After merge, `/workers` on a PD fleet shows the new labels per worker (e.g. `disaggregation_transfer_backend`, `kv_cache_dtype`); nothing in routing changes.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

