### PR TITLE
feat(pd): let the engine report its pairing protocol from SMG_PAIRING_PROTOCOL

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -1061,14 +1061,15 @@ jobs:
       test_timeout: ${{ matrix.test_timeout }}
       test_dirs: e2e_test/router/test_pd_topologies.py
       # The 2p2d slice (which carries the mixed-transport fleet on vLLM), the
-      # runtime-assembled fleet, the over-window burst, and the mismatched
-      # fleet that placement must refuse; the full sweep runs in nightly-pd.
+      # runtime-assembled fleet, the over-window burst, and the two fleets
+      # placement must refuse (mismatched transports, mismatched explicit
+      # protocols); the full sweep runs in nightly-pd.
       # Run 34440725835: 9-16 min of tests per row against the 42/60 budgets.
-      test_filter: ${{ matrix.test_filter || '-k "(2p2d and not http) or AssembledAtRuntime or SmallWindow or MismatchedTransport"' }}
+      test_filter: ${{ matrix.test_filter || '-k "(2p2d and not http) or AssembledAtRuntime or SmallWindow or MismatchedTransport or MismatchedProtocol"' }}
       extra_models: ${{ matrix.engine == 'tokenspeed' && 'Qwen/Qwen3.5-9B' || '' }}
-      # floor ≈ 95% of the slice: 14 cases on sglang/tokenspeed, 16 on vllm
-      # (its two transport classes); the 1p1d smoke selects 12, floor 11
-      min_selected: ${{ matrix.min_selected || 13 }}
+      # floor ≈ 93% of the slice: 15 cases on sglang/tokenspeed, 17 on vllm
+      # (its two transport classes); the 1p1d smoke selects 13, floor 11
+      min_selected: ${{ matrix.min_selected || 14 }}
       kv_backend: ${{ matrix.kv_backend || '' }}
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
       # The mixed-transport fleet needs both vLLM backends installed whatever the lane's own

--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -369,6 +369,10 @@ message GetServerInfoResponse {
   int32 block_size = 12;          // cache_config.block_size (0 until the engine resolves it)
   string attention_backend = 13;  // attention_config.backend name, "" when auto-selected
   string model_dtype = 14;        // model_config.dtype ("torch.bfloat16", ...)
+  // Operator-set PD pairing protocol, read from the SMG_PAIRING_PROTOCOL
+  // environment variable of the engine process; "" when unset. A prefill and
+  // a decode carrying one pair only when the values are equal.
+  string pairing_protocol = 15;
 }
 
 // =====================

--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -371,7 +371,7 @@ message GetServerInfoResponse {
   string model_dtype = 14;        // model_config.dtype ("torch.bfloat16", ...)
   // Operator-set PD pairing protocol, read from the SMG_PAIRING_PROTOCOL
   // environment variable of the engine process; "" when unset. A prefill and
-  // a decode carrying one pair only when the values are equal.
+  // a decode that both carry one can pair only when the values are equal.
   string pairing_protocol = 15;
 }
 

