### PR TITLE
ci: run SGLang over NIXL in the PD lanes

### DIFF
--- a/.github/workflows/nightly-pd.yml
+++ b/.github/workflows/nightly-pd.yml
@@ -46,7 +46,7 @@ jobs:
             map(if . == "vllm" then [{engine: "vllm"}, {engine: "vllm", kv_backend: "mooncake"}]
                 elif . == "sglang" then [{engine: "sglang"},
                   {engine: "sglang", kv_backend: "nixl",
-                   test_filter: "-k \"not sole_leg_outage and not survives_losing\""}]
+                   filter: "not sole_leg_outage and not survives_losing"}]
                 else [{engine: .}] end) | add')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "matrix: $matrix"
@@ -167,8 +167,13 @@ jobs:
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
       # The mixed-transport fleet needs both vLLM backends installed whatever the row's own
       vllm_extra_kv_backends: ${{ matrix.engine == 'vllm' && 'mooncake' || '' }}
-      # A row's own filter wins over the dispatch filter.
-      test_filter: ${{ matrix.test_filter || (inputs.filter != '' && format('-k "{0}"', inputs.filter)) || '' }}
+      # A row's own filter always applies; a dispatch filter narrows within it.
+      test_filter: >-
+        ${{ (inputs.filter != '' && matrix.filter != '')
+            && format('-k "({0}) and ({1})"', inputs.filter, matrix.filter)
+            || (inputs.filter != '' && format('-k "{0}"', inputs.filter))
+            || (matrix.filter != '' && format('-k "{0}"', matrix.filter))
+            || '' }}
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
       min_selected: 0
       tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.tokenspeed-image.outputs.image || '' }}

--- a/.github/workflows/nightly-pd.yml
+++ b/.github/workflows/nightly-pd.yml
@@ -36,11 +36,13 @@ jobs:
           ENGINES: ${{ inputs.engines }}
         run: |
           wanted="${ENGINES:-sglang vllm tokenspeed}"
