### PR TITLE
fix(responses_api): correct regular-path tool, reasoning, streaming and replay handling

### DIFF
--- a/crates/external_router/src/openai_bridge/tool_descriptors.rs
+++ b/crates/external_router/src/openai_bridge/tool_descriptors.rs
@@ -323,6 +323,9 @@ fn is_client_visible_output_item(
         ResponseOutputItem::FunctionToolCall { name, .. } => {
             !session.should_hide_function_call_like(name, user_function_names)
         }
+        // Custom tool calls are user-declared (never MCP-hosted), so they are
+        // always client-visible.
+        ResponseOutputItem::CustomToolCall { .. } => true,
         ResponseOutputItem::WebSearchCall { .. }
         | ResponseOutputItem::CodeInterpreterCall { .. }
         | ResponseOutputItem::FileSearchCall { .. }

--- a/crates/protocols/src/event_types.rs
+++ b/crates/protocols/src/event_types.rs
@@ -6,18 +6,21 @@ pub enum ResponseEvent {
     Created,
     InProgress,
     Completed,
+    Incomplete,
 }
 
 impl ResponseEvent {
     pub const CREATED: &'static str = "response.created";
     pub const IN_PROGRESS: &'static str = "response.in_progress";
     pub const COMPLETED: &'static str = "response.completed";
+    pub const INCOMPLETE: &'static str = "response.incomplete";
 
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Created => Self::CREATED,
             Self::InProgress => Self::IN_PROGRESS,
             Self::Completed => Self::COMPLETED,
+            Self::Incomplete => Self::INCOMPLETE,
         }
     }
 }
@@ -637,7 +640,10 @@ impl fmt::Display for RealtimeServerEvent {
 pub fn is_response_event(event_type: &str) -> bool {
     matches!(
         event_type,
-        ResponseEvent::CREATED | ResponseEvent::IN_PROGRESS | ResponseEvent::COMPLETED
+        ResponseEvent::CREATED
+            | ResponseEvent::IN_PROGRESS
+            | ResponseEvent::COMPLETED
+            | ResponseEvent::INCOMPLETE
     )
 }
 

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -328,11 +328,17 @@ impl ResponsesToolChoice {
                 mode: mode.clone(),
                 tools: tools.clone(),
             },
+            // The regular router downgrades custom tools to function tools
+            // (single `input` string parameter), so pinning the chat
+            // tool_choice by name preserves the forcing semantics.
+            Self::Custom { name, .. } => ChatToolChoice::Function {
+                tool_type: "function".to_string(),
+                function: FunctionChoice { name: name.clone() },
+            },
             // No matching Chat spec variant — fall through to `auto` so
             // downstream Chat backends still see tool-calling enabled.
             Self::Types { .. }
             | Self::Mcp { .. }
-            | Self::Custom { .. }
             | Self::ApplyPatch { .. }
             | Self::Shell { .. } => ChatToolChoice::Value(ChatToolChoiceValue::Auto),
         }
@@ -2301,6 +2307,19 @@ pub enum ResponseOutputItem {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         output: Option<String>,
         status: String,
+    },
+    /// `type: "custom_tool_call"` — the model's invocation of a user-declared
+    /// custom tool. Same wire shape as the [`ResponseInputOutputItem`] variant
+    /// so emitted items replay losslessly.
+    #[serde(rename = "custom_tool_call")]
+    CustomToolCall {
+        call_id: String,
+        input: String,
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        namespace: Option<String>,
     },
     #[serde(rename = "mcp_list_tools")]
     McpListTools {

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -11,7 +11,8 @@ use openai_protocol::{
         ResponseEvent,
     },
     responses::{
-        ResponseOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse, ResponsesUsage,
+        IncludeField, ResponseOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse,
+        ResponsesUsage,
     },
 };
 use serde_json::json;
@@ -64,6 +65,19 @@ struct OutputItemState {
     item_data: Option<serde_json::Value>,
 }
 
+/// Streaming state for one in-flight chat tool-call being translated into a
+/// Responses `function_call` output item.
+struct ToolCallStreamItem {
+    /// `delta.tool_calls[].index` from the chat stream.
+    chat_index: u32,
+    output_index: usize,
+    item_id: String,
+    call_id: String,
+    name: String,
+    arguments: String,
+    added_emitted: bool,
+}
+
 /// OpenAI-compatible event emitter for /v1/responses streaming
 ///
 /// Manages state and sequence numbers to emit proper event types:
@@ -103,6 +117,17 @@ pub(crate) struct ResponseStreamEventEmitter {
     current_message_output_index: Option<usize>,
     current_item_id: Option<String>,
     original_request: Option<ResponsesRequest>,
+    tool_call_items: Vec<ToolCallStreamItem>,
+    /// In-flight reasoning item: opened on the first reasoning delta, closed
+    /// before the first message/tool item or on finish.
+    reasoning_item: Option<ReasoningStreamItem>,
+}
+
+/// Streaming state for the reasoning output item of the current turn.
+struct ReasoningStreamItem {
+    output_index: usize,
+    item_id: String,
+    text: String,
 }
 
 impl ResponseStreamEventEmitter {
@@ -123,6 +148,8 @@ impl ResponseStreamEventEmitter {
             current_message_output_index: None,
             current_item_id: None,
             original_request: None,
+            tool_call_items: Vec::new(),
+            reasoning_item: None,
         }
     }
 
