### PR TITLE
chore(release): bump openai-protocol to 2.0.0 so smg-rl can publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4876,7 +4876,7 @@ dependencies = [
 
 [[package]]
 name = "openai-protocol"
-version = "1.13.0"
+version = "2.0.0"
 dependencies = [
  "axum",
  "bitflags 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.13.0", path = "crates/protocols" }
+openai-protocol = { version = "2.0.0", path = "crates/protocols" }
 smg-mm-rdma = { version = "0.1.1", path = "crates/mm_rdma" }
 reasoning-parser = { version = "1.7.0", path = "crates/reasoning_parser" }
 tool-parser = { version = "1.7.0", path = "crates/tool_parser" }

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.13.0"
+version = "2.0.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

The "Publish Crates" workflow has failed on every `Cargo.toml`-touching push to `main` since #2411 merged (runs [34406313804](https://github.com/smg-project/smg/actions/runs/34406313804) and [34413848223](https://github.com/smg-project/smg/actions/runs/34413848223)):

```
tier2 (smg-rl, crates/rl)
   Verifying smg-rl v0.1.0
error[E0432]: unresolved import `openai_protocol::rl`
error: failed to verify package tarball
tier3: skipped
tier4: skipped
```

#2411 added the `openai_protocol::rl` module (the `/v1/rl` wire types) without bumping `openai-protocol`, so tier 1 skipped it as "version unchanged" and `cargo publish` verified `smg-rl` against the `openai-protocol 1.13.0` that is on crates.io, which has no `rl` module. Tiers 3 and 4 never ran.

## What

Bump `openai-protocol` from 1.13.0 to **2.0.0** in the crate manifest, the workspace pin, and `Cargo.lock`. Nothing else changes.

### Why major, not minor

The first version of this PR said 1.14.0. Review pointed out that `WorkerLoadsResult` and `WorkerLoadInfo` were public in 1.13.0 (published from `v1.10.1`) and removed by #2418. `cargo semver-checks check-release -p openai-protocol --baseline-version 1.13.0` confirms it and finds more:

| Check | Items |
|---|---|
| `struct_missing` | `worker::WorkerLoadsResult`, `worker::WorkerLoadInfo` |
| `enum_variant_added` (exhaustive enums) | `ReasoningEffort::{None, Xhigh, Max}`, `ContentPart::Unknown` |
| `enum_no_repr_variant_discriminant_changed` | `ReasoningEffort::{Minimal, Low, Medium, High}` |
| `enum_struct_variant_field_added` | `namespace` on `ResponseInputOutputItem::FunctionToolCall` and `ResponseOutputItem::FunctionToolCall` |
| `constructible_struct_adds_field` | `WorkerInfo.{http2, pd_pairing, engine_load}`, `HttpPoolConfig.http2`, `WorkerSpec.pairing_protocol`, `SchedulerLoadSnapshot.{worker, worker_type}`, `ImageUrl.max_long_side_pixel`, `VideoUrl.{fps, max_long_side_pixel}`, `ResponsesFunctionToolChoice.namespace`, `WebSearchTool.external_web_access` |
| `copy_impl_added` | `responses::ReasoningEffort` |

`Summary semver requires new major version: 6 major and 0 minor checks failed`

The concrete hazard of 1.14.0: the published `smg 1.10.1` requires `openai-protocol ^1.13.0` and imports `WorkerLoadsResult`, so a plain `cargo install smg` (which re-resolves unless `--locked`) would pick 1.14.0 and fail to compile. With 2.0.0, `^1.13.0` keeps resolving to 1.13.0.

With this, tier 1 publishes `openai-protocol 2.0.0`, tier 2 can verify and publish `smg-rl 0.1.0`, and tiers 3 and 4 run again (and skip, since their versions are unchanged).

## Verification

- `cargo publish --dry-run -p openai-protocol` packages and verifies 2.0.0.
- `cargo tree --locked` resolves `openai-protocol 2.0.0` for `smg-rl` and `smg`.
- `cargo semver-checks` report saved from the run above.

## For the maintainers, not in this PR

1. **`smg-external-router` is not in the publish matrix.** It is a new 0.1.0 crate that `smg` depends on. At the next release-time bump, tier 4 will fail to verify `smg` unless `smg-external-router` is added to tier 2 (its deps `openai-protocol`, `smg-mcp`, `data-connector` are all tier 1).
2. **Every published crate that depends on `openai-protocol` must move to `^2.0.0` in the same release as `smg`,** or `smg`'s verify sees two incompatible `openai-protocol` majors in one graph. Direct dependents in the workspace: `smg`, `smg-grpc-client`, `tool-parser`, `smg-external-router`, `smg-rl`, `smg-client`, `smg-golang` (and `llm-tokenizer` as a dev-dependency only). The release script already lists `smg-grpc-client` and `tool-parser` as changed since `v1.10.1`, so they get bumped; the others need checking at release time.
3. `scripts/check_release_versions.sh` decides major/minor from `feat!:`/`BREAKING CHANGE` in commit messages only, which is how this removal was proposed as "minor". `cargo semver-checks` in that script, or in CI for `crates/protocols`, would catch it mechanically.