-          # One row per engine; vLLM also runs over Mooncake next to its NIXL
-          # default. SGLang over NIXL waits on a NIXL install for its venv (#2498).
+          # One row per engine, plus each engine's other KV transport: vLLM over
+          # Mooncake next to its NIXL default, SGLang over NIXL next to its
+          # Mooncake default (TokenSpeed only has Mooncake).
           matrix=$(printf '%s\n' $wanted | jq -Rsc '
             split("\n") | map(select(length > 0)) |
             map(if . == "vllm" then [{engine: "vllm"}, {engine: "vllm", kv_backend: "mooncake"}]
+                elif . == "sglang" then [{engine: "sglang"}, {engine: "sglang", kv_backend: "nixl"}]
                 else [{engine: .}] end) | add')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "matrix: $matrix"

--- a/.github/workflows/nightly-pd.yml
+++ b/.github/workflows/nightly-pd.yml
@@ -38,11 +38,15 @@ jobs:
           wanted="${ENGINES:-sglang vllm tokenspeed}"
           # One row per engine, plus each engine's other KV transport: vLLM over
           # Mooncake next to its NIXL default, SGLang over NIXL next to its
-          # Mooncake default (TokenSpeed only has Mooncake).
+          # Mooncake default (TokenSpeed only has Mooncake). The NIXL row skips
+          # the peer-restart tests: the SGLang prefill segfaults when its decode
+          # comes back on the same address (#2503).
           matrix=$(printf '%s\n' $wanted | jq -Rsc '
             split("\n") | map(select(length > 0)) |
             map(if . == "vllm" then [{engine: "vllm"}, {engine: "vllm", kv_backend: "mooncake"}]
-                elif . == "sglang" then [{engine: "sglang"}, {engine: "sglang", kv_backend: "nixl"}]
+                elif . == "sglang" then [{engine: "sglang"},
+                  {engine: "sglang", kv_backend: "nixl",
+                   test_filter: "-k \"not sole_leg_outage and not survives_losing\""}]
                 else [{engine: .}] end) | add')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "matrix: $matrix"
@@ -163,7 +167,8 @@ jobs:
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
       # The mixed-transport fleet needs both vLLM backends installed whatever the row's own
       vllm_extra_kv_backends: ${{ matrix.engine == 'vllm' && 'mooncake' || '' }}
-      test_filter: ${{ inputs.filter != '' && format('-k "{0}"', inputs.filter) || '' }}
+      # A row's own filter wins over the dispatch filter.
+      test_filter: ${{ matrix.test_filter || (inputs.filter != '' && format('-k "{0}"', inputs.filter)) || '' }}
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
       min_selected: 0
       tokenspeed_prebuilt_image: ${{ matrix.engine == 'tokenspeed' && needs.tokenspeed-image.outputs.image || '' }}

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1036,13 +1036,20 @@ jobs:
           - engine: tokenspeed
             timeout: 85
             test_timeout: 60
-          # vLLM's other KV transport: the same slice over Mooncake. TokenSpeed
-          # only has Mooncake; SGLang over NIXL waits on a NIXL install for its
-          # venv (#2498). The full sweeps run in nightly-pd.
+          # The other KV transport of each engine (TokenSpeed only has
+          # Mooncake): the same slice on vLLM over Mooncake, and a 1p1d
+          # smoke of SGLang over NIXL (its venv gets NIXL only on this row,
+          # #2498). The full sweeps run in nightly-pd.
           - engine: vllm
             kv_backend: mooncake
             timeout: 50
             test_timeout: 42
+          - engine: sglang
+            kv_backend: nixl
+            timeout: 60
+            test_timeout: 50
+            test_filter: -k "1p1d and not http"
+            min_selected: 11
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -1055,9 +1062,11 @@ jobs:
       # runtime-assembled fleet, the over-window burst, and the mismatched
       # fleet that placement must refuse; the full sweep runs in nightly-pd.
       # Run 34440725835: 9-16 min of tests per row against the 42/60 budgets.
-      test_filter: -k "(2p2d and not http) or AssembledAtRuntime or SmallWindow or MismatchedTransport"
+      test_filter: ${{ matrix.test_filter || '-k "(2p2d and not http) or AssembledAtRuntime or SmallWindow or MismatchedTransport"' }}
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
-      min_selected: 13 # floor ≈ 95% of the slice: 14 cases on sglang/tokenspeed, 16 on vllm (its two transport classes)
+      # floor ≈ 95% of the slice: 14 cases on sglang/tokenspeed, 16 on vllm
+      # (its two transport classes); the 1p1d smoke selects 13
+      min_selected: ${{ matrix.min_selected || 13 }}
       kv_backend: ${{ matrix.kv_backend || '' }}
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
       # The mixed-transport fleet needs both vLLM backends installed whatever the lane's own

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1049,7 +1049,7 @@ jobs:
             timeout: 60
             test_timeout: 50
             test_filter: -k "1p1d and not http"
-            min_selected: 11
+            min_selected: 12
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -1065,7 +1065,7 @@ jobs:
       test_filter: ${{ matrix.test_filter || '-k "(2p2d and not http) or AssembledAtRuntime or SmallWindow or MismatchedTransport"' }}
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
       # floor ≈ 95% of the slice: 14 cases on sglang/tokenspeed, 16 on vllm
-      # (its two transport classes); the 1p1d smoke selects 13
+      # (its two transport classes); the 1p1d smoke selects 13, floor 12
       min_selected: ${{ matrix.min_selected || 13 }}
       kv_backend: ${{ matrix.kv_backend || '' }}
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1039,7 +1039,9 @@ jobs:
           # The other KV transport of each engine (TokenSpeed only has
           # Mooncake): the same slice on vLLM over Mooncake, and a 1p1d
           # smoke of SGLang over NIXL (its venv gets NIXL only on this row,
-          # #2498). The full sweeps run in nightly-pd.
+          # #2498). The peer-restart test stays out of the NIXL smoke: the
+          # SGLang prefill segfaults when its decode comes back on the same
+          # address (#2503). The full sweeps run in nightly-pd.
           - engine: vllm
             kv_backend: mooncake
             timeout: 50
@@ -1048,8 +1050,8 @@ jobs:
             kv_backend: nixl
             timeout: 60
             test_timeout: 50
-            test_filter: -k "1p1d and not http"
-            min_selected: 12
+            test_filter: -k "1p1d and not http and not sole_leg_outage"
+            min_selected: 11
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -1065,7 +1067,7 @@ jobs:
       test_filter: ${{ matrix.test_filter || '-k "(2p2d and not http) or AssembledAtRuntime or SmallWindow or MismatchedTransport"' }}
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
       # floor ≈ 95% of the slice: 14 cases on sglang/tokenspeed, 16 on vllm
-      # (its two transport classes); the 1p1d smoke selects 13, floor 12
+      # (its two transport classes); the 1p1d smoke selects 12, floor 11
       min_selected: ${{ matrix.min_selected || 13 }}
       kv_backend: ${{ matrix.kv_backend || '' }}
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -551,6 +551,15 @@ class Worker:
             env.setdefault("NO_PROXY", "*")
             env.setdefault("no_proxy", "*")
 
+        if (
+            self.engine == "sglang"
+            and self.worker_type in (WorkerType.PREFILL, WorkerType.DECODE)
+            and self.effective_kv_backend() == "nixl"
+        ):
+            # SGLang's NIXL transfer engine rides on UCX too; see the vLLM
+            # branch below for why the CUDA IPC cache is off.
+            env.setdefault("UCX_CUDA_IPC_CACHE", "n")
+
         # vLLM PD workers need per-worker side-channel ports for their KV backend
         if self.engine == "vllm" and self.worker_type in (WorkerType.PREFILL, WorkerType.DECODE):
             if self.effective_kv_backend() == "mooncake":

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -443,7 +443,8 @@ class TestPDTopology:
         # that names a transport its workers never took sweeps the wrong thing
         # (#2498). gRPC discovery reads the engine's own server args, so the
         # transport is known there; HTTP discovery's curated server_info does
-        # not carry it and reads as "?".
+        # not carry it and reads as "?". TokenSpeed is not pinned by this: it
+        # only moves KV over Mooncake, so both sides are that constant.
         keys = _pairing_keys(gateway)
         logger.info("pairing keys: %s", keys)
         legs = gateway.prefill_workers + gateway.decode_workers

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -425,7 +425,7 @@ class TestPDTopology:
     # -- registration ------------------------------------------------------
 
     def test_workers_registered_by_role(self, setup_backend):
-        _, model, _, gateway = setup_backend
+        mode, model, _, gateway = setup_backend
         expected = {
             "prefill": {w.base_url for w in gateway.prefill_workers},
             "decode": {w.base_url for w in gateway.decode_workers},
@@ -438,6 +438,26 @@ class TestPDTopology:
         unhealthy = [w.url for ws in by_role.values() for w in ws if w.status != "healthy"]
         assert not unhealthy, f"unhealthy legs after startup: {unhealthy}"
         assert any(m.get("id") for m in gateway.list_models()), "no model listed"
+
+        # Every leg reports the KV transport the lane launched it with: a row
+        # that names a transport its workers never took sweeps the wrong thing
+        # (#2498). gRPC discovery reads the engine's own server args, so the
+        # transport is known there; HTTP discovery's curated server_info does
+        # not carry it and reads as "?".
+        keys = _pairing_keys(gateway)
+        logger.info("pairing keys: %s", keys)
+        legs = gateway.prefill_workers + gateway.decode_workers
+        reported = {w.base_url: keys.get(w.base_url, "?/?").split("/")[1] for w in legs}
+        launched = {w.base_url: w.effective_kv_backend() for w in legs}
+        wrong = {
+            u: (reported[u], launched[u]) for u in launched if reported[u] not in ("?", launched[u])
+        }
+        assert not wrong, (
+            f"legs report a different KV transport than they were launched with: {wrong}"
+        )
+        if mode == "pd_grpc":
+            unknown = [u for u, t in reported.items() if t == "?"]
+            assert not unknown, f"gRPC legs without a known KV transport on /workers: {unknown}"
 
     # -- placement ---------------------------------------------------------
 

--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -83,6 +83,23 @@ $RETRY 3 10 sudo apt-get install -y --no-install-recommends libnuma-dev libibver
 echo "Installing mooncake..."
 $RETRY 3 10 uv pip install mooncake-transfer-engine-cuda13==0.3.12.post1 nvidia-cuda-nvrtc
 
+# NIXL for SGLang PD disaggregation over NIXL (--disaggregation-transfer-backend
+# nixl), only on lanes that ask for it: Mooncake stays the default. Package,
+# pin and install shape track upstream sglang v0.5.18 CI (nixl and the backend
+# matching torch's CUDA, both --no-deps):
+# https://github.com/sgl-project/sglang/blob/v0.5.18/scripts/ci/cuda/ci_install_dependency.sh
+if [ "${E2E_KV_BACKEND:-}" = "nixl" ] || [ "${E2E_SGLANG_TRANSFER_BACKEND:-}" = "nixl" ]; then
+    NIXL_VERSION="1.3.0"
+    CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])")
+    echo "Installing nixl==${NIXL_VERSION} (cu${CUDA_MAJOR}) for SGLang PD over NIXL..."
+    $RETRY 3 10 uv pip install --no-deps "nixl==${NIXL_VERSION}" "nixl-cu${CUDA_MAJOR}==${NIXL_VERSION}"
+    # Import canary: fail here (not mid-e2e) if the install is broken. The
+    # bindings SGLang's NixlTransferEngine imports are checked, torch first so
+    # its bundled CUDA libraries are loaded.
+    python3 -c "import torch; from nixl._api import nixl_agent; from nixl._bindings import nixlRemoteDisconnectError"
+    echo "nixl import canary OK"
+fi
+
 # Install gRPC packages from source (not PyPI) so PR changes are always tested
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."
 $RETRY 3 10 uv pip install -e crates/grpc_client/python/


### PR DESCRIPTION
## Description

### Problem

The `sglang` + `kv_backend: nixl` rows dropped in #2464 never ran NIXL. `scripts/ci_install_sglang.sh` installs Mooncake only, so even now that the SGLang worker passes `--disaggregation-transfer-backend`, a NIXL lane would die at worker startup with SGLang's "Please install NIXL" import error. SGLang's second transport has no coverage (#2498).

### Solution

Install NIXL into the SGLang venv only on lanes that ask for it, mirroring upstream SGLang's own CI pin (`nixl==1.3.0` plus the backend matching torch's CUDA, `--no-deps`), guard the install with an import canary for the bindings SGLang's transfer engine loads, and bring the rows back: a 1p1d gRPC smoke on every PR and the full sweep in `nightly-pd`. SGLang PD workers on NIXL also start with `UCX_CUDA_IPC_CACHE=n`, the setting vLLM's NIXL workers already use so a decode does not keep a dead prefill's KV mapped across a restart.