@@ -753,12 +780,16 @@ impl ResponseStreamEventEmitter {
         // Allocate output index and generate ID
         let (output_index, item_id) = self.allocate_output_index(OutputItemKind::Reasoning);
 
-        // Build reasoning item structure
+        // Build reasoning item structure. `content` is an array of typed
+        // parts on the wire (a bare string breaks clients walking the
+        // content list).
         let item = json!({
             "id": item_id,
             "type": "reasoning",
             "summary": [],
-            "content": reasoning_content,
+            "content": reasoning_content
+                .map(|text| json!([{ "type": "reasoning_text", "text": text }]))
+                .unwrap_or(json!([])),
             "encrypted_content": null,
             "status": null
         });
@@ -777,6 +808,83 @@ impl ResponseStreamEventEmitter {
         Ok(())
     }
 
+    fn include_encrypted_reasoning(&self) -> bool {
+        self.original_request
+            .as_ref()
+            .and_then(|r| r.include.as_deref())
+            .is_some_and(|f| f.contains(&IncludeField::ReasoningEncryptedContent))
+    }
+
+    fn is_custom_tool(&self, name: &str) -> bool {
+        let tools = self
+            .original_request
+            .as_ref()
+            .and_then(|r| r.tools.as_deref());
+        super::utils::custom_tool_names(tools).contains(name)
+    }
+
+    fn emit_reasoning_text_delta(
+        &mut self,
+        output_index: usize,
+        item_id: &str,
+        delta: &str,
+    ) -> serde_json::Value {
+        json!({
+            "type": "response.reasoning_text.delta",
+            "sequence_number": self.next_sequence(),
+            "output_index": output_index,
+            "item_id": item_id,
+            "content_index": 0,
+            "delta": delta
+        })
+    }
+
+    fn emit_reasoning_text_done(
+        &mut self,
+        output_index: usize,
+        item_id: &str,
+        text: &str,
+    ) -> serde_json::Value {
+        json!({
+            "type": "response.reasoning_text.done",
+            "sequence_number": self.next_sequence(),
+            "output_index": output_index,
+            "item_id": item_id,
+            "content_index": 0,
+            "text": text
+        })
+    }
+
+    /// Close the in-flight reasoning item, if any: `reasoning_text.done`
+    /// followed by `output_item.done` carrying the full text.
+    async fn close_reasoning_item(&mut self, tx: &SseSender) -> Result<(), String> {
+        let Some(reasoning) = self.reasoning_item.take() else {
+            return Ok(());
+        };
+        let event = self.emit_reasoning_text_done(
+            reasoning.output_index,
+            &reasoning.item_id,
+            &reasoning.text,
+        );
+        self.send_event(&event, tx).await?;
+
+        let mut item = json!({
+            "id": reasoning.item_id,
+            "type": "reasoning",
+            "summary": [],
+            "content": [{ "type": "reasoning_text", "text": reasoning.text }],
+            "status": "completed"
+        });
+        if self.include_encrypted_reasoning() {
+            item["encrypted_content"] =
+                json!(super::utils::encode_reasoning_content(&reasoning.text));
+        }
+        let event = self.emit_output_item_done(reasoning.output_index, &item);
+        self.send_event(&event, tx).await?;
+        self.complete_output_item(reasoning.output_index);
+        Ok(())
+    }
+
     /// Process a chunk and emit appropriate events
     pub async fn process_chunk(
         &mut self,
@@ -785,10 +893,44 @@ impl ResponseStreamEventEmitter {
     ) -> Result<(), String> {
         // Process content if present
         if let Some(choice) = chunk.choices.first() {
+            // Reasoning streams as its own output item, opened on the first
+            // delta so it precedes the answer (OpenAI order).
+            if let Some(reasoning) = choice
+                .delta
+                .reasoning_content
+                .as_deref()
+                .filter(|r| !r.is_empty())
+            {
+                if self.reasoning_item.is_none() {
+                    let (output_index, item_id) =
+                        self.allocate_output_index(OutputItemKind::Reasoning);
+                    let item = json!({
+                        "id": item_id,
+                        "type": "reasoning",
+                        "summary": [],
+                        "content": [],
+                        "status": "in_progress"
+                    });
+                    let event = self.emit_output_item_added(output_index, &item);
+                    self.send_event(&event, tx).await?;
+                    self.reasoning_item = Some(ReasoningStreamItem {
+                        output_index,
+                        item_id,
+                        text: String::new(),
+                    });
+                }
+                if let Some(item) = self.reasoning_item.as_mut() {
+                    item.text.push_str(reasoning);
+                    let (output_index, item_id) = (item.output_index, item.item_id.clone());
+                    let event = self.emit_reasoning_text_delta(output_index, &item_id, reasoning);
+                    self.send_event(&event, tx).await?;
+                }
+            }
             if let Some(content) = &choice.delta.content {
                 if !content.is_empty() {
                     // Allocate output_index and item_id for this message item (once per message)
                     if self.current_item_id.is_none() {
+                        self.close_reasoning_item(tx).await?;
                         let (output_index, item_id) =
                             self.allocate_output_index(OutputItemKind::Message);
 
@@ -834,9 +976,97 @@ impl ResponseStreamEventEmitter {
                 }
             }
 
+            // Translate chat tool-call deltas into Responses function_call
+            // events; without this the streamed call is dropped entirely.
+            if let Some(tool_calls) = &choice.delta.tool_calls {
+                for tc in tool_calls {
+                    let pos = match self
+                        .tool_call_items
+                        .iter()
+                        .position(|i| i.chat_index == tc.index)
+                    {
+                        Some(pos) => pos,
+                        None => {
+                            self.close_reasoning_item(tx).await?;
+                            let (output_index, item_id) =
+                                self.allocate_output_index(OutputItemKind::FunctionCall);
+                            self.tool_call_items.push(ToolCallStreamItem {
+                                chat_index: tc.index,
+                                output_index,
+                                item_id,
+                                call_id: tc
+                                    .id
+                                    .clone()
+                                    .unwrap_or_else(|| format!("call_{}", Uuid::now_v7())),
+                                name: String::new(),
+                                arguments: String::new(),
+                                added_emitted: false,
+                            });
+                            self.tool_call_items.len() - 1
+                        }
+                    };
+                    let function = tc.function.as_ref();
+                    let name_delta = function
+                        .and_then(|f| f.name.as_deref())
+                        .filter(|n| !n.is_empty());
+                    let args_delta = function
+                        .and_then(|f| f.arguments.as_deref())
+                        .filter(|a| !a.is_empty());
+
+                    let item = &mut self.tool_call_items[pos];
+                    if let (true, Some(name)) = (item.name.is_empty(), name_delta) {
+                        item.name = name.to_string();
+                    }
+                    if let Some(args) = args_delta {
+                        item.arguments.push_str(args);
+                    }
+                    let emit_added = !item.added_emitted
+                        && (!item.name.is_empty() || !item.arguments.is_empty());
+                    item.added_emitted |= emit_added;
+                    let (output_index, item_id, call_id, name) = (
+                        item.output_index,
+                        item.item_id.clone(),
+                        item.call_id.clone(),
+                        item.name.clone(),
+                    );
+                    let custom = self.is_custom_tool(&name);
+
+                    if emit_added {
+                        let item = if custom {
+                            json!({
+                                "id": item_id,
+                                "type": "custom_tool_call",
+                                "call_id": call_id,
+                                "name": name,
+                                "input": "",
+                            })
+                        } else {
+                            json!({
+                                "id": item_id,
+                                "type": "function_call",
+                                "call_id": call_id,
+                                "name": name,
+                                "arguments": "",
+                                "status": "in_progress",
+                            })
+                        };
+                        let event = self.emit_output_item_added(output_index, &item);
+                        self.send_event(&event, tx).await?;
+                    }
+                    // Custom tool calls carry their payload as the raw `input`
+                    // string of the final item, not as streamed JSON arguments.
+                    if let Some(delta) = args_delta.filter(|_| !custom) {
+                        let event =
+                            self.emit_function_call_arguments_delta(output_index, &item_id, delta);
+                        self.send_event(&event, tx).await?;
+                    }
+                }
+            }
+
             // Check for finish_reason to emit completion events
             if let Some(reason) = &choice.finish_reason {
-                if reason == "stop" || reason == "length" {
+                self.close_reasoning_item(tx).await?;
+                if reason == "stop" || reason == "length" || reason == "tool_calls" {
                     if let (Some(output_index), Some(item_id)) = (
                         self.current_message_output_index,
                         self.current_item_id.clone(),
@@ -869,6 +1099,54 @@ impl ResponseStreamEventEmitter {
 
                         // Mark item as completed
                         self.complete_output_item(output_index);
+                    }
+                }
+                if reason == "tool_calls" {
+                    // Close every streamed tool-call item: arguments (or custom
+                    // input) done, then output_item.done, as the non-streaming
+                    // path pairs them.
+                    for item in std::mem::take(&mut self.tool_call_items) {
+                        let full = if self.is_custom_tool(&item.name) {
+                            let input = super::utils::custom_tool_input(&item.arguments);
+                            for (event_type, field) in [
+                                ("response.custom_tool_call_input.delta", "delta"),
+                                ("response.custom_tool_call_input.done", "input"),
+                            ] {
+                                let event = json!({
+                                    "type": event_type,
+                                    "sequence_number": self.next_sequence(),
+                                    "output_index": item.output_index,
+                                    "item_id": item.item_id,
+                                    field: input,
+                                });
+                                self.send_event(&event, tx).await?;
+                            }
+                            json!({
+                                "id": item.item_id,
+                                "type": "custom_tool_call",
+                                "call_id": item.call_id,
+                                "name": item.name,
+                                "input": input,
+                            })
+                        } else {
+                            let event = self.emit_function_call_arguments_done(
+                                item.output_index,
+                                &item.item_id,
+                                &item.arguments,
+                            );
+                            self.send_event(&event, tx).await?;
+                            json!({
+                                "id": item.item_id,
+                                "type": "function_call",
+                                "call_id": item.call_id,
+                                "name": item.name,
+                                "arguments": item.arguments,
+                                "status": "completed",
+                            })
+                        };
+                        let event = self.emit_output_item_done(item.output_index, &full);
+                        self.send_event(&event, tx).await?;
+                        self.complete_output_item(item.output_index);
                     }
                 }
             }
@@ -1089,5 +1367,190 @@ mod namespace_tests {
         let event = emitter.emit_completed(None);
         assert_eq!(event["response"]["output"][0]["name"], "lookup");
         assert_eq!(event["response"]["output"][0]["namespace"], "weather");
+    }
+}
+
+#[cfg(test)]
+mod process_chunk_tests {
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::routers::grpc::common::responses::utils::decode_reasoning_content;
+
+    fn chunk(
+        delta: serde_json::Value,
+        finish_reason: Option<&str>,
+    ) -> ChatCompletionStreamResponse {
+        serde_json::from_value(json!({
+            "id": "chat_test",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "test-model",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}]
+        }))
+        .unwrap()
+    }
+
+    /// Drive `chunks` through a fresh emitter; return the emitted events in
+    /// order plus the `output` array of `response.completed`.
+    async fn stream(
+        request: serde_json::Value,
+        chunks: &[ChatCompletionStreamResponse],
+    ) -> (Vec<serde_json::Value>, serde_json::Value) {
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_test".into(), "test-model".into(), 0);
+        emitter.set_original_request(serde_json::from_value(request).unwrap());
+        let (tx, mut rx) = mpsc::channel(256);
+        for chunk in chunks {
+            emitter.process_chunk(chunk, &tx).await.unwrap();
+        }
+        drop(tx);
+        let mut events = Vec::new();
+        while let Some(Ok(bytes)) = rx.recv().await {
+            let text = String::from_utf8(bytes.to_vec()).unwrap();
+            let data = text.lines().find_map(|l| l.strip_prefix("data: ")).unwrap();
+            events.push(serde_json::from_str(data).unwrap());
+        }
+        let completed = emitter.emit_completed(None);
+        (events, completed["response"]["output"].clone())
+    }
+
+    fn types(events: &[serde_json::Value]) -> Vec<&str> {
+        events.iter().map(|e| e["type"].as_str().unwrap()).collect()
+    }
+
+    #[tokio::test]
+    async fn reasoning_then_function_call_stream_as_paired_items() {
+        let (events, output) = stream(
+            json!({"model": "test-model", "input": "hi", "include": ["reasoning.encrypted_content"]}),
+            &[
+                chunk(json!({"reasoning_content": "thi"}), None),
+                chunk(json!({"reasoning_content": "nk"}), None),
+                chunk(
+                    json!({"tool_calls": [{"index": 0, "id": "call_1", "type": "function",
+                        "function": {"name": "get_weather", "arguments": ""}}]}),
+                    None,
+                ),
+                chunk(
+                    json!({"tool_calls": [{"index": 0, "function": {"arguments": "{\"city\":"}}]}),
+                    None,
+                ),
+                chunk(
+                    json!({"tool_calls": [{"index": 0, "function": {"arguments": "\"Paris\"}"}}]}),
+                    None,
+                ),
+                chunk(json!({}), Some("tool_calls")),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            types(&events),
+            [
+                "response.output_item.added",
+                "response.reasoning_text.delta",
+                "response.reasoning_text.delta",
+                "response.reasoning_text.done",
+                "response.output_item.done",
+                "response.output_item.added",
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+                "response.output_item.done",
+            ]
+        );
+        let seq: Vec<u64> = events
+            .iter()
+            .map(|e| e["sequence_number"].as_u64().unwrap())
+            .collect();
+        assert!(seq.windows(2).all(|w| w[0] < w[1]));
+
+        assert_eq!(output[0]["type"], "reasoning");
+        assert_eq!(
+            output[0]["content"],
+            json!([{"type": "reasoning_text", "text": "think"}])
+        );
+        assert_eq!(
+            decode_reasoning_content(output[0]["encrypted_content"].as_str().unwrap()).as_deref(),
+            Some("think")
+        );
+        assert_eq!(output[1]["type"], "function_call");
+        assert_eq!(output[1]["call_id"], "call_1");
+        assert_eq!(output[1]["name"], "get_weather");
+        assert_eq!(output[1]["arguments"], "{\"city\":\"Paris\"}");
+        assert_eq!(output[1]["status"], "completed");
+        // Each output_item.done carries the item response.completed reports.
+        assert_eq!(events[4]["item"], output[0]);
+        assert_eq!(events[9]["item"], output[1]);
+        assert_eq!(events[8]["arguments"], "{\"city\":\"Paris\"}");
+    }
+
+    #[tokio::test]
+    async fn custom_tool_call_streams_as_custom_input() {
+        let (events, output) = stream(
+            json!({"model": "test-model", "input": "hi",
+                "tools": [{"type": "custom", "name": "emit_command"}]}),
+            &[
+                chunk(
+                    json!({"tool_calls": [{"index": 0, "id": "call_c", "type": "function",
+                        "function": {"name": "emit_command", "arguments": "{\"input\": \"pwd\"}"}}]}),
+                    None,
+                ),
+                chunk(json!({}), Some("tool_calls")),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            types(&events),
+            [
+                "response.output_item.added",
+                "response.custom_tool_call_input.delta",
+                "response.custom_tool_call_input.done",
+                "response.output_item.done",
+            ]
+        );
+        assert_eq!(events[0]["item"]["type"], "custom_tool_call");
+        assert_eq!(events[1]["delta"], "pwd");
+        assert_eq!(events[2]["input"], "pwd");
+        assert_eq!(output[0]["type"], "custom_tool_call");
+        assert_eq!(output[0]["input"], "pwd");
+        assert_eq!(output[0]["call_id"], "call_c");
+        assert_eq!(events[3]["item"], output[0]);
+    }
+
+    #[tokio::test]
+    async fn text_after_reasoning_closes_the_reasoning_item_first() {
+        let (events, output) = stream(
+            json!({"model": "test-model", "input": "hi"}),
+            &[
+                chunk(json!({"reasoning_content": "why"}), None),
+                chunk(json!({"content": "Hel"}), None),
+                chunk(json!({"content": "lo"}), None),
+                chunk(json!({}), Some("stop")),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            types(&events),
+            [
+                "response.output_item.added",
+                "response.reasoning_text.delta",
+                "response.reasoning_text.done",
+                "response.output_item.done",
+                "response.output_item.added",
+                "response.content_part.added",
+                "response.output_text.delta",
+                "response.output_text.delta",
+                "response.output_text.done",
+                "response.content_part.done",
+                "response.output_item.done",
+            ]
+        );
+        assert_eq!(output[0]["type"], "reasoning");
+        assert!(output[0].get("encrypted_content").is_none());
+        assert_eq!(output[1]["type"], "message");
+        assert_eq!(output[1]["content"][0]["text"], "Hello");
     }
 }

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -11,8 +11,8 @@ use openai_protocol::{
         ResponseEvent,
     },
     responses::{
-        IncludeField, ResponseOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse,
-        ResponsesUsage,
+        IncludeField, IncompleteDetails, IncompleteReason, ResponseOutputItem, ResponseStatus,
+        ResponsesRequest, ResponsesResponse, ResponsesUsage,
     },
 };
 use serde_json::json;
@@ -86,6 +86,7 @@ struct ToolCallStreamItem {
 /// - response.output_item.added
 /// - response.output_item.done
 /// - response.completed
+/// - response.incomplete
 /// - response.content_part.added
 /// - response.content_part.done
 /// - response.output_text.delta
@@ -121,6 +122,9 @@ pub(crate) struct ResponseStreamEventEmitter {
     /// In-flight reasoning item: opened on the first reasoning delta, closed
     /// before the first message/tool item or on finish.
     reasoning_item: Option<ReasoningStreamItem>,
+    /// Chat `finish_reason` of the final chunk, e.g. `"length"` for a
+    /// `max_output_tokens` truncation. Drives the terminal event's status.
+    finish_reason: Option<String>,
 }
 
 /// Streaming state for the reasoning output item of the current turn.
@@ -150,6 +154,7 @@ impl ResponseStreamEventEmitter {
             original_request: None,
             tool_call_items: Vec::new(),
             reasoning_item: None,
+            finish_reason: None,
         }
     }
 
@@ -333,15 +338,24 @@ impl ResponseStreamEventEmitter {
             output
         };
 
+        // A `length` finish means max_output_tokens truncated the response;
+        // the Responses contract reports that as status=incomplete with
+        // incomplete_details and terminates the stream with
+        // response.incomplete, mirroring the non-streaming conversion.
+        let truncated = self.finish_reason.as_deref() == Some("length");
+
         // Build base response object
         let mut response_obj = json!({
             "id": self.response_id,
             "object": "response",
             "created_at": self.created_at,
-            "status": "completed",
+            "status": if truncated { "incomplete" } else { "completed" },
             "model": self.model,
             "output": output
         });
+        if truncated {
+            response_obj["incomplete_details"] = json!({ "reason": "max_output_tokens" });
+        }
 
         // Add usage if provided
         if let Some(usage_val) = usage {
@@ -388,7 +402,11 @@ impl ResponseStreamEventEmitter {
         }
 
         json!({
-            "type": ResponseEvent::COMPLETED,
+            "type": if truncated {
+                ResponseEvent::INCOMPLETE
+            } else {
+                ResponseEvent::COMPLETED
+            },
             "sequence_number": self.next_sequence(),
             "response": response_obj
         })
@@ -758,14 +776,29 @@ impl ResponseStreamEventEmitter {
             ResponsesUsage::Modern(usage_info.to_response_usage())
         });
 
+        // Match the streamed terminal event: a `length` finish reports
+        // status=incomplete with the truncation reason.
+        let (status, incomplete_details) = match self.finish_reason.as_deref() {
+            Some("length") => (
+                ResponseStatus::Incomplete,
+                Some(IncompleteDetails {
+                    reason: IncompleteReason::MaxOutputTokens,
+                }),
+            ),
+            _ => (ResponseStatus::Completed, None),
+        };
+
         // Build response using builder
-        ResponsesResponse::builder(&self.response_id, &self.model)
+        let mut builder = ResponsesResponse::builder(&self.response_id, &self.model)
             .created_at(self.created_at as i64)
-            .status(ResponseStatus::Completed)
+            .status(status)
             .output(output)
             .maybe_copy_from_request(self.original_request.as_ref())
-            .maybe_usage(responses_usage)
-            .build()
+            .maybe_usage(responses_usage);
+        if let Some(details) = incomplete_details {
+            builder = builder.incomplete_details(details);
+        }
+        builder.build()
     }
 
     /// Emit reasoning item wrapper events (added + done)
@@ -882,6 +915,59 @@ impl ResponseStreamEventEmitter {
         let event = self.emit_output_item_done(reasoning.output_index, &item);
         self.send_event(&event, tx).await?;
         self.complete_output_item(reasoning.output_index);
+        Ok(())
+    }
+
+    /// Close every streamed tool-call item: arguments (or custom input) done,
+    /// then output_item.done, as the non-streaming path pairs them. Called on
+    /// `tool_calls` and on `length` finishes — grammar-constrained models can
+    /// keep emitting valid tool calls until `max_output_tokens` truncates the
+    /// turn, and those (possibly partial) calls still belong in the final
+    /// output, so they must be closed and collected here.
+    async fn close_tool_call_items(&mut self, tx: &SseSender) -> Result<(), String> {
+        for item in std::mem::take(&mut self.tool_call_items) {
+            let full = if self.is_custom_tool(&item.name) {
+                let input = super::utils::custom_tool_input(&item.arguments);
+                for (event_type, field) in [
+                    ("response.custom_tool_call_input.delta", "delta"),
+                    ("response.custom_tool_call_input.done", "input"),
+                ] {
+                    let event = json!({
+                        "type": event_type,
+                        "sequence_number": self.next_sequence(),
+                        "output_index": item.output_index,
+                        "item_id": item.item_id,
+                        field: input,
+                    });
+                    self.send_event(&event, tx).await?;
+                }
+                json!({
+                    "id": item.item_id,
+                    "type": "custom_tool_call",
+                    "call_id": item.call_id,
+                    "name": item.name,
+                    "input": input,
+                })
+            } else {
+                let event = self.emit_function_call_arguments_done(
+                    item.output_index,
+                    &item.item_id,
+                    &item.arguments,
+                );
+                self.send_event(&event, tx).await?;
+                json!({
+                    "id": item.item_id,
+                    "type": "function_call",
+                    "call_id": item.call_id,
+                    "name": item.name,
+                    "arguments": item.arguments,
+                    "status": "completed",
+                })
+            };
+            let event = self.emit_output_item_done(item.output_index, &full);
+            self.send_event(&event, tx).await?;
+            self.complete_output_item(item.output_index);
+        }
         Ok(())
     }
 
@@ -1065,6 +1151,7 @@ impl ResponseStreamEventEmitter {
 
             // Check for finish_reason to emit completion events
             if let Some(reason) = &choice.finish_reason {
+                self.finish_reason = Some(reason.clone());
                 self.close_reasoning_item(tx).await?;
                 if reason == "stop" || reason == "length" || reason == "tool_calls" {
                     if let (Some(output_index), Some(item_id)) = (
@@ -1101,53 +1188,11 @@ impl ResponseStreamEventEmitter {
                         self.complete_output_item(output_index);
                     }
                 }
-                if reason == "tool_calls" {
-                    // Close every streamed tool-call item: arguments (or custom
-                    // input) done, then output_item.done, as the non-streaming
-                    // path pairs them.
-                    for item in std::mem::take(&mut self.tool_call_items) {
-                        let full = if self.is_custom_tool(&item.name) {
-                            let input = super::utils::custom_tool_input(&item.arguments);
-                            for (event_type, field) in [
-                                ("response.custom_tool_call_input.delta", "delta"),
-                                ("response.custom_tool_call_input.done", "input"),
-                            ] {
-                                let event = json!({
-                                    "type": event_type,
-                                    "sequence_number": self.next_sequence(),
-                                    "output_index": item.output_index,
-                                    "item_id": item.item_id,
-                                    field: input,
-                                });
-                                self.send_event(&event, tx).await?;
-                            }
-                            json!({
-                                "id": item.item_id,
-                                "type": "custom_tool_call",
-                                "call_id": item.call_id,
-                                "name": item.name,
-                                "input": input,
-                            })
-                        } else {
-                            let event = self.emit_function_call_arguments_done(
-                                item.output_index,
-                                &item.item_id,
-                                &item.arguments,
-                            );
-                            self.send_event(&event, tx).await?;
-                            json!({
-                                "id": item.item_id,
-                                "type": "function_call",
-                                "call_id": item.call_id,
-                                "name": item.name,
-                                "arguments": item.arguments,
-                                "status": "completed",
-                            })
-                        };
-                        let event = self.emit_output_item_done(item.output_index, &full);
-                        self.send_event(&event, tx).await?;
-                        self.complete_output_item(item.output_index);
-                    }
+                // Tool-call items close on `tool_calls` and on `length`:
+                // truncation can hit mid-call, but whatever arguments
+                // arrived still form a (partial) function-call output item.
+                if reason == "tool_calls" || reason == "length" {
+                    self.close_tool_call_items(tx).await?;
                 }
             }
         }
@@ -1392,8 +1437,9 @@ mod process_chunk_tests {
     }
 
     /// Drive `chunks` through a fresh emitter; return the emitted events in
-    /// order plus the `output` array of `response.completed`.
-    async fn stream(
+    /// order plus the terminal `response.completed`/`response.incomplete`
+    /// event.
+    async fn stream_with_terminal(
         request: serde_json::Value,
         chunks: &[ChatCompletionStreamResponse],
     ) -> (Vec<serde_json::Value>, serde_json::Value) {
@@ -1411,8 +1457,18 @@ mod process_chunk_tests {
             let data = text.lines().find_map(|l| l.strip_prefix("data: ")).unwrap();
             events.push(serde_json::from_str(data).unwrap());
         }
-        let completed = emitter.emit_completed(None);
-        (events, completed["response"]["output"].clone())
+        let terminal = emitter.emit_completed(None);
+        (events, terminal)
+    }
+
+    /// Drive `chunks` through a fresh emitter; return the emitted events in
+    /// order plus the `output` array of the terminal event.
+    async fn stream(
+        request: serde_json::Value,
+        chunks: &[ChatCompletionStreamResponse],
+    ) -> (Vec<serde_json::Value>, serde_json::Value) {
+        let (events, terminal) = stream_with_terminal(request, chunks).await;
+        (events, terminal["response"]["output"].clone())
     }
 
     fn types(events: &[serde_json::Value]) -> Vec<&str> {
@@ -1552,5 +1608,124 @@ mod process_chunk_tests {
         assert!(output[0].get("encrypted_content").is_none());
         assert_eq!(output[1]["type"], "message");
         assert_eq!(output[1]["content"][0]["text"], "Hello");
+    }
+
+    #[tokio::test]
+    async fn length_truncation_closes_tool_calls_and_marks_incomplete() {
+        // Grammar-constrained turn: one full call, a second call truncated
+        // mid-arguments by max_output_tokens.
+        let (events, terminal) = stream_with_terminal(
+            json!({"model": "test-model", "input": "hi"}),
+            &[
+                chunk(
+                    json!({"tool_calls": [{"index": 0, "id": "call_a", "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{\"city\":\"Paris\"}"}}]}),
+                    None,
+                ),
+                chunk(
+                    json!({"tool_calls": [{"index": 1, "id": "call_b", "type": "function",
+                        "function": {"name": "get_time", "arguments": "{\"tz\":"}}]}),
+                    None,
+                ),
+                chunk(json!({}), Some("length")),
+            ],
+        )
+        .await;
+
+        // Both streamed calls close even though the turn ended truncated.
+        assert_eq!(
+            types(&events),
+            [
+                "response.output_item.added",
+                "response.function_call_arguments.delta",
+                "response.output_item.added",
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+                "response.output_item.done",
+                "response.function_call_arguments.done",
+                "response.output_item.done",
+            ]
+        );
+
+        assert_eq!(terminal["type"], "response.incomplete");
+        assert_eq!(terminal["response"]["status"], "incomplete");
+        assert_eq!(
+            terminal["response"]["incomplete_details"],
+            json!({"reason": "max_output_tokens"})
+        );
+
+        let output = &terminal["response"]["output"];
+        assert_eq!(output.as_array().map(Vec::len), Some(2));
+        assert_eq!(output[0]["type"], "function_call");
+        assert_eq!(output[0]["name"], "get_weather");
+        assert_eq!(output[0]["arguments"], "{\"city\":\"Paris\"}");
+        assert_eq!(output[1]["type"], "function_call");
+        assert_eq!(output[1]["name"], "get_time");
+        assert_eq!(output[1]["arguments"], "{\"tz\":");
+    }
+
+    #[tokio::test]
+    async fn length_truncated_text_ends_with_response_incomplete() {
+        let (events, terminal) = stream_with_terminal(
+            json!({"model": "test-model", "input": "hi"}),
+            &[
+                chunk(json!({"content": "He"}), None),
+                chunk(json!({"content": "y"}), None),
+                chunk(json!({}), Some("length")),
+            ],
+        )
+        .await;
+
+        // The text item still closes normally; only the terminal event and
+        // response status change.
+        assert_eq!(
+            types(&events),
+            [
+                "response.output_item.added",
+                "response.content_part.added",
+                "response.output_text.delta",
+                "response.output_text.delta",
+                "response.output_text.done",
+                "response.content_part.done",
+                "response.output_item.done",
+            ]
+        );
+        assert_eq!(terminal["type"], "response.incomplete");
+        assert_eq!(terminal["response"]["status"], "incomplete");
+        assert_eq!(
+            terminal["response"]["incomplete_details"],
+            json!({"reason": "max_output_tokens"})
+        );
+        assert_eq!(
+            terminal["response"]["output"][0]["content"][0]["text"],
+            "Hey"
+        );
+    }
+
+    #[tokio::test]
+    async fn length_truncated_finalize_persists_incomplete_status() {
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_test".into(), "test-model".into(), 0);
+        emitter.set_original_request(
+            serde_json::from_value(json!({"model": "test-model", "input": "hi"})).unwrap(),
+        );
+        let (tx, mut rx) = mpsc::channel(256);
+        emitter
+            .process_chunk(&chunk(json!({"content": "par"}), None), &tx)
+            .await
+            .unwrap();
+        emitter
+            .process_chunk(&chunk(json!({}), Some("length")), &tx)
+            .await
+            .unwrap();
+        drop(tx);
+        while rx.recv().await.is_some() {}
+
+        let wire = serde_json::to_value(emitter.finalize(None)).unwrap();
+        assert_eq!(wire["status"], "incomplete");
+        assert_eq!(
+            wire["incomplete_details"],
+            json!({"reason": "max_output_tokens"})
+        );
     }
 }

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -3,9 +3,10 @@
 use std::sync::Arc;
 
 use axum::response::Response;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use openai_protocol::{
     common::Tool,
-    responses::{NamespaceTool, ResponseTool, ResponsesRequest, ResponsesResponse},
+    responses::{CustomTool, NamespaceTool, ResponseTool, ResponsesRequest, ResponsesResponse},
 };
 use serde_json::to_value;
 use smg_data_connector::{
@@ -126,6 +127,9 @@ pub(crate) fn validate_worker_availability(
 ///
 /// - **Regular router**: Extracts function tools during the initial conversion from
 ///   ResponsesRequest to ChatCompletionRequest. MCP tools are merged later by the tool loop.
+///
+/// Custom tools (`{"type": "custom"}`) are downgraded to function tools with a
+/// single `input: string` parameter; `chat_to_responses` maps the calls back.
 pub(crate) fn extract_tools_from_response_tools(
     response_tools: Option<&[ResponseTool]>,
 ) -> Vec<Tool> {
@@ -140,24 +144,102 @@ pub(crate) fn extract_tools_from_response_tools(
                 tool_type: "function".to_string(),
                 function: ft.function.clone(),
             }],
+            ResponseTool::Custom(ct) => vec![Tool {
+                tool_type: "function".to_string(),
+                function: custom_tool_as_function(ct),
+            }],
             ResponseTool::Namespace(namespace) => namespace
                 .tools
                 .iter()
-                .filter_map(|member| {
-                    let NamespaceTool::Function(ft) = member else {
-                        return None;
+                .map(|member| {
+                    let mut function = match member {
+                        NamespaceTool::Function(ft) => ft.function.clone(),
+                        NamespaceTool::Custom(ct) => custom_tool_as_function(ct),
                     };
-                    let mut function = ft.function.clone();
                     function.name = format!("{}.{}", namespace.name, function.name);
-                    Some(Tool {
+                    Tool {
                         tool_type: "function".to_string(),
                         function,
-                    })
+                    }
                 })
                 .collect(),
             _ => Vec::new(),
         })
         .collect()
+}
+
+/// Downgrade a Responses custom tool to a chat function tool whose single
+/// `input` string parameter carries the free-form payload.
+pub(crate) fn custom_tool_as_function(ct: &CustomTool) -> openai_protocol::common::Function {
+    openai_protocol::common::Function {
+        name: ct.name.clone(),
+        description: ct.description.clone(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "input": {
+                    "type": "string",
+                    "description": "The raw payload to pass to this custom tool."
+                }
+            },
+            "required": ["input"],
+            "additionalProperties": false
+        }),
+        strict: Some(false),
+    }
+}
+
+/// Recover a custom tool's raw `input` from the `{"input": "..."}` arguments
+/// of its downgraded function call.
+pub(crate) fn custom_tool_input(arguments: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(arguments)
+        .ok()
+        .and_then(|v| v.get("input")?.as_str().map(str::to_owned))
+        .unwrap_or_default()
+}
+
+/// Collect the names of all declared custom tools (top-level and namespaced),
+/// used to map function-shaped calls back to `custom_tool_call` items.
+pub(crate) fn custom_tool_names(
+    response_tools: Option<&[ResponseTool]>,
+) -> std::collections::HashSet<String> {
+    let mut names = std::collections::HashSet::new();
+    let Some(tools) = response_tools else {
+        return names;
+    };
+    for tool in tools {
+        match tool {
+            ResponseTool::Custom(ct) => {
+                names.insert(ct.name.clone());
+            }
+            ResponseTool::Namespace(namespace) => {
+                for member in &namespace.tools {
+                    if let NamespaceTool::Custom(ct) = member {
+                        names.insert(format!("{}.{}", namespace.name, ct.name));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    names
+}
+
+/// Version tag for the opaque `reasoning.encrypted_content` payload.
+const REASONING_BLOB_PREFIX: &str = "smg-reasoning-v1.";
+
+/// Encode reasoning text as the opaque `encrypted_content` blob a `store=false`
+/// client hands back on its next turn. The gateway is stateless, so the blob
+/// carries the text itself (version-tagged base64): opaque, not confidential.
+pub(crate) fn encode_reasoning_content(text: &str) -> String {
+    format!("{REASONING_BLOB_PREFIX}{}", BASE64_STANDARD.encode(text))
+}
+
+/// Recover reasoning text from a blob produced by [`encode_reasoning_content`].
+/// Blobs from other producers yield `None`.
+pub(crate) fn decode_reasoning_content(blob: &str) -> Option<String> {
+    let payload = blob.strip_prefix(REASONING_BLOB_PREFIX)?;
+    String::from_utf8(BASE64_STANDARD.decode(payload).ok()?).ok()
 }
 
 /// Recover structured identity only for a declared namespace member.

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -9,17 +9,23 @@
 
 use openai_protocol::{
     chat::{ChatCompletionRequest, ChatCompletionResponse, ChatMessage, MessageContent},
-    common::{FunctionCallResponse, JsonSchemaFormat, ResponseFormat, ToolCall, UsageInfo},
+    common::{
+        ContentPart, FunctionCallResponse, ImageUrl, JsonSchemaFormat, ResponseFormat, ToolCall,
+        ToolChoice, ToolChoiceValue, UsageInfo,
+    },
     responses::{
-        ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
-        ResponseReasoningContent::ReasoningText, ResponseStatus, ResponsesRequest,
-        ResponsesResponse, ResponsesUsage, StringOrContentParts, TextConfig, TextFormat,
+        CustomToolCallOutputContent, CustomToolInputContentPart, IncludeField, IncompleteDetails,
+        IncompleteReason, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
+        ResponseOutputItem, ResponseReasoningContent::ReasoningText, ResponseStatus,
+        ResponsesRequest, ResponsesResponse, ResponsesUsage, StringOrContentParts, TextConfig,
+        TextFormat,
     },
     UNKNOWN_MODEL_ID,
 };
 use tracing::warn;
 
 use crate::routers::grpc::common::responses::utils::{
+    custom_tool_input, custom_tool_names, decode_reasoning_content, encode_reasoning_content,
     extract_tools_from_response_tools, resolve_function_identity,
 };
 
@@ -54,35 +60,26 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
             });
         }
         ResponseInput::Items(items) => {
-            // Structured items → convert each to appropriate chat message
+            // Structured items → convert each to appropriate chat message.
+            // Assistant-side items are merged into one assistant turn by
+            // `push_chat_message`; see its doc comment.
             for item in items {
                 match item {
                     ResponseInputOutputItem::SimpleInputMessage { content, role, .. } => {
-                        // Convert SimpleInputMessage to chat message
-                        let text = match content {
-                            StringOrContentParts::String(s) => s.clone(),
+                        let content = match content {
+                            StringOrContentParts::String(s) => MessageContent::Text(s.clone()),
                             StringOrContentParts::Array(parts) => {
-                                // Extract text from content parts (only InputText supported)
-                                parts
-                                    .iter()
-                                    .filter_map(|part| match part {
-                                        ResponseContentPart::InputText { text } => {
-                                            Some(text.as_str())
-                                        }
-                                        _ => None,
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join(" ")
+                                response_parts_to_message_content(parts)
                             }
                         };
-
-                        messages.push(role_to_chat_message(role.as_str(), text));
+                        push_role_message(&mut messages, role, content);
                     }
                     ResponseInputOutputItem::Message { role, content, .. } => {
-                        // Extract text from content parts
-                        let text = extract_text_from_content(content);
-
-                        messages.push(role_to_chat_message(role.as_str(), text));
+                        push_role_message(
+                            &mut messages,
+                            role,
+                            response_parts_to_message_content(content),
+                        );
                     }
                     ResponseInputOutputItem::FunctionToolCall {
                         call_id,
@@ -92,52 +89,53 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                         output,
                         ..
                     } => {
-                        // Tool call from history - add as assistant message with tool call
-                        // followed by tool response if output exists
-                        let tool_call_id = call_id.clone();
-
-                        // Add assistant message with tool_calls (the LLM's decision)
-                        messages.push(ChatMessage::Assistant {
-                            content: None,
-                            name: None,
-                            tool_calls: Some(vec![ToolCall {
-                                id: tool_call_id.clone(),
-                                tool_type: "function".to_string(),
-                                function: FunctionCallResponse {
-                                    name: match namespace {
-                                        Some(namespace) => format!("{namespace}.{name}"),
-                                        None => name.clone(),
-                                    },
-                                    arguments: Some(arguments.clone()),
-                                },
-                            }]),
-                            reasoning_content: None,
-                        });
-
-                        // Add tool result message if output exists
+                        // Tool call from history: the assistant's decision,
+                        // then the tool result if the output is present.
+                        push_chat_message(
+                            &mut messages,
+                            assistant_tool_call(
+                                call_id,
+                                name,
+                                namespace.as_deref(),
+                                arguments.clone(),
+                            ),
+                        );
                         if let Some(output_text) = output {
                             messages.push(ChatMessage::Tool {
                                 content: MessageContent::Text(output_text.clone()),
-                                tool_call_id,
+                                tool_call_id: call_id.clone(),
                             });
                         }
                     }
-                    ResponseInputOutputItem::Reasoning { content, .. } => {
-                        // Reasoning content - add as assistant message with reasoning_content
-                        let reasoning_text = content
+                    ResponseInputOutputItem::Reasoning {
+                        content,
+                        encrypted_content,
+                        ..
+                    } => {
+                        // Prefer the plain text; a `store=false` client may hand
+                        // back only the opaque blob this gateway produced.
+                        let mut reasoning_text = content
                             .iter()
                             .map(|c| match c {
                                 ReasoningText { text } => text.as_str(),
                             })
                             .collect::<Vec<_>>()
                             .join("\n");
-
-                        messages.push(ChatMessage::Assistant {
-                            content: None,
-                            name: None,
-                            tool_calls: None,
-                            reasoning_content: Some(reasoning_text),
-                        });
+                        if reasoning_text.is_empty() {
+                            reasoning_text = encrypted_content
+                                .as_deref()
+                                .and_then(decode_reasoning_content)
+                                .unwrap_or_default();
+                        }
+                        if !reasoning_text.is_empty() {
+                            let assistant = ChatMessage::Assistant {
+                                content: None,
+                                name: None,
+                                tool_calls: None,
+                                reasoning_content: Some(reasoning_text),
+                            };
+                            push_chat_message(&mut messages, assistant);
+                        }
                     }
                     ResponseInputOutputItem::FunctionCallOutput {
                         call_id, output, ..
@@ -173,13 +171,46 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                     | ResponseInputOutputItem::ItemReference { .. } => {
                         return Err("Unsupported input item type".to_string());
                     }
-                    ResponseInputOutputItem::CustomToolCall { .. }
-                    | ResponseInputOutputItem::CustomToolCallOutput { .. } => {
-                        warn!(
-                            function = "responses_to_chat",
-                            "Custom tool item reached chat conversion"
+                    // Custom tool history replays as the function tool_call the
+                    // request-side downgrade produces ({"input": "..."}) plus a
+                    // plain tool message for the client's output.
+                    ResponseInputOutputItem::CustomToolCall {
+                        call_id,
+                        input,
+                        name,
+                        namespace,
+                        ..
+                    } => {
+                        push_chat_message(
+                            &mut messages,
+                            assistant_tool_call(
+                                call_id,
+                                name,
+                                namespace.as_deref(),
+                                serde_json::json!({ "input": input }).to_string(),
+                            ),
                         );
-                        return Err("Unsupported input item type".to_string());
+                    }
+                    ResponseInputOutputItem::CustomToolCallOutput {
+                        call_id, output, ..
+                    } => {
+                        let output_text = match output {
+                            CustomToolCallOutputContent::Text(s) => s.clone(),
+                            CustomToolCallOutputContent::Parts(parts) => parts
+                                .iter()
+                                .filter_map(|p| match p {
+                                    CustomToolInputContentPart::InputText { text } => {
+                                        Some(text.as_str())
+                                    }
+                                    _ => None,
+                                })
+                                .collect::<Vec<_>>()
+                                .join("\n"),
+                        };
+                        messages.push(ChatMessage::Tool {
+                            content: MessageContent::Text(output_text),
+                            tool_call_id: call_id.clone(),
+                        });
                     }
                     ResponseInputOutputItem::ShellCall { .. }
                     | ResponseInputOutputItem::ShellCallOutput { .. } => {
@@ -214,8 +245,14 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
 
     // 3. Extract function tools from ResponseTools.
     // MCP tools are merged later by the tool loop (see tool_loop.rs:prepare_chat_tools_and_choice).
+    // `tool_choice: none` forbids calls; offering the schemas anyway makes the
+    // model re-issue calls on replayed histories, and with parsing disabled the
+    // raw call markup leaks into the message text.
+    let tool_choice = req.tool_choice.as_ref().map(|tc| tc.to_chat_tool_choice());
     let function_tools = extract_tools_from_response_tools(req.tools.as_deref());
-    let tools = if function_tools.is_empty() {
+    let tools = if function_tools.is_empty()
+        || matches!(tool_choice, Some(ToolChoice::Value(ToolChoiceValue::None)))
+    {
         None
     } else {
         Some(function_tools)
@@ -251,58 +288,199 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
         top_p: req.top_p,
         skip_special_tokens: true,
         tools,
-        tool_choice: req.tool_choice.as_ref().map(|tc| tc.to_chat_tool_choice()),
+        tool_choice,
         response_format: map_text_to_response_format(req.text.as_ref()),
         reasoning_effort: req
             .reasoning
             .as_ref()
             .and_then(|r| r.effort)
             .map(|effort| effort.as_str().to_string()),
+        // `Default` leaves these false while the HTTP layer defaults them to
+        // true; without them a reasoning model's <think> block comes back as
+        // message text with any constrained tool-call JSON embedded in it.
+        separate_reasoning: true,
+        stream_reasoning: is_streaming,
         ..Default::default()
     })
 }
 
-/// Extract text content from ResponseContentPart array. `Refusal` is
-/// losslessly representable as text and is preserved verbatim. Image / file
-/// parts are currently dropped; the gRPC regular path is text-only and
-/// relies on the multimodal pipeline for media handling (R1/R2/R3 will
-/// implement full media handling).
-fn extract_text_from_content(content: &[ResponseContentPart]) -> String {
-    content
-        .iter()
-        .filter_map(|part| match part {
-            ResponseContentPart::InputText { text } => Some(text.as_str()),
-            ResponseContentPart::OutputText { text, .. } => Some(text.as_str()),
-            ResponseContentPart::Refusal { refusal } => Some(refusal.as_str()),
-            // R1/R2/R3 will implement full media handling
-            ResponseContentPart::InputImage { .. } | ResponseContentPart::InputFile { .. } => None,
-        })
-        .collect::<Vec<_>>()
-        .join("")
+/// Convert Responses content parts to chat message content. Text, output
+/// text and refusals become text parts, `input_image` becomes an `image_url`
+/// part, and `input_file` is dropped (no chat equivalent on this path).
+fn response_parts_to_message_content(content: &[ResponseContentPart]) -> MessageContent {
+    let mut parts = Vec::new();
+    for part in content {
+        match part {
+            ResponseContentPart::InputText { text }
+            | ResponseContentPart::OutputText { text, .. } => {
+                parts.push(ContentPart::Text { text: text.clone() });
+            }
+            ResponseContentPart::Refusal { refusal } => {
+                parts.push(ContentPart::Text {
+                    text: refusal.clone(),
+                });
+            }
+            ResponseContentPart::InputImage {
+                image_url: Some(url),
+                ..
+            } => {
+                parts.push(ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: url.clone(),
+                        detail: None,
+                        max_long_side_pixel: None,
+                    },
+                });
+            }
+            ResponseContentPart::InputImage { .. } | ResponseContentPart::InputFile { .. } => {}
+        }
+    }
+    // Plain text stays a string, as it did before parts were carried at all.
+    match parts.as_slice() {
+        [] => MessageContent::Text(String::new()),
+        [ContentPart::Text { text }] => MessageContent::Text(text.clone()),
+        _ => MessageContent::Parts(parts),
+    }
+}
+
+/// Append a role-tagged input message. A `developer` turn folds into the
+/// leading system message: OpenAI ranks it with `system`, above `user`, and
+/// appended unlabelled it reads as one more conversational turn that the
+/// latest user message is free to override.
+fn push_role_message(messages: &mut Vec<ChatMessage>, role: &str, content: MessageContent) {
+    if role != "developer" {
+        push_chat_message(messages, role_to_chat_message(role, content));
+        return;
+    }
+    let text = content.to_simple_string();
+    match messages.first_mut() {
+        Some(ChatMessage::System {
+            content: MessageContent::Text(existing),
+            ..
+        }) => {
+            existing.push_str("\n\nDeveloper instructions:\n");
+            existing.push_str(&text);
+        }
+        _ => messages.insert(
+            0,
+            ChatMessage::System {
+                content: MessageContent::Text(format!("Developer instructions:\n{text}")),
+                name: None,
+            },
+        ),
+    }
+}
+
+/// Replay one historical tool call as the assistant turn that issued it.
+fn assistant_tool_call(
+    call_id: &str,
+    name: &str,
+    namespace: Option<&str>,
+    arguments: String,
+) -> ChatMessage {
+    ChatMessage::Assistant {
+        content: None,
+        name: None,
+        tool_calls: Some(vec![ToolCall {
+            id: call_id.to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCallResponse {
+                name: match namespace {
+                    Some(namespace) => format!("{namespace}.{name}"),
+                    None => name.to_string(),
+                },
+                arguments: Some(arguments),
+            },
+        }]),
+        reasoning_content: None,
+    }
+}
+
+/// Append a chat message, merging consecutive assistant-side items into one
+/// assistant turn. One Responses assistant turn arrives as several items
+/// (reasoning, message, function_call, ...); replayed as separate assistant
+/// messages they render back-to-back assistant blocks the template never
+/// produces, and tool results pair with the wrong (reasoning-only) message.
+fn push_chat_message(messages: &mut Vec<ChatMessage>, message: ChatMessage) {
+    match (messages.last_mut(), message) {
+        (
+            Some(ChatMessage::Assistant {
+                content,
+                tool_calls,
+                reasoning_content,
+                ..
+            }),
+            ChatMessage::Assistant {
+                content: new_content,
+                tool_calls: new_tool_calls,
+                reasoning_content: new_reasoning,
+                ..
+            },
+        ) => {
+            if let Some(new_reasoning) = new_reasoning {
+                let merged = reasoning_content.get_or_insert_with(String::new);
+                if !merged.is_empty() {
+                    merged.push('\n');
+                }
+                merged.push_str(&new_reasoning);
+            }
+            if let Some(new_content) = new_content {
+                *content = Some(match content.take() {
+                    Some(existing) => merge_message_content(existing, new_content),
+                    None => new_content,
+                });
+            }
+            if let Some(new_tool_calls) = new_tool_calls {
+                tool_calls
+                    .get_or_insert_with(Vec::new)
+                    .extend(new_tool_calls);
+            }
+        }
+        (_, message) => messages.push(message),
+    }
+}
+
+fn merge_message_content(a: MessageContent, b: MessageContent) -> MessageContent {
+    match (a, b) {
+        (MessageContent::Text(mut a), MessageContent::Text(b)) => {
+            a.push('\n');
+            a.push_str(&b);
+            MessageContent::Text(a)
+        }
+        (a, b) => MessageContent::Parts(
+            [a, b]
+                .into_iter()
+                .flat_map(|content| match content {
+                    MessageContent::Text(text) => vec![ContentPart::Text { text }],
+                    MessageContent::Parts(parts) => parts,
+                })
+                .collect(),
+        ),
+    }
 }
 
 /// Convert role and text to ChatMessage
-fn role_to_chat_message(role: &str, text: String) -> ChatMessage {
+fn role_to_chat_message(role: &str, content: MessageContent) -> ChatMessage {
     match role {
         "user" => ChatMessage::User {
-            content: MessageContent::Text(text),
+            content,
             name: None,
         },
         "assistant" => ChatMessage::Assistant {
-            content: Some(MessageContent::Text(text)),
+            content: Some(content),
             name: None,
             tool_calls: None,
             reasoning_content: None,
         },
         "system" => ChatMessage::System {
-            content: MessageContent::Text(text),
+            content,
             name: None,
             ext: Default::default(),
         },
         _ => {
             // Unknown role, treat as user message
             ChatMessage::User {
-                content: MessageContent::Text(text),
+                content,
                 name: None,
             }
         }
@@ -354,8 +532,34 @@ pub(crate) fn chat_to_responses(
         .first()
         .ok_or_else(|| "Chat response contains no choices".to_string())?;
 
-    // Convert assistant message to output items
+    // Convert assistant message to output items. Reasoning comes first (OpenAI
+    // order), so items replayed in emitted order rebuild the same turn.
     let mut output: Vec<ResponseOutputItem> = Vec::new();
+
+    if let Some(reasoning) = &choice.message.reasoning_content {
+        if !reasoning.is_empty() {
+            let id = format!("reasoning_{}", chat_resp.id);
+            let content = vec![ReasoningText {
+                text: reasoning.clone(),
+            }];
+            let status = Some("completed".to_string());
+            let include_encrypted = original_req
+                .include
+                .as_deref()
+                .is_some_and(|f| f.contains(&IncludeField::ReasoningEncryptedContent));
+            output.push(if include_encrypted {
+                ResponseOutputItem::new_reasoning_encrypted(
+                    id,
+                    vec![],
+                    content,
+                    encode_reasoning_content(reasoning),
+                    status,
+                )
+            } else {
+                ResponseOutputItem::new_reasoning(id, vec![], content, status)
+            });
+        }
+    }
 
     // Convert message content to output item
     if let Some(content) = &choice.message.content {
@@ -374,25 +578,25 @@ pub(crate) fn chat_to_responses(
         }
     }
 
-    // Convert reasoning content if present (O1-style models)
-    if let Some(reasoning) = &choice.message.reasoning_content {
-        if !reasoning.is_empty() {
-            output.push(ResponseOutputItem::new_reasoning(
-                format!("reasoning_{}", chat_resp.id),
-                vec![],
-                vec![ReasoningText {
-                    text: reasoning.clone(),
-                }],
-                Some("completed".to_string()),
-            ));
-        }
-    }
-
-    // Convert tool calls if present
+    // Convert tool calls if present. Calls to downgraded custom tools map back
+    // to `custom_tool_call` items.
+    let custom_names = custom_tool_names(original_req.tools.as_deref());
     if let Some(tool_calls) = &choice.message.tool_calls {
         for tool_call in tool_calls {
             let (name, namespace) =
                 resolve_function_identity(original_req.tools.as_deref(), &tool_call.function.name);
+            if custom_names.contains(&tool_call.function.name) {
+                output.push(ResponseOutputItem::CustomToolCall {
+                    call_id: tool_call.id.clone(),
+                    input: custom_tool_input(
+                        tool_call.function.arguments.as_deref().unwrap_or_default(),
+                    ),
+                    name,
+                    id: Some(tool_call.id.clone()),
+                    namespace,
+                });
+                continue;
+            }
             output.push(ResponseOutputItem::FunctionToolCall {
                 id: Some(tool_call.id.clone()),
                 call_id: tool_call.id.clone(),
@@ -405,12 +609,20 @@ pub(crate) fn chat_to_responses(
         }
     }
 
-    // Determine response status based on finish_reason
-    let status = match choice.finish_reason.as_deref() {
-        Some("stop") | Some("length") => ResponseStatus::Completed,
-        Some("tool_calls") => ResponseStatus::InProgress, // Waiting for tool execution
-        Some("failed") | Some("error") => ResponseStatus::Failed,
-        _ => ResponseStatus::Completed, // Default to completed
+    // Determine response status based on finish_reason. "length" is a
+    // max_output_tokens truncation, which the Responses contract reports as
+    // status=incomplete with incomplete_details.
+    let (status, incomplete_details) = match choice.finish_reason.as_deref() {
+        Some("stop") => (ResponseStatus::Completed, None),
+        Some("length") => (
+            ResponseStatus::Incomplete,
+            Some(IncompleteDetails {
+                reason: IncompleteReason::MaxOutputTokens,
+            }),
+        ),
+        Some("tool_calls") => (ResponseStatus::InProgress, None), // Waiting for tool execution
+        Some("failed") | Some("error") => (ResponseStatus::Failed, None),
+        _ => (ResponseStatus::Completed, None), // Default to completed
     };
 
     // Convert usage from Usage to UsageInfo, then wrap in ResponsesUsage
@@ -430,14 +642,17 @@ pub(crate) fn chat_to_responses(
 
     // Generate response
     let response_id = response_id_override.unwrap_or_else(|| chat_resp.id.clone());
-    Ok(ResponsesResponse::builder(&response_id, &chat_resp.model)
+    let mut builder = ResponsesResponse::builder(&response_id, &chat_resp.model)
         .copy_from_request(original_req)
         .created_at(chat_resp.created as i64)
         .status(status)
         .output(output)
         .maybe_text(original_req.text.clone())
-        .maybe_usage(usage)
-        .build())
+        .maybe_usage(usage);
+    if let Some(details) = incomplete_details {
+        builder = builder.incomplete_details(details);
+    }
+    Ok(builder.build())
 }
 
 #[cfg(test)]

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -25,8 +25,9 @@ use openai_protocol::{
     },
     common::{FunctionCallResponse, ToolCall, Usage, UsageInfo},
     responses::{
-        ResponseContentPart, ResponseOutputItem, ResponseReasoningContent, ResponseStatus,
-        ResponsesRequest, ResponsesResponse, ResponsesUsage,
+        IncompleteDetails, IncompleteReason, ResponseContentPart, ResponseOutputItem,
+        ResponseReasoningContent, ResponseStatus, ResponsesRequest, ResponsesResponse,
+        ResponsesUsage,
     },
 };
 use serde_json::{json, Value};
@@ -412,12 +413,21 @@ impl StreamingResponseAccumulator {
             item
         }));
 
-        // Determine final status
-        let status = match self.finish_reason.as_deref() {
-            Some("stop") | Some("length") => ResponseStatus::Completed,
-            Some("tool_calls") => ResponseStatus::InProgress,
-            Some("failed") | Some("error") => ResponseStatus::Failed,
-            _ => ResponseStatus::Completed,
+        // Determine final status. A `length` finish is a max_output_tokens
+        // truncation, reported as status=incomplete with incomplete_details,
+        // matching the non-streaming conversion and the streamed terminal
+        // event.
+        let (status, incomplete_details) = match self.finish_reason.as_deref() {
+            Some("stop") => (ResponseStatus::Completed, None),
+            Some("length") => (
+                ResponseStatus::Incomplete,
+                Some(IncompleteDetails {
+                    reason: IncompleteReason::MaxOutputTokens,
+                }),
+            ),
+            Some("tool_calls") => (ResponseStatus::InProgress, None),
+            Some("failed") | Some("error") => (ResponseStatus::Failed, None),
+            _ => (ResponseStatus::Completed, None),
         };
 
         // Convert usage
@@ -435,13 +445,16 @@ impl StreamingResponseAccumulator {
             ResponsesUsage::Modern(usage_info.to_response_usage())
         });
 
-        ResponsesResponse::builder(&self.response_id, &self.model)
+        let mut builder = ResponsesResponse::builder(&self.response_id, &self.model)
             .copy_from_request(&self.original_request)
             .created_at(self.created_at)
             .status(status)
             .output(output)
-            .maybe_usage(usage)
-            .build()
+            .maybe_usage(usage);
+        if let Some(details) = incomplete_details {
+            builder = builder.incomplete_details(details);
+        }
+        builder.build()
     }
 }
 


### PR DESCRIPTION
## Summary

The regular router's `/v1/responses` conversion mishandled several shapes that Codex relies on:

- **Custom tools**: `type: custom` tools were dropped. They are now downgraded to function tools with a single `input` string, mapped back to `custom_tool_call` items, and replayable from history.
- **Streaming and reasoning**: streamed tool calls emitted no events and reasoning was never streamed. Tool calls and reasoning now stream as paired `output_item.added` / `delta` / `done` events, reasoning comes first, and `include=reasoning.encrypted_content` returns an opaque blob the replay path decodes.
- **Replay and precedence**: each replayed assistant item became its own turn, `tool_choice=none` still rendered tool schemas, and developer text lost its tier. Assistant items now merge into one turn, `none` drops the schemas, and developer text folds into a labelled system block. Also: `finish_reason=length` → `status=incomplete`, `input_image` → `image_url`.

Custom-tool grammar formats are not forwarded as engine constraints: the constraint slot is mutually exclusive with the JSON schema that forces a tool call.

## Changes

| File | Change |
| --- | --- |
| `crates/protocols/src/responses.rs` | Add `ResponseOutputItem::CustomToolCall`; `ResponsesToolChoice::Custom` pins the chat `tool_choice` by name |
| `crates/external_router/src/openai_bridge/tool_descriptors.rs` | `custom_tool_call` items are always client-visible |
| `model_gateway/src/routers/grpc/common/responses/utils.rs` | Custom-tool downgrade helpers (`custom_tool_as_function`, `custom_tool_input`, `custom_tool_names`); `encode/decode_reasoning_content` |
| `model_gateway/src/routers/grpc/common/responses/streaming.rs` | Stream reasoning and tool-call items with paired events; `encrypted_content` on request; 3 new `process_chunk` unit tests |
| `model_gateway/src/routers/grpc/regular/responses/conversions.rs` | Assistant-turn merging, developer folding, custom-tool and encrypted-reasoning replay, `tool_choice=none`, `input_image`, `status=incomplete`, reasoning-first output |

## Test

**Unit tests**

```bash
cargo test -p openai-protocol --lib                 # 121 passed
cargo test -p smg --lib -- responses chat_utils      # 68 passed, incl. 3 new streaming tests
cargo fmt --all -- --check
cargo clippy -p smg -p openai-protocol -p smg-external-router --all-targets -- -D warnings
```

**Conformance** — `codex_response_test.py` (26 cases, `compaction_replay` skipped) against `ts serve` + this build, GLM-5.3-Flash on 8×B200, five consecutive full passes:

| run | PASS | FAIL | SKIP | non-pass |
| --- | --- | --- | --- | --- |
| 1 | 25 | 0 | 1 | SKIP `reasoning_replay` |
| 2 | 25 | 0 | 1 | SKIP `reasoning_replay` |
| 3 | 25 | 0 | 1 | SKIP `reasoning_replay` |
| 4 | 25 | 0 | 1 | SKIP `reasoning_replay` |
| 5 | 25 | 0 | 1 | SKIP `reasoning_replay` |

Cases targeted by this PR (`custom_tool_*`, `tool_call_stream`, `stream_tool_and_text_order`, `reasoning_summary`, `tool_roundtrip`, `parallel_tool_roundtrip`, `developer_message`, `max_output_tokens_incomplete`, `image_input`) pass in every FAIL-free run. Before this change custom tools never reached the model, streamed tool calls produced no `function_call` events, and `developer_message` failed on every run.