### PR TITLE
ci: pin cuda-bindings for the TensorRT-LLM lane

### DIFF
--- a/scripts/ci_install_trtllm.sh
+++ b/scripts/ci_install_trtllm.sh
@@ -65,11 +65,21 @@ $RETRY 3 10 pip install --no-cache-dir "$NCCL_VERSION_CONSTRAINT"
 # The cu130 torch index is also needed so pip resolves torch 2.10+cu130
 # (cuda-bindings==13.x) instead of the default PyPI torch (cuda-bindings==12.9.4),
 # which conflicts with tensorrt-llm's cuda-python>=13 requirement.
+#
+# cuda-bindings is pinned: 13.4.1 (2026-09-10) dropped the `reserved` field
+# of cudaIpcMemHandle_t that tensorrt-llm's IPC memory setup still reads, so
+# every multi-GPU engine died at startup with an AttributeError the moment
+# the release appeared. 13.3.1 is the last version the lane ran on.
 echo "Installing tensorrt-llm==${TRTLLM_VERSION} from pypi.nvidia.com..."
 $RETRY 3 10 pip install --no-cache-dir --pre \
     --extra-index-url https://pypi.nvidia.com \
     --extra-index-url https://download.pytorch.org/whl/cu130 \
-    "tensorrt-llm==${TRTLLM_VERSION}"
+    "tensorrt-llm==${TRTLLM_VERSION}" "cuda-bindings==13.3.1"
+
+# Import canary: fail here (not 20 minutes into the lane) if the pin above
+# no longer matches what tensorrt-llm's IPC path expects.
+python3 -c "from cuda.bindings import runtime; runtime.cudaIpcMemHandle_t().reserved"
+echo "cuda-bindings IPC handle canary OK"
 
 # typer >= 0.26 leaks click.exceptions.Exit through its main on CLI exit, so
 # every `hf` invocation (model downloads) exits 1 even on success. The


### PR DESCRIPTION
## Description

### Problem

Since about 01:16 UTC today every `e2e-4gpu-chat (trtllm)` lane fails at engine startup with

```
AttributeError: 'cuda.bindings.runtime.cudaIpcMemHandle_t' object has no attribute 'reserved'
```

from `tensorrt_llm/_ipc_utils.py`. `cuda-bindings` 13.4.1 was published at that time and removed the field; the TensorRT-LLM install has no pin on it (it arrives through `torch==2.11.0+cu130 → cuda-bindings<14,>=13.0.3`), so lanes that resolved 13.3.1 this afternoon started resolving 13.4.1 tonight. First seen on #2492's CI; unrelated to that change.

### Solution

Pin `cuda-bindings==13.3.1` next to `tensorrt-llm` in `scripts/ci_install_trtllm.sh`, and add an import canary that touches the field so a future drift fails at install time rather than twenty minutes into the lane.

## Changes

- `scripts/ci_install_trtllm.sh`: the pin and the canary.

## Test Plan

- `bash -n` on the script.
- The `e2e-4gpu-chat (trtllm)` lane on this PR is the real test.

<details>
<summary>Checklist</summary>

- [x] Format your code: `make fmt` / `cargo +nightly fmt --all`
- [ ] Add unit or integration tests
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