## Changes

- `scripts/ci_install_sglang.sh`: when `E2E_KV_BACKEND=nixl` or `E2E_SGLANG_TRANSFER_BACKEND=nixl`, install `nixl==1.3.0` and `nixl-cu<major>==1.3.0` with `--no-deps` (upstream sglang v0.5.18 CI's shape), then import `nixl._api.nixl_agent` and `nixl._bindings.nixlRemoteDisconnectError` so a broken install fails in setup rather than mid-e2e. Mooncake lanes are untouched.
- `e2e_test/infra/worker.py`: SGLang prefill/decode workers whose effective backend is `nixl` get `UCX_CUDA_IPC_CACHE=n`.
- `.github/workflows/pr-test-rust.yml`: the `sglang` + `nixl` row returns to `e2e-4gpu-pd` (`-k "1p1d and not http"`, 60/50 budget, `min_selected: 11` of the 13 it selects); `test_filter` / `min_selected` take the row's override again.
- `.github/workflows/nightly-pd.yml`: the `{engine: sglang, kv_backend: nixl}` row returns to the matrix, with a per-row `test_filter` (which now wins over the dispatch filter) that leaves out the peer-restart tests.
- Peer restart is excluded on both NIXL rows for now: the first full run of the smoke showed the SGLang prefill segfaulting in `add_remote_agent` when its decode comes back on the same address (#2503, with the trace). Serving, streaming, aborts, `n>1` and the handoff itself pass on that fleet; the PR smoke drops `test_sole_leg_outage` (12 selected, floor 11).
- `e2e_test/router/test_pd_topologies.py`: the registration test reads every leg's pairing key from `/workers`, logs it, and requires the transport to match the worker's effective backend (known on every gRPC row). A lane that claims a transport its workers never took fails here instead of sweeping the wrong thing.

## Test Plan

- This PR's `e2e-4gpu-pd (sglang-nixl)` lane is the proof: the install step prints `nixl import canary OK` (`Installing nixl==1.3.0 (cu13)`), the worker logs show `Initialized NIXL agent` / `Backend UCX was instantiated` on both legs (captured from the run that hit #2503), and the registration test asserts and logs `sglang/nixl/...` pairing keys for both legs. First run: 11 passed / 2 skipped of 13 selected in 5m44s; the run with the restart test then reproduced #2503, which is why that test is excluded here. The other four PD rows must stay green (they run the same worker and install code with `E2E_KV_BACKEND` unset); the transport assertion runs on all of them, so it also pins `vllm/nixl`, `vllm/mooncake` and `sglang/mooncake` on their rows (TokenSpeed only has Mooncake, so both sides are that constant there and the row is not pinned by it).
- Before: the same row on #2464's earlier pushes selected 13 and passed, but the SGLang worker logs showed Mooncake on both legs.
- After merge: `nightly-pd` gains the fifth row; its first run measures the full-sweep time for the 170/150 budget.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
