### PR TITLE
fix(http): do not relay empty upstream chunks as empty h2 DATA frames

### DIFF
--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -964,6 +964,15 @@ impl Router {
                 loop {
                     tokio::select! {
                         chunk = stream.next() => match chunk {
+                            // An upstream body can yield a zero-length chunk (the
+                            // chunked-encoding terminator surfaces as one). Forwarded,
+                            // hyper's h2 server sends it as an empty non-END_STREAM
+                            // DATA frame, and h2 >= 0.4.16 clients count those per
+                            // connection (never reset) and close the connection with
+                            // ENHANCE_YOUR_CALM after 100 — i.e. after ~100 streamed
+                            // responses on one client connection. Carry no bytes, send
+                            // no frame.
+                            Some(Ok(bytes)) if bytes.is_empty() => {}
                             Some(Ok(bytes)) => {
                                 if tx.send(Ok(bytes)).await.is_err() {
                                     client_disconnected = true;
@@ -1206,6 +1215,9 @@ impl Router {
                 loop {
                     tokio::select! {
                         chunk = stream.next() => match chunk {
+                            // Same as the regular relay: an empty upstream chunk must
+                            // not become an empty h2 DATA frame toward the client.
+                            Some(Ok(bytes)) if bytes.is_empty() => {}
                             Some(Ok(bytes)) => {
                                 if tx.send(Ok(bytes)).await.is_err() {
                                     break;


### PR DESCRIPTION
## Summary

The HTTP router's two streaming relays forward every upstream body chunk to the client, including the zero-length chunk hyper yields for a chunked-encoding terminator. hyper's h2 server sends a zero-length chunk as an empty DATA frame without END_STREAM. h2 0.4.16+ clients (the workspace lock is on 0.4.19) treat those as flood abuse: they count them per connection, never reset the count, and close the connection with `ENHANCE_YOUR_CALM` / `too_many_data_frames` once it passes 100.

Through the gateway that is one empty frame per streamed `/generate` response, so any h2 client on a current h2 crate loses its connection after ~100 streamed responses, and every stream in flight on that connection fails mid-response. Another SMG instance fronting this one over h2 is such a client.

Both relays now skip empty chunks. 12 lines, comment explains the why.

## Evidence

Raw h2 client against a gateway relaying a realistic-engine mock worker, one streamed `/generate` per stream, before the fix — DATA frames per response as `(payload bytes, END_STREAM)`:

```
stream 1: status 200
stream 1: 5 DATA frames [(168, False), (424, False), (14, False), (0, False), (0, True)]  zero-length non-EOS: 1
stream 3: status 200
stream 3: 5 DATA frames [(168, False), (424, False), (14, False), (0, False), (0, True)]  zero-length non-EOS: 1
```

The fourth frame is the relayed terminator. Under load (8 gateways, 120 mock workers, ~400 req/s, a reqwest/h2 load generator with 16 connections per gateway) that produced a 60% transport-error rate, every error reading:

```
error decoding response body <- request or response body error <- error reading a body from connection
<- connection error detected: detected excessive load generating behavior (b"too_many_data_frames")
```

The same load over HTTP/1.1 ran with zero errors, and the same load over h2 with this change applied ran 4 × 163,958 requests with zero errors.

Where the counter lives: `h2-0.4.19/src/proto/streams/counts.rs` (`record_data_frame`: `payload_len == 0` increments `num_recv_empty_data_frames`, capped at `MAX_RECV_EMPTY_DATA_FRAMES = 100`, exempting only END_STREAM frames). Where hyper sends empty chunks through: `hyper-1.11.0/src/proto/h2/mod.rs` ("Zero-length data frames need no capacity; send them straight through").

## Test plan

- `cargo +1.98.0 clippy -p smg --all-targets -- -D warnings` clean.
- `cargo test -p smg --lib -- routers::http`: 74 passed.
- Behavioral check above (raw h2 probe + loaded run) on a main-based tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7LDLMD8QeFy6MRwgxExmo