--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.4.17"
+version = "0.4.18"
 description = "SMG gRPC proto definitions for vLLM, TRT-LLM, MLX, TokenSpeed, and SGLang"
 requires-python = ">=3.10"
 dependencies = [

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -688,8 +688,12 @@ pub struct WorkerSpec {
     pub kv_block_size: Option<usize>,
     /// Explicit PD pairing protocol. A prefill and a decode with this set
     /// pair only when the values are equal, and nothing derived about their
-    /// transport, engine version or KV layout is compared. Absent: the router
-    /// derives the pairing descriptor from the worker's discovered labels.
+    /// transport, engine version or KV layout is compared. The same value
+    /// can arrive as a `pairing_protocol` worker label, or from the engine
+    /// itself: the gRPC servicers report their `SMG_PAIRING_PROTOCOL`
+    /// environment in server info, so a deployment can inject it into the
+    /// engine container. Absent everywhere: the router derives the pairing
+    /// descriptor from the worker's discovered labels.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pairing_protocol: Option<String>,
 

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -244,7 +244,9 @@ def setup_backend(request: pytest.FixtureRequest):
       - ``("pd_grpc", (n_prefill, n_decode[, prefill_tp, decode_tp]))`` as
         the param: PD counts, optionally with asymmetric per-leg tp; a
         trailing dict may add ``prefill_kv`` / ``decode_kv`` lists naming
-        each worker's KV transfer backend, so one fleet can mix transports
+        each worker's KV transfer backend, so one fleet can mix transports,
+        and ``prefill_env`` / ``decode_env`` dicts of engine environment
+        for one leg (a deployment-injected ``SMG_PAIRING_PROTOCOL``)
       - ``@pytest.mark.gateway(policy=..., timeout=..., extra_args=...)``: Gateway config
 
     Returns:
@@ -309,6 +311,9 @@ def setup_backend(request: pytest.FixtureRequest):
         for key in ("prefill_kv", "decode_kv"):
             if key in leg_options:
                 workers_config = {**workers_config, key: list(leg_options[key])}
+        for key in ("prefill_env", "decode_env"):
+            if key in leg_options:
+                workers_config = {**workers_config, key: dict(leg_options[key])}
     log_dir = os.environ.get("E2E_LOG_DIR") or gateway_config.get("log_dir")
 
     fail_count = _worker_start_failures.get(engine, 0)
@@ -453,6 +458,7 @@ def _start_pd_leg(
     tp,
     kv_backends: list[str] | None,
     extra_engine_args: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> list:
     """Start one PD leg; a per-worker KV backend list starts the workers one by one."""
     if kv_backends is None:
@@ -467,6 +473,7 @@ def _start_pd_leg(
             wait_ready=wait_ready,
             tp=tp,
             extra_engine_args=extra_engine_args,
+            extra_env=extra_env,
         )
     spec_tp = tp or get_model_spec(model_id).get("tp", 1)
     workers: list = []
@@ -484,6 +491,7 @@ def _start_pd_leg(
                 tp=tp,
                 kv_backend=backend,
                 extra_engine_args=extra_engine_args,
+                extra_env=extra_env,
             )
         )
     return workers
@@ -540,6 +548,7 @@ def _setup_pd(
             tp=prefill_tp,
             kv_backends=prefill_kv,
             extra_engine_args=extra_engine_args,
+            extra_env=workers_config.get("prefill_env"),
         )
         all_workers.extend(prefill_workers)
 
@@ -557,6 +566,7 @@ def _setup_pd(
             tp=decode_tp,
             kv_backends=decode_kv,
             extra_engine_args=extra_engine_args,
+            extra_env=workers_config.get("decode_env"),
         )
         all_workers.extend(decode_workers)
         if parallel_start:

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -63,6 +63,9 @@ class Worker:
     # KV transfer backend for this PD worker ("nixl" or "mooncake"); None
     # takes the lane's default, so one fleet can mix transports.
     kv_backend: str | None = None
+    # Environment for the engine process on top of the infra's own settings
+    # (a deployment-injected SMG_PAIRING_PROTOCOL, for instance).
+    extra_env: dict[str, str] | None = None
     process: subprocess.Popen | None = field(default=None, repr=False)
     _log_file: IO[Any] | None = field(default=None, repr=False)
     # Used memory per GPU just before launch; ``stop`` waits for it to come back.
@@ -594,6 +597,8 @@ class Worker:
                 env["NCCL_SHM_DISABLE"] = "1"
                 env["TLLM_DISABLE_ALLREDUCE_AUTOTUNE"] = "1"
 
+        if self.extra_env:
+            env.update(self.extra_env)
         return env
 
     def _spawn_process(self, cmd: list[str], env: dict[str, str]) -> subprocess.Popen:
@@ -689,6 +694,7 @@ def start_workers(
     extra_engine_args: list[str] | None = None,
     tp: int | None = None,
     kv_backend: str | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> list[Worker]:
     """Start N workers for a model. GPU IDs assigned sequentially.
 
@@ -774,6 +780,7 @@ def start_workers(
                 extra_engine_args=extra_engine_args,
                 tp=tp,
                 kv_backend=kv_backend,
+                extra_env=extra_env,
             )
 
             # Stagger launches to avoid resource contention

--- a/e2e_test/infra/worker_pool.py
+++ b/e2e_test/infra/worker_pool.py
@@ -72,6 +72,7 @@ class WorkerPool:
         wait_ready: bool = True,
         tp: int | None = None,
         kv_backend: str | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> list[Worker]:
         """Return ``count`` healthy workers for the given key.
 
@@ -120,11 +121,13 @@ class WorkerPool:
                     wait_ready=wait_ready,
                     tp=tp,
                     kv_backend=kv_backend,
+                    extra_env=extra_env,
                 )
 
-            if tp is not None or kv_backend is not None:
+            if tp is not None or kv_backend is not None or extra_env is not None:
                 raise ValueError(
-                    "a per-leg tp or kv_backend is only meaningful for PD prefill/decode workers"
+                    "a per-leg tp, kv_backend or extra_env is only meaningful for "
+                    "PD prefill/decode workers"
                 )
 
             # REGULAR workers always start at gpu 0; ``gpu_offset`` is only

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -840,6 +840,62 @@ class TestPDMismatchedTransport:
 
 
 # ---------------------------------------------------------------------------
+# an explicit pairing protocol injected into the engines
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.engine("sglang", "vllm", "tokenspeed")
+@pytest.mark.gpu(4)
+@pytest.mark.e2e
+@pytest.mark.model(_MODEL, tokenspeed=_MODEL_BY_ENGINE["tokenspeed"])
+@pytest.mark.workers(parallel_start=True)
+@pytest.mark.gateway(log_level="debug", log_dir=str(_LOG_DIR), extra_args=_GATEWAY_ARGS)
+@pytest.mark.parametrize(
+    "setup_backend",
+    [
+        pytest.param(
+            (
+                "pd_grpc",
+                (
+                    1,
+                    1,
+                    {
+                        "prefill_env": {"SMG_PAIRING_PROTOCOL": "kv-v1"},
+                        "decode_env": {"SMG_PAIRING_PROTOCOL": "kv-v2"},
+                    },
+                ),
+            ),
+            id="1p1d-protocol-mismatch",
+        )
+    ],
+    indirect=True,
+)
+class TestPDMismatchedProtocol:
+    """A pairing protocol set in the engine's environment reaches placement.
+
+    A deployment injects ``SMG_PAIRING_PROTOCOL`` into the engine container;
+    the servicer reports it in server info and the gateway pairs on it alone.
+    Two legs with different values are refused with `no_compatible_pd_pair`,
+    whatever their transport and layout say.
+    """
+
+    def test_legs_with_different_protocols_are_refused(self, setup_backend):
+        _, model, _, gateway = setup_backend
+        _wait_for_healthy_workers(gateway, 2, timeout=120.0)
+        keys = _pairing_keys(gateway)
+        logger.info("explicit-protocol fleet pairing keys: %s", keys)
+        by_url = {w.base_url: role for role, ws in _workers_by_role(gateway).items() for w in ws}
+        reported = {by_url.get(url, url): key for url, key in keys.items()}
+        # The explicit value is the whole key: the engine's environment, as
+        # the servicer reported it, replaces runtime/transport/layout.
+        assert reported == {"prefill": "kv-v1", "decode": "kv-v2"}, keys
+
+        resp = _raw_chat(gateway, model, "Say hello.", timeout=60.0)
+        assert resp.status_code == 503, resp.text
+        assert _error_code(resp) == "no_compatible_pd_pair", resp.text
+
+
+# ---------------------------------------------------------------------------
 # a decode window smaller than the burst
 # ---------------------------------------------------------------------------
 

--- a/e2e_test/router/test_pd_topologies.py
+++ b/e2e_test/router/test_pd_topologies.py
@@ -884,7 +884,7 @@ class TestPDMismatchedProtocol:
         _wait_for_healthy_workers(gateway, 2, timeout=120.0)
         keys = _pairing_keys(gateway)
         logger.info("explicit-protocol fleet pairing keys: %s", keys)
-        by_url = {w.base_url: role for role, ws in _workers_by_role(gateway).items() for w in ws}
+        by_url = {w.url: role for role, ws in _workers_by_role(gateway).items() for w in ws}
         reported = {by_url.get(url, url): key for url, key in keys.items()}
         # The explicit value is the whole key: the engine's environment, as
         # the servicer reported it, replaces runtime/transport/layout.

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.9.1"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, MLX, TokenSpeed, SGLang)"
 requires-python = ">=3.10"
 dependencies = [
-    "smg-grpc-proto>=0.4.17",  # 0.4.17: first release with the vLLM GetServerInfoResponse pairing fields (11-14)
+    "smg-grpc-proto>=0.4.18",  # 0.4.18: first release with GetServerInfoResponse.pairing_protocol (15)
     "grpcio>=1.81.1",
     "grpcio-reflection>=1.81.1",
     "grpcio-health-checking>=1.81.1",

--- a/grpc_servicer/smg_grpc_servicer/pd_pairing.py
+++ b/grpc_servicer/smg_grpc_servicer/pd_pairing.py
@@ -1,0 +1,19 @@
+"""The operator-set PD pairing protocol, read from the engine's environment.
+
+A deployment can inject ``SMG_PAIRING_PROTOCOL`` into the engine container;
+each servicer reports the value in its server info, the gateway turns it into
+the worker's ``pairing_protocol`` label, and a prefill and a decode carrying
+one pair only when the values are equal (nothing derived about transport,
+version or KV layout is compared). Unset or blank means "derive it".
+"""
+
+import os
+from collections.abc import Mapping
+
+PAIRING_PROTOCOL_ENV = "SMG_PAIRING_PROTOCOL"
+
+
+def pairing_protocol_from_env(environ: Mapping[str, str] | None = None) -> str:
+    """The trimmed ``SMG_PAIRING_PROTOCOL`` value, or ``""`` when unset or blank."""
+    source = os.environ if environ is None else environ
+    return (source.get(PAIRING_PROTOCOL_ENV) or "").strip()

--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -62,6 +62,8 @@ from smg_grpc_servicer.sglang.request_manager import GrpcRequestManager
 from smg_grpc_servicer.sglang.utils import abort_code_from_output, to_token_id_array
 from smg_grpc_servicer.tokenizer_bundle import CHUNK_SIZE, build_tokenizer_zip
 
+from ..pd_pairing import pairing_protocol_from_env
+
 logger = logging.getLogger(__name__)
 HEALTH_CHECK_TIMEOUT = int(os.getenv("SGLANG_HEALTH_CHECK_TIMEOUT", 20))
 # Profile round-trips include trace serialization, which can take minutes.
@@ -493,6 +495,11 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 return str(obj)
 
         serializable_args = make_serializable(server_args_dict)
+        # The operator's PD pairing protocol rides with the server args, so
+        # the gateway reads it as the worker's `pairing_protocol` label.
+        pairing_protocol = pairing_protocol_from_env()
+        if pairing_protocol:
+            serializable_args["pairing_protocol"] = pairing_protocol
         server_args_struct.update(serializable_args)
 
         # Convert scheduler_info to Struct

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -49,6 +49,8 @@ from smg_grpc_servicer.tokenspeed.health_servicer import TokenSpeedHealthService
 from smg_grpc_servicer.tokenspeed.kv_events import resolve_kv_events_config
 from smg_grpc_servicer.tokenspeed.loads import convert_load_to_protobuf, running_window
 
+from ..pd_pairing import pairing_protocol_from_env
+
 if TYPE_CHECKING:
     # Type-only — keeps these out of the cold-path graph when the servicer is
     # imported by tooling that stubs the engine surface.
@@ -581,6 +583,11 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             if isinstance(dp_size, int) and dp_size > 1:
                 server_args_dict["dp_size"] = dp_size
 
+        # The operator's PD pairing protocol rides with the server args, so
+        # the gateway reads it as the worker's `pairing_protocol` label.
+        pairing_protocol = pairing_protocol_from_env()
+        if pairing_protocol:
+            server_args_dict["pairing_protocol"] = pairing_protocol
         server_args_struct = Struct()
         server_args_struct.update(_make_json_serializable(server_args_dict))
 

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -52,6 +52,8 @@ from smg_grpc_servicer.vllm.kv_transfer import (
 )
 from smg_grpc_servicer.vllm.mm_salt import has_preprocessed_mm_payload, mm_identity_cache_salt
 
+from ..pd_pairing import pairing_protocol_from_env
+
 logger = init_logger(__name__)
 SAMPLING_DEFAULT_KEYS = (
     "temperature",
@@ -525,6 +527,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             kv_engine_id=kv_engine_id,
             data_parallel_size=parallel.data_parallel_size,
             shm_namespace_id=mm_shm.shm_namespace_id(),
+            pairing_protocol=pairing_protocol_from_env(),
             **pairing_fields(self.engine.vllm_config),
         )
 

--- a/grpc_servicer/tests/test_pd_pairing_fields.py
+++ b/grpc_servicer/tests/test_pd_pairing_fields.py
@@ -18,6 +18,11 @@ kv_transfer = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(kv_transfer)
 pairing_fields = kv_transfer.pairing_fields
 
+_PAIRING_PATH = Path(__file__).parents[1] / "smg_grpc_servicer" / "pd_pairing.py"
+_pspec = importlib.util.spec_from_file_location("pd_pairing", _PAIRING_PATH)
+pd_pairing = importlib.util.module_from_spec(_pspec)
+_pspec.loader.exec_module(pd_pairing)
+
 
 def _config(**overrides):
     base = {
@@ -67,3 +72,28 @@ def test_pairing_fields_round_trip_the_proto():
     assert parsed.block_size == 16
     assert parsed.attention_backend == "FLASH_ATTN"
     assert parsed.model_dtype == "torch.bfloat16"
+
+
+def test_pairing_protocol_comes_from_the_engine_environment():
+    assert pd_pairing.pairing_protocol_from_env({}) == ""
+    assert pd_pairing.pairing_protocol_from_env({"SMG_PAIRING_PROTOCOL": "  "}) == ""
+    assert pd_pairing.pairing_protocol_from_env({"SMG_PAIRING_PROTOCOL": " kv-v1 "}) == "kv-v1"
+    assert pd_pairing.PAIRING_PROTOCOL_ENV == "SMG_PAIRING_PROTOCOL"
+
+
+def test_pairing_protocol_round_trips_the_vllm_proto():
+    from smg_grpc_proto import vllm_engine_pb2 as pb2
+
+    fields = pb2.GetServerInfoResponse.DESCRIPTOR.fields_by_name
+    if "pairing_protocol" not in fields:
+        pytest.skip(
+            "smg_grpc_proto stubs predate GetServerInfoResponse.pairing_protocol; "
+            "regenerate from crates/grpc_client/proto"
+        )
+    assert fields["pairing_protocol"].number == 15
+    info = pb2.GetServerInfoResponse(
+        pairing_protocol=pd_pairing.pairing_protocol_from_env({"SMG_PAIRING_PROTOCOL": "kv-v1"})
+    )
+    assert (
+        pb2.GetServerInfoResponse.FromString(info.SerializeToString()).pairing_protocol == "kv-v1"
+    )

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -859,6 +859,9 @@ const SGLANG_GRPC_KEYS: &[&str] = &[
     "kv_cache_dtype",
     "page_size",
     "attention_backend",
+    // The operator's explicit protocol, which the servicer reads from the
+    // engine's SMG_PAIRING_PROTOCOL environment.
+    "pairing_protocol",
 ];
 
 /// Keys worth extracting from TokenSpeed gRPC `server_args` (post-rename: bare
@@ -893,6 +896,7 @@ const TOKENSPEED_GRPC_KEYS: &[&str] = &[
     "disaggregation_bootstrap_port",
     "kv_cache_dtype",
     "attention_backend",
+    "pairing_protocol",
 ];
 
 // ---------------------------------------------------------------------------
@@ -1109,6 +1113,7 @@ mod tests {
                     ("kv_cache_dtype".to_string(), string_value("fp8_e5m2")),
                     ("page_size".to_string(), number_value(64.0)),
                     ("attention_backend".to_string(), string_value("fa3")),
+                    ("pairing_protocol".to_string(), string_value("kv-v1")),
                     // Not in SGLANG_GRPC_KEYS — must not become a label.
                     ("api_key".to_string(), string_value("secret")),
                 ]),
@@ -1152,6 +1157,11 @@ mod tests {
         assert_eq!(
             labels.get("attention_backend").map(String::as_str),
             Some("fa3")
+        );
+        // The explicit protocol the servicer read from the engine's environment.
+        assert_eq!(
+            labels.get("pairing_protocol").map(String::as_str),
+            Some("kv-v1")
         );
     }
 

--- a/model_gateway/src/worker/pd_pairing.rs
+++ b/model_gateway/src/worker/pd_pairing.rs
@@ -5,8 +5,11 @@
 //! a KV transport (NIXL vs Mooncake) and a compatible KV layout, and normally
 //! an engine version. Each PD worker carries a [`PdPairing`] derived from the
 //! labels its engine reports at discovery, or from an explicit
-//! `pairing_protocol` the operator sets on the worker; placement pairs a
-//! prefill only with a decode whose descriptor is compatible.
+//! `pairing_protocol` the operator sets: on the worker spec, as a worker
+//! label, or in the engine's own environment (`SMG_PAIRING_PROTOCOL`, which
+//! the gRPC servicers report in server info and so reaches the same label).
+//! Placement pairs a prefill only with a decode whose descriptor is
+//! compatible.
 //! [`PdPairingMode::Lenient`] refuses only a known difference in runtime,
 //! transport or a KV layout fact, so a fleet that reports nothing keeps
 //! working and a rolling engine upgrade keeps pairing;
@@ -19,11 +22,12 @@ use openai_protocol::worker::{RuntimeType, WorkerSpec};
 
 pub use crate::config::types::PdPairingMode;
 
-/// Label under which an operator may set the pairing protocol explicitly,
-/// alongside the `pairing_protocol` field on the worker spec.
+/// Label under which the pairing protocol arrives when it is not on the
+/// worker spec: set by the operator as a worker label, or reported by the
+/// engine's servicer from its `SMG_PAIRING_PROTOCOL` environment. A worker
+/// label wins over the reported value, since config labels are merged over
+/// discovered ones.
 pub const PAIRING_PROTOCOL_LABEL: &str = "pairing_protocol";
-/// The Kubernetes annotation flattened into the same label.
-pub const PAIRING_PROTOCOL_ANNOTATION_LABEL: &str = "smg.ai/pairing-protocol";
 
 /// The KV layout facts engines report: the short name used in the pairing
 /// key, the canonical label, and alias labels (vLLM's `block_size` is the
@@ -85,11 +89,6 @@ impl PdPairing {
             .pairing_protocol
             .as_deref()
             .or_else(|| labels.get(PAIRING_PROTOCOL_LABEL).map(String::as_str))
-            .or_else(|| {
-                labels
-                    .get(PAIRING_PROTOCOL_ANNOTATION_LABEL)
-                    .map(String::as_str)
-            })
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string);
@@ -345,9 +344,11 @@ mod tests {
         let mut s = spec(RuntimeType::Vllm, &[("version", "0.27.1")]);
         s.pairing_protocol = Some("blue".to_string());
         assert_eq!(PdPairing::derive(&s).key(), "blue");
+        // The label path, which both a worker label and the engine's
+        // SMG_PAIRING_PROTOCOL environment (via server info) arrive through.
         let labelled = spec(
             RuntimeType::Vllm,
-            &[("smg.ai/pairing-protocol", "green"), ("version", "0.1.0")],
+            &[("pairing_protocol", " green "), ("version", "0.1.0")],
         );
         assert_eq!(PdPairing::derive(&labelled).key(), "green");
     }


### PR DESCRIPTION
## Description

### Problem

An operator can pin the PD pairing protocol on the gateway side only: the `pairing_protocol` worker-spec field or a `pairing_protocol` worker label. The code also named a Kubernetes annotation for it, but nothing flattens pod annotations into labels, so that path never worked. A deployment that owns the engine container has the natural place to declare the protocol, its environment, and no way to make the gateway see it.

### Solution

Let the engine side carry it. The three gRPC servicers read `SMG_PAIRING_PROTOCOL` from their environment and report it in server info: vLLM as a new typed field (`GetServerInfoResponse.pairing_protocol = 15`), SGLang and TokenSpeed as a `pairing_protocol` entry next to their server args. The gateway's label mapping picks it up, so it lands in the same `pairing_protocol` label the descriptor already reads, with the existing precedence: spec field, then a worker label (config labels are merged over discovered ones), then the engine-reported value. The dead annotation constant goes away.

Semantics are unchanged: two legs carrying an explicit protocol pair only when the values are equal, and nothing derived is compared; one leg carrying one is ignored under lenient and refused under strict.

## Changes

- `crates/grpc_client/proto/vllm_engine.proto`: `string pairing_protocol = 15` on `GetServerInfoResponse`; `smg-grpc-proto` 0.4.17 → 0.4.18 and the servicer floor to match.
- `grpc_servicer/smg_grpc_servicer/pd_pairing.py` (new): `SMG_PAIRING_PROTOCOL`, `pairing_protocol_from_env()` (trimmed, `""` when unset). The vLLM, SGLang and TokenSpeed servicers report it in `GetServerInfo`.
- `model_gateway/src/routers/grpc/client.rs`: `pairing_protocol` joins the SGLang and TokenSpeed server-args key lists (vLLM's typed response flattens on its own).
- `model_gateway/src/worker/pd_pairing.rs`: the annotation constant and its lookup are removed; the module and label docs describe the three ways the value arrives.
- `crates/protocols/src/worker.rs`: `WorkerSpec.pairing_protocol` doc.
- e2e: `Worker.extra_env` and a `prefill_env` / `decode_env` per-leg option on the PD fixture; `TestPDMismatchedProtocol` (all three engines, 1p1d) injects `kv-v1` into the prefill's environment and `kv-v2` into the decode's, asserts `/workers` reports exactly those keys, and gets `503 no_compatible_pd_pair`. Added to the PR slice filter (`min_selected` 13 → 14).

## Test Plan

- Unit: `grpc_servicer/tests/test_pd_pairing_fields.py` (env helper; proto field 15 round-trip) — 5 passed against stubs regenerated from the proto. `model_gateway` tests: the SGLang server-info label test picks `pairing_protocol`; the pairing test derives the explicit key from the label path.
- e2e: `e2e-4gpu-pd` on every engine runs `TestPDMismatchedProtocol[1p1d-protocol-mismatch]`, which only passes if the env var travels engine → servicer → server info → label → placement on that engine.
- Before: setting `SMG_PAIRING_PROTOCOL` in an engine container has no effect on pairing. After: the `/workers` `pd_pairing` key is the injected value, and legs with different values are refused.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (`-p smg -p smg-grpc-client`)
- [x] (Optional) Documentation updated (module, label and spec docs)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
