### PR TITLE
fix(tool_parser): preserve Qwen XML streamed arguments

### DIFF
--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -174,13 +174,20 @@ impl QwenXmlParser {
 
     /// Parse and stream complete parameters from buffer
     /// Returns tool call items to emit (similar to Python's _parse_and_stream_parameters)
-    fn parse_and_stream_parameters(&mut self, tools: &[Tool]) -> Vec<ToolCallItem> {
+    fn parse_and_stream_parameters(
+        &mut self,
+        tools: &[Tool],
+        parameter_end: usize,
+    ) -> Vec<ToolCallItem> {
         let mut calls: Vec<ToolCallItem> = vec![];
         let param_types = helpers::param_types_for_function(tools, &self.current_function_name);
 
-        // Find all complete parameter patterns in buffer
+        // Leave parameters from subsequent coalesced calls for their own iteration.
         let mut new_params = serde_json::Map::new();
-        for cap in self.xml_param_pattern.captures_iter(&self.buffer) {
+        for cap in self
+            .xml_param_pattern
+            .captures_iter(&self.buffer[..parameter_end])
+        {
             if let (Some(key_match), Some(value_match)) = (cap.get(1), cap.get(2)) {
                 let key = key_match.as_str().trim().to_string();
                 let value = value_match.as_str();
@@ -422,26 +429,23 @@ impl ToolParser for QwenXmlParser {
 
             // Parse parameters (only complete ones)
             if self.current_tool_name_sent {
-                let param_calls = self.parse_and_stream_parameters(tools);
+                let end_pos = self.buffer.find(self.tool_call_end_token);
+                let parameter_end = end_pos.unwrap_or(self.buffer.len());
+                let param_calls = self.parse_and_stream_parameters(tools, parameter_end);
                 calls.extend(param_calls);
 
                 // Check if tool call is complete
-                if let Some(end_pos) = self.buffer.find(self.tool_call_end_token) {
-                    // Close JSON object if we have parameters
-                    let current_args = &self.streamed_args_for_tool[self.current_tool_id as usize];
-                    if !current_args.is_empty() {
-                        // Count braces to check if JSON is complete
-                        let open_braces = current_args.matches('{').count();
-                        let close_braces = current_args.matches('}').count();
-                        if open_braces > close_braces {
-                            calls.push(ToolCallItem {
-                                tool_index: self.current_tool_id as usize,
-                                name: None,
-                                parameters: "}".to_string(),
-                            });
-                            self.streamed_args_for_tool[self.current_tool_id as usize].push('}');
-                        }
-                    }
+                if let Some(end_pos) = end_pos {
+                    // Parameter fragments leave the root open; braces in values are data.
+                    let current_args =
+                        &mut self.streamed_args_for_tool[self.current_tool_id as usize];
+                    let closing = if current_args.is_empty() { "{}" } else { "}" };
+                    calls.push(ToolCallItem {
+                        tool_index: self.current_tool_id as usize,
+                        name: None,
+                        parameters: closing.to_string(),
+                    });
+                    current_args.push_str(closing);
 
                     // Complete the tool call
                     self.buffer =
@@ -466,6 +470,23 @@ impl ToolParser for QwenXmlParser {
     }
 
     fn get_unstreamed_tool_args(&self) -> Option<Vec<ToolCallItem>> {
+        let tool_index = self.prev_tool_call_arr.len().checked_sub(1)?;
+        let actual = self.streamed_args_for_tool.get(tool_index)?;
+        let expected = self.prev_tool_call_arr[tool_index].get("arguments")?;
+        // XML parameters use spaced JSON, unlike the generic compact-prefix recovery.
+        // Append only the root brace, and only for exactly the already parsed values.
+        if !actual.is_empty()
+            && serde_json::from_str::<Value>(&format!("{actual}}}"))
+                .ok()
+                .as_ref()
+                == Some(expected)
+        {
+            return Some(vec![ToolCallItem {
+                tool_index,
+                name: None,
+                parameters: "}".to_string(),
+            }]);
+        }
         helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
     }
 

--- a/crates/tool_parser/tests/tool_parser_qwen_xml.rs
+++ b/crates/tool_parser/tests/tool_parser_qwen_xml.rs
@@ -8,6 +8,151 @@ use common::{create_test_tools, streaming_helpers};
 use serde_json::json;
 use tool_parser::{parsers::QwenXmlParser, traits::ToolParser};
 
+// Exercise the same terminal getters as the gRPC streaming caller. Fixtures are synthetic.
+#[expect(clippy::unwrap_used, reason = "assertions in a shared test helper")]
+async fn assert_streamed_arguments(
+    input: &str,
+    expected: &[(&str, serde_json::Value)],
+    complete: bool,
+) {
+    let tools = create_test_tools();
+    let mut feeds = vec![
+        vec![input.to_string()],
+        input.chars().map(|c| c.to_string()).collect(),
+    ];
+    // Also cover every possible two-chunk split, including coalesced calls.
+    for (split, _) in input.char_indices().skip(1) {
+        feeds.push(vec![input[..split].to_string(), input[split..].to_string()]);
+    }
+    for chunks in feeds {
+        let mut parser = QwenXmlParser::new();
+        let mut deltas = Vec::new();
+        for chunk in &chunks {
+            let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+            assert!(result.normal_text.is_empty());
+            deltas.extend(result.calls);
+        }
+        assert!(parser.take_unstreamed_normal_text().is_empty());
+        let pending = parser.get_unstreamed_tool_args();
+        if complete {
+            assert!(pending.is_none(), "completed calls must already be closed");
+            assert!(parser
+                .parse_incremental("", &tools)
+                .await
+                .unwrap()
+                .calls
+                .is_empty());
+        }
+        deltas.extend(pending.unwrap_or_default());
+        let names: Vec<_> = deltas
+            .iter()
+            .filter_map(|d| d.name.as_deref().map(|name| (d.tool_index, name)))
+            .collect();
+        let expected_names: Vec<_> = expected
+            .iter()
+            .enumerate()
+            .map(|(index, (name, _))| (index, *name))
+            .collect();
+        assert_eq!(names, expected_names, "chunks: {chunks:?}");
+        assert!(deltas.iter().all(|d| d.tool_index < expected.len()));
+        for (index, (_, expected_args)) in expected.iter().enumerate() {
+            let args: String = deltas
+                .iter()
+                .filter(|d| d.tool_index == index)
+                .map(|d| d.parameters.as_str())
+                .collect();
+            let parsed = serde_json::from_str::<serde_json::Value>(&args);
+            assert_eq!(
+                parsed.as_ref().ok(),
+                Some(expected_args),
+                "args: {args}; chunks: {chunks:?}"
+            );
+        }
+        parser.reset();
+        assert!(parser.get_unstreamed_tool_args().is_none());
+    }
+}
+
+#[tokio::test]
+async fn test_qwen_xml_streaming_braces_inside_string_do_not_close_object() {
+    let input = "<tool_call><function=get_weather><parameter=city>echo '}'</parameter></function></tool_call>";
+    assert_streamed_arguments(input, &[("get_weather", json!({"city": "echo '}'"}))], true).await;
+}
+
+#[tokio::test]
+async fn test_qwen_xml_eos_closes_only_complete_parameter_values() {
+    let input = "<tool_call><function=get_weather><parameter=city>Tokyo</parameter>";
+    for suffix in ["", "<parameter=units>cels"] {
+        assert_streamed_arguments(
+            &format!("{input}{suffix}"),
+            &[("get_weather", json!({"city": "Tokyo"}))],
+            false,
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn test_qwen_xml_eos_does_not_invent_unfinished_parameter() {
+    assert_streamed_arguments(
+        "<tool_call><function=get_weather><parameter=city>Tok",
+        &[("get_weather", json!({}))],
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_qwen_xml_eos_closes_last_of_multiple_calls() {
+    let input = concat!(
+        "<tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>",
+        "<tool_call><function=get_weather><parameter=city>Tokyo</parameter>",
+    );
+    assert_streamed_arguments(
+        input,
+        &[
+            ("get_weather", json!({"city": "Paris"})),
+            ("get_weather", json!({"city": "Tokyo"})),
+        ],
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_qwen_xml_coalesced_calls_do_not_share_parameters() {
+    let input = concat!(
+        "<tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>",
+        "<tool_call><function=get_weather><parameter=city>Tokyo</parameter><parameter=units>celsius</parameter></function></tool_call>",
+    );
+    assert_streamed_arguments(
+        input,
+        &[
+            ("get_weather", json!({"city": "Paris"})),
+            ("get_weather", json!({"city": "Tokyo", "units": "celsius"})),
+        ],
+        true,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_qwen_xml_empty_calls_and_nested_values_are_closed_once() {
+    let input = concat!(
+        "<tool_call><function=get_time></function></tool_call>",
+        r#"<tool_call><function=process><parameter=data>{"x":"}"}</parameter></function></tool_call>"#,
+    );
+    assert_streamed_arguments(
+        input,
+        &[
+            ("get_time", json!({})),
+            ("process", json!({"data": {"x": "}"}})),
+        ],
+        true,
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn test_qwen_xml_single_tool() {
     let parser = QwenXmlParser::new();


### PR DESCRIPTION
## Description
### Problem

QwenXmlParser can emit invalid or cross-contaminated tool arguments depending on the argument content and chunk boundaries:

- A literal `}` inside a parameter string is counted as a structural JSON brace. For `<tool_call><function=get_weather><parameter=city>echo '}'</parameter></function></tool_call>`, the streamed arguments omit the root closing brace.
- At end of stream, `<tool_call><function=get_weather><parameter=city>Tokyo</parameter>` leaves an open argument object. The generic recovery helper compares compact serialized JSON with the parser's spaced fragments and finds no matching prefix.
- When adjacent calls arrive together, parameter scanning includes subsequent calls. A Paris call can acquire the next call's fields or have its city overwritten by Tokyo.

### Minimal reproducer

On a clean SMG checkout at `9c87ef5d499604089b25bd1900ea7f6804cbf1db`, save the following temporary file as `crates/tool_parser/tests/qwen_xml_minimal_repro.rs`. It uses one tool, one string parameter containing `}`, and one complete chunk; no model server or GPU is needed.

```rust
use serde_json::{json, Value};
use tool_parser::{parsers::QwenXmlParser, ToolParser};

#[tokio::test]
async fn qwen_xml_minimal_repro() {
    let tools = vec![serde_json::from_value(json!({
        "type": "function",
        "function": {
            "name": "f",
            "parameters": {"type": "object", "properties": {"x": {"type": "string"}}}
        }
    }))
    .unwrap()];
    let mut parser = QwenXmlParser::new();
    let mut result = parser
        .parse_incremental(
            "<tool_call><function=f><parameter=x>}</parameter></function></tool_call>",
            &tools,
        )
        .await
        .unwrap();
    result
        .calls
        .extend(parser.get_unstreamed_tool_args().unwrap_or_default());
    let args: String = result
        .calls
        .iter()
        .map(|call| call.parameters.as_str())
        .collect();
    assert_eq!(
        serde_json::from_str::<Value>(&args).ok(),
        Some(json!({"x": "}"})),
        "arguments: {args}"
    );
}
```

Run from the repository root:

```sh
cargo test --locked -p tool-parser --test qwen_xml_minimal_repro -- --nocapture
```

**Before the fix:** the assertion fails with `arguments: {"x": "}"`; the root closing brace is missing. Result: **0 passed / 1 failed** (exit 101), including the terminal argument getter.

**With this fix:** the same snippet passes and the collected arguments parse to `{"x":"}"}`. Result: **1 passed / 0 failed** (exit 0). Both runs were executed against the same base, changing only the parser implementation. This temporary reproducer is documentation material; the committed patch still adds six regression tests.

### Solution

Limit parameter extraction to the current `</tool_call>` boundary and close each argument object when that boundary is consumed, emitting `{}` for an empty call. At EOS, append only the root `}` when the resulting JSON equals exactly the already parsed argument object. Unfinished parameter values remain absent.

The repair stays within QwenXmlParser; the shared recovery helper, argument coercion, and caller finish-reason policies are unchanged. Existing tests retain coverage for the schema coercion from [#1841](https://github.com/smg-project/smg/pull/1841) and literal argument values from [#1899](https://github.com/smg-project/smg/pull/1899). The existing `qwen_coder` and `nemotron` aliases use the same parser implementation.

### Prior work

This change follows earlier work on final argument validity, per-call isolation, and streaming completion:

| Prior PR / review | Earlier contribution | How this PR follows it |
| --- | --- | --- |
| Original Qwen XML parser, [SGLang #12909](https://github.com/sgl-project/sglang/pull/12909) | [CatherineSue's review](https://github.com/sgl-project/sglang/pull/12909#discussion_r2535686611) asked about final concatenated argument JSON and nested objects. | Reconstruct arguments per tool index and assert exact parsed JSON after streaming and terminal flush. |
| MiniMax-M2 parallel calls, [SMG #1824](https://github.com/smg-project/smg/pull/1824) | Fixed missing calls. A separate [automated review by chatgpt-codex-connector](https://github.com/smg-project/smg/pull/1824#discussion_r3462315616) identified parameter leakage when adjacent calls are scanned together. | Bound Qwen XML scanning to one call and assert exact arguments per index, covering foreign-field leakage and same-name overwrites. |
| Cohere framing, [SMG #1941](https://github.com/smg-project/smg/pull/1941) | Distinguished literal markers inside JSON strings from framing; [review follow-through](https://github.com/smg-project/smg/pull/1941#discussion_r3609781619) removed unsafe recovery fallbacks. | Treat braces inside parameter values as data. Qwen's emitted root object is already known to be open, so close it at the tool boundary without adding a string scanner; keep EOS recovery conservative. |
| Shared JSON streaming, [SMG #2271](https://github.com/smg-project/smg/pull/2271) | Repaired buffered-content loss and missing arguments when a call completed in one parser invocation, with regression coverage for shared-helper consumers. | Cover coalesced input and terminal getters in the separate XML implementation, which does not use that shared streaming helper. |

The three Qwen mechanisms were present in the initial XML implementation. Following its mainline history through renaming and value-coercion changes found no intervening repair-and-revert sequence.

## Changes

- Find the current tool boundary once, reuse it for parameter scanning and closure, and retain independent tool indices.
- Replace raw brace counting with closure at the tool boundary, including empty calls.
- Add a Qwen XML EOS recovery check using parsed JSON equality.
- Add six focused regression tests to the existing Qwen XML integration suite, covering argument closure, conservative EOS recovery, last-tool indexing, and per-call isolation.

## Test Plan

### Rebase validation

Rebased onto main `a8dc4f4088974925ee6e05f8a4c8aae65b011a23` as `1a3ff347dc3ed12dbc94b64d1dec21a50f99146f`. `git range-diff` confirms the original parser/test patch is unchanged: two files, +186/-20. On this new commit, the CPU run of `cargo test --locked -p tool-parser` passed **501 tests / 0 failures / 0 ignored** across 26 completed harnesses. `cargo clippy --locked -p tool-parser --all-targets --all-features -- -D warnings`, nightly whole-repository formatting, and the base-to-head whitespace check all returned exit 0. The initial full-workspace result below is historical; new-head hosted CI, including the GPU lanes, remains required.

The [previous CI run](https://github.com/smg-project/smg/actions/runs/34414993780) had two independent failures plus the aggregate `finish` failure:

- TensorRT-LLM failed during engine startup because cuda-bindings 13.4.1 removed `cudaIpcMemHandle_t.reserved`. The rebase includes the exact dependency pin and canary from merged [#2494](https://github.com/smg-project/smg/pull/2494).
- vLLM failed during the first no-tool warmup request with UCX/RoCE connection errors, before the multimodal assertions. The same runner host has [a prior diagnosis and successful unchanged-code rerun on another host](https://github.com/smg-project/smg/pull/2464#issuecomment-5599044608). This supports a runner transport cause; the exact device configuration was not inspected.
- `finish` failed because those two prerequisite jobs failed. No parser or CI-gate changes were added for these failures.

### Original red/green evidence

Reproduction baseline: `a5901cb5905eb929ec60448f39b3c082d5940b91`. The initial publication base was `9c87ef5d499604089b25bd1900ea7f6804cbf1db`; neither Qwen XML file changed upstream, and the reviewed patch is byte-for-byte unchanged. Applying only the final test-file changes to the unchanged production baseline gives **39 passed / 5 failed**; adding the production fix gives **44 passed / 0 failed**. All **38 pre-existing tests pass in both runs**. Of the **six new tests**, five expose defects in the baseline and one protects already-correct handling of an unfinished parameter. All fixtures are synthetic.

### New regression tests: baseline versus fix

All test names below have the prefix `test_qwen_xml_` and live in `crates/tool_parser/tests/tool_parser_qwen_xml.rs`. The baseline column records the first observed failing assertion in each test; later subcases in that test are not claimed as independently reproduced failures.

| New test | Unchanged baseline | With this fix |
| --- | --- | --- |
| `streaming_braces_inside_string_do_not_close_object` | **FAIL:** the `echo '}'` value leaves streamed JSON without its root closing brace. | **PASS:** retain the literal brace string and emit valid JSON. |
| `eos_closes_only_complete_parameter_values` | **FAIL:** a completed `city=Tokyo` parameter followed by EOS leaves the argument object open. | **PASS:** close the object after a completed parameter, including when an unfinished next parameter follows; preserve only completed values. |
| `eos_does_not_invent_unfinished_parameter` | **PASS:** an unfinished first parameter, `city=Tok`, retains the existing `{}` fallback. | **PASS:** recovery still does not invent a value for the unfinished parameter. |
| `eos_closes_last_of_multiple_calls` | **FAIL:** the second call's Tokyo value overwrites the first call's Paris value. | **PASS:** keep calls independent and emit the EOS closure for the last call at index 1. This checks an index that the standalone EOS case cannot exercise. |
| `coalesced_calls_do_not_share_parameters` | **FAIL:** the first Paris call becomes Tokyo and acquires `units=celsius` from the second call. | **PASS:** one fixture checks both value overwriting and foreign-field leakage, with exact arguments per index. |
| `empty_calls_and_nested_values_are_closed_once` | **FAIL:** the first empty call receives malformed arguments containing the following call's nested data. | **PASS:** the earlier empty call emits `{}`; the following nested value remains exact; completed calls need no additional argument flush or duplicate closure. |

The six tests cover whole input, character-by-character input, and every valid two-chunk split. Assertions reconstruct exact semantic JSON per tool index, verify names and terminal getters, and check reset behavior. Completed fixtures require no pending closure. Each test protects a distinct boundary: payload braces, single-call EOS, no completed value, last-call EOS, adjacent-call isolation, or an earlier empty call. Existing suites supply nonstream and factory-mapping coverage.

### Original-base commands and broader compatibility checks

Run from the repository root with Rust 1.95 and nightly rustfmt:

```sh
cargo test --locked -p tool-parser --test tool_parser_qwen_xml
cargo test --locked -p tool-parser --lib \
  --test tool_parser_qwen_xml --test tool_parser_qwen_dotted \
  --test tool_parser_nemotron --test tool_parser_streaming_flush
cargo clippy --locked -p tool-parser --all-targets --all-features -- -D warnings
cargo +nightly fmt --all -- --check
git diff --check
```

The original focused CPU run passed **166 tests with zero failures**:

| Suite | Passed | Checked surface |
| --- | ---: | --- |
| Library (`--lib`) | 113 | Existing tool-parser unit coverage. |
| `tool_parser_qwen_xml` | 44 | 38 existing tests plus six new regressions above. |
| `tool_parser_qwen_dotted` | 3 | Qwen dotted-family mappings, earlier-family compatibility, and a representative Qwen3.8 nonstream parse. |
| `tool_parser_nemotron` | 3 | Nemotron mappings, named alias, earlier-family exclusion, and a representative Nemotron-3.5 nonstream parse. |
| `tool_parser_streaming_flush` | 3 | Buffered text recovery, streamed arguments, and reset behavior in shared-helper consumers. |

The family suites verify parser selection and representative nonstream parsing; they do not establish model-serving qualification.

The initial full publication gate was run on `9c87ef5d499604089b25bd1900ea7f6804cbf1db` plus the unchanged patch, on a CPU builder with Rust 1.95:

| Command | Result |
| --- | --- |
| `cargo test --locked` | **5,481 passed / 0 failed / 40 ignored**, summed across 120 completed test harnesses; exit 0. Includes the 44-test Qwen XML suite. No additional test filters were applied. |
| `cargo clippy --locked --workspace --all-targets -- -D warnings` | Exit 0. Uses the [documented fallback without OpenCV](https://github.com/smg-project/smg/blob/9c87ef5d499604089b25bd1900ea7f6804cbf1db/CONTRIBUTING.md#the-pre-pr-gate); workspace non-default features were not linted. The tool-parser-only all-features check above also passed. |
| `cargo +nightly fmt --all -- --check` | Silent success, exit 0. |
| `git diff --check` | Silent success, exit 0. |

Representative output from the full workspace test run and final workspace Clippy run:

```text
test result: ok. 44 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.22s
    Finished `dev` profile [unoptimized] target(s) in 4m 13s
```

The first line is the Qwen XML test harness, not the workspace total. The earlier 166-test focused run is overlapping evidence and is not added to the 5,481-test total. Cargo emitted existing workspace-manifest warnings; there were no Clippy lint failures.

The gRPC ChatCompletion streaming caller's terminal getters were checked in source and exercised by the parser tests. The workspace run includes mock transport/gRPC tests, but no live-model Qwen gRPC or GPU serving canary was run. Existing delimiter ambiguity and duplicate parameter names within a single call remain outside this change. There is no configuration migration. Deployment validation remains a separate step; reverting this change restores the previous parser behavior.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (documented alternative without OpenCV); tool-parser scoped `--all-features` also passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
