### PR TITLE
feat(pd): pair prefill and decode workers by KV transfer protocol

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -32,7 +32,7 @@ use smg::{
         circuit_breaker::{CircuitBreaker, CircuitState},
         resilience::ResolvedResilience,
         worker::{RuntimeType, WorkerMetadata, WorkerRoutingKeyLoad},
-        ConnectionMode, OverloadThresholds, Worker, WorkerResult, WorkerType,
+        ConnectionMode, OverloadThresholds, PdPairing, Worker, WorkerResult, WorkerType,
     },
 };
 use smg_grpc_client::sglang_scheduler::{SglangGenerateRequestOptions, SglangSchedulerClient};
@@ -71,6 +71,7 @@ impl GrpcWorker {
         spec.runtime_type = RuntimeType::Sglang;
 
         let metadata = WorkerMetadata {
+            pd_pairing: PdPairing::derive(&spec),
             spec: Arc::new(spec),
             health_config: HealthCheckConfig::default(),
             health_endpoint: "/health".to_string(),

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -686,6 +686,12 @@ pub struct WorkerSpec {
     /// Typically matches the backend engine's page size (e.g. 16 for SGLang).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kv_block_size: Option<usize>,
+    /// Explicit PD pairing protocol. A prefill and a decode with this set
+    /// pair only when the values are equal, and nothing derived about their
+    /// transport, engine version or KV layout is compared. Absent: the router
+    /// derives the pairing descriptor from the worker's discovered labels.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pairing_protocol: Option<String>,
 
     /// Per-worker health check overrides (partial — only `Some` fields override router defaults).
     #[serde(default, skip_serializing_if = "HealthCheckUpdate::is_empty")]
@@ -758,6 +764,7 @@ impl WorkerSpec {
             kv_role: None,
             kv_engine_id: None,
             kv_block_size: None,
+            pairing_protocol: None,
             health: HealthCheckUpdate::default(),
             http_pool: HttpPoolConfig::default(),
             resilience: ResilienceUpdate::default(),
@@ -866,6 +873,13 @@ pub struct WorkerInfo {
     #[serde(default)]
     pub http2: bool,
 
+    /// The effective PD pairing key of a prefill or decode worker: the
+    /// explicit `pairing_protocol`, else the descriptor derived from the
+    /// engine's labels (`runtime/transport/version/layout`). Prefill and
+    /// decode workers pair only within one key. Absent on regular workers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pd_pairing: Option<String>,
+
     /// The worker's last polled engine load, as published by the load
     /// monitor. `None` when load monitoring has produced nothing for this
     /// worker yet. Unrelated to `load` above, which counts in-flight
@@ -888,6 +902,7 @@ impl WorkerInfo {
             status: Some(WorkerStatus::Pending),
             load: 0,
             http2: false,
+            pd_pairing: None,
             engine_load: None,
             job_status,
         }

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -875,7 +875,8 @@ pub struct WorkerInfo {
 
     /// The effective PD pairing key of a prefill or decode worker: the
     /// explicit `pairing_protocol`, else the descriptor derived from the
-    /// engine's labels (`runtime/transport/version/layout`). Prefill and
+    /// engine's labels (`runtime/transport/layout`; the engine version is
+    /// left out because it only counts under strict mode). Prefill and
     /// decode workers pair only within one key. Absent on regular workers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pd_pairing: Option<String>,

--- a/model_gateway/benches/workers_endpoint.rs
+++ b/model_gateway/benches/workers_endpoint.rs
@@ -97,6 +97,7 @@ fn deep_clone_info(w: &Arc<dyn Worker>) -> WorkerInfo {
         status: Some(status),
         load: w.load(),
         http2: meta.http2,
+        pd_pairing: None,
         engine_load: None,
         job_status: None,
     }

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -569,10 +569,13 @@ impl AppContextBuilder {
 
     /// Create policy registry
     fn with_policy_registry(mut self, config: &RouterConfig) -> Self {
-        self.policy_registry = Some(Arc::new(PolicyRegistry::with_override(
-            config.policy.clone(),
-            config.routing_key_override.clone(),
-        )));
+        self.policy_registry = Some(Arc::new(
+            PolicyRegistry::with_override(
+                config.policy.clone(),
+                config.routing_key_override.clone(),
+            )
+            .with_pd_pairing_mode(config.pd_pairing_mode),
+        ));
         self
     }
 

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -5,8 +5,8 @@ use smg_mcp::McpConfig;
 
 use super::{
     CacheIndexKind, CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig,
-    HealthCheckConfig, HistoryBackend, MetricsConfig, OracleConfig, PolicyConfig, PostgresConfig,
-    RedisConfig, RetryConfig, RouterConfig, RoutingKeyOverrideConfig, RoutingMode,
+    HealthCheckConfig, HistoryBackend, MetricsConfig, OracleConfig, PdPairingMode, PolicyConfig,
+    PostgresConfig, RedisConfig, RetryConfig, RouterConfig, RoutingKeyOverrideConfig, RoutingMode,
     TenantApiKeyEntry, TokenizerCacheConfig, TraceConfig,
 };
 use crate::worker::{ConnectionMode, RuntimeType};
@@ -665,6 +665,11 @@ impl RouterConfigBuilder {
 
     pub fn routing_key_override(mut self, config: RoutingKeyOverrideConfig) -> Self {
         self.config.routing_key_override = config;
+        self
+    }
+
+    pub fn pd_pairing_mode(mut self, mode: PdPairingMode) -> Self {
+        self.config.pd_pairing_mode = mode;
         self
     }
 

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -44,7 +44,7 @@ pub struct RouterConfig {
     #[serde(default, alias = "sticky_sessions")]
     pub routing_key_override: RoutingKeyOverrideConfig,
     /// How strictly PD placement pairs a prefill with a decode on their KV
-    /// transfer protocol (transport, engine version, KV layout).
+    /// transfer protocol; see [`PdPairingMode`].
     #[serde(default)]
     pub pd_pairing_mode: PdPairingMode,
     pub host: String,
@@ -530,6 +530,44 @@ pub enum ManualAssignmentMode {
     Delegate,
 }
 
+/// How strictly PD placement pairs a prefill with a decode on their KV
+/// transfer protocol (#2483). A descriptor component an engine does not report
+/// is "unknown".
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PdPairingMode {
+    /// Pair on nothing: placement behaves as if no descriptor existed.
+    Off,
+    /// A known difference in runtime, transport or KV layout refuses the
+    /// pair; unknown components and engine versions pair with anything.
+    #[default]
+    Lenient,
+    /// Runtime, transport and KV layout must be known on both sides and
+    /// agree, and reported engine versions must match.
+    Strict,
+}
+
+impl PdPairingMode {
+    /// Parse the CLI spelling (`off` / `lenient` / `strict`).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "off" => Some(Self::Off),
+            "lenient" => Some(Self::Lenient),
+            "strict" => Some(Self::Strict),
+            _ => None,
+        }
+    }
+
+    /// The CLI spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Lenient => "lenient",
+            Self::Strict => "strict",
+        }
+    }
+}
+
 /// Per-request sticky-routing override: when a sticky key is present, any
 /// eligible policy routes via manual sticky-map semantics. Reuses the manual
 /// policy knobs for the sticky map; eviction defaults match the manual policy so
@@ -541,39 +579,6 @@ pub enum ManualAssignmentMode {
 /// configured header carrying a valid value is the fallback when no rid is
 /// present. An enabled override keeps automatic body forwarding buffered so
 /// body `rid` precedence is preserved.
-/// How strictly PD placement pairs a prefill with a decode on their KV
-/// transfer protocol (#2483). A descriptor component an engine does not report
-/// is "unknown": lenient pairing lets it match anything (a fleet that reports
-/// nothing keeps working), strict pairing treats it as a mismatch.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum PdPairingMode {
-    /// Unknown components pair with anything; known components must agree.
-    #[default]
-    Lenient,
-    /// Every component must be known on both sides and agree.
-    Strict,
-}
-
-impl PdPairingMode {
-    /// Parse the CLI spelling (`lenient` / `strict`).
-    pub fn parse(value: &str) -> Option<Self> {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "lenient" => Some(Self::Lenient),
-            "strict" => Some(Self::Strict),
-            _ => None,
-        }
-    }
-
-    /// The CLI spelling.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Lenient => "lenient",
-            Self::Strict => "strict",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoutingKeyOverrideConfig {
     /// When false, policies are used unchanged.

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -43,6 +43,10 @@ pub struct RouterConfig {
     /// Per-request sticky-session routing (rid-lineage keys, header fallback).
     #[serde(default, alias = "sticky_sessions")]
     pub routing_key_override: RoutingKeyOverrideConfig,
+    /// How strictly PD placement pairs a prefill with a decode on their KV
+    /// transfer protocol (transport, engine version, KV layout).
+    #[serde(default)]
+    pub pd_pairing_mode: PdPairingMode,
     pub host: String,
     pub port: u16,
     /// Dedicated port for the isolated Kubernetes liveness/readiness/health
@@ -537,6 +541,39 @@ pub enum ManualAssignmentMode {
 /// configured header carrying a valid value is the fallback when no rid is
 /// present. An enabled override keeps automatic body forwarding buffered so
 /// body `rid` precedence is preserved.
+/// How strictly PD placement pairs a prefill with a decode on their KV
+/// transfer protocol (#2483). A descriptor component an engine does not report
+/// is "unknown": lenient pairing lets it match anything (a fleet that reports
+/// nothing keeps working), strict pairing treats it as a mismatch.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PdPairingMode {
+    /// Unknown components pair with anything; known components must agree.
+    #[default]
+    Lenient,
+    /// Every component must be known on both sides and agree.
+    Strict,
+}
+
+impl PdPairingMode {
+    /// Parse the CLI spelling (`lenient` / `strict`).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "lenient" => Some(Self::Lenient),
+            "strict" => Some(Self::Strict),
+            _ => None,
+        }
+    }
+
+    /// The CLI spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Lenient => "lenient",
+            Self::Strict => "strict",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoutingKeyOverrideConfig {
     /// When false, policies are used unchanged.
@@ -1063,6 +1100,7 @@ impl Default for RouterConfig {
             policy: PolicyConfig::Random,
             cache_boundaries: Vec::new(),
             routing_key_override: RoutingKeyOverrideConfig::default(),
+            pd_pairing_mode: PdPairingMode::default(),
             host: "0.0.0.0".to_string(),
             port: 3001,
             health_check_port: None,

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -548,6 +548,18 @@ pub enum PdPairingMode {
 }
 
 impl PdPairingMode {
+    /// Number of modes, for per-mode caches.
+    pub const COUNT: usize = 3;
+
+    /// A dense index for per-mode caches.
+    pub const fn index(self) -> usize {
+        match self {
+            Self::Off => 0,
+            Self::Lenient => 1,
+            Self::Strict => 2,
+        }
+    }
+
     /// Parse the CLI spelling (`off` / `lenient` / `strict`).
     pub fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -14,9 +14,10 @@ use smg::{
     config::{
         resolve_worker_auto_recovery, validate_mesh_server_name, CacheIndexKind,
         CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
-        HistoryBackend, ManualAssignmentMode, MetricsConfig, OracleConfig, PolicyConfig,
-        PostgresConfig, RedisConfig, RetryConfig, RouterConfig, RoutingKeyOverrideConfig,
-        RoutingMode, SchemaConfig, TenantApiKeyEntry, TokenizerCacheConfig, TraceConfig,
+        HistoryBackend, ManualAssignmentMode, MetricsConfig, OracleConfig, PdPairingMode,
+        PolicyConfig, PostgresConfig, RedisConfig, RetryConfig, RouterConfig,
+        RoutingKeyOverrideConfig, RoutingMode, SchemaConfig, TenantApiKeyEntry,
+        TokenizerCacheConfig, TraceConfig,
     },
     observability::{
         metrics::{register_jemalloc_as_global_allocator, PrometheusConfig},
@@ -439,6 +440,18 @@ struct CliArgs {
         help_heading = "Routing Policy"
     )]
     routing_key_override: bool,
+
+    /// How strictly PD placement pairs a prefill with a decode on their KV
+    /// transfer protocol (transport, engine version, KV layout). `lenient`
+    /// lets a component an engine does not report pair with anything;
+    /// `strict` treats it as a mismatch.
+    #[arg(
+        long,
+        value_parser = ["lenient", "strict"],
+        default_value = "lenient",
+        help_heading = "Routing Policy"
+    )]
+    pd_pairing_mode: String,
 
     /// Ordered header names checked for the routing key; the first header
     /// present with a valid value wins. Header keys get the same
@@ -1907,6 +1920,7 @@ impl CliArgs {
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
             .dp_aware(self.dp_aware)
+            .pd_pairing_mode(PdPairingMode::parse(&self.pd_pairing_mode).unwrap_or_default())
             .routing_key_override(RoutingKeyOverrideConfig {
                 enabled: self.routing_key_override,
                 eviction_interval_secs: self.eviction_interval,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -442,12 +442,13 @@ struct CliArgs {
     routing_key_override: bool,
 
     /// How strictly PD placement pairs a prefill with a decode on their KV
-    /// transfer protocol (transport, engine version, KV layout). `lenient`
-    /// lets a component an engine does not report pair with anything;
-    /// `strict` treats it as a mismatch.
+    /// transfer protocol. `lenient` refuses only a known difference in
+    /// runtime, transport or KV layout (unknown components and engine
+    /// versions pair with anything); `strict` also refuses unknown
+    /// components and version differences; `off` pairs on nothing.
     #[arg(
         long,
-        value_parser = ["lenient", "strict"],
+        value_parser = ["off", "lenient", "strict"],
         default_value = "lenient",
         help_heading = "Routing Policy"
     )]

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -21,7 +21,7 @@ use super::{
     ManualPolicy, PolicyFactory, SelectWorkerInfo, WorkerLeg,
 };
 use crate::{
-    config::types::{ManualAssignmentMode, PolicyConfig, RoutingKeyOverrideConfig},
+    config::types::{ManualAssignmentMode, PdPairingMode, PolicyConfig, RoutingKeyOverrideConfig},
     mesh::adapters::TreeSyncAdapter,
     observability::metrics::Metrics,
     policies::cache_aware::LoadReceiver,
@@ -84,6 +84,8 @@ pub struct PolicyRegistry {
     /// `routing_key_override.headers`; the first header present with a valid
     /// value wins.
     routing_key_headers: Arc<Vec<HeaderName>>,
+    /// How strictly PD placement pairs prefill and decode descriptors.
+    pd_pairing_mode: PdPairingMode,
 }
 
 /// A sticky key with this many of its own requests already in flight on its
@@ -161,7 +163,20 @@ impl PolicyRegistry {
             dp_rank_policy: Arc::new(OnceLock::new()),
             routing_key_sticky,
             routing_key_headers: Arc::new(routing_key_headers),
+            pd_pairing_mode: PdPairingMode::default(),
         }
+    }
+
+    /// Set how strictly PD placement pairs prefill and decode descriptors.
+    #[must_use]
+    pub fn with_pd_pairing_mode(mut self, mode: PdPairingMode) -> Self {
+        self.pd_pairing_mode = mode;
+        self
+    }
+
+    /// How strictly PD placement pairs prefill and decode descriptors.
+    pub fn pd_pairing_mode(&self) -> PdPairingMode {
+        self.pd_pairing_mode
     }
 
     /// Derive the session key from a request id: trailing `_r<n>` retry and

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -229,7 +229,6 @@ pub(crate) fn single_failure(
     failure_from(candidates.as_slice(), model_id)
 }
 
-/// Classify a failed placement from the candidates it drew from.
 /// The distinct components on which the legs' descriptors disagree, sorted.
 fn pairing_mismatches(
     prefill: &[Arc<dyn Worker>],
@@ -258,6 +257,7 @@ fn pairing_keys(leg: &[Arc<dyn Worker>]) -> Vec<String> {
     keys
 }
 
+/// Classify a failed placement from the candidates it drew from.
 pub(crate) fn failure_from(candidates: &[Arc<dyn Worker>], model_id: &str) -> PlacementFailure {
     if candidates.is_empty() {
         return PlacementFailure::NoCandidates;

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -25,8 +25,8 @@ use crate::{
     },
     routers::common::overload,
     worker::{
-        ConnectionMode, ConnectionModeExt, PdPairingMode, RoutingPool, RuntimeType, Worker,
-        WorkerRegistry,
+        ConnectionMode, ConnectionModeExt, PairingMismatch, PdPairingMode, RoutingPool,
+        RuntimeType, Worker, WorkerRegistry,
     },
 };
 
@@ -84,10 +84,12 @@ pub(crate) enum PlacementFailure {
     /// Available candidates existed but the named policy picked none.
     PolicyDeclined(&'static str),
     /// Both legs had available workers, but no prefill shares a KV transfer
-    /// protocol with any decode (#2483). Carries each leg's pairing keys.
+    /// protocol with any decode (#2483). Carries each leg's pairing keys and
+    /// the components the legs disagreed on.
     NoCompatiblePair {
         prefill: Vec<String>,
         decode: Vec<String>,
+        mismatches: Vec<String>,
     },
 }
 
@@ -228,6 +230,26 @@ pub(crate) fn single_failure(
 }
 
 /// Classify a failed placement from the candidates it drew from.
+/// The distinct components on which the legs' descriptors disagree, sorted.
+fn pairing_mismatches(
+    prefill: &[Arc<dyn Worker>],
+    decode: &[Arc<dyn Worker>],
+    mode: PdPairingMode,
+) -> Vec<String> {
+    let mut mismatches: Vec<String> = prefill
+        .iter()
+        .flat_map(|p| {
+            decode
+                .iter()
+                .filter_map(move |d| p.pd_pairing().mismatch(d.pd_pairing(), mode))
+        })
+        .map(PairingMismatch::describe)
+        .collect();
+    mismatches.sort();
+    mismatches.dedup();
+    mismatches
+}
+
 /// The distinct pairing keys of one leg's candidates, sorted.
 fn pairing_keys(leg: &[Arc<dyn Worker>]) -> Vec<String> {
     let mut keys: Vec<String> = leg.iter().map(|w| w.pd_pairing().key()).collect();
@@ -322,7 +344,8 @@ pub(crate) fn select_pair(
     }
 
     // A rendezvous only works between legs that share a KV transfer
-    // protocol (transport, KV layout, or an explicit pairing protocol).
+    // protocol (runtime, transport, KV layout, or an explicit pairing
+    // protocol).
     // Narrow the prefill pool to workers with at least one compatible
     // decode, so the policy's pick always has a partner; the decode pool
     // narrows to that pick's partners below. The keys are only built for
@@ -336,9 +359,11 @@ pub(crate) fn select_pair(
     if pairing_mode != PdPairingMode::Off && !prefill.iter().any(&has_partner) {
         let prefill_keys = pairing_keys(&prefill);
         let decode_keys = pairing_keys(&decode);
+        let mismatches = pairing_mismatches(&prefill, &decode, pairing_mode);
         warn!(
             model_id,
             mode = pairing_mode.as_str(),
+            ?mismatches,
             ?prefill_keys,
             ?decode_keys,
             "No prefill/decode pair shares a KV transfer protocol"
@@ -348,6 +373,7 @@ pub(crate) fn select_pair(
             verdict: PlacementFailure::NoCompatiblePair {
                 prefill: prefill_keys,
                 decode: decode_keys,
+                mismatches,
             },
         }));
     }
@@ -531,9 +557,14 @@ mod tests {
             .expect("no pair shares a transport");
         assert_eq!(failure.leg, WorkerLeg::Decode);
         match failure.verdict {
-            PlacementFailure::NoCompatiblePair { prefill, decode } => {
-                assert_eq!(prefill, ["vllm/nixl/?/?"]);
-                assert_eq!(decode, ["vllm/mooncake/?/?"]);
+            PlacementFailure::NoCompatiblePair {
+                prefill,
+                decode,
+                mismatches,
+            } => {
+                assert_eq!(prefill, ["vllm/nixl/?"]);
+                assert_eq!(decode, ["vllm/mooncake/?"]);
+                assert_eq!(mismatches, ["transport"]);
             }
             _ => panic!("expected NoCompatiblePair"),
         }

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -83,9 +83,11 @@ pub(crate) enum PlacementFailure {
     Unavailable,
     /// Available candidates existed but the named policy picked none.
     PolicyDeclined(&'static str),
-    /// Both legs had available workers, but no prefill shares a KV transfer
-    /// protocol with any decode (#2483). Carries each leg's pairing keys and
-    /// the components the legs disagreed on.
+    /// Both legs have workers, whatever their availability, but no prefill
+    /// shares a KV transfer protocol with any decode (#2483): judged from
+    /// membership alone, since it cannot change until membership does.
+    /// Carries each leg's pairing keys and the components the legs
+    /// disagreed on.
     NoCompatiblePair {
         prefill: Vec<String>,
         decode: Vec<String>,
@@ -97,9 +99,8 @@ pub(crate) enum PlacementFailure {
 pub(crate) struct Pair {
     pub prefill: Arc<dyn Worker>,
     pub decode: Arc<dyn Worker>,
-    /// The runtime both legs run when homogeneity was required. Otherwise
-    /// it is the first available prefill worker's, which says nothing about
-    /// the selected pair; only a homogeneous caller should read it.
+    /// The selected prefill worker's runtime, which under a homogeneous
+    /// caller is the runtime both legs run.
     pub runtime: RuntimeType,
 }
 
@@ -292,35 +293,38 @@ pub(crate) fn select_pair(
     }
 
     // Live state: a prefill is open when it is available and so is one of
-    // its partners.
-    let mut open: Vec<usize> = (0..pairs.prefill.len())
-        .filter(|&i| eligible(&pairs.prefill[i]) && pairs.partners[i].iter().any(eligible))
-        .collect();
+    // its partners, so the policy's pick can always be paired. Where the
+    // wire's rendezvous is runtime-specific, both legs must also share a
+    // runtime, the first available prefill worker's; the index keeps
+    // runtimes apart already unless pairing is off or a runtime is unknown.
+    let partner_open = |d: &Arc<dyn Worker>, runtime: Option<RuntimeType>| {
+        eligible(d) && runtime.is_none_or(|r| d.metadata().spec.runtime_type == r)
+    };
+    let open_prefills = |runtime: Option<RuntimeType>| -> Vec<usize> {
+        (0..pairs.prefill.len())
+            .filter(|&i| {
+                let p = &pairs.prefill[i];
+                eligible(p)
+                    && runtime.is_none_or(|r| p.metadata().spec.runtime_type == r)
+                    && pairs.partners[i].iter().any(|d| partner_open(d, runtime))
+            })
+            .collect()
+    };
+    let Some(first) = pairs.prefill.iter().find(|p| eligible(p)) else {
+        debug!("No available prefill workers");
+        return Err(fail(
+            WorkerLeg::Prefill,
+            failure_from(&pairs.prefill, model_id),
+        ));
+    };
+    let leg_runtime = homogeneous_runtime.then_some(first.metadata().spec.runtime_type);
+    let open = open_prefills(leg_runtime);
     if open.is_empty() {
-        // Name the leg that is short: the prefills, else their partners.
-        let (leg, candidates): (WorkerLeg, &[Arc<dyn Worker>]) =
-            if pairs.prefill.iter().any(eligible) {
-                (WorkerLeg::Decode, &pairs.decode_pool)
-            } else {
-                (WorkerLeg::Prefill, &pairs.prefill)
-            };
-        debug!(?leg, "No available PD pair");
-        return Err(fail(leg, failure_from(candidates, model_id)));
-    }
-
-    // Where the wire's rendezvous is runtime-specific, both legs must share a
-    // runtime: take the first open prefill worker's and narrow both legs to
-    // it. The index already keeps runtimes apart unless pairing is off.
-    let runtime = pairs.prefill[open[0]].metadata().spec.runtime_type;
-    if homogeneous_runtime {
-        let before = open.len();
-        open.retain(|&i| pairs.prefill[i].metadata().spec.runtime_type == runtime);
-        if open.len() != before {
-            warn!(
-                ?runtime,
-                "Mixed runtime types among open prefill workers; using the first"
-            );
-        }
+        debug!(?leg_runtime, "No available PD pair");
+        return Err(fail(
+            WorkerLeg::Decode,
+            failure_from(&pairs.decode_pool, model_id),
+        ));
     }
     let prefill: Vec<Arc<dyn Worker>> = open
         .iter()
@@ -354,17 +358,18 @@ pub(crate) fn select_pair(
         return Err(declined(WorkerLeg::Prefill, prefill_policy.name()));
     };
     let selected_prefill = prefill[prefill_idx].clone();
-    // The pick's partners, live-filtered; non-empty by construction unless
-    // the runtime narrowing (pairing off, mixed runtimes) emptied it.
+    // The pick's open partners: non-empty by construction, short of an
+    // availability flip between the two reads.
     let decode: Vec<Arc<dyn Worker>> = pairs.partners[open[prefill_idx]]
         .iter()
-        .filter(|d| {
-            eligible(d) && (!homogeneous_runtime || d.metadata().spec.runtime_type == runtime)
-        })
+        .filter(|d| partner_open(d, leg_runtime))
         .cloned()
         .collect();
     if decode.is_empty() {
-        debug!("No available PD pair for runtime {:?}", runtime);
+        debug!(
+            ?leg_runtime,
+            "The selected prefill's partners went unavailable"
+        );
         return Err(fail(WorkerLeg::Decode, PlacementFailure::Unavailable));
     }
     info.leg = WorkerLeg::Decode;
@@ -481,6 +486,43 @@ mod tests {
             pair.prefill.pd_pairing().transport(),
             pair.decode.pd_pairing().transport()
         );
+    }
+
+    #[test]
+    fn a_homogeneous_pair_skips_a_prefill_whose_only_partner_runs_another_runtime() {
+        // P1 (NIXL) pairs only with D1, whose runtime probe failed; P2
+        // (Mooncake) pairs with D1 and D2. On the gRPC wire both legs must
+        // share a runtime, so P1 is never open and every placement lands on
+        // P2/D2 instead of failing every other request.
+        let registry = pd_registry(&[
+            ("grpc://p:1", WorkerType::Prefill, Some("NixlConnector")),
+            ("grpc://p:2", WorkerType::Prefill, Some("MooncakeConnector")),
+            ("grpc://d:2", WorkerType::Decode, Some("MooncakeConnector")),
+        ]);
+        registry
+            .register(Arc::new(
+                BasicWorkerBuilder::new("grpc://d:1")
+                    .model(ModelCard::new(MODEL))
+                    .worker_type(WorkerType::Decode)
+                    .connection_mode(ConnectionMode::Grpc)
+                    .runtime_type(RuntimeType::Unspecified)
+                    .health_config(HealthCheckConfig {
+                        disable_health_check: true,
+                        ..Default::default()
+                    })
+                    .build(),
+            ))
+            .expect("worker registers");
+        let policies = PolicyRegistry::new(PolicyConfig::RoundRobin);
+
+        for _ in 0..4 {
+            let pair = pair_from(&registry, &policies)
+                .ok()
+                .expect("P2 and D2 pair on one runtime");
+            assert_eq!(pair.prefill.url(), "grpc://p:2");
+            assert_eq!(pair.decode.url(), "grpc://d:2");
+            assert_eq!(pair.runtime, RuntimeType::Vllm);
+        }
     }
 
     #[test]

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -25,8 +25,8 @@ use crate::{
     },
     routers::common::overload,
     worker::{
-        ConnectionMode, ConnectionModeExt, PairingMismatch, PdPairingMode, RoutingPool,
-        RuntimeType, Worker, WorkerRegistry,
+        ConnectionMode, ConnectionModeExt, PdPairIndex, RoutingPool, RuntimeType, Worker,
+        WorkerRegistry,
     },
 };
 
@@ -91,14 +91,6 @@ pub(crate) enum PlacementFailure {
         decode: Vec<String>,
         mismatches: Vec<String>,
     },
-}
-
-/// The two legs of a disaggregated placement, each the pool it selects over
-/// before the availability filter. Both must come from one registry snapshot
-/// so the pair cannot straddle a membership change.
-pub(crate) struct PairCandidates<'a> {
-    pub prefill: &'a [Arc<dyn Worker>],
-    pub decode: &'a [Arc<dyn Worker>],
 }
 
 /// A selected prefill/decode pair.
@@ -229,34 +221,6 @@ pub(crate) fn single_failure(
     failure_from(candidates.as_slice(), model_id)
 }
 
-/// The distinct components on which the legs' descriptors disagree, sorted.
-fn pairing_mismatches(
-    prefill: &[Arc<dyn Worker>],
-    decode: &[Arc<dyn Worker>],
-    mode: PdPairingMode,
-) -> Vec<String> {
-    let mut mismatches: Vec<String> = prefill
-        .iter()
-        .flat_map(|p| {
-            decode
-                .iter()
-                .filter_map(move |d| p.pd_pairing().mismatch(d.pd_pairing(), mode))
-        })
-        .map(PairingMismatch::describe)
-        .collect();
-    mismatches.sort();
-    mismatches.dedup();
-    mismatches
-}
-
-/// The distinct pairing keys of one leg's candidates, sorted.
-fn pairing_keys(leg: &[Arc<dyn Worker>]) -> Vec<String> {
-    let mut keys: Vec<String> = leg.iter().map(|w| w.pd_pairing().key()).collect();
-    keys.sort();
-    keys.dedup();
-    keys
-}
-
 /// Classify a failed placement from the candidates it drew from.
 pub(crate) fn failure_from(candidates: &[Arc<dyn Worker>], model_id: &str) -> PlacementFailure {
     if candidates.is_empty() {
@@ -271,113 +235,97 @@ pub(crate) fn failure_from(candidates: &[Arc<dyn Worker>], model_id: &str) -> Pl
 /// Pick a prefill/decode pair for `model_id`, one worker per leg, each under
 /// its own policy and sticky namespace.
 ///
-/// Every leg is judged live for availability; `wire` pins both legs to the
-/// retained plan's runtime and transport on a retry; `homogeneous_runtime` narrows both
-/// legs to the first available prefill worker's runtime, which the gRPC
-/// wire needs because its rendezvous is runtime-specific. A miss names the
-/// leg and carries the verdict judged from that leg's own candidates.
+/// `pairs` is the snapshot's compatibility index (see [`PdPairIndex`]):
+/// which decodes each prefill may hand off to was decided when membership
+/// last changed, so this path compares no descriptors. Every leg is judged
+/// live for availability, and a prefill counts only while one of its
+/// partners is available, so the policy's pick can always be paired; `wire`
+/// pins both legs to the retained plan's runtime and transport on a retry;
+/// `homogeneous_runtime` narrows both legs to the first open prefill
+/// worker's runtime, which the gRPC wire needs because its rendezvous is
+/// runtime-specific. A miss names the leg and carries the verdict judged
+/// from that leg's own candidates.
 pub(crate) fn select_pair(
     registry: &WorkerRegistry,
     policies: &PolicyRegistry,
     model_id: &str,
-    candidates: PairCandidates<'_>,
+    pairs: &PdPairIndex,
     wire: Option<WireConstraint>,
     homogeneous_runtime: bool,
     inputs: PlacementInputs<'_>,
 ) -> Result<Pair, Box<PairFailure>> {
-    let available = |leg: &[Arc<dyn Worker>]| -> Vec<Arc<dyn Worker>> {
-        leg.iter()
-            .filter(|w| {
-                w.is_available()
-                    && wire.is_none_or(|wire| {
-                        w.metadata().spec.runtime_type == wire.runtime
-                            && *w.connection_mode() == wire.connection
-                    })
+    let eligible = |w: &Arc<dyn Worker>| {
+        w.is_available()
+            && wire.is_none_or(|wire| {
+                w.metadata().spec.runtime_type == wire.runtime
+                    && *w.connection_mode() == wire.connection
             })
-            .cloned()
-            .collect()
     };
-    let mut prefill = available(candidates.prefill);
-    let mut decode = available(candidates.decode);
+    let fail = |leg: WorkerLeg, verdict: PlacementFailure| Box::new(PairFailure { leg, verdict });
 
-    if prefill.is_empty() {
-        debug!("No available prefill workers");
-        return Err(Box::new(PairFailure {
-            leg: WorkerLeg::Prefill,
-            verdict: failure_from(candidates.prefill, model_id),
-        }));
+    // A leg with no worker at all names itself before pairing is judged.
+    if pairs.prefill_pool.is_empty() {
+        debug!("No prefill workers");
+        return Err(fail(WorkerLeg::Prefill, PlacementFailure::NoCandidates));
     }
-    if decode.is_empty() {
-        debug!("No available decode workers");
-        return Err(Box::new(PairFailure {
-            leg: WorkerLeg::Decode,
-            verdict: failure_from(candidates.decode, model_id),
-        }));
+    if pairs.decode_pool.is_empty() {
+        debug!("No decode workers");
+        return Err(fail(WorkerLeg::Decode, PlacementFailure::NoCandidates));
+    }
+    if let Some(refusal) = &pairs.refusal {
+        warn!(
+            model_id,
+            mode = policies.pd_pairing_mode().as_str(),
+            mismatches = ?refusal.mismatches,
+            prefill = ?refusal.prefill,
+            decode = ?refusal.decode,
+            "No prefill/decode pair shares a KV transfer protocol"
+        );
+        return Err(fail(
+            WorkerLeg::Decode,
+            PlacementFailure::NoCompatiblePair {
+                prefill: refusal.prefill.clone(),
+                decode: refusal.decode.clone(),
+                mismatches: refusal.mismatches.clone(),
+            },
+        ));
+    }
+
+    // Live state: a prefill is open when it is available and so is one of
+    // its partners.
+    let mut open: Vec<usize> = (0..pairs.prefill.len())
+        .filter(|&i| eligible(&pairs.prefill[i]) && pairs.partners[i].iter().any(eligible))
+        .collect();
+    if open.is_empty() {
+        // Name the leg that is short: the prefills, else their partners.
+        let (leg, candidates): (WorkerLeg, &[Arc<dyn Worker>]) =
+            if pairs.prefill.iter().any(eligible) {
+                (WorkerLeg::Decode, &pairs.decode_pool)
+            } else {
+                (WorkerLeg::Prefill, &pairs.prefill)
+            };
+        debug!(?leg, "No available PD pair");
+        return Err(fail(leg, failure_from(candidates, model_id)));
     }
 
     // Where the wire's rendezvous is runtime-specific, both legs must share a
-    // runtime: take the first prefill worker's and narrow both legs to it.
-    let runtime = prefill[0].metadata().spec.runtime_type;
+    // runtime: take the first open prefill worker's and narrow both legs to
+    // it. The index already keeps runtimes apart unless pairing is off.
+    let runtime = pairs.prefill[open[0]].metadata().spec.runtime_type;
     if homogeneous_runtime {
-        let prefill_mixed = prefill
-            .iter()
-            .skip(1)
-            .any(|w| w.metadata().spec.runtime_type != runtime);
-        let decode_mixed = decode
-            .iter()
-            .any(|w| w.metadata().spec.runtime_type != runtime);
-        if prefill_mixed || decode_mixed {
+        let before = open.len();
+        open.retain(|&i| pairs.prefill[i].metadata().spec.runtime_type == runtime);
+        if open.len() != before {
             warn!(
-                "Mixed runtime types in PD workers (prefill_mixed={}, decode_mixed={}). Using {:?}.",
-                prefill_mixed, decode_mixed, runtime
+                ?runtime,
+                "Mixed runtime types among open prefill workers; using the first"
             );
         }
-        prefill.retain(|w| w.metadata().spec.runtime_type == runtime);
-        decode.retain(|w| w.metadata().spec.runtime_type == runtime);
-        if decode.is_empty() {
-            debug!("No available PD pair for runtime {:?}", runtime);
-            return Err(Box::new(PairFailure {
-                leg: WorkerLeg::Decode,
-                verdict: PlacementFailure::Unavailable,
-            }));
-        }
     }
-
-    // A rendezvous only works between legs that share a KV transfer
-    // protocol (runtime, transport, KV layout, or an explicit pairing
-    // protocol).
-    // Narrow the prefill pool to workers with at least one compatible
-    // decode, so the policy's pick always has a partner; the decode pool
-    // narrows to that pick's partners below. The keys are only built for
-    // the failure report.
-    let pairing_mode = policies.pd_pairing_mode();
-    let has_partner = |p: &Arc<dyn Worker>| {
-        decode
-            .iter()
-            .any(|d| p.pd_pairing().compatible(d.pd_pairing(), pairing_mode))
-    };
-    if pairing_mode != PdPairingMode::Off && !prefill.iter().any(&has_partner) {
-        let prefill_keys = pairing_keys(&prefill);
-        let decode_keys = pairing_keys(&decode);
-        let mismatches = pairing_mismatches(&prefill, &decode, pairing_mode);
-        warn!(
-            model_id,
-            mode = pairing_mode.as_str(),
-            ?mismatches,
-            ?prefill_keys,
-            ?decode_keys,
-            "No prefill/decode pair shares a KV transfer protocol"
-        );
-        return Err(Box::new(PairFailure {
-            leg: WorkerLeg::Decode,
-            verdict: PlacementFailure::NoCompatiblePair {
-                prefill: prefill_keys,
-                decode: decode_keys,
-                mismatches,
-            },
-        }));
-    }
-    prefill.retain(has_partner);
+    let prefill: Vec<Arc<dyn Worker>> = open
+        .iter()
+        .map(|&i| Arc::clone(&pairs.prefill[i]))
+        .collect();
 
     // Independent prefill/decode policies so stateful ones (round robin) do
     // not share a counter; each leg tags the sticky key with its own prefix.
@@ -406,18 +354,25 @@ pub(crate) fn select_pair(
         return Err(declined(WorkerLeg::Prefill, prefill_policy.name()));
     };
     let selected_prefill = prefill[prefill_idx].clone();
-    // Non-empty by construction: the prefill pool was narrowed to workers
-    // with a compatible decode.
-    decode.retain(|d| {
-        selected_prefill
-            .pd_pairing()
-            .compatible(d.pd_pairing(), pairing_mode)
-    });
+    // The pick's partners, live-filtered; non-empty by construction unless
+    // the runtime narrowing (pairing off, mixed runtimes) emptied it.
+    let decode: Vec<Arc<dyn Worker>> = pairs.partners[open[prefill_idx]]
+        .iter()
+        .filter(|d| {
+            eligible(d) && (!homogeneous_runtime || d.metadata().spec.runtime_type == runtime)
+        })
+        .cloned()
+        .collect();
+    if decode.is_empty() {
+        debug!("No available PD pair for runtime {:?}", runtime);
+        return Err(fail(WorkerLeg::Decode, PlacementFailure::Unavailable));
+    }
     info.leg = WorkerLeg::Decode;
     let Some(decode_idx) = policies.select_worker(&decode_policy, &decode, &info) else {
         return Err(declined(WorkerLeg::Decode, decode_policy.name()));
     };
     let selected_decode = decode[decode_idx].clone();
+    let runtime = selected_prefill.metadata().spec.runtime_type;
     Metrics::record_worker_selection(
         metrics_labels::WORKER_PREFILL,
         selected_prefill.connection_mode().as_metric_label(),
@@ -444,8 +399,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        config::types::PolicyConfig,
-        worker::{BasicWorkerBuilder, ModelCard, WorkerType},
+        config::types::{PdPairingMode, PolicyConfig},
+        worker::{BasicWorkerBuilder, ModelCard, PdWire, WorkerType},
     };
 
     const MODEL: &str = "m";
@@ -474,21 +429,21 @@ mod tests {
         registry
     }
 
+    fn pairs_of(registry: &WorkerRegistry, policies: &PolicyRegistry) -> Arc<PdPairIndex> {
+        registry
+            .get_routing_snapshot(MODEL)
+            .pd_pairs(PdWire::Grpc, policies.pd_pairing_mode())
+    }
+
     fn pair_from(
         registry: &WorkerRegistry,
         policies: &PolicyRegistry,
     ) -> Result<Pair, Box<PairFailure>> {
-        let snapshot = registry.get_routing_snapshot(MODEL);
-        let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
-        let decode = snapshot.pool(RoutingPool::GrpcDecode);
         select_pair(
             registry,
             policies,
             MODEL,
-            PairCandidates {
-                prefill: &prefill,
-                decode: &decode,
-            },
+            &pairs_of(registry, policies),
             None,
             true,
             PlacementInputs::default(),
@@ -504,37 +459,21 @@ mod tests {
             ("grpc://d:2", WorkerType::Decode, Some("MooncakeConnector")),
         ]);
         let policies = PolicyRegistry::new(PolicyConfig::RoundRobin);
-        let snapshot = registry.get_routing_snapshot(MODEL);
-        let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
-        let decode = snapshot.pool(RoutingPool::GrpcDecode);
 
-        // Whichever prefill worker the policy is handed, the decode leg is
-        // narrowed to the worker that speaks the same transport.
-        for p in prefill.iter() {
-            let pair = select_pair(
-                &registry,
-                &policies,
-                MODEL,
-                PairCandidates {
-                    prefill: std::slice::from_ref(p),
-                    decode: &decode,
-                },
-                None,
-                true,
-                PlacementInputs::default(),
-            )
-            .ok()
-            .expect("every prefill worker has a partner");
-            assert_eq!(pair.prefill.url(), p.url());
+        // The snapshot's index pairs each prefill with the decode that
+        // speaks its transport, once, for every request to read.
+        let pairs = pairs_of(&registry, &policies);
+        assert_eq!(pairs.prefill.len(), 2);
+        for (prefill, partners) in pairs.prefill.iter().zip(&pairs.partners) {
+            assert_eq!(partners.len(), 1, "{}", prefill.url());
             assert_eq!(
-                pair.prefill.pd_pairing().transport(),
-                pair.decode.pd_pairing().transport(),
-                "{} paired with {}",
-                pair.prefill.url(),
-                pair.decode.url()
+                prefill.pd_pairing().transport(),
+                partners[0].pd_pairing().transport()
             );
         }
-        // And the unnarrowed fleet still yields a matching pair.
+        assert!(Arc::ptr_eq(&pairs, &pairs_of(&registry, &policies)));
+
+        // And a placement lands on a matching pair.
         let pair = pair_from(&registry, &policies)
             .ok()
             .expect("the fleet has matching pairs");
@@ -716,24 +655,10 @@ mod tests {
             ),
         ]);
         let policies = PolicyRegistry::new(PolicyConfig::RoundRobin);
-        let snapshot = registry.get_routing_snapshot(MODEL);
-        let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
-        let decode = snapshot.pool(RoutingPool::GrpcDecode);
 
-        let pair = select_pair(
-            &registry,
-            &policies,
-            MODEL,
-            PairCandidates {
-                prefill: &prefill,
-                decode: &decode,
-            },
-            None,
-            true,
-            PlacementInputs::default(),
-        )
-        .ok()
-        .expect("a pair exists under either runtime");
+        let pair = pair_from(&registry, &policies)
+            .ok()
+            .expect("a pair exists under either runtime");
         assert_eq!(pair.prefill.metadata().spec.runtime_type, pair.runtime);
         assert_eq!(pair.decode.metadata().spec.runtime_type, pair.runtime);
 
@@ -744,23 +669,9 @@ mod tests {
             ConnectionMode::Grpc,
             RuntimeType::Sglang,
         )]);
-        let snapshot = only_prefill.get_routing_snapshot(MODEL);
-        let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
-        let decode = snapshot.pool(RoutingPool::GrpcDecode);
-        let failure = select_pair(
-            &only_prefill,
-            &policies,
-            MODEL,
-            PairCandidates {
-                prefill: &prefill,
-                decode: &decode,
-            },
-            None,
-            true,
-            PlacementInputs::default(),
-        )
-        .err()
-        .expect("no decode worker exists");
+        let failure = pair_from(&only_prefill, &policies)
+            .err()
+            .expect("no decode worker exists");
         assert_eq!(failure.leg, WorkerLeg::Decode);
         assert!(matches!(failure.verdict, PlacementFailure::NoCandidates));
     }
@@ -790,19 +701,19 @@ mod tests {
                 .filter(|w| *w.worker_type() == worker_type)
                 .collect()
         };
-        let prefill = by_type(WorkerType::Prefill);
-        let decode = by_type(WorkerType::Decode);
-        let candidates = || PairCandidates {
-            prefill: &prefill,
-            decode: &decode,
-        };
+        // Built from raw legs, as a caller with its own candidate lists would.
+        let pairs = PdPairIndex::build(
+            by_type(WorkerType::Prefill).into(),
+            by_type(WorkerType::Decode).into(),
+            policies.pd_pairing_mode(),
+        );
 
         // Unpinned, the ZMQ decode worker is a candidate like any other.
         assert!(select_pair(
             &registry,
             &policies,
             MODEL,
-            candidates(),
+            &pairs,
             None,
             false,
             PlacementInputs::default(),
@@ -814,7 +725,7 @@ mod tests {
             &registry,
             &policies,
             MODEL,
-            candidates(),
+            &pairs,
             Some(WireConstraint {
                 runtime: RuntimeType::Sglang,
                 connection: ConnectionMode::Grpc,

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -80,6 +80,12 @@ pub(crate) enum PlacementFailure {
     Unavailable,
     /// Available candidates existed but the named policy picked none.
     PolicyDeclined(&'static str),
+    /// Both legs had available workers, but no prefill shares a KV transfer
+    /// protocol with any decode (#2483). Carries each leg's pairing keys.
+    NoCompatiblePair {
+        prefill: Vec<String>,
+        decode: Vec<String>,
+    },
 }
 
 /// The two legs of a disaggregated placement, each the pool it selects over
@@ -219,6 +225,14 @@ pub(crate) fn single_failure(
 }
 
 /// Classify a failed placement from the candidates it drew from.
+/// The distinct pairing keys of one leg's candidates, sorted.
+fn pairing_keys(leg: &[Arc<dyn Worker>]) -> Vec<String> {
+    let mut keys: Vec<String> = leg.iter().map(|w| w.pd_pairing().key()).collect();
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
 pub(crate) fn failure_from(candidates: &[Arc<dyn Worker>], model_id: &str) -> PlacementFailure {
     if candidates.is_empty() {
         return PlacementFailure::NoCandidates;
@@ -304,6 +318,36 @@ pub(crate) fn select_pair(
         }
     }
 
+    // A rendezvous only works between legs that share a KV transfer
+    // protocol (transport, engine version, KV layout, or an explicit
+    // pairing protocol). Narrow the prefill pool to workers with at least
+    // one compatible decode, so the policy's pick always has a partner; the
+    // decode pool narrows to that pick's partners below.
+    let pairing_mode = policies.pd_pairing_mode();
+    let prefill_keys = pairing_keys(&prefill);
+    prefill.retain(|p| {
+        decode
+            .iter()
+            .any(|d| p.pd_pairing().compatible(d.pd_pairing(), pairing_mode))
+    });
+    if prefill.is_empty() {
+        let decode_keys = pairing_keys(&decode);
+        warn!(
+            model_id,
+            mode = pairing_mode.as_str(),
+            ?prefill_keys,
+            ?decode_keys,
+            "No prefill/decode pair shares a KV transfer protocol"
+        );
+        return Err(Box::new(PairFailure {
+            leg: WorkerLeg::Decode,
+            verdict: PlacementFailure::NoCompatiblePair {
+                prefill: prefill_keys,
+                decode: decode_keys,
+            },
+        }));
+    }
+
     // Independent prefill/decode policies so stateful ones (round robin) do
     // not share a counter; each leg tags the sticky key with its own prefix.
     let prefill_policy = policies.get_prefill_policy();
@@ -330,12 +374,18 @@ pub(crate) fn select_pair(
     let Some(prefill_idx) = policies.select_worker(&prefill_policy, &prefill, &info) else {
         return Err(declined(WorkerLeg::Prefill, prefill_policy.name()));
     };
+    let selected_prefill = prefill[prefill_idx].clone();
+    // Non-empty by construction: the prefill pool was narrowed to workers
+    // with a compatible decode.
+    decode.retain(|d| {
+        selected_prefill
+            .pd_pairing()
+            .compatible(d.pd_pairing(), pairing_mode)
+    });
     info.leg = WorkerLeg::Decode;
     let Some(decode_idx) = policies.select_worker(&decode_policy, &decode, &info) else {
         return Err(declined(WorkerLeg::Decode, decode_policy.name()));
     };
-
-    let selected_prefill = prefill[prefill_idx].clone();
     let selected_decode = decode[decode_idx].clone();
     Metrics::record_worker_selection(
         metrics_labels::WORKER_PREFILL,
@@ -363,11 +413,147 @@ mod tests {
 
     use super::*;
     use crate::{
-        config::types::PolicyConfig,
+        config::types::{PdPairingMode, PolicyConfig},
         worker::{BasicWorkerBuilder, ModelCard, WorkerType},
     };
 
     const MODEL: &str = "m";
+
+    /// A vLLM gRPC PD fleet whose legs carry the given KV connectors
+    /// (`None` leaves the transport unknown).
+    fn pd_registry(workers: &[(&str, WorkerType, Option<&str>)]) -> WorkerRegistry {
+        let registry = WorkerRegistry::new();
+        for (url, worker_type, connector) in workers {
+            let mut builder = BasicWorkerBuilder::new(*url)
+                .model(ModelCard::new(MODEL))
+                .worker_type(*worker_type)
+                .connection_mode(ConnectionMode::Grpc)
+                .runtime_type(RuntimeType::Vllm)
+                .health_config(HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                });
+            if let Some(connector) = connector {
+                builder = builder.kv_connector(*connector);
+            }
+            registry
+                .register(Arc::new(builder.build()))
+                .expect("worker registers");
+        }
+        registry
+    }
+
+    fn pair_from(
+        registry: &WorkerRegistry,
+        policies: &PolicyRegistry,
+    ) -> Result<Pair, Box<PairFailure>> {
+        let snapshot = registry.get_routing_snapshot(MODEL);
+        let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
+        let decode = snapshot.pool(RoutingPool::GrpcDecode);
+        select_pair(
+            registry,
+            policies,
+            MODEL,
+            PairCandidates {
+                prefill: &prefill,
+                decode: &decode,
+            },
+            None,
+            true,
+            PlacementInputs::default(),
+        )
+    }
+
+    #[test]
+    fn a_pair_shares_its_kv_transport() {
+        let registry = pd_registry(&[
+            ("grpc://p:1", WorkerType::Prefill, Some("NixlConnector")),
+            ("grpc://p:2", WorkerType::Prefill, Some("MooncakeConnector")),
+            ("grpc://d:1", WorkerType::Decode, Some("NixlConnector")),
+            ("grpc://d:2", WorkerType::Decode, Some("MooncakeConnector")),
+        ]);
+        let policies = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        let snapshot = registry.get_routing_snapshot(MODEL);
+        let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
+        let decode = snapshot.pool(RoutingPool::GrpcDecode);
+
+        // Whichever prefill worker the policy is handed, the decode leg is
+        // narrowed to the worker that speaks the same transport.
+        for p in prefill.iter() {
+            let pair = select_pair(
+                &registry,
+                &policies,
+                MODEL,
+                PairCandidates {
+                    prefill: std::slice::from_ref(p),
+                    decode: &decode,
+                },
+                None,
+                true,
+                PlacementInputs::default(),
+            )
+            .ok()
+            .expect("every prefill worker has a partner");
+            assert_eq!(pair.prefill.url(), p.url());
+            assert_eq!(
+                pair.prefill.pd_pairing().transport(),
+                pair.decode.pd_pairing().transport(),
+                "{} paired with {}",
+                pair.prefill.url(),
+                pair.decode.url()
+            );
+        }
+        // And the unnarrowed fleet still yields a matching pair.
+        let pair = pair_from(&registry, &policies)
+            .ok()
+            .expect("the fleet has matching pairs");
+        assert_eq!(
+            pair.prefill.pd_pairing().transport(),
+            pair.decode.pd_pairing().transport()
+        );
+    }
+
+    #[test]
+    fn a_fleet_without_a_shared_transport_names_both_legs() {
+        let registry = pd_registry(&[
+            ("grpc://p:1", WorkerType::Prefill, Some("NixlConnector")),
+            ("grpc://d:1", WorkerType::Decode, Some("MooncakeConnector")),
+        ]);
+        let policies = PolicyRegistry::new(PolicyConfig::RoundRobin);
+
+        let failure = pair_from(&registry, &policies)
+            .err()
+            .expect("no pair shares a transport");
+        assert_eq!(failure.leg, WorkerLeg::Decode);
+        match failure.verdict {
+            PlacementFailure::NoCompatiblePair { prefill, decode } => {
+                assert_eq!(prefill, ["vllm/nixl/?/?"]);
+                assert_eq!(decode, ["vllm/mooncake/?/?"]);
+            }
+            _ => panic!("expected NoCompatiblePair"),
+        }
+    }
+
+    #[test]
+    fn an_unknown_transport_pairs_leniently_and_fails_strictly() {
+        let registry = pd_registry(&[
+            ("grpc://p:1", WorkerType::Prefill, Some("NixlConnector")),
+            ("grpc://d:1", WorkerType::Decode, None),
+        ]);
+
+        let lenient = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        assert!(pair_from(&registry, &lenient).is_ok());
+
+        let strict = PolicyRegistry::new(PolicyConfig::RoundRobin)
+            .with_pd_pairing_mode(PdPairingMode::Strict);
+        let failure = pair_from(&registry, &strict)
+            .err()
+            .expect("strict mode refuses an unknown transport");
+        assert!(matches!(
+            failure.verdict,
+            PlacementFailure::NoCompatiblePair { .. }
+        ));
+    }
 
     fn registry_with(workers: &[(&str, ConnectionMode, RuntimeType)]) -> WorkerRegistry {
         let typed: Vec<_> = workers

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -24,7 +24,10 @@ use crate::{
         WorkerLeg,
     },
     routers::common::overload,
-    worker::{ConnectionMode, ConnectionModeExt, RoutingPool, RuntimeType, Worker, WorkerRegistry},
+    worker::{
+        ConnectionMode, ConnectionModeExt, PdPairingMode, RoutingPool, RuntimeType, Worker,
+        WorkerRegistry,
+    },
 };
 
 /// The wire a retained plan was built for. Retry re-selection filters
@@ -319,18 +322,19 @@ pub(crate) fn select_pair(
     }
 
     // A rendezvous only works between legs that share a KV transfer
-    // protocol (transport, engine version, KV layout, or an explicit
-    // pairing protocol). Narrow the prefill pool to workers with at least
-    // one compatible decode, so the policy's pick always has a partner; the
-    // decode pool narrows to that pick's partners below.
+    // protocol (transport, KV layout, or an explicit pairing protocol).
+    // Narrow the prefill pool to workers with at least one compatible
+    // decode, so the policy's pick always has a partner; the decode pool
+    // narrows to that pick's partners below. The keys are only built for
+    // the failure report.
     let pairing_mode = policies.pd_pairing_mode();
-    let prefill_keys = pairing_keys(&prefill);
-    prefill.retain(|p| {
+    let has_partner = |p: &Arc<dyn Worker>| {
         decode
             .iter()
             .any(|d| p.pd_pairing().compatible(d.pd_pairing(), pairing_mode))
-    });
-    if prefill.is_empty() {
+    };
+    if pairing_mode != PdPairingMode::Off && !prefill.iter().any(&has_partner) {
+        let prefill_keys = pairing_keys(&prefill);
         let decode_keys = pairing_keys(&decode);
         warn!(
             model_id,
@@ -347,6 +351,7 @@ pub(crate) fn select_pair(
             },
         }));
     }
+    prefill.retain(has_partner);
 
     // Independent prefill/decode policies so stateful ones (round robin) do
     // not share a counter; each leg tags the sticky key with its own prefix.
@@ -413,7 +418,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        config::types::{PdPairingMode, PolicyConfig},
+        config::types::PolicyConfig,
         worker::{BasicWorkerBuilder, ModelCard, WorkerType},
     };
 
@@ -532,6 +537,11 @@ mod tests {
             }
             _ => panic!("expected NoCompatiblePair"),
         }
+
+        // `off` restores pre-pairing placement for the same fleet.
+        let off =
+            PolicyRegistry::new(PolicyConfig::RoundRobin).with_pd_pairing_mode(PdPairingMode::Off);
+        assert!(pair_from(&registry, &off).is_ok());
     }
 
     #[test]

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -242,9 +242,9 @@ pub(crate) fn failure_from(candidates: &[Arc<dyn Worker>], model_id: &str) -> Pl
 /// live for availability, and a prefill counts only while one of its
 /// partners is available, so the policy's pick can always be paired; `wire`
 /// pins both legs to the retained plan's runtime and transport on a retry;
-/// `homogeneous_runtime` narrows both legs to the first open prefill
-/// worker's runtime, which the gRPC wire needs because its rendezvous is
-/// runtime-specific. A miss names the leg and carries the verdict judged
+/// `homogeneous_runtime` narrows both legs to the runtime of the first
+/// prefill worker open under its own runtime, which the gRPC wire needs
+/// because its rendezvous is runtime-specific. A miss names the leg and carries the verdict judged
 /// from that leg's own candidates.
 pub(crate) fn select_pair(
     registry: &WorkerRegistry,
@@ -295,30 +295,58 @@ pub(crate) fn select_pair(
     // Live state: a prefill is open when it is available and so is one of
     // its partners, so the policy's pick can always be paired. Where the
     // wire's rendezvous is runtime-specific, both legs must also share a
-    // runtime, the first available prefill worker's; the index keeps
-    // runtimes apart already unless pairing is off or a runtime is unknown.
+    // runtime: that of the first prefill worker open under its own runtime,
+    // so a prefill whose partners are all down never shuts out a healthy
+    // pair on another runtime. The index keeps runtimes apart already
+    // unless pairing is off or a runtime is unknown.
     let partner_open = |d: &Arc<dyn Worker>, runtime: Option<RuntimeType>| {
         eligible(d) && runtime.is_none_or(|r| d.metadata().spec.runtime_type == r)
     };
-    let open_prefills = |runtime: Option<RuntimeType>| -> Vec<usize> {
-        (0..pairs.prefill.len())
-            .filter(|&i| {
-                let p = &pairs.prefill[i];
-                eligible(p)
-                    && runtime.is_none_or(|r| p.metadata().spec.runtime_type == r)
-                    && pairs.partners[i].iter().any(|d| partner_open(d, runtime))
-            })
-            .collect()
+    let can_pair_on = |i: usize, runtime: Option<RuntimeType>| {
+        pairs.partners[i].iter().any(|d| partner_open(d, runtime))
     };
-    let Some(first) = pairs.prefill.iter().find(|p| eligible(p)) else {
+    if !pairs.prefill.iter().any(&eligible) {
         debug!("No available prefill workers");
         return Err(fail(
             WorkerLeg::Prefill,
             failure_from(&pairs.prefill, model_id),
         ));
-    };
-    let leg_runtime = homogeneous_runtime.then_some(first.metadata().spec.runtime_type);
-    let open = open_prefills(leg_runtime);
+    }
+    let leg_runtime = homogeneous_runtime
+        .then(|| {
+            pairs.prefill.iter().enumerate().find_map(|(i, p)| {
+                let runtime = p.metadata().spec.runtime_type;
+                (eligible(p) && can_pair_on(i, Some(runtime))).then_some(runtime)
+            })
+        })
+        .flatten();
+    // One pass: the open prefills on the leg's runtime, counting the
+    // pairable ones the narrowing excluded so the exclusion leaves a trace.
+    let mut excluded = 0usize;
+    let open: Vec<usize> = (0..pairs.prefill.len())
+        .filter(|&i| {
+            let p = &pairs.prefill[i];
+            if !eligible(p) {
+                return false;
+            }
+            let own = p.metadata().spec.runtime_type;
+            if leg_runtime.is_some_and(|runtime| own != runtime) {
+                if can_pair_on(i, Some(own)) {
+                    excluded += 1;
+                }
+                return false;
+            }
+            can_pair_on(i, leg_runtime)
+        })
+        .collect();
+    if excluded > 0 {
+        warn!(
+            model_id,
+            ?leg_runtime,
+            excluded,
+            "Mixed runtime types in PD workers; pairable prefill workers on another runtime were excluded"
+        );
+    }
     if open.is_empty() {
         debug!(?leg_runtime, "No available PD pair");
         return Err(fail(
@@ -400,7 +428,7 @@ pub(crate) fn select_pair(
 
 #[cfg(test)]
 mod tests {
-    use openai_protocol::worker::HealthCheckConfig;
+    use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
     use super::*;
     use crate::{
@@ -522,6 +550,55 @@ mod tests {
             assert_eq!(pair.prefill.url(), "grpc://p:2");
             assert_eq!(pair.decode.url(), "grpc://d:2");
             assert_eq!(pair.runtime, RuntimeType::Vllm);
+        }
+    }
+
+    #[test]
+    fn a_pair_whose_partners_are_down_does_not_shut_out_a_healthy_pair_on_another_runtime() {
+        // One model served by a vLLM pair and an SGLang pair mid-migration.
+        // The vLLM decode goes down: the vLLM prefill, first in pool order,
+        // must not dictate the runtime, so the SGLang pair keeps serving.
+        let registry = registry_of(&[
+            (
+                "grpc://p:vllm",
+                WorkerType::Prefill,
+                ConnectionMode::Grpc,
+                RuntimeType::Vllm,
+            ),
+            (
+                "grpc://p:sglang",
+                WorkerType::Prefill,
+                ConnectionMode::Grpc,
+                RuntimeType::Sglang,
+            ),
+            (
+                "grpc://d:vllm",
+                WorkerType::Decode,
+                ConnectionMode::Grpc,
+                RuntimeType::Vllm,
+            ),
+            (
+                "grpc://d:sglang",
+                WorkerType::Decode,
+                ConnectionMode::Grpc,
+                RuntimeType::Sglang,
+            ),
+        ]);
+        let policies = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        let vllm_decode = registry
+            .get_all()
+            .into_iter()
+            .find(|w| w.url() == "grpc://d:vllm")
+            .expect("registered");
+        vllm_decode.set_status(WorkerStatus::NotReady);
+
+        for _ in 0..3 {
+            let pair = pair_from(&registry, &policies)
+                .ok()
+                .expect("the SGLang pair is healthy");
+            assert_eq!(pair.prefill.url(), "grpc://p:sglang");
+            assert_eq!(pair.decode.url(), "grpc://d:sglang");
+            assert_eq!(pair.runtime, RuntimeType::Sglang);
         }
     }
 

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -358,7 +358,9 @@ impl WorkerSelectionStage {
             };
             match verdict {
                 PlacementFailure::AllOverloaded(shed) => return shed,
-                PlacementFailure::Unavailable | PlacementFailure::PolicyDeclined(_) => {
+                PlacementFailure::Unavailable
+                | PlacementFailure::PolicyDeclined(_)
+                | PlacementFailure::NoCompatiblePair { .. } => {
                     unavailable = true;
                 }
                 PlacementFailure::NoCandidates => {}
@@ -403,6 +405,23 @@ impl WorkerSelectionStage {
             PlacementFailure::AllOverloaded(shed) => shed,
             PlacementFailure::Unavailable | PlacementFailure::PolicyDeclined(_) => {
                 self.workers_unavailable(model_id)
+            }
+            PlacementFailure::NoCompatiblePair { prefill, decode } => {
+                error!(
+                    function = "WorkerSelectionStage::execute",
+                    mode = ?self.mode,
+                    model_id = %model_id,
+                    ?prefill,
+                    ?decode,
+                    "No prefill/decode pair shares a KV transfer protocol"
+                );
+                error::service_unavailable(
+                    "no_compatible_pd_pair",
+                    format!(
+                        "No prefill/decode pair for model '{model_id}' shares a KV transfer \
+                         protocol (prefill: {prefill:?}, decode: {decode:?})"
+                    ),
+                )
             }
             PlacementFailure::NoCandidates => {
                 error!(

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -406,11 +406,16 @@ impl WorkerSelectionStage {
             PlacementFailure::Unavailable | PlacementFailure::PolicyDeclined(_) => {
                 self.workers_unavailable(model_id)
             }
-            PlacementFailure::NoCompatiblePair { prefill, decode } => {
+            PlacementFailure::NoCompatiblePair {
+                prefill,
+                decode,
+                mismatches,
+            } => {
                 error!(
                     function = "WorkerSelectionStage::execute",
                     mode = ?self.mode,
                     model_id = %model_id,
+                    ?mismatches,
                     ?prefill,
                     ?decode,
                     "No prefill/decode pair shares a KV transfer protocol"
@@ -419,7 +424,8 @@ impl WorkerSelectionStage {
                     "no_compatible_pd_pair",
                     format!(
                         "No prefill/decode pair for model '{model_id}' shares a KV transfer \
-                         protocol (prefill: {prefill:?}, decode: {decode:?})"
+                         protocol (mismatch on {mismatches:?}; prefill: {prefill:?}, decode: \
+                         {decode:?})"
                     ),
                 )
             }

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -14,7 +14,7 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     policies::{CacheNamespace, LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo, WorkerLeg},
     routers::{
-        common::placement::{self, PairCandidates, PairFailure, PlacementFailure, PlacementInputs},
+        common::placement::{self, PairFailure, PlacementFailure, PlacementInputs},
         error,
         grpc::{
             context::{
@@ -25,7 +25,7 @@ use crate::{
         },
     },
     worker::{
-        ConnectionModeExt, HashRing, ModelWorkerSnapshot, RoutingPool, RuntimeType, Worker,
+        ConnectionModeExt, HashRing, ModelWorkerSnapshot, PdWire, RoutingPool, RuntimeType, Worker,
         WorkerRegistry, WorkerType,
     },
 };
@@ -531,16 +531,12 @@ impl WorkerSelectionStage {
         // share a runtime, the rendezvous being runtime-specific, and a retry
         // pins both to the retained plan's runtime.
         let snapshot = self.worker_registry.get_routing_snapshot(model_id);
-        let prefill = snapshot.pool(RoutingPool::GrpcPrefill);
-        let decode = snapshot.pool(RoutingPool::GrpcDecode);
+        let pairs = snapshot.pd_pairs(PdWire::Grpc, self.policy_registry.pd_pairing_mode());
         let pair = placement::select_pair(
             &self.worker_registry,
             &self.policy_registry,
             model_id,
-            PairCandidates {
-                prefill: &prefill,
-                decode: &decode,
-            },
+            &pairs,
             wire,
             true,
             PlacementInputs {

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -42,7 +42,7 @@ use crate::{
                 KvConnectorMode, NIXL_PREFILL_KV_PARAMS,
             },
             overload,
-            placement::{self, PairCandidates, PairFailure, PlacementFailure, PlacementInputs},
+            placement::{self, PairFailure, PlacementFailure, PlacementInputs},
             request_lease::{ReleasePoint, RequestLease, RoutingDerivatives},
             retry::{is_retryable_response, RetryExecutor},
             serialize_json_sized,
@@ -54,7 +54,10 @@ use crate::{
         http::router::send_with_stale_conn_retry,
         RouterTrait,
     },
-    worker::{RoutingPool, RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry, UNKNOWN_MODEL_ID},
+    worker::{
+        PdPairIndex, PdWire, RoutingPool, RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry,
+        UNKNOWN_MODEL_ID,
+    },
 };
 
 /// Why PD pair selection produced nothing.
@@ -1321,40 +1324,34 @@ impl PDRouter {
         // and win when present; only an empty entry widens to every HTTP
         // prefill/decode worker ("auto" means pick any).
         let is_unknown_model = model_id == UNKNOWN_MODEL_ID;
-        let model_snapshot = self.worker_registry.model_routing_snapshot(model_id);
-        let global_snapshot =
-            is_unknown_model.then(|| self.worker_registry.get_routing_snapshot(UNKNOWN_MODEL_ID));
-
-        let prefill_workers = {
-            let by_model = match &model_snapshot {
-                Some(snapshot) => snapshot.pool(RoutingPool::HttpPrefill),
-                None => WorkerRegistry::empty_pool(),
-            };
-            match &global_snapshot {
-                Some(global) if by_model.is_empty() => global.pool(RoutingPool::HttpPrefill),
-                _ => by_model,
+        let mode = self.policy_registry.pd_pairing_mode();
+        let by_model = self
+            .worker_registry
+            .model_routing_snapshot(model_id)
+            .map(|snapshot| snapshot.pd_pairs(PdWire::Http, mode));
+        let pairs = match by_model {
+            // The literal "unknown" entry wins while it can pair; the
+            // wildcard widens to the global snapshot (both legs from one
+            // snapshot, a superset of the entry) only when a leg is empty.
+            Some(index)
+                if !is_unknown_model
+                    || (!index.prefill_pool.is_empty() && !index.decode_pool.is_empty()) =>
+            {
+                index
             }
-        };
-
-        let decode_workers = {
-            let by_model = match &model_snapshot {
-                Some(snapshot) => snapshot.pool(RoutingPool::HttpDecode),
-                None => WorkerRegistry::empty_pool(),
-            };
-            match &global_snapshot {
-                Some(global) if by_model.is_empty() => global.pool(RoutingPool::HttpDecode),
-                _ => by_model,
-            }
+            _ if is_unknown_model => self
+                .worker_registry
+                .get_routing_snapshot(UNKNOWN_MODEL_ID)
+                .pd_pairs(PdWire::Http, mode),
+            Some(index) => index,
+            None => Arc::new(PdPairIndex::empty()),
         };
 
         let pair = placement::select_pair(
             &self.worker_registry,
             &self.policy_registry,
             model_id,
-            PairCandidates {
-                prefill: &prefill_workers,
-                decode: &decode_workers,
-            },
+            &pairs,
             None,
             false,
             PlacementInputs {

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -71,6 +71,9 @@ enum PdSelectionFailure {
     /// The pre-existing string: no workers configured, all unhealthy or
     /// circuit-broken, or the policy declined.
     Unavailable(String),
+    /// Both legs are up, but no prefill shares a KV transfer protocol with
+    /// any decode (#2483).
+    Incompatible(String),
 }
 
 #[derive(Debug)]
@@ -207,6 +210,10 @@ impl PDRouter {
             // counter; re-describing it as a circuit-breaker/health failure is
             // exactly the misdiagnosis this path used to hand operators.
             PdSelectionFailure::Shed(shed) => shed,
+            PdSelectionFailure::Incompatible(error) => {
+                error!("Failed to select PD pair error={}", error);
+                error::service_unavailable("no_compatible_pd_pair", error)
+            }
             PdSelectionFailure::Unavailable(error) => {
                 error!("Failed to select PD pair error={}", error);
                 // Same code the regular HTTP router and the gRPC routers use
@@ -1382,6 +1389,12 @@ impl PDRouter {
             PlacementFailure::PolicyDeclined(policy) => PdSelectionFailure::Unavailable(
                 format!("Policy {policy} failed to select a {leg} worker"),
             ),
+            PlacementFailure::NoCompatiblePair { prefill, decode } => {
+                PdSelectionFailure::Incompatible(format!(
+                    "No prefill/decode pair shares a KV transfer protocol \
+                     (prefill: {prefill:?}, decode: {decode:?})"
+                ))
+            }
         }
     }
 
@@ -1776,6 +1789,9 @@ impl RouterTrait for PDRouter {
                 // broken one already did.
                 Err(failure) => match *failure {
                     PdSelectionFailure::Shed(shed) => return shed,
+                    PdSelectionFailure::Incompatible(e) => {
+                        return error::service_unavailable("no_compatible_pd_pair", e);
+                    }
                     PdSelectionFailure::Unavailable(e) => {
                         return error::service_unavailable(
                             "no_healthy_worker_pair",
@@ -2364,6 +2380,9 @@ mod tests {
                 assert!(error.contains("No prefill workers available"));
             }
             PdSelectionFailure::Shed(_) => panic!("an empty fleet is not an overload shed"),
+            PdSelectionFailure::Incompatible(_) => {
+                panic!("an empty fleet has no pairing to be incompatible about")
+            }
         }
     }
 

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1316,13 +1316,9 @@ impl PDRouter {
 
         // Shared HTTP-transport projections: this router proxies plain HTTP
         // to the selected worker's URL, so a gRPC or ZMQ worker must never
-        // be selectable. Both legs derive from ONE model snapshot (and, for
-        // the wildcard fallback, ONE global snapshot) — separate lookups
-        // could straddle a concurrent membership change and pair workers
-        // that never coexisted. The fallback stays conditional, matching the
-        // old code: untagged workers index under the literal "unknown" entry
-        // and win when present; only an empty entry widens to every HTTP
-        // prefill/decode worker ("auto" means pick any).
+        // be selectable. Both legs derive from ONE snapshot's pair index:
+        // separate lookups could straddle a concurrent membership change and
+        // pair workers that never coexisted.
         let is_unknown_model = model_id == UNKNOWN_MODEL_ID;
         let mode = self.policy_registry.pd_pairing_mode();
         let by_model = self
@@ -1330,21 +1326,18 @@ impl PDRouter {
             .model_routing_snapshot(model_id)
             .map(|snapshot| snapshot.pd_pairs(PdWire::Http, mode));
         let pairs = match by_model {
-            // The literal "unknown" entry wins while it can pair; the
-            // wildcard widens to the global snapshot (both legs from one
-            // snapshot, a superset of the entry) only when a leg is empty.
-            Some(index)
-                if !is_unknown_model
-                    || (!index.prefill_pool.is_empty() && !index.decode_pool.is_empty()) =>
-            {
-                index
-            }
+            // A named model routes within its own entry. The wildcard's
+            // literal "unknown" entry wins while it can pair at all; when it
+            // cannot (a leg empty, or no compatible pair) both legs widen
+            // together to the global snapshot, a superset of the entry. This
+            // widening is all-or-nothing per index, unlike the old per-leg
+            // widening, so the two legs always come from one snapshot.
+            Some(index) if !is_unknown_model || index.can_pair() => index,
             _ if is_unknown_model => self
                 .worker_registry
                 .get_routing_snapshot(UNKNOWN_MODEL_ID)
                 .pd_pairs(PdWire::Http, mode),
-            Some(index) => index,
-            None => Arc::new(PdPairIndex::empty()),
+            _ => Arc::new(PdPairIndex::empty()),
         };
 
         let pair = placement::select_pair(

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1389,12 +1389,14 @@ impl PDRouter {
             PlacementFailure::PolicyDeclined(policy) => PdSelectionFailure::Unavailable(
                 format!("Policy {policy} failed to select a {leg} worker"),
             ),
-            PlacementFailure::NoCompatiblePair { prefill, decode } => {
-                PdSelectionFailure::Incompatible(format!(
-                    "No prefill/decode pair shares a KV transfer protocol \
-                     (prefill: {prefill:?}, decode: {decode:?})"
-                ))
-            }
+            PlacementFailure::NoCompatiblePair {
+                prefill,
+                decode,
+                mismatches,
+            } => PdSelectionFailure::Incompatible(format!(
+                "No prefill/decode pair shares a KV transfer protocol (mismatch on \
+                 {mismatches:?}; prefill: {prefill:?}, decode: {decode:?})"
+            )),
         }
     }
 

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -515,12 +515,12 @@ impl Router {
                 ) {
                     PlacementFailure::NoCandidates => error::model_not_found(model_id),
                     PlacementFailure::AllOverloaded(shed) => shed,
-                    PlacementFailure::Unavailable | PlacementFailure::PolicyDeclined(_) => {
-                        error::service_unavailable(
-                            "no_available_workers",
-                            "All workers are unavailable (circuit breaker open or unhealthy)",
-                        )
-                    }
+                    PlacementFailure::Unavailable
+                    | PlacementFailure::PolicyDeclined(_)
+                    | PlacementFailure::NoCompatiblePair { .. } => error::service_unavailable(
+                        "no_available_workers",
+                        "All workers are unavailable (circuit breaker open or unhealthy)",
+                    ),
                 };
             }
         };
@@ -822,7 +822,8 @@ impl Router {
                 PlacementFailure::AllOverloaded(shed) => shed,
                 PlacementFailure::NoCandidates
                 | PlacementFailure::Unavailable
-                | PlacementFailure::PolicyDeclined(_) => {
+                | PlacementFailure::PolicyDeclined(_)
+                | PlacementFailure::NoCompatiblePair { .. } => {
                     // The verdict cannot tell a policy miss from a drained
                     // pool; the pool can.
                     let message = if non_dp_workers.iter().any(|w| w.is_available()) {

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -17,7 +17,10 @@ use super::{
         WorkerType,
     },
 };
-use crate::{observability::metrics::Metrics, routers::grpc::backend_client::BackendClient};
+use crate::{
+    observability::metrics::Metrics, routers::grpc::backend_client::BackendClient,
+    worker::pd_pairing::PdPairing,
+};
 
 /// Builder for creating BasicWorker instances with fluent API.
 ///
@@ -319,6 +322,7 @@ impl BasicWorkerBuilder {
 
         let metadata = WorkerMetadata {
             overload: OverloadThresholds::resolve(&self.spec.overload, self.overload_defaults),
+            pd_pairing: PdPairing::derive(&self.spec),
             spec: Arc::new(self.spec),
             health_config,
             health_endpoint: self.health_endpoint,

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -45,7 +45,7 @@ pub use openai_protocol::{
     worker::{ProviderType, WorkerGroupKey},
 };
 pub use overload::OverloadThresholds;
-pub use pd_pairing::{PairingMismatch, PdPairing};
+pub use pd_pairing::{PairingMismatch, PdPairing, PdPairingMode};
 pub(crate) use registry::{ModelWorkerSnapshot, RoutingPool};
 pub use registry::{WorkerOrigin, WorkerRegistry};
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -13,6 +13,7 @@ pub mod manager;
 pub mod metrics_aggregator;
 pub mod monitor;
 pub mod overload;
+pub mod pd_pairing;
 pub mod registry;
 pub mod resilience;
 pub mod sampling_defaults;
@@ -44,6 +45,7 @@ pub use openai_protocol::{
     worker::{ProviderType, WorkerGroupKey},
 };
 pub use overload::OverloadThresholds;
+pub use pd_pairing::{PairingMismatch, PdPairing};
 pub(crate) use registry::{ModelWorkerSnapshot, RoutingPool};
 pub use registry::{WorkerOrigin, WorkerRegistry};
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -13,6 +13,7 @@ pub mod manager;
 pub mod metrics_aggregator;
 pub mod monitor;
 pub mod overload;
+pub mod pd_pair_index;
 pub mod pd_pairing;
 pub mod registry;
 pub mod resilience;
@@ -45,6 +46,7 @@ pub use openai_protocol::{
     worker::{ProviderType, WorkerGroupKey},
 };
 pub use overload::OverloadThresholds;
+pub(crate) use pd_pair_index::{PdPairIndex, PdWire};
 pub use pd_pairing::{PairingMismatch, PdPairing, PdPairingMode};
 pub(crate) use registry::{ModelWorkerSnapshot, RoutingPool};
 pub use registry::{WorkerOrigin, WorkerRegistry};

--- a/model_gateway/src/worker/pd_pair_index.rs
+++ b/model_gateway/src/worker/pd_pair_index.rs
@@ -118,6 +118,12 @@ impl PdPairIndex {
         }
     }
 
+    /// Whether some prefill can pair at all: both legs have workers and at
+    /// least one pair is compatible. Availability is not consulted.
+    pub(crate) fn can_pair(&self) -> bool {
+        !self.prefill.is_empty()
+    }
+
     /// An index over two empty pools.
     pub(crate) fn empty() -> Self {
         Self::build(Arc::from([]), Arc::from([]), PdPairingMode::Off)

--- a/model_gateway/src/worker/pd_pair_index.rs
+++ b/model_gateway/src/worker/pd_pair_index.rs
@@ -1,0 +1,277 @@
+//! The compatible prefill/decode pairs of a membership snapshot (#2483).
+//!
+//! Pairing descriptors ([`super::pd_pairing`]) never change after a worker is
+//! built and membership changes rarely, so which decodes a prefill may pair
+//! with is decided once per snapshot, here, and shared by every request.
+//! Placement then reads a prefill's partner list instead of comparing
+//! descriptors on the request path.
+
+use std::sync::Arc;
+
+use super::{
+    pd_pairing::{PairingMismatch, PdPairing, PdPairingMode},
+    registry::RoutingPool,
+    Worker,
+};
+
+/// A shared, immutable list of workers, as the routing snapshot holds them.
+type Workers = Arc<[Arc<dyn Worker>]>;
+
+/// The wire a PD pair is drawn from: each has its own prefill and decode
+/// pools, since the rendezvous rides the transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PdWire {
+    Grpc,
+    Http,
+}
+
+impl PdWire {
+    pub(crate) const COUNT: usize = 2;
+
+    pub(crate) const fn index(self) -> usize {
+        match self {
+            Self::Grpc => 0,
+            Self::Http => 1,
+        }
+    }
+
+    /// The (prefill, decode) pools of this wire.
+    pub(crate) const fn pools(self) -> (RoutingPool, RoutingPool) {
+        match self {
+            Self::Grpc => (RoutingPool::GrpcPrefill, RoutingPool::GrpcDecode),
+            Self::Http => (RoutingPool::HttpPrefill, RoutingPool::HttpDecode),
+        }
+    }
+}
+
+/// Why no prefill in a snapshot can pair with any decode: each leg's distinct
+/// pairing keys and the components the legs disagreed on, sorted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PairingRefusal {
+    pub prefill: Vec<String>,
+    pub decode: Vec<String>,
+    pub mismatches: Vec<String>,
+}
+
+/// One wire's prefill and decode pools with, for every prefill that has at
+/// least one compatible decode, that prefill's partners.
+#[derive(Debug)]
+pub(crate) struct PdPairIndex {
+    /// The prefill pool as the snapshot holds it, for leg verdicts.
+    pub prefill_pool: Arc<[Arc<dyn Worker>]>,
+    /// The decode pool as the snapshot holds it, for leg verdicts.
+    pub decode_pool: Arc<[Arc<dyn Worker>]>,
+    /// Prefill workers with at least one compatible decode, in pool order.
+    pub prefill: Arc<[Arc<dyn Worker>]>,
+    /// Parallel to `prefill`: each worker's compatible decodes, in pool
+    /// order. Prefills with equal descriptors share one list.
+    pub partners: Vec<Arc<[Arc<dyn Worker>]>>,
+    /// Set when both pools have workers and no pair is compatible.
+    pub refusal: Option<PairingRefusal>,
+}
+
+impl PdPairIndex {
+    /// Pair every prefill with its compatible decodes under `mode`.
+    pub(crate) fn build(
+        prefill_pool: Arc<[Arc<dyn Worker>]>,
+        decode_pool: Arc<[Arc<dyn Worker>]>,
+        mode: PdPairingMode,
+    ) -> Self {
+        let mut by_descriptor: Vec<(&PdPairing, Workers)> = Vec::new();
+        let mut prefill: Vec<Arc<dyn Worker>> = Vec::new();
+        let mut partners: Vec<Workers> = Vec::new();
+        for worker in prefill_pool.iter() {
+            let descriptor = worker.pd_pairing();
+            let list = match by_descriptor.iter().find(|(d, _)| *d == descriptor) {
+                Some((_, list)) => Arc::clone(list),
+                None => {
+                    let list: Workers = if mode == PdPairingMode::Off {
+                        Arc::clone(&decode_pool)
+                    } else {
+                        decode_pool
+                            .iter()
+                            .filter(|d| descriptor.compatible(d.pd_pairing(), mode))
+                            .cloned()
+                            .collect()
+                    };
+                    by_descriptor.push((descriptor, Arc::clone(&list)));
+                    list
+                }
+            };
+            if !list.is_empty() {
+                prefill.push(Arc::clone(worker));
+                partners.push(list);
+            }
+        }
+        let refusal = (prefill.is_empty() && !prefill_pool.is_empty() && !decode_pool.is_empty())
+            .then(|| PairingRefusal {
+                prefill: pairing_keys(&prefill_pool),
+                decode: pairing_keys(&decode_pool),
+                mismatches: pairing_mismatches(&prefill_pool, &decode_pool, mode),
+            });
+        Self {
+            prefill_pool,
+            decode_pool,
+            prefill: prefill.into(),
+            partners,
+            refusal,
+        }
+    }
+
+    /// An index over two empty pools.
+    pub(crate) fn empty() -> Self {
+        Self::build(Arc::from([]), Arc::from([]), PdPairingMode::Off)
+    }
+}
+
+/// The distinct pairing keys of one leg, sorted.
+fn pairing_keys(leg: &[Arc<dyn Worker>]) -> Vec<String> {
+    let mut keys: Vec<String> = leg.iter().map(|w| w.pd_pairing().key()).collect();
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
+/// The distinct components on which the legs' descriptors disagree, sorted.
+fn pairing_mismatches(
+    prefill: &[Arc<dyn Worker>],
+    decode: &[Arc<dyn Worker>],
+    mode: PdPairingMode,
+) -> Vec<String> {
+    let mut mismatches: Vec<String> = prefill
+        .iter()
+        .flat_map(|p| {
+            decode
+                .iter()
+                .filter_map(move |d| p.pd_pairing().mismatch(d.pd_pairing(), mode))
+        })
+        .map(PairingMismatch::describe)
+        .collect();
+    mismatches.sort();
+    mismatches.dedup();
+    mismatches
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::worker::HealthCheckConfig;
+
+    use super::*;
+    use crate::worker::{BasicWorkerBuilder, ConnectionMode, ModelCard, RuntimeType, WorkerType};
+
+    fn worker(url: &str, worker_type: WorkerType, connector: Option<&str>) -> Arc<dyn Worker> {
+        let mut builder = BasicWorkerBuilder::new(url)
+            .model(ModelCard::new("m"))
+            .worker_type(worker_type)
+            .connection_mode(ConnectionMode::Grpc)
+            .runtime_type(RuntimeType::Vllm)
+            .health_config(HealthCheckConfig {
+                disable_health_check: true,
+                ..Default::default()
+            });
+        if let Some(connector) = connector {
+            builder = builder.kv_connector(connector);
+        }
+        Arc::new(builder.build())
+    }
+
+    fn urls(workers: &[Arc<dyn Worker>]) -> Vec<&str> {
+        workers.iter().map(|w| w.url()).collect()
+    }
+
+    #[test]
+    fn each_prefill_lists_the_decodes_it_can_hand_off_to() {
+        let prefill: Arc<[Arc<dyn Worker>]> = Arc::from([
+            worker("grpc://p:nixl", WorkerType::Prefill, Some("NixlConnector")),
+            worker(
+                "grpc://p:mooncake",
+                WorkerType::Prefill,
+                Some("MooncakeConnector"),
+            ),
+            worker("grpc://p:silent", WorkerType::Prefill, None),
+        ]);
+        let decode: Arc<[Arc<dyn Worker>]> = Arc::from([
+            worker("grpc://d:nixl", WorkerType::Decode, Some("NixlConnector")),
+            worker(
+                "grpc://d:mooncake",
+                WorkerType::Decode,
+                Some("MooncakeConnector"),
+            ),
+        ]);
+
+        let index = PdPairIndex::build(
+            Arc::clone(&prefill),
+            Arc::clone(&decode),
+            PdPairingMode::Lenient,
+        );
+        assert_eq!(
+            urls(&index.prefill),
+            ["grpc://p:nixl", "grpc://p:mooncake", "grpc://p:silent"]
+        );
+        assert_eq!(urls(&index.partners[0]), ["grpc://d:nixl"]);
+        assert_eq!(urls(&index.partners[1]), ["grpc://d:mooncake"]);
+        // An unknown transport pairs with either side under lenient mode.
+        assert_eq!(
+            urls(&index.partners[2]),
+            ["grpc://d:nixl", "grpc://d:mooncake"]
+        );
+        assert!(index.refusal.is_none());
+
+        // Strict mode drops the prefill that reports no transport.
+        let strict = PdPairIndex::build(
+            Arc::clone(&prefill),
+            Arc::clone(&decode),
+            PdPairingMode::Strict,
+        );
+        assert_eq!(
+            urls(&strict.prefill),
+            ["grpc://p:nixl", "grpc://p:mooncake"]
+        );
+
+        // Off pairs everything: every prefill shares the whole decode pool.
+        let off = PdPairIndex::build(prefill, Arc::clone(&decode), PdPairingMode::Off);
+        assert_eq!(off.prefill.len(), 3);
+        assert!(off.partners.iter().all(|list| Arc::ptr_eq(list, &decode)));
+    }
+
+    #[test]
+    fn prefills_with_one_descriptor_share_one_partner_list() {
+        let prefill: Arc<[Arc<dyn Worker>]> = Arc::from([
+            worker("grpc://p:1", WorkerType::Prefill, Some("NixlConnector")),
+            worker("grpc://p:2", WorkerType::Prefill, Some("NixlConnector")),
+        ]);
+        let decode: Arc<[Arc<dyn Worker>]> = Arc::from([worker(
+            "grpc://d:1",
+            WorkerType::Decode,
+            Some("NixlConnector"),
+        )]);
+        let index = PdPairIndex::build(prefill, decode, PdPairingMode::Lenient);
+        assert!(Arc::ptr_eq(&index.partners[0], &index.partners[1]));
+    }
+
+    #[test]
+    fn a_fleet_without_a_shared_transport_records_the_refusal() {
+        let prefill: Arc<[Arc<dyn Worker>]> = Arc::from([worker(
+            "grpc://p:1",
+            WorkerType::Prefill,
+            Some("NixlConnector"),
+        )]);
+        let decode: Arc<[Arc<dyn Worker>]> = Arc::from([worker(
+            "grpc://d:1",
+            WorkerType::Decode,
+            Some("MooncakeConnector"),
+        )]);
+        let index = PdPairIndex::build(prefill, decode, PdPairingMode::Lenient);
+        assert!(index.prefill.is_empty());
+        assert_eq!(
+            index.refusal,
+            Some(PairingRefusal {
+                prefill: vec!["vllm/nixl/?".to_string()],
+                decode: vec!["vllm/mooncake/?".to_string()],
+                mismatches: vec!["transport".to_string()],
+            })
+        );
+        // A leg with no workers at all is not a refusal.
+        assert!(PdPairIndex::empty().refusal.is_none());
+    }
+}

--- a/model_gateway/src/worker/pd_pairing.rs
+++ b/model_gateway/src/worker/pd_pairing.rs
@@ -1,18 +1,19 @@
 //! PD pairing descriptors: what a prefill and a decode must agree on for a
 //! KV handoff to work (#2483).
 //!
-//! A rendezvous only succeeds between two workers that share a transport
-//! (NIXL vs Mooncake) and a compatible KV layout, and normally an engine
-//! version. Each PD worker carries a [`PdPairing`] derived from the labels its
-//! engine reports at discovery, or from an explicit `pairing_protocol` the
-//! operator sets on the worker; placement pairs a prefill only with a decode
-//! whose descriptor is compatible. [`PdPairingMode::Lenient`] refuses only a
-//! known difference in transport or KV layout, so a fleet that reports
-//! nothing keeps working and a rolling engine upgrade keeps pairing;
-//! [`PdPairingMode::Strict`] also refuses unknown components and version
-//! differences; [`PdPairingMode::Off`] pairs on nothing.
+//! A rendezvous only succeeds between two workers of one runtime that share
+//! a KV transport (NIXL vs Mooncake) and a compatible KV layout, and normally
+//! an engine version. Each PD worker carries a [`PdPairing`] derived from the
+//! labels its engine reports at discovery, or from an explicit
+//! `pairing_protocol` the operator sets on the worker; placement pairs a
+//! prefill only with a decode whose descriptor is compatible.
+//! [`PdPairingMode::Lenient`] refuses only a known difference in runtime,
+//! transport or a KV layout fact, so a fleet that reports nothing keeps
+//! working and a rolling engine upgrade keeps pairing;
+//! [`PdPairingMode::Strict`] also refuses a component one side does not
+//! report and a version difference; [`PdPairingMode::Off`] pairs on nothing.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use openai_protocol::worker::{RuntimeType, WorkerSpec};
 
@@ -23,6 +24,16 @@ pub use crate::config::types::PdPairingMode;
 pub const PAIRING_PROTOCOL_LABEL: &str = "pairing_protocol";
 /// The Kubernetes annotation flattened into the same label.
 pub const PAIRING_PROTOCOL_ANNOTATION_LABEL: &str = "smg.ai/pairing-protocol";
+
+/// The KV layout facts engines report: the short name used in the pairing
+/// key, the canonical label, and alias labels (vLLM's `block_size` is the
+/// page size before canonicalisation).
+const LAYOUT_FACTS: [(&str, &str, &[&str]); 4] = [
+    ("dtype", "kv_cache_dtype", &[]),
+    ("page", "page_size", &["block_size"]),
+    ("attn", "attention_backend", &[]),
+    ("model", "model_dtype", &[]),
+];
 
 /// The component two descriptors disagree on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,10 +46,24 @@ pub enum PairingMismatch {
     Transport,
     /// Different engine versions (strict mode only).
     Version,
-    /// Different KV cache layouts (dtype, page size, attention backend).
-    KvLayout,
+    /// Both sides report the named KV layout fact and disagree.
+    KvLayout(&'static str),
     /// A component one side does not report, rejected under strict mode.
     Unknown(&'static str),
+}
+
+impl PairingMismatch {
+    /// The component, for logs and the placement failure.
+    pub fn describe(self) -> String {
+        match self {
+            Self::Runtime => "runtime".to_string(),
+            Self::Explicit => "pairing_protocol".to_string(),
+            Self::Transport => "transport".to_string(),
+            Self::Version => "version".to_string(),
+            Self::KvLayout(fact) => fact.to_string(),
+            Self::Unknown(component) => format!("unknown {component}"),
+        }
+    }
 }
 
 /// What one PD worker offers a rendezvous partner.
@@ -48,7 +73,8 @@ pub struct PdPairing {
     explicit: Option<String>,
     transport: Option<String>,
     version: Option<String>,
-    kv_layout: Option<String>,
+    /// The reported KV layout facts by short name (see `LAYOUT_FACTS`).
+    kv_layout: BTreeMap<&'static str, String>,
 }
 
 impl PdPairing {
@@ -86,19 +112,36 @@ impl PdPairing {
         self.transport.as_deref()
     }
 
-    /// One string that names the pairing group: the explicit protocol, else
-    /// `runtime/transport/version/layout` with `?` for an unknown component.
+    /// The engine version, when reported.
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
+    }
+
+    /// The group a worker pairs in: the explicit protocol, else
+    /// `runtime/transport/layout` with `?` for an unknown component. Version
+    /// is left out: it only counts under strict mode, and a rolling upgrade
+    /// would otherwise show two keys for workers that do pair.
     pub fn key(&self) -> String {
         if let Some(explicit) = &self.explicit {
             return explicit.clone();
         }
-        let part = |value: &Option<String>| value.as_deref().unwrap_or("?").to_string();
+        let layout: Vec<String> = LAYOUT_FACTS
+            .iter()
+            .filter_map(|(short, _, _)| {
+                self.kv_layout
+                    .get(short)
+                    .map(|value| format!("{short}={value}"))
+            })
+            .collect();
         format!(
-            "{}/{}/{}/{}",
+            "{}/{}/{}",
             self.runtime.as_str(),
-            part(&self.transport),
-            part(&self.version),
-            part(&self.kv_layout),
+            self.transport.as_deref().unwrap_or("?"),
+            if layout.is_empty() {
+                "?".to_string()
+            } else {
+                layout.join(",")
+            },
         )
     }
 
@@ -109,12 +152,13 @@ impl PdPairing {
 
     /// The first component the two descriptors disagree on, if any.
     ///
-    /// Runtime, transport and KV layout are hard facts: a known difference
-    /// refuses the pair in every mode but `Off`, an unknown one only under
-    /// `Strict`. Version is a soft fact: engines report it unevenly (vLLM's
-    /// gRPC server info carries none) and a rolling upgrade legitimately
-    /// mixes versions, so it counts only under `Strict`, and only when both
-    /// sides report one.
+    /// Runtime, transport and each KV layout fact are hard facts: a known
+    /// difference refuses the pair in every mode but `Off`, a fact one side
+    /// reports and the other does not only under `Strict`, and a layout fact
+    /// neither side reports is not compared. Version is a soft fact: engines
+    /// report it unevenly (vLLM's gRPC server info carries none) and a
+    /// rolling upgrade legitimately mixes versions, so it counts only under
+    /// `Strict`, and only when both sides report one.
     pub fn mismatch(&self, other: &Self, mode: PdPairingMode) -> Option<PairingMismatch> {
         if mode == PdPairingMode::Off {
             return None;
@@ -130,33 +174,34 @@ impl PdPairing {
             (mine, theirs) if mine != theirs => return Some(PairingMismatch::Runtime),
             _ => {}
         }
-        // An explicit protocol is the operator's assertion: it is compared
-        // whole and nothing derived is consulted.
+        // Two explicit protocols are the operators' assertion, compared
+        // whole. One explicit protocol cannot be checked against derived
+        // facts: strict refuses, lenient falls through to the facts rather
+        // than pairing blindly.
         match (&self.explicit, &other.explicit) {
             (Some(a), Some(b)) => return (a != b).then_some(PairingMismatch::Explicit),
             (None, None) => {}
-            _ => return unknown("pairing_protocol"),
+            _ => {
+                if let Some(mismatch) = unknown("pairing_protocol") {
+                    return Some(mismatch);
+                }
+            }
         }
-        let hard_facts = [
-            (
-                "transport",
-                &self.transport,
-                &other.transport,
-                PairingMismatch::Transport,
-            ),
-            (
-                "kv_layout",
-                &self.kv_layout,
-                &other.kv_layout,
-                PairingMismatch::KvLayout,
-            ),
-        ];
-        for (name, mine, theirs, mismatch) in hard_facts {
-            match (mine, theirs) {
-                (Some(a), Some(b)) if a != b => return Some(mismatch),
-                (Some(_), Some(_)) => {}
+        match (&self.transport, &other.transport) {
+            (Some(a), Some(b)) if a != b => return Some(PairingMismatch::Transport),
+            (Some(_), Some(_)) => {}
+            _ => {
+                if let Some(mismatch) = unknown("transport") {
+                    return Some(mismatch);
+                }
+            }
+        }
+        for (short, label, _) in LAYOUT_FACTS {
+            match (self.kv_layout.get(short), other.kv_layout.get(short)) {
+                (Some(a), Some(b)) if a != b => return Some(PairingMismatch::KvLayout(label)),
+                (Some(_), Some(_)) | (None, None) => {}
                 _ => {
-                    if let Some(mismatch) = unknown(name) {
+                    if let Some(mismatch) = unknown(label) {
                         return Some(mismatch);
                     }
                 }
@@ -220,25 +265,18 @@ fn normalise_connector(connector: &str) -> String {
     }
 }
 
-/// The KV layout facts the engines report: cache dtype, page or block size,
-/// attention backend, model dtype. `None` when the worker reports none of
-/// them.
-fn kv_layout_of(labels: &HashMap<String, String>) -> Option<String> {
-    const FACTS: [(&str, &str); 5] = [
-        ("kv_cache_dtype", "dtype"),
-        ("page_size", "page"),
-        ("block_size", "page"),
-        ("attention_backend", "attn"),
-        ("model_dtype", "model"),
-    ];
-    let parts: Vec<String> = FACTS
+/// The KV layout facts the engine reports, by short name; a fact the labels
+/// do not carry is absent.
+fn kv_layout_of(labels: &HashMap<String, String>) -> BTreeMap<&'static str, String> {
+    LAYOUT_FACTS
         .iter()
-        .filter_map(|(label, short)| {
-            non_empty(labels.get(*label))
-                .map(|value| format!("{short}={}", value.to_ascii_lowercase()))
+        .filter_map(|(short, label, aliases)| {
+            std::iter::once(label)
+                .chain(aliases.iter())
+                .find_map(|name| non_empty(labels.get(*name)))
+                .map(|value| (*short, value.to_ascii_lowercase()))
         })
-        .collect();
-    (!parts.is_empty()).then(|| parts.join(","))
+        .collect()
 }
 
 #[cfg(test)]
@@ -270,9 +308,10 @@ mod tests {
         s.kv_connector = Some("NixlConnector".to_string());
         let pairing = PdPairing::derive(&s);
         assert_eq!(pairing.transport(), Some("nixl"));
+        assert_eq!(pairing.version(), Some("0.27.1"));
         assert_eq!(
             pairing.key(),
-            "vllm/nixl/0.27.1/dtype=auto,page=16,attn=flash_attn,model=torch.bfloat16"
+            "vllm/nixl/dtype=auto,page=16,attn=flash_attn,model=torch.bfloat16"
         );
         // The connector may also arrive as a discovered label.
         let s = spec(
@@ -292,15 +331,12 @@ mod tests {
                 ("page_size", "64"),
             ],
         );
-        assert_eq!(
-            PdPairing::derive(&sglang).key(),
-            "sglang/nixl/0.5.18/page=64"
-        );
+        assert_eq!(PdPairing::derive(&sglang).key(), "sglang/nixl/page=64");
         // TokenSpeed has only Mooncake, so an unreported backend is Mooncake.
         let tokenspeed = spec(RuntimeType::TokenSpeed, &[("version", "0.3.0")]);
         assert_eq!(
             PdPairing::derive(&tokenspeed).key(),
-            "tokenspeed/mooncake/0.3.0/?"
+            "tokenspeed/mooncake/?"
         );
     }
 
@@ -361,19 +397,42 @@ mod tests {
                 ("kv_cache_dtype", "fp8_e5m2"),
             ],
         ));
-        let auto = PdPairing::derive(&spec(
-            RuntimeType::Sglang,
+        assert_eq!(
+            fp8.mismatch(&nixl, PdPairingMode::Lenient),
+            Some(PairingMismatch::KvLayout("kv_cache_dtype"))
+        );
+        assert_eq!(
+            fp8.mismatch(&nixl, PdPairingMode::Strict),
+            Some(PairingMismatch::KvLayout("kv_cache_dtype"))
+        );
+        assert!(nixl.compatible(&nixl.clone(), PdPairingMode::Strict));
+    }
+
+    #[test]
+    fn a_layout_fact_one_side_omits_is_unknown_and_one_neither_reports_is_not_a_fact() {
+        let requested = PdPairing::derive(&spec(
+            RuntimeType::Vllm,
             &[
-                ("disaggregation_transfer_backend", "nixl"),
-                ("version", "1"),
+                ("kv_connector", "NixlConnector"),
+                ("kv_cache_dtype", "auto"),
+                ("attention_backend", "FLASH_ATTN"),
+            ],
+        ));
+        // The auto path reports no attention backend.
+        let auto = PdPairing::derive(&spec(
+            RuntimeType::Vllm,
+            &[
+                ("kv_connector", "NixlConnector"),
                 ("kv_cache_dtype", "auto"),
             ],
         ));
+        assert!(requested.compatible(&auto, PdPairingMode::Lenient));
         assert_eq!(
-            fp8.mismatch(&auto, PdPairingMode::Strict),
-            Some(PairingMismatch::KvLayout)
+            requested.mismatch(&auto, PdPairingMode::Strict),
+            Some(PairingMismatch::Unknown("attention_backend"))
         );
-        assert!(nixl.compatible(&nixl.clone(), PdPairingMode::Strict));
+        // Neither side reports the backend: nothing to compare, even strictly.
+        assert!(auto.compatible(&auto.clone(), PdPairingMode::Strict));
     }
 
     #[test]
@@ -388,8 +447,8 @@ mod tests {
             known.mismatch(&silent, PdPairingMode::Strict),
             Some(PairingMismatch::Unknown("transport"))
         );
-        // Explicit on one side only: the operator's assertion cannot be
-        // checked against a derived descriptor.
+        // Explicit on one side only: strict refuses, lenient still compares
+        // the derived facts, so a known transport difference is refused.
         let mut asserted = spec(RuntimeType::Vllm, &[("kv_connector", "NixlConnector")]);
         asserted.pairing_protocol = Some("blue".to_string());
         let asserted = PdPairing::derive(&asserted);
@@ -397,6 +456,14 @@ mod tests {
         assert_eq!(
             asserted.mismatch(&known, PdPairingMode::Strict),
             Some(PairingMismatch::Unknown("pairing_protocol"))
+        );
+        let mooncake = PdPairing::derive(&spec(
+            RuntimeType::Vllm,
+            &[("kv_connector", "MooncakeConnector")],
+        ));
+        assert_eq!(
+            asserted.mismatch(&mooncake, PdPairingMode::Lenient),
+            Some(PairingMismatch::Transport)
         );
         let other = PdPairing::derive(&{
             let mut s = spec(RuntimeType::Vllm, &[]);
@@ -442,5 +509,18 @@ mod tests {
             Some(PairingMismatch::Runtime)
         );
         assert!(nixl.compatible(&mooncake, PdPairingMode::Off));
+    }
+
+    #[test]
+    fn a_mismatch_describes_its_component() {
+        assert_eq!(PairingMismatch::Transport.describe(), "transport");
+        assert_eq!(
+            PairingMismatch::KvLayout("page_size").describe(),
+            "page_size"
+        );
+        assert_eq!(
+            PairingMismatch::Unknown("attention_backend").describe(),
+            "unknown attention_backend"
+        );
     }
 }

--- a/model_gateway/src/worker/pd_pairing.rs
+++ b/model_gateway/src/worker/pd_pairing.rs
@@ -2,13 +2,15 @@
 //! KV handoff to work (#2483).
 //!
 //! A rendezvous only succeeds between two workers that share a transport
-//! (NIXL vs Mooncake), a compatible engine version and a compatible KV
-//! layout. Each PD worker carries a [`PdPairing`] derived from the labels its
+//! (NIXL vs Mooncake) and a compatible KV layout, and normally an engine
+//! version. Each PD worker carries a [`PdPairing`] derived from the labels its
 //! engine reports at discovery, or from an explicit `pairing_protocol` the
 //! operator sets on the worker; placement pairs a prefill only with a decode
-//! whose descriptor is compatible. [`PdPairingMode::Lenient`] lets an
-//! unknown component pair with anything, so a fleet that reports nothing keeps
-//! working; [`PdPairingMode::Strict`] treats unknown as a mismatch.
+//! whose descriptor is compatible. [`PdPairingMode::Lenient`] refuses only a
+//! known difference in transport or KV layout, so a fleet that reports
+//! nothing keeps working and a rolling engine upgrade keeps pairing;
+//! [`PdPairingMode::Strict`] also refuses unknown components and version
+//! differences; [`PdPairingMode::Off`] pairs on nothing.
 
 use std::collections::HashMap;
 
@@ -31,7 +33,7 @@ pub enum PairingMismatch {
     Explicit,
     /// Different KV transports (NIXL vs Mooncake).
     Transport,
-    /// Different engine versions.
+    /// Different engine versions (strict mode only).
     Version,
     /// Different KV cache layouts (dtype, page size, attention backend).
     KvLayout,
@@ -106,32 +108,41 @@ impl PdPairing {
     }
 
     /// The first component the two descriptors disagree on, if any.
+    ///
+    /// Runtime, transport and KV layout are hard facts: a known difference
+    /// refuses the pair in every mode but `Off`, an unknown one only under
+    /// `Strict`. Version is a soft fact: engines report it unevenly (vLLM's
+    /// gRPC server info carries none) and a rolling upgrade legitimately
+    /// mixes versions, so it counts only under `Strict`, and only when both
+    /// sides report one.
     pub fn mismatch(&self, other: &Self, mode: PdPairingMode) -> Option<PairingMismatch> {
-        if self.runtime != other.runtime {
-            return Some(PairingMismatch::Runtime);
+        if mode == PdPairingMode::Off {
+            return None;
+        }
+        let strict = mode == PdPairingMode::Strict;
+        let unknown = |name: &'static str| strict.then_some(PairingMismatch::Unknown(name));
+        match (self.runtime, other.runtime) {
+            (RuntimeType::Unspecified, _) | (_, RuntimeType::Unspecified) => {
+                if let Some(mismatch) = unknown("runtime") {
+                    return Some(mismatch);
+                }
+            }
+            (mine, theirs) if mine != theirs => return Some(PairingMismatch::Runtime),
+            _ => {}
         }
         // An explicit protocol is the operator's assertion: it is compared
         // whole and nothing derived is consulted.
         match (&self.explicit, &other.explicit) {
             (Some(a), Some(b)) => return (a != b).then_some(PairingMismatch::Explicit),
             (None, None) => {}
-            _ => {
-                return (mode == PdPairingMode::Strict)
-                    .then_some(PairingMismatch::Unknown("pairing_protocol"))
-            }
+            _ => return unknown("pairing_protocol"),
         }
-        let components = [
+        let hard_facts = [
             (
                 "transport",
                 &self.transport,
                 &other.transport,
                 PairingMismatch::Transport,
-            ),
-            (
-                "version",
-                &self.version,
-                &other.version,
-                PairingMismatch::Version,
             ),
             (
                 "kv_layout",
@@ -140,14 +151,21 @@ impl PdPairing {
                 PairingMismatch::KvLayout,
             ),
         ];
-        for (name, mine, theirs, mismatch) in components {
+        for (name, mine, theirs, mismatch) in hard_facts {
             match (mine, theirs) {
                 (Some(a), Some(b)) if a != b => return Some(mismatch),
                 (Some(_), Some(_)) => {}
                 _ => {
-                    if mode == PdPairingMode::Strict {
-                        return Some(PairingMismatch::Unknown(name));
+                    if let Some(mismatch) = unknown(name) {
+                        return Some(mismatch);
                     }
+                }
+            }
+        }
+        if strict {
+            if let (Some(mine), Some(theirs)) = (&self.version, &other.version) {
+                if mine != theirs {
+                    return Some(PairingMismatch::Version);
                 }
             }
         }
@@ -305,6 +323,7 @@ mod tests {
             &[
                 ("disaggregation_transfer_backend", "nixl"),
                 ("version", "1"),
+                ("kv_cache_dtype", "auto"),
             ],
         ));
         let mooncake = PdPairing::derive(&spec(
@@ -312,6 +331,7 @@ mod tests {
             &[
                 ("disaggregation_transfer_backend", "mooncake"),
                 ("version", "1"),
+                ("kv_cache_dtype", "auto"),
             ],
         ));
         assert_eq!(
@@ -323,10 +343,14 @@ mod tests {
             &[
                 ("disaggregation_transfer_backend", "nixl"),
                 ("version", "0"),
+                ("kv_cache_dtype", "auto"),
             ],
         ));
+        // A version difference is tolerated leniently (rolling upgrades) and
+        // refused strictly.
+        assert!(nixl.compatible(&older, PdPairingMode::Lenient));
         assert_eq!(
-            nixl.mismatch(&older, PdPairingMode::Lenient),
+            nixl.mismatch(&older, PdPairingMode::Strict),
             Some(PairingMismatch::Version)
         );
         let fp8 = PdPairing::derive(&spec(
@@ -349,8 +373,7 @@ mod tests {
             fp8.mismatch(&auto, PdPairingMode::Strict),
             Some(PairingMismatch::KvLayout)
         );
-        assert!(nixl.compatible(&nixl.clone(), PdPairingMode::Lenient));
-        assert!(fp8.compatible(&fp8.clone(), PdPairingMode::Strict));
+        assert!(nixl.compatible(&nixl.clone(), PdPairingMode::Strict));
     }
 
     #[test]
@@ -387,12 +410,37 @@ mod tests {
     }
 
     #[test]
-    fn different_runtimes_never_pair() {
+    fn different_runtimes_never_pair_but_an_undetected_one_is_unknown() {
         let sglang = PdPairing::derive(&spec(RuntimeType::Sglang, &[]));
         let vllm = PdPairing::derive(&spec(RuntimeType::Vllm, &[]));
         assert_eq!(
             sglang.mismatch(&vllm, PdPairingMode::Lenient),
             Some(PairingMismatch::Runtime)
         );
+        // A worker whose runtime probe failed has an unknown runtime, not a
+        // different one.
+        let undetected = PdPairing::derive(&spec(RuntimeType::Unspecified, &[]));
+        assert!(vllm.compatible(&undetected, PdPairingMode::Lenient));
+        assert_eq!(
+            vllm.mismatch(&undetected, PdPairingMode::Strict),
+            Some(PairingMismatch::Unknown("runtime"))
+        );
+    }
+
+    #[test]
+    fn off_pairs_anything() {
+        let nixl = PdPairing::derive(&spec(
+            RuntimeType::Sglang,
+            &[("disaggregation_transfer_backend", "nixl")],
+        ));
+        let mooncake = PdPairing::derive(&spec(
+            RuntimeType::Vllm,
+            &[("kv_connector", "MooncakeConnector")],
+        ));
+        assert_eq!(
+            nixl.mismatch(&mooncake, PdPairingMode::Lenient),
+            Some(PairingMismatch::Runtime)
+        );
+        assert!(nixl.compatible(&mooncake, PdPairingMode::Off));
     }
 }

--- a/model_gateway/src/worker/pd_pairing.rs
+++ b/model_gateway/src/worker/pd_pairing.rs
@@ -1,0 +1,398 @@
+//! PD pairing descriptors: what a prefill and a decode must agree on for a
+//! KV handoff to work (#2483).
+//!
+//! A rendezvous only succeeds between two workers that share a transport
+//! (NIXL vs Mooncake), a compatible engine version and a compatible KV
+//! layout. Each PD worker carries a [`PdPairing`] derived from the labels its
+//! engine reports at discovery, or from an explicit `pairing_protocol` the
+//! operator sets on the worker; placement pairs a prefill only with a decode
+//! whose descriptor is compatible. [`PdPairingMode::Lenient`] lets an
+//! unknown component pair with anything, so a fleet that reports nothing keeps
+//! working; [`PdPairingMode::Strict`] treats unknown as a mismatch.
+
+use std::collections::HashMap;
+
+use openai_protocol::worker::{RuntimeType, WorkerSpec};
+
+pub use crate::config::types::PdPairingMode;
+
+/// Label under which an operator may set the pairing protocol explicitly,
+/// alongside the `pairing_protocol` field on the worker spec.
+pub const PAIRING_PROTOCOL_LABEL: &str = "pairing_protocol";
+/// The Kubernetes annotation flattened into the same label.
+pub const PAIRING_PROTOCOL_ANNOTATION_LABEL: &str = "smg.ai/pairing-protocol";
+
+/// The component two descriptors disagree on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairingMismatch {
+    /// Different runtimes never pair.
+    Runtime,
+    /// Both sides set an explicit protocol and they differ.
+    Explicit,
+    /// Different KV transports (NIXL vs Mooncake).
+    Transport,
+    /// Different engine versions.
+    Version,
+    /// Different KV cache layouts (dtype, page size, attention backend).
+    KvLayout,
+    /// A component one side does not report, rejected under strict mode.
+    Unknown(&'static str),
+}
+
+/// What one PD worker offers a rendezvous partner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PdPairing {
+    runtime: RuntimeType,
+    explicit: Option<String>,
+    transport: Option<String>,
+    version: Option<String>,
+    kv_layout: Option<String>,
+}
+
+impl PdPairing {
+    /// Derive the descriptor from a worker's spec and discovered labels.
+    pub fn derive(spec: &WorkerSpec) -> Self {
+        let labels = &spec.labels;
+        let explicit = spec
+            .pairing_protocol
+            .as_deref()
+            .or_else(|| labels.get(PAIRING_PROTOCOL_LABEL).map(String::as_str))
+            .or_else(|| {
+                labels
+                    .get(PAIRING_PROTOCOL_ANNOTATION_LABEL)
+                    .map(String::as_str)
+            })
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        Self {
+            runtime: spec.runtime_type,
+            explicit,
+            transport: transport_of(spec),
+            version: non_empty(labels.get("version")),
+            kv_layout: kv_layout_of(labels),
+        }
+    }
+
+    /// The operator-set protocol, when there is one.
+    pub fn explicit(&self) -> Option<&str> {
+        self.explicit.as_deref()
+    }
+
+    /// The KV transport, when known.
+    pub fn transport(&self) -> Option<&str> {
+        self.transport.as_deref()
+    }
+
+    /// One string that names the pairing group: the explicit protocol, else
+    /// `runtime/transport/version/layout` with `?` for an unknown component.
+    pub fn key(&self) -> String {
+        if let Some(explicit) = &self.explicit {
+            return explicit.clone();
+        }
+        let part = |value: &Option<String>| value.as_deref().unwrap_or("?").to_string();
+        format!(
+            "{}/{}/{}/{}",
+            self.runtime.as_str(),
+            part(&self.transport),
+            part(&self.version),
+            part(&self.kv_layout),
+        )
+    }
+
+    /// Whether the two workers may form a PD pair under `mode`.
+    pub fn compatible(&self, other: &Self, mode: PdPairingMode) -> bool {
+        self.mismatch(other, mode).is_none()
+    }
+
+    /// The first component the two descriptors disagree on, if any.
+    pub fn mismatch(&self, other: &Self, mode: PdPairingMode) -> Option<PairingMismatch> {
+        if self.runtime != other.runtime {
+            return Some(PairingMismatch::Runtime);
+        }
+        // An explicit protocol is the operator's assertion: it is compared
+        // whole and nothing derived is consulted.
+        match (&self.explicit, &other.explicit) {
+            (Some(a), Some(b)) => return (a != b).then_some(PairingMismatch::Explicit),
+            (None, None) => {}
+            _ => {
+                return (mode == PdPairingMode::Strict)
+                    .then_some(PairingMismatch::Unknown("pairing_protocol"))
+            }
+        }
+        let components = [
+            (
+                "transport",
+                &self.transport,
+                &other.transport,
+                PairingMismatch::Transport,
+            ),
+            (
+                "version",
+                &self.version,
+                &other.version,
+                PairingMismatch::Version,
+            ),
+            (
+                "kv_layout",
+                &self.kv_layout,
+                &other.kv_layout,
+                PairingMismatch::KvLayout,
+            ),
+        ];
+        for (name, mine, theirs, mismatch) in components {
+            match (mine, theirs) {
+                (Some(a), Some(b)) if a != b => return Some(mismatch),
+                (Some(_), Some(_)) => {}
+                _ => {
+                    if mode == PdPairingMode::Strict {
+                        return Some(PairingMismatch::Unknown(name));
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+fn non_empty(value: Option<&String>) -> Option<String> {
+    value
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// The KV transport by runtime: vLLM names a connector, SGLang a transfer
+/// backend, TokenSpeed has only Mooncake.
+fn transport_of(spec: &WorkerSpec) -> Option<String> {
+    let labels = &spec.labels;
+    match spec.runtime_type {
+        RuntimeType::Vllm => spec
+            .kv_connector
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .or_else(|| non_empty(labels.get("kv_connector")))
+            .map(|connector| normalise_connector(&connector)),
+        RuntimeType::Sglang => {
+            non_empty(labels.get("disaggregation_transfer_backend")).map(|s| s.to_ascii_lowercase())
+        }
+        RuntimeType::TokenSpeed => Some(
+            non_empty(labels.get("disaggregation_transfer_backend"))
+                .map_or_else(|| "mooncake".to_string(), |s| s.to_ascii_lowercase()),
+        ),
+        RuntimeType::Trtllm
+        | RuntimeType::Mlx
+        | RuntimeType::Generic
+        | RuntimeType::External
+        | RuntimeType::Unspecified => None,
+    }
+}
+
+/// `NixlConnector` / `MooncakeConnector` (and their store variants) fold to
+/// the transport name; anything else is kept lower-cased.
+fn normalise_connector(connector: &str) -> String {
+    let lower = connector.to_ascii_lowercase();
+    if lower.contains("nixl") {
+        "nixl".to_string()
+    } else if lower.contains("mooncake") {
+        "mooncake".to_string()
+    } else {
+        lower
+    }
+}
+
+/// The KV layout facts the engines report: cache dtype, page or block size,
+/// attention backend, model dtype. `None` when the worker reports none of
+/// them.
+fn kv_layout_of(labels: &HashMap<String, String>) -> Option<String> {
+    const FACTS: [(&str, &str); 5] = [
+        ("kv_cache_dtype", "dtype"),
+        ("page_size", "page"),
+        ("block_size", "page"),
+        ("attention_backend", "attn"),
+        ("model_dtype", "model"),
+    ];
+    let parts: Vec<String> = FACTS
+        .iter()
+        .filter_map(|(label, short)| {
+            non_empty(labels.get(*label))
+                .map(|value| format!("{short}={}", value.to_ascii_lowercase()))
+        })
+        .collect();
+    (!parts.is_empty()).then(|| parts.join(","))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(runtime: RuntimeType, labels: &[(&str, &str)]) -> WorkerSpec {
+        let mut spec = WorkerSpec::new("grpc://w:1");
+        spec.runtime_type = runtime;
+        spec.labels = labels
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        spec
+    }
+
+    #[test]
+    fn vllm_derives_transport_from_the_connector_and_layout_from_the_labels() {
+        let mut s = spec(
+            RuntimeType::Vllm,
+            &[
+                ("version", "0.27.1"),
+                ("kv_cache_dtype", "auto"),
+                ("block_size", "16"),
+                ("attention_backend", "FLASH_ATTN"),
+                ("model_dtype", "torch.bfloat16"),
+            ],
+        );
+        s.kv_connector = Some("NixlConnector".to_string());
+        let pairing = PdPairing::derive(&s);
+        assert_eq!(pairing.transport(), Some("nixl"));
+        assert_eq!(
+            pairing.key(),
+            "vllm/nixl/0.27.1/dtype=auto,page=16,attn=flash_attn,model=torch.bfloat16"
+        );
+        // The connector may also arrive as a discovered label.
+        let s = spec(
+            RuntimeType::Vllm,
+            &[("kv_connector", "MooncakeStoreConnector")],
+        );
+        assert_eq!(PdPairing::derive(&s).transport(), Some("mooncake"));
+    }
+
+    #[test]
+    fn sglang_and_tokenspeed_derive_transport_from_the_transfer_backend() {
+        let sglang = spec(
+            RuntimeType::Sglang,
+            &[
+                ("disaggregation_transfer_backend", "nixl"),
+                ("version", "0.5.18"),
+                ("page_size", "64"),
+            ],
+        );
+        assert_eq!(
+            PdPairing::derive(&sglang).key(),
+            "sglang/nixl/0.5.18/page=64"
+        );
+        // TokenSpeed has only Mooncake, so an unreported backend is Mooncake.
+        let tokenspeed = spec(RuntimeType::TokenSpeed, &[("version", "0.3.0")]);
+        assert_eq!(
+            PdPairing::derive(&tokenspeed).key(),
+            "tokenspeed/mooncake/0.3.0/?"
+        );
+    }
+
+    #[test]
+    fn an_explicit_protocol_is_the_whole_key() {
+        let mut s = spec(RuntimeType::Vllm, &[("version", "0.27.1")]);
+        s.pairing_protocol = Some("blue".to_string());
+        assert_eq!(PdPairing::derive(&s).key(), "blue");
+        let labelled = spec(
+            RuntimeType::Vllm,
+            &[("smg.ai/pairing-protocol", "green"), ("version", "0.1.0")],
+        );
+        assert_eq!(PdPairing::derive(&labelled).key(), "green");
+    }
+
+    #[test]
+    fn transports_versions_and_layouts_must_match_when_both_are_known() {
+        let nixl = PdPairing::derive(&spec(
+            RuntimeType::Sglang,
+            &[
+                ("disaggregation_transfer_backend", "nixl"),
+                ("version", "1"),
+            ],
+        ));
+        let mooncake = PdPairing::derive(&spec(
+            RuntimeType::Sglang,
+            &[
+                ("disaggregation_transfer_backend", "mooncake"),
+                ("version", "1"),
+            ],
+        ));
+        assert_eq!(
+            nixl.mismatch(&mooncake, PdPairingMode::Lenient),
+            Some(PairingMismatch::Transport)
+        );
+        let older = PdPairing::derive(&spec(
+            RuntimeType::Sglang,
+            &[
+                ("disaggregation_transfer_backend", "nixl"),
+                ("version", "0"),
+            ],
+        ));
+        assert_eq!(
+            nixl.mismatch(&older, PdPairingMode::Lenient),
+            Some(PairingMismatch::Version)
+        );
+        let fp8 = PdPairing::derive(&spec(
+            RuntimeType::Sglang,
+            &[
+                ("disaggregation_transfer_backend", "nixl"),
+                ("version", "1"),
+                ("kv_cache_dtype", "fp8_e5m2"),
+            ],
+        ));
+        let auto = PdPairing::derive(&spec(
+            RuntimeType::Sglang,
+            &[
+                ("disaggregation_transfer_backend", "nixl"),
+                ("version", "1"),
+                ("kv_cache_dtype", "auto"),
+            ],
+        ));
+        assert_eq!(
+            fp8.mismatch(&auto, PdPairingMode::Strict),
+            Some(PairingMismatch::KvLayout)
+        );
+        assert!(nixl.compatible(&nixl.clone(), PdPairingMode::Lenient));
+        assert!(fp8.compatible(&fp8.clone(), PdPairingMode::Strict));
+    }
+
+    #[test]
+    fn unknown_components_pair_leniently_and_fail_strictly() {
+        let known = PdPairing::derive(&spec(
+            RuntimeType::Vllm,
+            &[("kv_connector", "NixlConnector"), ("version", "0.27.1")],
+        ));
+        let silent = PdPairing::derive(&spec(RuntimeType::Vllm, &[]));
+        assert!(known.compatible(&silent, PdPairingMode::Lenient));
+        assert_eq!(
+            known.mismatch(&silent, PdPairingMode::Strict),
+            Some(PairingMismatch::Unknown("transport"))
+        );
+        // Explicit on one side only: the operator's assertion cannot be
+        // checked against a derived descriptor.
+        let mut asserted = spec(RuntimeType::Vllm, &[("kv_connector", "NixlConnector")]);
+        asserted.pairing_protocol = Some("blue".to_string());
+        let asserted = PdPairing::derive(&asserted);
+        assert!(asserted.compatible(&known, PdPairingMode::Lenient));
+        assert_eq!(
+            asserted.mismatch(&known, PdPairingMode::Strict),
+            Some(PairingMismatch::Unknown("pairing_protocol"))
+        );
+        let other = PdPairing::derive(&{
+            let mut s = spec(RuntimeType::Vllm, &[]);
+            s.pairing_protocol = Some("red".to_string());
+            s
+        });
+        assert_eq!(
+            asserted.mismatch(&other, PdPairingMode::Lenient),
+            Some(PairingMismatch::Explicit)
+        );
+    }
+
+    #[test]
+    fn different_runtimes_never_pair() {
+        let sglang = PdPairing::derive(&spec(RuntimeType::Sglang, &[]));
+        let vllm = PdPairing::derive(&spec(RuntimeType::Vllm, &[]));
+        assert_eq!(
+            sglang.mismatch(&vllm, PdPairingMode::Lenient),
+            Some(PairingMismatch::Runtime)
+        );
+    }
+}

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -34,6 +34,8 @@ use crate::{
         circuit_breaker::CircuitState,
         event::{WorkerConnected, WorkerEvent},
         hash_ring::HashRing,
+        pd_pair_index::{PdPairIndex, PdWire},
+        pd_pairing::PdPairingMode,
         worker::{RuntimeType, WorkerType},
         ConnectionMode, Worker, DEFAULT_SAMPLING_PARAMS_LABEL, UNKNOWN_MODEL_ID,
     },
@@ -177,6 +179,9 @@ impl RoutingPool {
 pub(crate) struct ModelWorkerSnapshot {
     all: WorkerSnapshot,
     pools: [LazyRoutingPool; RoutingPool::COUNT],
+    /// The compatible prefill/decode pairs per wire and pairing mode, built
+    /// once from the pools above (see [`PdPairIndex`]).
+    pd_pairs: [[OnceLock<Arc<PdPairIndex>>; PdPairingMode::COUNT]; PdWire::COUNT],
 }
 
 impl ModelWorkerSnapshot {
@@ -184,7 +189,24 @@ impl ModelWorkerSnapshot {
         Self {
             all,
             pools: std::array::from_fn(|_| OnceLock::new()),
+            pd_pairs: std::array::from_fn(|_| std::array::from_fn(|_| OnceLock::new())),
         }
+    }
+
+    /// The compatible prefill/decode pairs of `wire` under `mode`: descriptor
+    /// comparisons happen here, once per membership snapshot, never on the
+    /// request path.
+    pub(crate) fn pd_pairs(&self, wire: PdWire, mode: PdPairingMode) -> Arc<PdPairIndex> {
+        self.pd_pairs[wire.index()][mode.index()]
+            .get_or_init(|| {
+                let (prefill, decode) = wire.pools();
+                Arc::new(PdPairIndex::build(
+                    self.pool(prefill),
+                    self.pool(decode),
+                    mode,
+                ))
+            })
+            .clone()
     }
 
     pub(crate) fn pool(&self, pool: RoutingPool) -> WorkerSnapshot {
@@ -629,11 +651,6 @@ impl WorkerRegistry {
         }
         self.model_routing_snapshot(model_id)
             .unwrap_or_else(Self::empty_routing_snapshot)
-    }
-
-    /// Shared empty candidate slice.
-    pub(crate) fn empty_pool() -> Arc<[Arc<dyn Worker>]> {
-        Arc::from(Self::EMPTY_WORKERS)
     }
 
     /// Shared empty snapshot for unknown models.

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -26,8 +26,8 @@ use tokio::{
 };
 
 use super::{
-    event::WorkerConnected, overload::OverloadThresholds, CircuitBreaker, ResolvedResilience,
-    WorkerError, WorkerResult, UNKNOWN_MODEL_ID,
+    event::WorkerConnected, overload::OverloadThresholds, pd_pairing::PdPairing, CircuitBreaker,
+    ResolvedResilience, WorkerError, WorkerResult, UNKNOWN_MODEL_ID,
 };
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
@@ -425,6 +425,12 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
 
     /// Get worker-specific metadata
     fn metadata(&self) -> &WorkerMetadata;
+
+    /// The PD pairing descriptor placement compares across a prefill and a
+    /// decode.
+    fn pd_pairing(&self) -> &PdPairing {
+        &self.metadata().pd_pairing
+    }
 
     /// Worker-reported in-flight capacity, if available.
     ///
@@ -888,6 +894,9 @@ pub struct WorkerMetadata {
     /// `spec.http_pool.http2` when declared, else negotiated at registration
     /// under `upstream_http2`.
     pub http2: bool,
+    /// What this worker offers a PD rendezvous partner, derived once from
+    /// the spec and its discovered labels (#2483).
+    pub pd_pairing: PdPairing,
 }
 
 impl WorkerMetadata {
@@ -1954,6 +1963,9 @@ pub fn worker_to_info(worker: &Arc<dyn Worker>) -> WorkerInfo {
     let metadata = worker.metadata();
     let spec = metadata.spec.clone();
     let status = worker.status();
+    // Only PD legs pair; a regular worker's descriptor would be noise.
+    let pd_pairing = matches!(spec.worker_type, WorkerType::Prefill | WorkerType::Decode)
+        .then(|| metadata.pd_pairing.key());
 
     WorkerInfo {
         id: worker.url().to_string(),
@@ -1963,6 +1975,7 @@ pub fn worker_to_info(worker: &Arc<dyn Worker>) -> WorkerInfo {
         status: Some(status),
         load: worker.load(),
         http2: metadata.http2,
+        pd_pairing,
         engine_load: None,
         job_status: None,
     }
@@ -2850,6 +2863,7 @@ mod tests {
     #[test]
     fn test_worker_metadata_empty_models_accepts_all() {
         let metadata = WorkerMetadata {
+            pd_pairing: PdPairing::derive(&WorkerSpec::new("http://test:8080")),
             spec: Arc::new(WorkerSpec::new("http://test:8080")),
             health_config: HealthCheckConfig::default(),
             health_endpoint: "/health".to_string(),
@@ -2875,6 +2889,7 @@ mod tests {
         let mut spec = WorkerSpec::new("http://test:8080");
         spec.models = WorkerModels::from(vec![model1, model2]);
         let metadata = WorkerMetadata {
+            pd_pairing: PdPairing::derive(&spec),
             spec: Arc::new(spec),
             health_config: HealthCheckConfig::default(),
             health_endpoint: "/health".to_string(),


### PR DESCRIPTION
## Description

Step 2 of the PD pairing protocol (#2483): placement now only pairs prefill and decode workers that share a KV transfer protocol. Builds on the labels from #2484 (merged); rebased onto main.

### Problem

`select_pair` filtered candidates by availability, wire and runtime, then let the prefill and decode policies pick independently. Nothing checked that the two legs could actually complete a KV rendezvous. A fleet mixing transports (vLLM `NixlConnector` next to `MooncakeConnector`, SGLang `nixl` next to `mooncake`), engine versions, or KV layouts could be handed a pair that cannot transfer the cache, and the request died at the rendezvous instead of at placement. The `2p2d-mixed-kv` e2e case on #2464 pins this today as a strict xfail.

### Solution

Every PD worker carries a `PdPairing` descriptor derived at build time from its spec and discovered labels:

- the operator's explicit protocol when set (`WorkerSpec.pairing_protocol`, the `pairing_protocol` label, or the `smg.ai/pairing-protocol` annotation) is compared whole and nothing derived is consulted;
- otherwise runtime, KV transport (vLLM connector folded to `nixl`/`mooncake`, SGLang and TokenSpeed `disaggregation_transfer_backend`, TokenSpeed defaulting to `mooncake`), engine `version`, and the KV-layout facts `kv_cache_dtype`, `page_size` (vLLM `block_size`), `attention_backend` and `model_dtype`, each compared on its own.

Compatibility is decided once per membership snapshot, not per request: `ModelWorkerSnapshot` builds a `PdPairIndex` lazily per wire and pairing mode (every prefill with at least one compatible decode, its partner list, shared between prefills with equal descriptors, and the refusal report when nothing pairs), rebuilt only when a worker joins or leaves. `select_pair` reads it: a prefill is open when it and one of its partners are available, the prefill policy picks among open prefills, and the decode policy runs over the pick's available partners. The request path compares no descriptors; the live availability checks it always did remain. When no prefill shares a protocol with any decode, placement fails with a new `PlacementFailure::NoCompatiblePair` carrying each leg's distinct keys and the components the legs disagreed on, mapped to a `503 no_compatible_pd_pair` on the gRPC PD path, the HTTP PD router (and its `/health_generate` probe), and the HTTP regular path. The key on `/workers` is `runtime/transport/layout` (or the explicit protocol); version is left out of it because lenient mode ignores it.

`--pd-pairing-mode off|lenient|strict` (default `lenient`, under Routing Policy): runtime, transport and KV layout are hard facts, so a known difference refuses the pair in lenient and strict and an unknown one (a failed runtime probe, an engine that reports no layout) only in strict. Engine version is a soft fact, compared only under strict and only when both legs report one, so a rolling upgrade keeps pairing and a vLLM gRPC fleet (whose server info carries no version) can still run strict. `off` restores pre-pairing placement. `/workers` reports each PD worker's `pd_pairing` key so a mismatch is visible without reading logs.

## Changes

- `model_gateway/src/worker/pd_pairing.rs` (new): `PdPairing::derive`/`key`/`compatible`/`mismatch`, `PairingMismatch`, label constants, unit tests.
- `crates/protocols/src/worker.rs`: `WorkerSpec.pairing_protocol`, `WorkerInfo.pd_pairing`.
- `model_gateway/src/worker/{worker,builder,mod}.rs`: `WorkerMetadata.pd_pairing` (derived in the builder), `Worker::pd_pairing()` accessor, `worker_to_info` reports the key for PD legs.
- `model_gateway/src/worker/pd_pair_index.rs` (new): `PdPairIndex` (per-wire prefill/decode pools, partner lists, refusal report), `PdWire`, unit tests; `worker/registry.rs`: the index cached on `ModelWorkerSnapshot` per wire and mode.
- `model_gateway/src/routers/common/placement.rs`: `select_pair` consumes the index, `PlacementFailure::NoCompatiblePair`, placement tests (mixed transports pair by transport; a fleet without a shared transport names both legs; unknown transport pairs leniently and fails strictly).
- `model_gateway/src/routers/grpc/common/stages/worker_selection.rs`, `routers/http/{router,pd_router}.rs`: both PD routers take their legs from the snapshot index; the new verdict maps to `no_compatible_pd_pair` (`PdSelectionFailure::Incompatible` on the HTTP PD router).
- `config/types.rs`, `config/builder.rs`, `main.rs`, `policies/registry.rs`, `app_context.rs`: `PdPairingMode` and the `--pd-pairing-mode` flag plumbed to the policy registry.
- `bindings/golang/src/policy.rs`, `model_gateway/benches/workers_endpoint.rs`: struct literals gain the new field.

## Review notes

- Per-request cost: the pairing part is O(1) (index lookups). Placement still walks each leg once for live availability, as it did before this PR; an eligible-only pool snapshot is a separate change.

- TP, PP and DP are deliberately not part of the key: every engine negotiates them at the handshake, and the asymmetric `1p2d-ptp2-dtp1` / `2p1d-ptp1-dtp2` topologies on #2464 must keep pairing.
- `attention_backend` is part of the KV-layout component for every runtime. vLLM's own NIXL compatibility hash includes it, so that leg is exact; if an SGLang deployment legitimately runs different attention backends on prefill and decode, it can set an explicit `pairing_protocol` on both legs, run `--pd-pairing-mode off`, or we drop the fact for SGLang (a one-line change in `kv_layout_of`).
- Lenient is the default so a fleet whose engine reports nothing (TokenSpeed has no page size, older servicers have no layout fields) keeps pairing exactly as before this PR.
- The third commit follows the second review pass: a one-sided explicit protocol falls through to the derived facts under lenient (strict refuses it), KV layout facts are compared one at a time (a fact one side omits is unknown, a fact neither reports is not compared), the key drops version, and the refusal names its components.
- The second commit follows the bot review: an undetected runtime is unknown rather than different, version is a strict-only soft fact, `off` exists, the failure keys are built lazily, and the mode enum sits above the sticky-override docs instead of inside them. The Python bindings do not get a `pd_pairing_mode` argument in this PR: the default is what Python-launched routers already run, and the knob exists as a rollout safety valve; parity can follow when a Python user needs strict.

## Test Plan

- `cargo clippy -p smg -p smg-golang --all-targets -- -D warnings`: clean.
- `cargo test -p smg --lib -- placement pd_pairing worker_to_info registry::tests pd_router policies::registry config::types`: 202 passed.
- `cargo test -p smg --test grpc_pd_fanout_test`: 12 passed; `cargo test -p openai-protocol --lib`: 121 passed.
- `cargo check -p smg-golang` and `cargo check --manifest-path bindings/python/Cargo.toml`: clean.
- On hardware (#2464 sweep run 34377572974, vLLM 4-GPU lane, this branch): the `2p2d-mixed-kv` fleet (one NIXL pair, one Mooncake pair) served 12/12 requests with every logged pair on one transport and both transports serving; the `1p1d-kv-mismatch` fleet (NIXL prefill, Mooncake decode) was refused with `503 no_compatible_pd_pair` naming `mismatch on ["transport"]` and both keys.

<details>
<summary>Checklist</summary>

- [x] Format your code: `make fmt` / `cargo +nightly fmt --all`
- [x] Add unit or integration tests
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
