### PR TITLE
ci: semver-check openai-protocol in PRs and preflight registry deps before publishing

### DIFF
--- a/.github/actions/publish-crate/action.yml
+++ b/.github/actions/publish-crate/action.yml
@@ -50,6 +50,15 @@ runs:
       with:
         repo-token: ${{ github.token }}
 
+    # A path dependency becomes a plain version requirement in the packaged
+    # manifest. If that version is not on crates.io the verify build fails
+    # deep in rustc output after the earlier tiers already ran; name the
+    # missing crates up front instead.
+    - name: Check workspace dependencies are on crates.io
+      if: steps.check.outputs.changed == 'true'
+      shell: bash
+      run: bash scripts/check_publish_deps.sh ${{ inputs.crate }}
+
     - name: Publish to crates.io
       if: steps.check.outputs.changed == 'true'
       shell: bash

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -386,6 +386,60 @@ jobs:
   # not a merge blocker: it shows up as a warning annotation and in the step
   # summary (BENCH_ENFORCE_THRESHOLDS=1 makes it fail). Results are still
   # uploaded and summarized.
+  # Public-API guard for the published protocol crate: `cargo semver-checks`
+  # diffs openai-protocol against the newest version on crates.io. Versions
+  # are bumped at release time, so mid-cycle the manifest usually still says
+  # the published version; then only breaking changes fail (release type
+  # "minor"), and the fix is to bump the major in the PR that breaks the API.
+  # Once the manifest is bumped, the allowed change is derived from the two
+  # version numbers instead. Background: #2505, where a removal shipped as a
+  # plain feat: and the release script proposed a minor bump.
+  protocols-semver:
+    needs: [detect-changes]
+    if: >-
+      always()
+      && !cancelled()
+      && needs.detect-changes.result == 'success'
+      && (
+        github.event_name != 'pull_request'
+        || needs.detect-changes.outputs.protocols == 'true'
+      )
+    runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Decide the release type
+        id: release-type
+        run: |
+          local_version=$(grep -E '^version = ' crates/protocols/Cargo.toml | head -1 | cut -d'"' -f2)
+          published=$(curl -sf -A "smg-ci (${{ github.repository }})" https://crates.io/api/v1/crates/openai-protocol \
+            | grep -o '"max_version":"[^"]*"' | cut -d'"' -f4)
+          if [ -z "$published" ]; then
+            echo "could not read openai-protocol's published version from crates.io" >&2
+            exit 1
+          fi
+          echo "openai-protocol: manifest ${local_version}, crates.io ${published}"
+          if [ "$local_version" = "$published" ]; then
+            echo "Unbumped since the last publish: only breaking changes fail; bump the major in this PR to allow them"
+            echo "release-type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "Manifest already bumped: the allowed change is derived from ${published} -> ${local_version}"
+            echo "release-type=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: cargo semver-checks openai-protocol
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: openai-protocol
+          feature-group: all-features
+          rust-toolchain: manual
+          release-type: ${{ steps.release-type.outputs.release-type }}
+
   benchmarks:
     needs: build-wheel
     runs-on: ${{ vars.SMG_RUNNER_GPU_4 || '4-gpu-h100' }}
@@ -477,6 +531,7 @@ jobs:
       realtime: ${{ steps.filter.outputs.realtime }}
       go-bindings: ${{ steps.filter.outputs.go-bindings }}
       rust-ci: ${{ steps.filter.outputs.rust-ci }}
+      protocols: ${{ steps.filter.outputs.protocols }}
       tokenspeed-image: ${{ steps.tokenspeed-image.outputs.image }}
     steps:
       - uses: actions/checkout@v7
@@ -581,6 +636,11 @@ jobs:
               - 'e2e_test/realtime/**'
             go-bindings:
               - 'e2e_test/bindings_go/**'
+            protocols:
+              - 'crates/protocols/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/pr-test-rust.yml'
             rust-ci:
               - 'Cargo.toml'
               - 'Cargo.lock'
@@ -1388,7 +1448,7 @@ jobs:
           path: benchmark_go_bindings/
 
   finish:
-    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-chat-zmq, e2e-2gpu-chat-zmq-dp, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-realtime, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-4gpu-pd, e2e-vendor, go-unit-tests, go-bindings-e2e]
+    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, protocols-semver, benchmarks, e2e-1gpu-chat, e2e-1gpu-chat-zmq, e2e-2gpu-chat-zmq-dp, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-realtime, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-4gpu-pd, e2e-vendor, go-unit-tests, go-bindings-e2e]
     if: always()
     runs-on: ${{ vars.SMG_RUNNER_CPU || 'k8s-runner-cpu' }}
     permissions:
@@ -1445,6 +1505,7 @@ jobs:
                 "${{ needs.build-wheel.result }}" == "failure" || \
                 "${{ needs.python-unit-tests.result }}" == "failure" || \
                 "${{ needs.unit-tests.result }}" == "failure" || \
+                "${{ needs.protocols-semver.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-chat.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-chat-zmq.result }}" == "failure" || \
                 "${{ needs.e2e-2gpu-chat-zmq-dp.result }}" == "failure" || \

--- a/scripts/check_publish_deps.sh
+++ b/scripts/check_publish_deps.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Fail before `cargo publish` when a workspace dependency of CRATE is not on
+# crates.io at the version the packaged manifest will require.
+#
+# `cargo publish` rewrites every path dependency into a plain version
+# requirement, so a workspace crate that was never published (or not yet
+# published at the pinned version) makes the verify build fail with an
+# unhelpful "unresolved import" or "no matching package" deep in rustc
+# output, and it does so only after the earlier tiers have already run.
+# This check names the missing crates up front.
+#
+# Usage: scripts/check_publish_deps.sh <crate-name>
+# Env:   CRATES_INDEX_URL  sparse-index base (default https://index.crates.io),
+#                          overridable for tests.
+set -euo pipefail
+
+crate="${1:?usage: $0 <crate-name>}"
+index="${CRATES_INDEX_URL:-https://index.crates.io}"
+
+# Sparse-index path for a crate name (https://doc.rust-lang.org/cargo/reference/registry-index.html).
+index_path() {
+    local name="$1"
+    case ${#name} in
+        1) echo "1/${name}" ;;
+        2) echo "2/${name}" ;;
+        3) echo "3/${name:0:1}/${name}" ;;
+        *) echo "${name:0:2}/${name:2:2}/${name}" ;;
+    esac
+}
+
+stderr=$(mktemp)
+trap 'rm -f "$stderr"' EXIT
+if ! metadata=$(cargo metadata --format-version 1 --no-deps --locked 2> "$stderr"); then
+    cat "$stderr" >&2
+    exit 2
+fi
+if ! jq -e --arg c "$crate" '.packages[] | select(.name == $c)' <<< "$metadata" > /dev/null; then
+    echo "check_publish_deps: no workspace package named '${crate}'" >&2
+    exit 2
+fi
+
+# Every workspace path dependency that survives packaging: "<name> <req>".
+# Dev-dependencies are dropped from the published manifest, so they are
+# not checked; normal and build dependencies are.
+deps=$(jq -r --arg c "$crate" \
+    '.packages[] | select(.name == $c) | .dependencies[] | select(.path != null and .kind != "dev") | "\(.name) \(.req)"' \
+    <<< "$metadata" | sort -u)
+
+if [[ -z "$deps" ]]; then
+    echo "${crate}: no workspace dependencies to check"
+    exit 0
+fi
+
+missing=()
+while read -r name req; do
+    [[ -z "$name" ]] && continue
+    version="${req#^}"      # workspace pins are exact: ^X.Y.Z
+    body=$(curl -sf "${index}/$(index_path "$name")" || true)
+    if [[ -n "$body" ]] && jq -se --arg v "$version" 'any(.[]; .vers == $v and (.yanked | not))' <<< "$body" > /dev/null; then
+        echo "  ok       ${name} ${version}"
+    else
+        echo "  MISSING  ${name} ${version}"
+        missing+=("${name} ${version}")
+    fi
+done <<< "$deps"
+
+if (( ${#missing[@]} )); then
+    echo
+    echo "${crate}: ${#missing[@]} workspace dependenc$([[ ${#missing[@]} -eq 1 ]] && echo y || echo ies) not on crates.io at the required version:"
+    printf '  %s\n' "${missing[@]}"
+    echo "Publish them first (an earlier tier in .github/workflows/release-crates.yml), or bump them so the pin matches a published version."
+    exit 1
+fi
+echo "${crate}: every workspace dependency is on crates.io"


### PR DESCRIPTION
## Why

#2505 showed two gaps in the release plumbing:

- `crates/protocols` (`openai-protocol`, published) had public structs removed by a plain `feat:` commit, so `scripts/check_release_versions.sh` proposed a **minor** bump for what is a **major** change. Nothing in CI looks at the crate's actual public API.
- The crates release job discovers a missing dependency only when `cargo publish` verifies the tarball, as an `unresolved import` deep in rustc output, after the earlier tiers already ran (runs [34406313804](https://github.com/smg-project/smg/actions/runs/34406313804), [34413848223](https://github.com/smg-project/smg/actions/runs/34413848223)). Right now `smg` depends on `smg-external-router 0.1.0` and `smg-rl 0.1.0`, neither of which is on crates.io.

## What

### 1. `protocols-semver` job (PR workflow)

Runs [`cargo semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) on `openai-protocol` against the newest version on crates.io, gated by a new `protocols` path filter (`crates/protocols/**`, `Cargo.toml`, `Cargo.lock`, the workflow itself), and wired into `finish` so it gates merge like `unit-tests`.

Because this repo bumps versions at release time, the job picks the mode from the manifest:

| Manifest version vs crates.io | Mode | Effect |
|---|---|---|
| equal (the usual mid-cycle state) | `--release-type minor` | additive changes pass; a breaking change fails, and the fix is to bump the major in that PR |
| different (already bumped) | derived from the two version numbers | the bump must be large enough for the detected changes |

Verified locally on current `main` (manifest 1.13.0 == crates.io 1.13.0, so `minor` mode):

```
Checking openai-protocol v1.13.0 -> v1.13.0 (assume minor change)
Checked 196 checks: 190 pass, 6 fail, 0 warn, 58 skip
Summary semver requires new major version: 6 major and 0 minor checks failed
```

which is the #2505 situation caught at PR time. With the 2.0.0 bump in place it passes (`1.13.0 -> 2.0.0`, major allowed). The action's `release-type` input is omitted when empty, so the derived mode is the tool's default.

### 2. Registry preflight in the publish action

`scripts/check_publish_deps.sh <crate>` runs in `.github/actions/publish-crate` before `cargo publish`, for every tier. It reads `cargo metadata`, takes each workspace path dependency that survives packaging (normal and build kinds; dev-dependencies are stripped from the published manifest), and checks the sparse index for the pinned version, un-yanked. Output on today's `main` for `smg`:

```
  ok       data-connector 2.3.4
  ...
  MISSING  smg-external-router 0.1.0
  ...
  MISSING  smg-rl 0.1.0
smg: 2 workspace dependencies not on crates.io at the required version:
  smg-external-router 0.1.0
  smg-rl 0.1.0
Publish them first (an earlier tier in .github/workflows/release-crates.yml), or bump them so the pin matches a published version.
```

`openai-protocol` (no workspace deps) and `smg-rl` (only `openai-protocol 1.13.0`) pass. `CRATES_INDEX_URL` can be pointed at a local mirror for tests.

## Verification

- `actionlint` on the workflow: the only findings are pre-existing on `main` (same count before and after).
- `shellcheck scripts/check_publish_deps.sh` clean.
- YAML parses for both edited files.

## Not in this PR

`smg-external-router` still needs a tier-2 entry in `release-crates.yml` before the next `smg` release; this PR makes that failure explicit rather than fixing it. #2505 handles the `openai-protocol` bump.
