### PR TITLE
feat(pd): quarantine a prefill/decode pair after consecutive rendezvous failures

### DIFF
--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -28,7 +28,10 @@ use crate::{
         grpc::multimodal::MultimodalConfigRegistry,
     },
     wasm::{config::WasmRuntimeConfig, module_manager::WasmModuleManager},
-    worker::{KvEventMonitor, WorkerHttpClientCache, WorkerMonitor, WorkerRegistry, WorkerService},
+    worker::{
+        pd_pair_health, KvEventMonitor, WorkerHttpClientCache, WorkerMonitor, WorkerRegistry,
+        WorkerService,
+    },
     workflow::{JobQueue, WorkflowEngines},
 };
 
@@ -639,6 +642,11 @@ impl AppContextBuilder {
         // PD dispatch waits here, not in the decode engine's queue, when the
         // pair's running window is full.
         pd_admission::set_pd_admission_wait_secs(config.pd_admission_wait_secs);
+        // Pair-level quarantine after consecutive rendezvous failures.
+        pd_pair_health::configure(
+            config.pd_pair_quarantine_failures,
+            config.pd_pair_quarantine_secs,
+        );
         // Wire the backend load-snapshot feed into every policy that consumes
         // it; the monitor polls every group by default, conditionally under
         // `--disable-load-monitoring`.

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -268,6 +268,16 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn pd_pair_quarantine_failures(mut self, failures: u32) -> Self {
+        self.config.pd_pair_quarantine_failures = failures;
+        self
+    }
+
+    pub fn pd_pair_quarantine_secs(mut self, secs: u64) -> Self {
+        self.config.pd_pair_quarantine_secs = secs;
+        self
+    }
+
     pub fn disable_load_monitoring(mut self, disabled: bool) -> Self {
         self.config.disable_load_monitoring = disabled;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -12,7 +12,10 @@ use super::{validation::ConfigValidator, ConfigResult};
 use crate::{
     routers::common::pd_admission::DEFAULT_PD_ADMISSION_WAIT_SECS,
     tenant::DEFAULT_TENANT_HEADER_NAME,
-    worker::{ConnectionMode, RuntimeType},
+    worker::{
+        pd_pair_health::{DEFAULT_PD_PAIR_QUARANTINE_FAILURES, DEFAULT_PD_PAIR_QUARANTINE_SECS},
+        ConnectionMode, RuntimeType,
+    },
 };
 
 /// Main router configuration
@@ -104,6 +107,15 @@ pub struct RouterConfig {
     /// that report no running window.
     #[serde(default = "default_pd_admission_wait_secs")]
     pub pd_admission_wait_secs: u64,
+    /// Consecutive rendezvous failures on one prefill/decode pair before
+    /// placement quarantines the pair and steers around it while another
+    /// compatible pair is open. `0` disables pair quarantine.
+    #[serde(default = "default_pd_pair_quarantine_failures")]
+    pub pd_pair_quarantine_failures: u32,
+    /// Seconds a quarantined prefill/decode pair is steered around before it
+    /// is tried again. `0` disables pair quarantine.
+    #[serde(default = "default_pd_pair_quarantine_secs")]
+    pub pd_pair_quarantine_secs: u64,
     /// Restore the conditional load-monitor poll gate: only poll worker groups
     /// when a load-aware routing policy, `engine_metrics`, or overload
     /// protection needs the data. Default `false` — the monitor polls every
@@ -344,6 +356,14 @@ pub struct TokenizerCacheConfig {
 
 fn default_load_monitor_interval_secs() -> u64 {
     10
+}
+
+fn default_pd_pair_quarantine_failures() -> u32 {
+    DEFAULT_PD_PAIR_QUARANTINE_FAILURES
+}
+
+fn default_pd_pair_quarantine_secs() -> u64 {
+    DEFAULT_PD_PAIR_QUARANTINE_SECS
 }
 
 fn default_pd_admission_wait_secs() -> u64 {
@@ -1134,6 +1154,8 @@ impl Default for RouterConfig {
             job_queue_concurrency: default_job_queue_concurrency(),
             load_monitor_interval_secs: 10,
             pd_admission_wait_secs: default_pd_admission_wait_secs(),
+            pd_pair_quarantine_failures: default_pd_pair_quarantine_failures(),
+            pd_pair_quarantine_secs: default_pd_pair_quarantine_secs(),
             disable_load_monitoring: false,
             worker_overload_protection: false,
             worker_overload_waiting_requests: None,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -559,6 +559,17 @@ struct CliArgs {
     #[arg(long, default_value_t = 30, help_heading = "Load Monitoring")]
     pd_admission_wait_secs: u64,
 
+    /// Consecutive rendezvous failures on one prefill/decode pair before
+    /// placement quarantines the pair and steers around it while another
+    /// compatible pair is open. 0 disables pair quarantine.
+    #[arg(long, default_value_t = 3, help_heading = "Routing Policy")]
+    pd_pair_quarantine_failures: u32,
+
+    /// Seconds a quarantined prefill/decode pair is steered around before it
+    /// is tried again. 0 disables pair quarantine.
+    #[arg(long, default_value_t = 30, help_heading = "Routing Policy")]
+    pd_pair_quarantine_secs: u64,
+
     /// TTL in seconds for event-driven cache-aware indexer entries: entries
     /// neither stored nor read by a query within this window are pruned.
     /// Bounds index growth when a backend stops emitting removal events.
@@ -1839,6 +1850,8 @@ impl CliArgs {
             .job_queue_concurrency(self.job_queue_concurrency)
             .load_monitor_interval_secs(self.load_monitor_interval)
             .pd_admission_wait_secs(self.pd_admission_wait_secs)
+            .pd_pair_quarantine_failures(self.pd_pair_quarantine_failures)
+            .pd_pair_quarantine_secs(self.pd_pair_quarantine_secs)
             .disable_load_monitoring(self.disable_load_monitoring)
             .worker_overload_protection(self.worker_overload_protection)
             .worker_overload_waiting_requests(self.worker_overload_waiting_requests)

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -263,6 +263,14 @@ pub(crate) fn init_metrics() {
         "smg_pd_kv_transfer_failures_total",
         "PD KV-transfer failures (missing connector params at decode handoff)"
     );
+    describe_counter!(
+        "smg_pd_pair_quarantines_total",
+        "Prefill/decode pairs quarantined after consecutive rendezvous failures"
+    );
+    describe_gauge!(
+        "smg_pd_pairs_quarantined",
+        "Prefill/decode pairs currently quarantined"
+    );
 
     // Layer 3: Worker metrics
     describe_gauge!(
@@ -1124,6 +1132,18 @@ impl Metrics {
     /// Record a PD KV-transfer failure (missing connector params at handoff).
     pub fn record_pd_kv_transfer_failure() {
         counter!("smg_pd_kv_transfer_failures_total").increment(1);
+    }
+
+    /// Record a prefill/decode pair entering quarantine, and how many pairs
+    /// are quarantined now.
+    pub fn record_pd_pair_quarantine(quarantined: usize) {
+        counter!("smg_pd_pair_quarantines_total").increment(1);
+        Self::set_pd_pairs_quarantined(quarantined);
+    }
+
+    /// The number of prefill/decode pairs currently quarantined.
+    pub fn set_pd_pairs_quarantined(quarantined: usize) {
+        gauge!("smg_pd_pairs_quarantined").set(quarantined as f64);
     }
 
     /// Record a PD dispatch that had to wait for a decode admission slot.

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -25,8 +25,8 @@ use crate::{
     },
     routers::common::overload,
     worker::{
-        ConnectionMode, ConnectionModeExt, PdPairIndex, RoutingPool, RuntimeType, Worker,
-        WorkerRegistry,
+        pd_pair_health, ConnectionMode, ConnectionModeExt, PdPairIndex, RoutingPool, RuntimeType,
+        Worker, WorkerRegistry,
     },
 };
 
@@ -298,12 +298,22 @@ pub(crate) fn select_pair(
     // runtime: that of the first prefill worker open under its own runtime,
     // so a prefill whose partners are all down never shuts out a healthy
     // pair on another runtime. The index keeps runtimes apart already
-    // unless pairing is off or a runtime is unknown.
-    let partner_open = |d: &Arc<dyn Worker>, runtime: Option<RuntimeType>| {
-        eligible(d) && runtime.is_none_or(|r| d.metadata().spec.runtime_type == r)
-    };
-    let can_pair_on = |i: usize, runtime: Option<RuntimeType>| {
-        pairs.partners[i].iter().any(|d| partner_open(d, runtime))
+    // unless pairing is off or a runtime is unknown. A pair in quarantine
+    // (consecutive rendezvous failures, see `pd_pair_health`) is steered
+    // around while another open pair exists; when every open pair is
+    // quarantined, placement serves through it, since the quarantine is a
+    // hint drawn from failures, not a veto.
+    let partner_open =
+        |p: &Arc<dyn Worker>, d: &Arc<dyn Worker>, runtime: Option<RuntimeType>, steer: bool| {
+            eligible(d)
+                && runtime.is_none_or(|r| d.metadata().spec.runtime_type == r)
+                && (!steer || !pd_pair_health::is_quarantined(p.url(), d.url()))
+        };
+    let can_pair_on = |i: usize, runtime: Option<RuntimeType>, steer: bool| {
+        let p = &pairs.prefill[i];
+        pairs.partners[i]
+            .iter()
+            .any(|d| partner_open(p, d, runtime, steer))
     };
     if !pairs.prefill.iter().any(&eligible) {
         debug!("No available prefill workers");
@@ -316,29 +326,44 @@ pub(crate) fn select_pair(
         .then(|| {
             pairs.prefill.iter().enumerate().find_map(|(i, p)| {
                 let runtime = p.metadata().spec.runtime_type;
-                (eligible(p) && can_pair_on(i, Some(runtime))).then_some(runtime)
+                (eligible(p) && can_pair_on(i, Some(runtime), false)).then_some(runtime)
             })
         })
         .flatten();
     // One pass: the open prefills on the leg's runtime, counting the
     // pairable ones the narrowing excluded so the exclusion leaves a trace.
-    let mut excluded = 0usize;
-    let open: Vec<usize> = (0..pairs.prefill.len())
-        .filter(|&i| {
-            let p = &pairs.prefill[i];
-            if !eligible(p) {
-                return false;
-            }
-            let own = p.metadata().spec.runtime_type;
-            if leg_runtime.is_some_and(|runtime| own != runtime) {
-                if can_pair_on(i, Some(own)) {
-                    excluded += 1;
+    let open_on = |steer: bool| -> (Vec<usize>, usize) {
+        let mut excluded = 0usize;
+        let open: Vec<usize> = (0..pairs.prefill.len())
+            .filter(|&i| {
+                let p = &pairs.prefill[i];
+                if !eligible(p) {
+                    return false;
                 }
-                return false;
-            }
-            can_pair_on(i, leg_runtime)
-        })
-        .collect();
+                let own = p.metadata().spec.runtime_type;
+                if leg_runtime.is_some_and(|runtime| own != runtime) {
+                    if can_pair_on(i, Some(own), steer) {
+                        excluded += 1;
+                    }
+                    return false;
+                }
+                can_pair_on(i, leg_runtime, steer)
+            })
+            .collect();
+        (open, excluded)
+    };
+    let mut steer = true;
+    let (mut open, mut excluded) = open_on(true);
+    if open.is_empty() {
+        steer = false;
+        (open, excluded) = open_on(false);
+        if !open.is_empty() {
+            debug!(
+                model_id,
+                "Every open PD pair is quarantined; placing through the quarantine"
+            );
+        }
+    }
     if excluded > 0 {
         warn!(
             model_id,
@@ -390,7 +415,7 @@ pub(crate) fn select_pair(
     // availability flip between the two reads.
     let decode: Vec<Arc<dyn Worker>> = pairs.partners[open[prefill_idx]]
         .iter()
-        .filter(|d| partner_open(d, leg_runtime))
+        .filter(|d| partner_open(&selected_prefill, d, leg_runtime, steer))
         .cloned()
         .collect();
     if decode.is_empty() {
@@ -631,6 +656,40 @@ mod tests {
         let off =
             PolicyRegistry::new(PolicyConfig::RoundRobin).with_pd_pairing_mode(PdPairingMode::Off);
         assert!(pair_from(&registry, &off).is_ok());
+    }
+
+    #[test]
+    fn a_quarantined_pair_is_steered_around_while_another_is_open() {
+        let _guard = pd_pair_health::test_guard();
+        let (p1, d1, d2) = ("grpc://qp:1", "grpc://qd:1", "grpc://qd:2");
+        let registry = pd_registry(&[
+            (p1, WorkerType::Prefill, Some("NixlConnector")),
+            (d1, WorkerType::Decode, Some("NixlConnector")),
+            (d2, WorkerType::Decode, Some("NixlConnector")),
+        ]);
+        let policies = PolicyRegistry::new(PolicyConfig::RoundRobin);
+
+        for _ in 0..pd_pair_health::DEFAULT_PD_PAIR_QUARANTINE_FAILURES {
+            pd_pair_health::record_failure(p1, d1);
+        }
+        assert!(pd_pair_health::is_quarantined(p1, d1));
+        for _ in 0..4 {
+            let pair = pair_from(&registry, &policies)
+                .ok()
+                .expect("the other decode is open");
+            assert_eq!(pair.decode.url(), d2);
+        }
+
+        // Every pair quarantined: placement still serves.
+        for _ in 0..pd_pair_health::DEFAULT_PD_PAIR_QUARANTINE_FAILURES {
+            pd_pair_health::record_failure(p1, d2);
+        }
+        assert!(pair_from(&registry, &policies).is_ok());
+
+        // A completed handoff clears the pair.
+        pd_pair_health::record_success(p1, d1);
+        assert!(!pd_pair_health::is_quarantined(p1, d1));
+        pd_pair_health::forget(p1);
     }
 
     #[test]

--- a/model_gateway/src/routers/common/placement.rs
+++ b/model_gateway/src/routers/common/placement.rs
@@ -411,13 +411,20 @@ pub(crate) fn select_pair(
         return Err(declined(WorkerLeg::Prefill, prefill_policy.name()));
     };
     let selected_prefill = prefill[prefill_idx].clone();
-    // The pick's open partners: non-empty by construction, short of an
-    // availability flip between the two reads.
-    let decode: Vec<Arc<dyn Worker>> = pairs.partners[open[prefill_idx]]
-        .iter()
-        .filter(|d| partner_open(&selected_prefill, d, leg_runtime, steer))
-        .cloned()
-        .collect();
+    // The pick's open partners. A quarantine entered between the two reads
+    // falls back the way the first pass does; what is left empty went
+    // unavailable in between.
+    let partners_open = |steer: bool| -> Vec<Arc<dyn Worker>> {
+        pairs.partners[open[prefill_idx]]
+            .iter()
+            .filter(|d| partner_open(&selected_prefill, d, leg_runtime, steer))
+            .cloned()
+            .collect()
+    };
+    let mut decode = partners_open(steer);
+    if decode.is_empty() && steer {
+        decode = partners_open(false);
+    }
     if decode.is_empty() {
         debug!(
             ?leg_runtime,

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -34,7 +34,7 @@ use crate::{
             utils::tonic_ext::{TonicResultExt, TonicStatusExt},
         },
     },
-    worker::{ConnectionModeExt, Worker},
+    worker::{pd_pair_health, ConnectionModeExt, Worker},
 };
 
 type StreamResult = Result<ProtoStream, tonic::Status>;
@@ -168,6 +168,13 @@ fn fan_out_pd_request(
             sub
         })
         .collect()
+}
+
+/// The (prefill, decode) URLs of a disaggregated selection, for pair health.
+fn pd_pair_urls(workers: &WorkerSelection) -> Option<(&str, &str)> {
+    workers
+        .disaggregated_pair()
+        .map(|(prefill, decode)| (prefill.url(), decode.url()))
 }
 
 /// Metric connection labels for the PD legs (a leg can be gRPC or ZMQ).
@@ -619,6 +626,19 @@ async fn execute_parallel_pd(
                 prefill_result.cb_status_code(),
                 decode_result.cb_status_code(),
             );
+            // An engine-side failure on either leg at the rendezvous counts
+            // against the pair (see `pd_pair_health`).
+            if let Some((prefill_url, decode_url)) = pd_pair_urls(workers) {
+                let engine_failed = [
+                    prefill_result.cb_status_code(),
+                    decode_result.cb_status_code(),
+                ]
+                .into_iter()
+                .any(pd_pair_health::pair_attributable);
+                if engine_failed {
+                    pd_pair_health::record_failure(prefill_url, decode_url);
+                }
+            }
 
             // Both legs are translated before either is propagated: a
             // decode-side failure is logged and counted even when the prefill
@@ -642,6 +662,14 @@ async fn execute_parallel_pd(
             // if prefill is still running there is nothing to hand off yet, and
             // stopping it promptly frees capacity.
             let decode_stream = decode_stream.defer_abort_until_first_item();
+            // The first decode response proves the handoff; an engine error
+            // before it counts against the pair.
+            let decode_stream = match pd_pair_urls(workers) {
+                Some((prefill_url, decode_url)) => {
+                    decode_stream.observe_pd_pair(prefill_url, decode_url)
+                }
+                None => decode_stream,
+            };
 
             Ok(ExecutionResult::PrefillDecode {
                 prefill: prefill_stream,
@@ -658,6 +686,11 @@ async fn execute_parallel_pd(
             partner,
         } => {
             let status = error.http_status().as_u16();
+            if pd_pair_health::pair_attributable(status) {
+                if let Some((prefill_url, decode_url)) = pd_pair_urls(workers) {
+                    pd_pair_health::record_failure(prefill_url, decode_url);
+                }
+            }
             // Only the leg that answered is recorded: the abandoned one has
             // said nothing about its worker yet, and `retire_pd_leg` records
             // it when it finally does.
@@ -1038,7 +1071,15 @@ async fn execute_sequential_pd(
 
     // Send request to decode
     let decode_stream = decode_client.generate(decode_request).await.map_err(|e| {
-        workers.record_outcome_decode(e.http_status().as_u16());
+        let status = e.http_status().as_u16();
+        workers.record_outcome_decode(status);
+        // The prefill already finished alone, so a decode-side engine
+        // failure is about the handoff (see `pd_pair_health`).
+        if pd_pair_health::pair_attributable(status) {
+            if let Some((prefill_url, decode_url)) = pd_pair_urls(workers) {
+                pd_pair_health::record_failure(prefill_url, decode_url);
+            }
+        }
         Metrics::record_worker_error(
             metrics_labels::WORKER_DECODE,
             decode_label,
@@ -1073,6 +1114,10 @@ async fn execute_sequential_pd(
     // decode response proves the handoff finished (see the parallel PD
     // path for the same invariant).
     let decode_stream = decode_stream.defer_abort_until_first_item();
+    let decode_stream = match pd_pair_urls(workers) {
+        Some((prefill_url, decode_url)) => decode_stream.observe_pd_pair(prefill_url, decode_url),
+        None => decode_stream,
+    };
 
     Ok(ExecutionResult::Single {
         stream: decode_stream,

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -42,7 +42,13 @@ use smg_grpc_client::{
 };
 use smg_mm_rdma::RdmaExporter;
 
-use crate::routers::grpc::{multimodal::mm_rdma_exporter, zmq_client::ZmqGenerateStream};
+use crate::{
+    routers::grpc::{
+        multimodal::mm_rdma_exporter, utils::tonic_ext::TonicStatusExt,
+        zmq_client::ZmqGenerateStream,
+    },
+    worker::pd_pair_health,
+};
 
 /// How a streaming response's per-token payloads (token ids, sampled
 /// logprobs, token counts) relate across the responses of one stream.
@@ -2265,6 +2271,9 @@ pub enum ProtoStream {
     /// An n>1 fan-out over rendezvous-room PD pairs: one child per sample,
     /// each response stamped with its sample's index (see [`FanoutStream`]).
     Fanout(FanoutStream),
+    /// A disaggregated decode leg whose first item is reported to the PD
+    /// pair-health table (see [`ObservedStream`]).
+    Observed(Box<ObservedStream>),
 }
 
 impl ProtoStream {
@@ -2304,6 +2313,7 @@ impl ProtoStream {
                 .await
                 .map(|result| result.map(|r| ProtoGenerateResponse::Vllm(Box::new(r)))),
             Self::Fanout(stream) => stream.next().await,
+            Self::Observed(stream) => stream.next().await,
         }
     }
 
@@ -2317,6 +2327,7 @@ impl ProtoStream {
             Self::TokenSpeed(stream) => stream.mark_completed(),
             Self::Zmq(stream) => stream.mark_completed(),
             Self::Fanout(stream) => stream.mark_completed(),
+            Self::Observed(stream) => stream.inner.mark_completed(),
         }
     }
 
@@ -2338,6 +2349,75 @@ impl ProtoStream {
             Self::TokenSpeed(stream) => Self::TokenSpeed(stream.defer_abort_until_first_item()),
             Self::Zmq(stream) => Self::Zmq(stream),
             Self::Fanout(stream) => Self::Fanout(stream.defer_abort_until_first_item()),
+            Self::Observed(stream) => {
+                Self::Observed(Box::new(stream.defer_abort_until_first_item()))
+            }
+        }
+    }
+
+    /// Report this decode leg's first item to the PD pair-health table for
+    /// the (prefill, decode) pair it belongs to.
+    #[must_use]
+    pub fn observe_pd_pair(self, prefill: &str, decode: &str) -> Self {
+        Self::Observed(Box::new(ObservedStream {
+            inner: self,
+            observer: Some(PdPairObserver::new(prefill, decode)),
+        }))
+    }
+}
+
+/// A disaggregated decode leg whose first item is reported to the PD
+/// pair-health table: a response proves the handoff and clears the pair, an
+/// engine-side error before any response counts against it, and a stream
+/// dropped before either (the client went away) reports nothing.
+pub struct ObservedStream {
+    inner: ProtoStream,
+    observer: Option<PdPairObserver>,
+}
+
+impl ObservedStream {
+    async fn next(&mut self) -> Option<Result<ProtoGenerateResponse, tonic::Status>> {
+        // Boxed: `ProtoStream::next` reaches back here for a nested stream.
+        let item = Box::pin(self.inner.next()).await;
+        if let Some(observer) = self.observer.take() {
+            observer.observe(item.as_ref());
+        }
+        item
+    }
+
+    fn defer_abort_until_first_item(self) -> Self {
+        Self {
+            inner: self.inner.defer_abort_until_first_item(),
+            observer: self.observer,
+        }
+    }
+}
+
+/// The pair a decode leg belongs to, reported once.
+#[derive(Debug, Clone)]
+pub struct PdPairObserver {
+    prefill: String,
+    decode: String,
+}
+
+impl PdPairObserver {
+    pub fn new(prefill: &str, decode: &str) -> Self {
+        Self {
+            prefill: prefill.to_string(),
+            decode: decode.to_string(),
+        }
+    }
+
+    /// Report the leg's first item.
+    pub fn observe(self, item: Option<&Result<ProtoGenerateResponse, tonic::Status>>) {
+        match item {
+            Some(Ok(_)) => pd_pair_health::record_success(&self.prefill, &self.decode),
+            Some(Err(status))
+                if pd_pair_health::pair_attributable(status.http_status().as_u16()) =>
+            {
+                pd_pair_health::record_failure(&self.prefill, &self.decode);
+            }
+            _ => {}
         }
     }
 }

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -2280,6 +2280,16 @@ impl ProtoStream {
     /// Get next item from stream
     pub async fn next(&mut self) -> Option<Result<ProtoGenerateResponse, tonic::Status>> {
         match self {
+            // Dispatched here so the observed leg polls its inner stream
+            // through `next_inner` without boxing (see [`ObservedStream`]).
+            Self::Observed(stream) => stream.next().await,
+            _ => self.next_inner().await,
+        }
+    }
+
+    /// The per-engine dispatch behind [`Self::next`].
+    async fn next_inner(&mut self) -> Option<Result<ProtoGenerateResponse, tonic::Status>> {
+        match self {
             Self::Sglang(stream) => stream
                 .next()
                 .await
@@ -2313,7 +2323,9 @@ impl ProtoStream {
                 .await
                 .map(|result| result.map(|r| ProtoGenerateResponse::Vllm(Box::new(r)))),
             Self::Fanout(stream) => stream.next().await,
-            Self::Observed(stream) => stream.next().await,
+            // `observe_pd_pair` never nests an observed stream, so this arm
+            // is not reached; boxing keeps the future type finite.
+            Self::Observed(stream) => Box::pin(stream.next()).await,
         }
     }
 
@@ -2356,20 +2368,26 @@ impl ProtoStream {
     }
 
     /// Report this decode leg's first item to the PD pair-health table for
-    /// the (prefill, decode) pair it belongs to.
+    /// the (prefill, decode) pair it belongs to. An already observed stream
+    /// gets the new observer rather than a second wrapper.
     #[must_use]
     pub fn observe_pd_pair(self, prefill: &str, decode: &str) -> Self {
-        Self::Observed(Box::new(ObservedStream {
-            inner: self,
-            observer: Some(PdPairObserver::new(prefill, decode)),
-        }))
+        let observer = Some(PdPairObserver::new(prefill, decode));
+        match self {
+            Self::Observed(mut stream) => {
+                stream.observer = observer;
+                Self::Observed(stream)
+            }
+            inner => Self::Observed(Box::new(ObservedStream { inner, observer })),
+        }
     }
 }
 
 /// A disaggregated decode leg whose first item is reported to the PD
 /// pair-health table: a response proves the handoff and clears the pair, an
-/// engine-side error before any response counts against it, and a stream
-/// dropped before either (the client went away) reports nothing.
+/// engine-side error or a clean close before any response counts against
+/// it. A stream dropped before it is polled (the client went away) reports
+/// nothing. After the first item the wrapper only forwards.
 pub struct ObservedStream {
     inner: ProtoStream,
     observer: Option<PdPairObserver>,
@@ -2377,8 +2395,9 @@ pub struct ObservedStream {
 
 impl ObservedStream {
     async fn next(&mut self) -> Option<Result<ProtoGenerateResponse, tonic::Status>> {
-        // Boxed: `ProtoStream::next` reaches back here for a nested stream.
-        let item = Box::pin(self.inner.next()).await;
+        // `next_inner`, not `next`: the inner stream is never observed
+        // itself, and going through `next` would make this future recursive.
+        let item = self.inner.next_inner().await;
         if let Some(observer) = self.observer.take() {
             observer.observe(item.as_ref());
         }
@@ -2412,12 +2431,17 @@ impl PdPairObserver {
     pub fn observe(self, item: Option<&Result<ProtoGenerateResponse, tonic::Status>>) {
         match item {
             Some(Ok(_)) => pd_pair_health::record_success(&self.prefill, &self.decode),
-            Some(Err(status))
-                if pd_pair_health::pair_attributable(status.http_status().as_u16()) =>
-            {
+            Some(Err(status)) => {
+                if pd_pair_health::pair_attributable(status.http_status().as_u16()) {
+                    pd_pair_health::record_failure(&self.prefill, &self.decode);
+                }
+            }
+            // Closed without a response: the engine accepted the leg and
+            // produced nothing, which is a failed handoff. A client that
+            // goes away drops the stream unpolled and never reaches here.
+            None => {
                 pd_pair_health::record_failure(&self.prefill, &self.decode);
             }
-            _ => {}
         }
     }
 }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1,4 +1,9 @@
-use std::{sync::Arc, time::Instant};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{ready, Context, Poll},
+    time::Instant,
+};
 
 use async_trait::async_trait;
 use axum::{
@@ -654,7 +659,6 @@ impl PDRouter {
         // parsed request and its routing derivatives now when retries are
         // disabled.
         lease.release_dispatch();
-        let is_stream = context.is_stream;
 
         let response = self
             .execute_dual_dispatch_internal(
@@ -671,13 +675,11 @@ impl PDRouter {
         prefill.record_outcome(status.as_u16());
         decode.record_outcome(status.as_u16());
         // Pair health (see `pd_pair_health`): an engine-side failure counts
-        // against the pair. A buffered success proves the handoff; a
-        // streaming 200 is only the decode's header, sent before any token,
-        // so it is left neutral rather than clearing a real failure run.
+        // against the pair. Successes are reported by `forward_decode_body`,
+        // where the decode's body is seen: a 200 header is sent before any
+        // token and proves nothing about the handoff.
         if pd_pair_health::pair_attributable(status.as_u16()) {
             pd_pair_health::record_failure(prefill.url(), decode.url());
-        } else if status.is_success() && !is_stream {
-            pd_pair_health::record_success(prefill.url(), decode.url());
         }
 
         // Record worker errors for server errors (5xx)
@@ -939,6 +941,7 @@ impl PDRouter {
             decode_response,
             status,
             &context,
+            Some(&prefill),
             decode,
             load_guards,
             prefill_body,
@@ -1138,6 +1141,10 @@ impl PDRouter {
             }
             _ => None,
         };
+        // Pair health (see `pd_pair_health`) is judged only when a handoff was
+        // attempted: a fan-out or a prefill that minted nothing lets decode
+        // recompute the prompt, which proves nothing about the pair.
+        let handoff = relay && decode_params.is_some();
         if let (Some(obj), Some(params)) = (decode_json.as_object_mut(), decode_params) {
             obj.insert("kv_transfer_params".to_string(), params);
         }
@@ -1176,6 +1183,11 @@ impl PDRouter {
         let status = StatusCode::from_u16(decode_response.status().as_u16())
             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
         Self::record_sequential_leg(decode.as_ref(), metrics_labels::WORKER_DECODE, status);
+        // The sequential path returns before the parallel path's pair-health
+        // block, so an engine-side decode failure is counted here.
+        if handoff && pd_pair_health::pair_attributable(status.as_u16()) {
+            pd_pair_health::record_failure(prefill.url(), decode.url());
+        }
         if !status.is_success() {
             error!(
                 "Decode server returned error status decode_url={} status={}",
@@ -1196,8 +1208,16 @@ impl PDRouter {
             dispatch_start.elapsed(),
         );
 
-        self.forward_decode_body(decode_response, status, &context, decode, load_guards, None)
-            .await
+        self.forward_decode_body(
+            decode_response,
+            status,
+            &context,
+            handoff.then_some(&prefill),
+            decode,
+            load_guards,
+            None,
+        )
+        .await
     }
 
     /// Map a failed prefill response to a client-facing error. The exact
@@ -1237,16 +1257,20 @@ impl PDRouter {
 
     /// Forward a successful decode response to the client, streaming or not,
     /// merging prefill logprobs when requested. Shared by the parallel and
-    /// sequential PD dispatch paths.
+    /// sequential PD dispatch paths. `prefill` is the leg a KV handoff was
+    /// attempted from, if any: only then does the body speak for the pair.
+    #[expect(clippy::too_many_arguments)]
     async fn forward_decode_body(
         &self,
         decode_response: reqwest::Response,
         status: StatusCode,
         context: &PDRequestContext<'_>,
+        prefill: Option<&Arc<dyn Worker>>,
         decode: Arc<dyn Worker>,
         load_guards: Vec<WorkerLoadGuard>,
         prefill_body: Option<Bytes>,
     ) -> Response {
+        let pair = prefill.map(|prefill| (prefill.url().to_string(), decode.url().to_string()));
         if context.is_stream {
             // Streaming response
             let prefill_logprobs = if context.return_logprob {
@@ -1262,8 +1286,14 @@ impl PDRouter {
                 header_utils::preserve_response_headers(decode_response.headers());
             header_utils::insert_routed_worker_id(&mut response_headers, decode.url());
 
+            // The first body chunk is the proof the handoff completed (see
+            // `ObservedDecodeBody`); the header above came before any token.
+            let body = ObservedDecodeBody {
+                inner: Box::pin(decode_response.bytes_stream()),
+                pair,
+            };
             self.create_streaming_response(
-                decode_response.bytes_stream(),
+                body,
                 status,
                 prefill_logprobs,
                 context.return_logprob,
@@ -1299,6 +1329,13 @@ impl PDRouter {
                     }
                 }
             };
+            // The body was read in full, so a success here proves the
+            // handoff; a failure was already counted at the dispatch site.
+            if let Some((prefill, decode)) = &pair {
+                if response.status().is_success() {
+                    pd_pair_health::record_success(prefill, decode);
+                }
+            }
 
             // The decode worker is the one that produced the body the client
             // sees, on both the merged-logprob and passthrough paths.
@@ -2122,6 +2159,34 @@ impl RouterTrait for PDRouter {
 
     fn router_type(&self) -> &'static str {
         "pd"
+    }
+}
+
+/// A decode body whose first chunk is reported to the pair-health table: a
+/// chunk proves the handoff, an error or a close before any chunk counts
+/// against the pair. The 200 header alone is sent before any token and proves
+/// nothing (the gRPC leg's `ObservedStream` makes the same call). With no pair
+/// (no handoff was attempted) the body is forwarded untouched.
+struct ObservedDecodeBody {
+    inner: Pin<Box<dyn futures_util::Stream<Item = Result<Bytes, reqwest::Error>> + Send>>,
+    pair: Option<(String, String)>,
+}
+
+impl futures_util::Stream for ObservedDecodeBody {
+    type Item = Result<Bytes, reqwest::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        let item = ready!(this.inner.as_mut().poll_next(cx));
+        if let Some((prefill, decode)) = this.pair.take() {
+            match &item {
+                Some(Ok(_)) => pd_pair_health::record_success(&prefill, &decode),
+                _ => {
+                    pd_pair_health::record_failure(&prefill, &decode);
+                }
+            }
+        }
+        Poll::Ready(item)
     }
 }
 

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -55,8 +55,8 @@ use crate::{
         RouterTrait,
     },
     worker::{
-        PdPairIndex, PdWire, RoutingPool, RuntimeType, Worker, WorkerLoadGuard, WorkerRegistry,
-        UNKNOWN_MODEL_ID,
+        pd_pair_health, PdPairIndex, PdWire, RoutingPool, RuntimeType, Worker, WorkerLoadGuard,
+        WorkerRegistry, UNKNOWN_MODEL_ID,
     },
 };
 
@@ -654,6 +654,7 @@ impl PDRouter {
         // parsed request and its routing derivatives now when retries are
         // disabled.
         lease.release_dispatch();
+        let is_stream = context.is_stream;
 
         let response = self
             .execute_dual_dispatch_internal(
@@ -669,6 +670,15 @@ impl PDRouter {
         let status = response.status();
         prefill.record_outcome(status.as_u16());
         decode.record_outcome(status.as_u16());
+        // Pair health (see `pd_pair_health`): an engine-side failure counts
+        // against the pair. A buffered success proves the handoff; a
+        // streaming 200 is only the decode's header, sent before any token,
+        // so it is left neutral rather than clearing a real failure run.
+        if pd_pair_health::pair_attributable(status.as_u16()) {
+            pd_pair_health::record_failure(prefill.url(), decode.url());
+        } else if status.is_success() && !is_stream {
+            pd_pair_health::record_success(prefill.url(), decode.url());
+        }
 
         // Record worker errors for server errors (5xx)
         if status.is_server_error() {

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -13,6 +13,7 @@ pub mod manager;
 pub mod metrics_aggregator;
 pub mod monitor;
 pub mod overload;
+pub mod pd_pair_health;
 pub mod pd_pair_index;
 pub mod pd_pairing;
 pub mod registry;

--- a/model_gateway/src/worker/pd_pair_health.rs
+++ b/model_gateway/src/worker/pd_pair_health.rs
@@ -1,0 +1,241 @@
+//! Pair-level health for PD placement (#2483).
+//!
+//! The pairing descriptor ([`super::pd_pairing`]) keeps a prefill and a
+//! decode apart when their labels say a KV handoff cannot work. This table is
+//! the defence for the mismatch the labels miss: an engine-side failure at
+//! the rendezvous, or before the decode's first response, counts against the
+//! (prefill, decode) pair, and a run of consecutive failures quarantines the
+//! pair for a bounded time. Placement steers around a quarantined pair while
+//! another compatible pair is open and keeps serving through it when none
+//! is: the quarantine is a hint drawn from failures, not a veto. The decode's
+//! first response is the proof the handoff completed and clears the pair.
+//!
+//! Like the PD admission wait, the thresholds and the table are
+//! process-global: the dispatch paths that observe a rendezvous carry no
+//! handle on the registry.
+
+use std::{
+    sync::{
+        atomic::{AtomicU32, AtomicU64, Ordering},
+        LazyLock,
+    },
+    time::{Duration, Instant},
+};
+
+use dashmap::DashMap;
+use tracing::{debug, warn};
+
+use crate::observability::metrics::Metrics;
+
+/// Consecutive failures that quarantine a pair. `0` disables the table.
+pub const DEFAULT_PD_PAIR_QUARANTINE_FAILURES: u32 = 3;
+/// How long a quarantined pair is steered around. `0` disables the table.
+pub const DEFAULT_PD_PAIR_QUARANTINE_SECS: u64 = 30;
+
+static FAILURES: AtomicU32 = AtomicU32::new(DEFAULT_PD_PAIR_QUARANTINE_FAILURES);
+static QUARANTINE_SECS: AtomicU64 = AtomicU64::new(DEFAULT_PD_PAIR_QUARANTINE_SECS);
+/// Prefill URL, then decode URL: two levels so a lookup borrows `&str`
+/// instead of allocating a pair key on the placement path.
+static PAIRS: LazyLock<DashMap<String, DashMap<String, PairState>>> = LazyLock::new(DashMap::new);
+
+#[derive(Debug, Default)]
+struct PairState {
+    consecutive_failures: u32,
+    quarantined_until: Option<Instant>,
+}
+
+impl PairState {
+    fn quarantined(&self, now: Instant) -> bool {
+        self.quarantined_until.is_some_and(|until| now < until)
+    }
+}
+
+/// Latch the thresholds at startup; either `0` disables quarantining.
+pub fn configure(failures: u32, quarantine_secs: u64) {
+    FAILURES.store(failures, Ordering::Relaxed);
+    QUARANTINE_SECS.store(quarantine_secs, Ordering::Relaxed);
+}
+
+fn enabled() -> bool {
+    FAILURES.load(Ordering::Relaxed) > 0 && QUARANTINE_SECS.load(Ordering::Relaxed) > 0
+}
+
+/// Whether a leg's failure says something about the pair rather than about
+/// one worker: an engine-side error other than an overload shed or an
+/// unavailable worker, which the per-worker circuit breaker and overload
+/// protection already own.
+pub fn pair_attributable(status: u16) -> bool {
+    status >= 500 && status != 503
+}
+
+/// Whether placement should steer around this pair right now.
+pub fn is_quarantined(prefill: &str, decode: &str) -> bool {
+    if !enabled() || PAIRS.is_empty() {
+        return false;
+    }
+    let now = Instant::now();
+    PAIRS.get(prefill).is_some_and(|by_decode| {
+        by_decode
+            .get(decode)
+            .is_some_and(|state| state.quarantined(now))
+    })
+}
+
+/// A rendezvous or first-response failure on the pair. Returns `true` when
+/// this failure put the pair into quarantine.
+pub fn record_failure(prefill: &str, decode: &str) -> bool {
+    if !enabled() {
+        return false;
+    }
+    let now = Instant::now();
+    let by_decode = PAIRS.entry(prefill.to_string()).or_default();
+    let mut state = by_decode.entry(decode.to_string()).or_default();
+    state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+    if state.consecutive_failures < FAILURES.load(Ordering::Relaxed) || state.quarantined(now) {
+        return false;
+    }
+    let quarantine = Duration::from_secs(QUARANTINE_SECS.load(Ordering::Relaxed));
+    state.quarantined_until = Some(now + quarantine);
+    warn!(
+        prefill,
+        decode,
+        consecutive_failures = state.consecutive_failures,
+        quarantine_secs = quarantine.as_secs(),
+        "Quarantining PD pair after consecutive rendezvous failures"
+    );
+    // Both guards must be released before the count walks the table.
+    drop(state);
+    drop(by_decode);
+    Metrics::record_pd_pair_quarantine(quarantined_count());
+    true
+}
+
+/// The decode leg answered: the handoff completed, so the pair is healthy.
+pub fn record_success(prefill: &str, decode: &str) {
+    if !enabled() || PAIRS.is_empty() {
+        return;
+    }
+    let Some(by_decode) = PAIRS.get(prefill) else {
+        return;
+    };
+    let Some((_, state)) = by_decode.remove(decode) else {
+        return;
+    };
+    drop(by_decode);
+    if state.quarantined_until.is_some() {
+        debug!(
+            prefill,
+            decode, "PD pair cleared quarantine after a successful handoff"
+        );
+        Metrics::set_pd_pairs_quarantined(quarantined_count());
+    }
+}
+
+/// Drop every pair the worker took part in (the worker was removed).
+pub fn forget(url: &str) {
+    if PAIRS.is_empty() {
+        return;
+    }
+    PAIRS.remove(url);
+    for by_decode in PAIRS.iter() {
+        by_decode.remove(url);
+    }
+    PAIRS.retain(|_, by_decode| !by_decode.is_empty());
+}
+
+/// Pairs currently in quarantine.
+pub fn quarantined_count() -> usize {
+    let now = Instant::now();
+    PAIRS
+        .iter()
+        .map(|by_decode| {
+            by_decode
+                .iter()
+                .filter(|state| state.quarantined(now))
+                .count()
+        })
+        .sum()
+}
+
+/// Serialises tests that change the thresholds or count the whole table;
+/// tests that only touch their own URLs need not take it.
+#[cfg(test)]
+pub(crate) fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_pair_is_quarantined_after_consecutive_failures_and_cleared_by_a_success() {
+        let _guard = test_guard();
+        let (p, d) = ("grpc://health-p:1", "grpc://health-d:1");
+        for _ in 1..DEFAULT_PD_PAIR_QUARANTINE_FAILURES {
+            assert!(!record_failure(p, d));
+            assert!(!is_quarantined(p, d));
+        }
+        assert!(record_failure(p, d));
+        assert!(is_quarantined(p, d));
+        // Only the failing pair is affected.
+        assert!(!is_quarantined(p, "grpc://health-d:2"));
+        assert!(!is_quarantined("grpc://health-p:2", d));
+        // Already quarantined: another failure does not re-quarantine.
+        assert!(!record_failure(p, d));
+
+        record_success(p, d);
+        assert!(!is_quarantined(p, d));
+        forget(p);
+    }
+
+    #[test]
+    fn a_quarantine_expires_and_a_removed_worker_is_forgotten() {
+        let _guard = test_guard();
+        configure(1, 1);
+        let (p, d) = ("grpc://expiry-p:1", "grpc://expiry-d:1");
+        assert!(record_failure(p, d));
+        assert!(is_quarantined(p, d));
+        std::thread::sleep(Duration::from_millis(1100));
+        assert!(!is_quarantined(p, d));
+        // The count persists, so the next failure re-quarantines at once.
+        assert!(record_failure(p, d));
+        assert!(is_quarantined(p, d));
+
+        forget(d);
+        assert!(!is_quarantined(p, d));
+        assert!(!record_failure(p, d) || quarantined_count() >= 1);
+        forget(p);
+        configure(
+            DEFAULT_PD_PAIR_QUARANTINE_FAILURES,
+            DEFAULT_PD_PAIR_QUARANTINE_SECS,
+        );
+    }
+
+    #[test]
+    fn disabled_thresholds_record_nothing() {
+        let _guard = test_guard();
+        configure(0, DEFAULT_PD_PAIR_QUARANTINE_SECS);
+        let (p, d) = ("grpc://off-p:1", "grpc://off-d:1");
+        for _ in 0..5 {
+            assert!(!record_failure(p, d));
+        }
+        assert!(!is_quarantined(p, d));
+        configure(
+            DEFAULT_PD_PAIR_QUARANTINE_FAILURES,
+            DEFAULT_PD_PAIR_QUARANTINE_SECS,
+        );
+    }
+
+    #[test]
+    fn only_engine_side_errors_count_against_a_pair() {
+        assert!(pair_attributable(500));
+        assert!(pair_attributable(504));
+        assert!(!pair_attributable(503));
+        assert!(!pair_attributable(429));
+        assert!(!pair_attributable(400));
+        assert!(!pair_attributable(200));
+    }
+}

--- a/model_gateway/src/worker/pd_pair_health.rs
+++ b/model_gateway/src/worker/pd_pair_health.rs
@@ -12,11 +12,12 @@
 //!
 //! Like the PD admission wait, the thresholds and the table are
 //! process-global: the dispatch paths that observe a rendezvous carry no
-//! handle on the registry.
+//! handle on the registry. The placement path pays nothing while no pair is
+//! quarantined: `QUARANTINED` gates every lookup.
 
 use std::{
     sync::{
-        atomic::{AtomicU32, AtomicU64, Ordering},
+        atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering},
         LazyLock,
     },
     time::{Duration, Instant},
@@ -35,8 +36,13 @@ pub const DEFAULT_PD_PAIR_QUARANTINE_SECS: u64 = 30;
 static FAILURES: AtomicU32 = AtomicU32::new(DEFAULT_PD_PAIR_QUARANTINE_FAILURES);
 static QUARANTINE_SECS: AtomicU64 = AtomicU64::new(DEFAULT_PD_PAIR_QUARANTINE_SECS);
 /// Prefill URL, then decode URL: two levels so a lookup borrows `&str`
-/// instead of allocating a pair key on the placement path.
+/// instead of allocating a pair key on the placement path. An inner map is
+/// dropped as soon as it empties, so the table is empty whenever no pair has
+/// a pending failure.
 static PAIRS: LazyLock<DashMap<String, DashMap<String, PairState>>> = LazyLock::new(DashMap::new);
+/// Pairs whose `quarantined_until` is set. Counts an expired quarantine
+/// until a lookup on that pair clears it, so it never undercounts.
+static QUARANTINED: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug, Default)]
 struct PairState {
@@ -68,17 +74,49 @@ pub fn pair_attributable(status: u16) -> bool {
     status >= 500 && status != 503
 }
 
+/// Pairs currently counted as quarantined (the `smg_pd_pairs_quarantined`
+/// gauge). An expired quarantine stays counted until the next lookup on
+/// that pair clears it, which placement does on its next decision.
+pub fn quarantined_count() -> usize {
+    QUARANTINED.load(Ordering::Relaxed)
+}
+
+fn uncount(pairs: usize) {
+    let _ = QUARANTINED.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+        Some(n.saturating_sub(pairs))
+    });
+    Metrics::set_pd_pairs_quarantined(quarantined_count());
+}
+
 /// Whether placement should steer around this pair right now.
 pub fn is_quarantined(prefill: &str, decode: &str) -> bool {
-    if !enabled() || PAIRS.is_empty() {
+    if !enabled() || quarantined_count() == 0 {
         return false;
     }
     let now = Instant::now();
-    PAIRS.get(prefill).is_some_and(|by_decode| {
-        by_decode
-            .get(decode)
-            .is_some_and(|state| state.quarantined(now))
-    })
+    let Some(by_decode) = PAIRS.get(prefill) else {
+        return false;
+    };
+    match by_decode
+        .get(decode)
+        .and_then(|state| state.quarantined_until)
+    {
+        Some(until) if now < until => true,
+        // Expired since it was entered: clear the flag so the count and
+        // gauge follow. The failure count stays, so the next failure
+        // re-quarantines at once.
+        Some(_) => {
+            if let Some(mut state) = by_decode.get_mut(decode) {
+                if state.quarantined_until.is_some_and(|until| until <= now) {
+                    state.quarantined_until = None;
+                    drop(state);
+                    uncount(1);
+                }
+            }
+            false
+        }
+        None => false,
+    }
 }
 
 /// A rendezvous or first-response failure on the pair. Returns `true` when
@@ -95,17 +133,22 @@ pub fn record_failure(prefill: &str, decode: &str) -> bool {
         return false;
     }
     let quarantine = Duration::from_secs(QUARANTINE_SECS.load(Ordering::Relaxed));
+    // An expired quarantine nobody looked up yet is still counted.
+    let counted = state.quarantined_until.is_some();
     state.quarantined_until = Some(now + quarantine);
+    let consecutive_failures = state.consecutive_failures;
+    drop(state);
+    drop(by_decode);
+    if !counted {
+        QUARANTINED.fetch_add(1, Ordering::Relaxed);
+    }
     warn!(
         prefill,
         decode,
-        consecutive_failures = state.consecutive_failures,
+        consecutive_failures,
         quarantine_secs = quarantine.as_secs(),
         "Quarantining PD pair after consecutive rendezvous failures"
     );
-    // Both guards must be released before the count walks the table.
-    drop(state);
-    drop(by_decode);
     Metrics::record_pd_pair_quarantine(quarantined_count());
     true
 }
@@ -118,16 +161,18 @@ pub fn record_success(prefill: &str, decode: &str) {
     let Some(by_decode) = PAIRS.get(prefill) else {
         return;
     };
-    let Some((_, state)) = by_decode.remove(decode) else {
-        return;
-    };
+    let removed = by_decode.remove(decode).map(|(_, state)| state);
+    let emptied = by_decode.is_empty();
     drop(by_decode);
-    if state.quarantined_until.is_some() {
+    if emptied {
+        PAIRS.remove_if(prefill, |_, by_decode| by_decode.is_empty());
+    }
+    if removed.is_some_and(|state| state.quarantined_until.is_some()) {
         debug!(
             prefill,
             decode, "PD pair cleared quarantine after a successful handoff"
         );
-        Metrics::set_pd_pairs_quarantined(quarantined_count());
+        uncount(1);
     }
 }
 
@@ -136,34 +181,34 @@ pub fn forget(url: &str) {
     if PAIRS.is_empty() {
         return;
     }
-    PAIRS.remove(url);
+    let flagged = |state: &PairState| state.quarantined_until.is_some();
+    let mut cleared = 0;
+    if let Some((_, by_decode)) = PAIRS.remove(url) {
+        cleared += by_decode.iter().filter(|state| flagged(state)).count();
+    }
     for by_decode in PAIRS.iter() {
-        by_decode.remove(url);
+        if let Some((_, state)) = by_decode.remove(url) {
+            cleared += usize::from(flagged(&state));
+        }
     }
     PAIRS.retain(|_, by_decode| !by_decode.is_empty());
+    if cleared > 0 {
+        uncount(cleared);
+    }
 }
 
-/// Pairs currently in quarantine.
-pub fn quarantined_count() -> usize {
-    let now = Instant::now();
-    PAIRS
-        .iter()
-        .map(|by_decode| {
-            by_decode
-                .iter()
-                .filter(|state| state.quarantined(now))
-                .count()
-        })
-        .sum()
-}
-
-/// Serialises tests that change the thresholds or count the whole table;
-/// tests that only touch their own URLs need not take it.
+/// Serialises tests that touch the table; they assert on its global state.
 #[cfg(test)]
 pub(crate) fn test_guard() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     LOCK.lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Pairs with a pending failure count, quarantined or not.
+#[cfg(test)]
+pub(crate) fn tracked_pairs() -> usize {
+    PAIRS.iter().map(|by_decode| by_decode.len()).sum()
 }
 
 #[cfg(test)]
@@ -180,15 +225,20 @@ mod tests {
         }
         assert!(record_failure(p, d));
         assert!(is_quarantined(p, d));
+        assert_eq!(quarantined_count(), 1);
         // Only the failing pair is affected.
         assert!(!is_quarantined(p, "grpc://health-d:2"));
         assert!(!is_quarantined("grpc://health-p:2", d));
         // Already quarantined: another failure does not re-quarantine.
         assert!(!record_failure(p, d));
+        assert_eq!(quarantined_count(), 1);
 
         record_success(p, d);
         assert!(!is_quarantined(p, d));
-        forget(p);
+        assert_eq!(quarantined_count(), 0);
+        // A success on the only pending pair leaves the table empty, so the
+        // placement fast path is back.
+        assert_eq!(tracked_pairs(), 0);
     }
 
     #[test]
@@ -198,16 +248,27 @@ mod tests {
         let (p, d) = ("grpc://expiry-p:1", "grpc://expiry-d:1");
         assert!(record_failure(p, d));
         assert!(is_quarantined(p, d));
+        assert_eq!(quarantined_count(), 1);
         std::thread::sleep(Duration::from_millis(1100));
+        // The lookup that sees the expiry clears the count.
         assert!(!is_quarantined(p, d));
-        // The count persists, so the next failure re-quarantines at once.
+        assert_eq!(quarantined_count(), 0);
+        // The failure count persists, so the next failure re-quarantines.
         assert!(record_failure(p, d));
         assert!(is_quarantined(p, d));
+        assert_eq!(quarantined_count(), 1);
 
+        // Removing the decode drops the pair and its quarantine.
         forget(d);
         assert!(!is_quarantined(p, d));
-        assert!(!record_failure(p, d) || quarantined_count() >= 1);
+        assert_eq!(quarantined_count(), 0);
+        assert_eq!(tracked_pairs(), 0);
+
+        // Removing the prefill drops every pair it led.
+        assert!(record_failure(p, d));
         forget(p);
+        assert_eq!(quarantined_count(), 0);
+        assert_eq!(tracked_pairs(), 0);
         configure(
             DEFAULT_PD_PAIR_QUARANTINE_FAILURES,
             DEFAULT_PD_PAIR_QUARANTINE_SECS,
@@ -223,6 +284,7 @@ mod tests {
             assert!(!record_failure(p, d));
         }
         assert!(!is_quarantined(p, d));
+        assert_eq!(tracked_pairs(), 0);
         configure(
             DEFAULT_PD_PAIR_QUARANTINE_FAILURES,
             DEFAULT_PD_PAIR_QUARANTINE_SECS,

--- a/model_gateway/src/worker/pd_pair_health.rs
+++ b/model_gateway/src/worker/pd_pair_health.rs
@@ -47,6 +47,9 @@ static QUARANTINED: AtomicUsize = AtomicUsize::new(0);
 #[derive(Debug, Default)]
 struct PairState {
     consecutive_failures: u32,
+    /// When the last failure was recorded: a run older than one quarantine
+    /// window is not consecutive any more.
+    last_failure: Option<Instant>,
     quarantined_until: Option<Instant>,
 }
 
@@ -126,13 +129,24 @@ pub fn record_failure(prefill: &str, decode: &str) -> bool {
         return false;
     }
     let now = Instant::now();
+    let quarantine = Duration::from_secs(QUARANTINE_SECS.load(Ordering::Relaxed));
     let by_decode = PAIRS.entry(prefill.to_string()).or_default();
     let mut state = by_decode.entry(decode.to_string()).or_default();
+    // Failures count as a run only within one quarantine window of each
+    // other: an unrelated failure hours later does not extend a run. A pair
+    // that already reached the threshold keeps its count, so the one probe
+    // placement lets through after expiry re-quarantines it at once.
+    let aged_out = state
+        .last_failure
+        .is_some_and(|last| now.duration_since(last) > quarantine);
+    if aged_out && state.consecutive_failures < FAILURES.load(Ordering::Relaxed) {
+        state.consecutive_failures = 0;
+    }
+    state.last_failure = Some(now);
     state.consecutive_failures = state.consecutive_failures.saturating_add(1);
     if state.consecutive_failures < FAILURES.load(Ordering::Relaxed) || state.quarantined(now) {
         return false;
     }
-    let quarantine = Duration::from_secs(QUARANTINE_SECS.load(Ordering::Relaxed));
     // An expired quarantine nobody looked up yet is still counted.
     let counted = state.quarantined_until.is_some();
     state.quarantined_until = Some(now + quarantine);
@@ -269,6 +283,32 @@ mod tests {
         forget(p);
         assert_eq!(quarantined_count(), 0);
         assert_eq!(tracked_pairs(), 0);
+        configure(
+            DEFAULT_PD_PAIR_QUARANTINE_FAILURES,
+            DEFAULT_PD_PAIR_QUARANTINE_SECS,
+        );
+    }
+
+    #[test]
+    fn failures_further_apart_than_the_window_are_not_a_run() {
+        let _guard = test_guard();
+        configure(2, 1);
+        let (p, d) = ("grpc://stale-p:1", "grpc://stale-d:1");
+        assert!(!record_failure(p, d));
+        std::thread::sleep(Duration::from_millis(1100));
+        // The old failure has aged out: this one starts a new run.
+        assert!(!record_failure(p, d));
+        assert!(!is_quarantined(p, d));
+        // Two within the window do quarantine.
+        assert!(record_failure(p, d));
+        assert!(is_quarantined(p, d));
+        // Past the threshold the count is kept: the one probe placement
+        // lets through after expiry re-quarantines at once.
+        std::thread::sleep(Duration::from_millis(1100));
+        assert!(!is_quarantined(p, d));
+        assert!(record_failure(p, d));
+        assert!(is_quarantined(p, d));
+        forget(p);
         configure(
             DEFAULT_PD_PAIR_QUARANTINE_FAILURES,
             DEFAULT_PD_PAIR_QUARANTINE_SECS,

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -27,6 +27,7 @@ use openai_protocol::worker::WorkerStatus;
 use tokio::sync::{broadcast, mpsc};
 use uuid::Uuid;
 
+use super::pd_pair_health;
 use crate::{
     config::types::RetryConfig,
     observability::metrics::Metrics,
@@ -1642,6 +1643,7 @@ impl WorkerRegistry {
         };
         if let Some((_, worker)) = removed {
             self.url_to_id.remove(worker.url());
+            pd_pair_health::forget(worker.url());
             // We hold _guard; drop the DashMap entry but the Mutex stays alive via Arc.
             self.worker_mutation_locks.remove(worker_id);
             self.worker_origins.remove(worker_id);


### PR DESCRIPTION
## Description

Step 3 of the PD pairing protocol (#2483): pair-level health. Stacked on #2486 (placement), which is stacked on #2484 (labels); the base moves down as they merge.

### Problem

The pairing descriptor (#2486) keeps a prefill and a decode apart when their labels say a KV handoff cannot work. It cannot catch what the labels miss: an engine that resolves a different attention backend than it requested, a transport that is configured identically but broken between two hosts, a version pair that reports compatible facts and still fails the handshake. Such a pair failed every rendezvous and kept being selected, because nothing at the gateway remembered that the *pair* had failed; the per-worker circuit breakers see two healthy workers.

### Solution

A process-global pair-health table (`worker/pd_pair_health.rs`, the same shape as the PD admission wait) keyed by prefill URL then decode URL:

- **What counts.** An engine-side error (5xx other than 503) on either leg at the rendezvous, or on the decode stream before its first response, counts against the pair. Overload sheds (429) and unavailable workers (503) never do: the per-worker breaker and overload protection own those. The decode's first response is the proof the handoff completed and clears the pair.
- **Quarantine.** After `--pd-pair-quarantine-failures` consecutive failures (default 3) the pair is quarantined for `--pd-pair-quarantine-secs` (default 30). The count persists through expiry, so a still-broken pair is re-quarantined on its next failure (one probe per window). Either knob at `0` disables the table.
- **Placement.** On top of the snapshot's pair index (#2486), `select_pair` treats a prefill as open only while one of its partners is available and not quarantined, and runs the decode policy over the pick's open partners. When every open pair is quarantined it serves through the quarantine: a hint drawn from failures, not a veto. With nothing quarantined the check is one atomic load per candidate.
- **Where it hooks.** gRPC parallel PD (both-answered and fail-fast outcomes), gRPC sequential PD (vLLM decode start), and the HTTP PD router's dual dispatch. The decode leg is wrapped in a new `ProtoStream::Observed` variant that reports its first item once, so the regular, harmony, fan-out and non-streaming consumers are covered without touching them. A removed worker's pairs are forgotten in `WorkerRegistry::remove`.
- **Visibility.** `smg_pd_pair_quarantines_total` (counter) and `smg_pd_pairs_quarantined` (gauge), plus a warn log naming the pair when it enters quarantine.

## Changes

- `model_gateway/src/worker/pd_pair_health.rs` (new): table, `configure`, `is_quarantined`, `record_failure`, `record_success`, `forget`, `pair_attributable`, unit tests.
- `model_gateway/src/routers/common/placement.rs`: quarantine steering in `select_pair`, test.
- `model_gateway/src/routers/grpc/proto_wrapper.rs`: `ProtoStream::Observed`, `ObservedStream`, `PdPairObserver`, `observe_pd_pair`.
- `model_gateway/src/routers/grpc/common/stages/request_execution.rs`: failure accounting in `execute_parallel_pd` and `execute_sequential_pd`, decode streams observed.
- `model_gateway/src/routers/http/pd_router.rs`: dual-dispatch outcome reported.
- `model_gateway/src/worker/registry.rs`: forget pairs on removal.
- `model_gateway/src/observability/metrics.rs`: the two metrics.
- `config/types.rs`, `config/builder.rs`, `main.rs`, `app_context.rs`: `--pd-pair-quarantine-failures` / `--pd-pair-quarantine-secs` plumbed to the table.

## Review notes

- The HTTP PD router only sees the final status, not which leg produced it, so a prefill-side 5xx also counts against the pair there; the gRPC paths attribute per leg. Both reset on the next success.
- `/workers` does not yet list a worker's quarantined partners; the metrics and the warn log are the visibility for now. Mock-worker integration tests for the quarantine are the coverage step of #2483.

## Review follow-up

- The quarantine count is an atomic that gates every placement lookup, and an emptied inner map is dropped, so a table holding only recovered failure counts costs placement nothing.
- The gauge follows that count: entry counts up, success and worker removal count down what they drop, and a lookup that sees an expired quarantine clears it. A pair that expires with no further placement for its prefill stays counted until one happens (module doc).
- `ProtoStream::next` dispatches the observed leg to a per-engine `next_inner`, so polling a PD decode stream allocates nothing; only the unreachable nested-observed arm is boxed.
- A decode stream that closes without a response on its first poll counts as a failed handoff; an unpolled drop on client disconnect still reports nothing.

## Test Plan

- `cargo clippy -p smg -p smg-golang --all-targets -- -D warnings`: clean.
- `cargo test -p smg --lib -- placement pd_pairing pd_pair_health worker_to_info config::types policies::registry request_execution`: 135 passed (50 of them re-run after the review follow-up).
- `cargo test -p smg --test grpc_pd_fanout_test`: 12 passed.
- `cargo check -p smg-golang` and `cargo check --manifest-path bindings/python/Cargo.toml`: clean.

<details>
<summary>Checklist</summary>

- [x] Format your code: `make fmt` / `cargo +nightly fmt --all`
- [x] Add unit or integration tests
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
