### PR TITLE
feat(policies): count cache-aware tree decisions by branch and match ratio

### DIFF
--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -130,7 +130,7 @@ pub(crate) const UPKEEP_INTERVAL_SECS: u64 = 5 * 60;
 /// Histogram buckets for `smg_cache_aware_match_ratio`. The ratio is
 /// dimensionless (matched/input, 0..1), so it takes deciles instead of the
 /// duration buckets; `le="0"` isolates requests with no cached prefix at all.
-const CACHE_AWARE_MATCH_RATIO_BUCKETS: &[f64] =
+pub(crate) const CACHE_AWARE_MATCH_RATIO_BUCKETS: &[f64] =
     &[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
 
 /// Marks jemalloc as the final artifact's Rust global allocator.

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -127,6 +127,12 @@ impl Default for PrometheusConfig {
 /// `PrometheusBuilder::upkeep_timeout()` in `start_prometheus`.
 pub(crate) const UPKEEP_INTERVAL_SECS: u64 = 5 * 60;
 
+/// Histogram buckets for `smg_cache_aware_match_ratio`. The ratio is
+/// dimensionless (matched/input, 0..1), so it takes deciles instead of the
+/// duration buckets; `le="0"` isolates requests with no cached prefix at all.
+const CACHE_AWARE_MATCH_RATIO_BUCKETS: &[f64] =
+    &[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
+
 /// Marks jemalloc as the final artifact's Rust global allocator.
 ///
 /// Call this before [`start_prometheus`] only from a binary or extension that
@@ -331,6 +337,15 @@ pub(crate) fn init_metrics() {
         "smg_cache_placement_entries",
         "Cache-aware hash-index placement entries by model (keys with a live holder)"
     );
+    describe_counter!(
+        "smg_cache_aware_policy_branch_total",
+        "Cache-aware tree-mode selection branch (tree_match, spill, expected_wait_fallback, \
+         first_healthy_fallback)"
+    );
+    describe_histogram!(
+        "smg_cache_aware_match_ratio",
+        "Cache-aware tree-mode best prefix match ratio per request (matched/input, 0..1)"
+    );
 
     // Layer 3: Worker resilience metrics (circuit breaker)
     describe_gauge!(
@@ -513,6 +528,11 @@ pub fn start_prometheus(config: PrometheusConfig) -> PrometheusHandle {
     let ttft_matcher = Matcher::Suffix(String::from("ttft_seconds"));
     let tpot_matcher = Matcher::Suffix(String::from("tpot_seconds"));
 
+    // The cache-aware match ratio is a dimensionless 0..1 value: no `_seconds`
+    // matcher applies, so it also needs its own buckets or it renders as a
+    // summary.
+    let match_ratio_matcher = Matcher::Full(String::from("smg_cache_aware_match_ratio"));
+
     PrometheusBuilder::new()
         .upkeep_timeout(Duration::from_secs(UPKEEP_INTERVAL_SECS))
         .set_buckets_for_metric(duration_matcher, &duration_bucket)
@@ -526,6 +546,8 @@ pub fn start_prometheus(config: PrometheusConfig) -> PrometheusHandle {
             super::runtime_metrics::EVENT_LOOP_DELAY_BUCKETS,
         )
         .expect("failed to set event loop delay buckets")
+        .set_buckets_for_metric(match_ratio_matcher, CACHE_AWARE_MATCH_RATIO_BUCKETS)
+        .expect("failed to set cache-aware match ratio buckets")
         .install_recorder()
         .inspect(|_| {
             #[cfg(all(
@@ -1281,6 +1303,21 @@ impl Metrics {
         gauge!("smg_cache_placement_entries", "model" => model).set(count as f64);
     }
 
+    /// Record cache-aware policy execution branch for tree-mode routing decisions
+    pub fn record_worker_cache_aware_policy_branch(branch: &'static str) {
+        counter!(
+            "smg_cache_aware_policy_branch_total",
+            "branch" => branch
+        )
+        .increment(1);
+    }
+
+    /// Record the best prefix match ratio (matched/input, 0..1) of a cache-aware
+    /// tree-mode routing decision
+    pub fn record_cache_aware_match_ratio(ratio: f64) {
+        histogram!("smg_cache_aware_match_ratio").record(ratio);
+    }
+
     /// Record consistent hashing policy execution branch for routing decisions
     pub fn record_worker_consistent_hashing_policy_branch(branch: &'static str) {
         counter!(
@@ -1824,6 +1861,61 @@ mod tests {
                 "smg_cache_tree_tenants {tree} series missing; rendered:\n{rendered}"
             );
         }
+    }
+
+    /// The match ratio must render as a real histogram (`_bucket{le=...}`
+    /// lines) once its buckets are registered the way `start_prometheus` does;
+    /// without them the recorder falls back to a summary.
+    #[test]
+    fn cache_aware_decision_metrics_render_counter_and_bucketed_histogram() {
+        let recorder = PrometheusBuilder::new()
+            .set_buckets_for_metric(
+                Matcher::Full(String::from("smg_cache_aware_match_ratio")),
+                CACHE_AWARE_MATCH_RATIO_BUCKETS,
+            )
+            .expect("bucket override")
+            .build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            Metrics::record_worker_cache_aware_policy_branch("tree_match");
+            Metrics::record_worker_cache_aware_policy_branch("tree_match");
+            Metrics::record_worker_cache_aware_policy_branch("spill");
+            Metrics::record_cache_aware_match_ratio(0.0);
+            Metrics::record_cache_aware_match_ratio(0.75);
+        });
+        let rendered = handle.render();
+
+        for (branch, value) in [("tree_match", "2"), ("spill", "1")] {
+            let series =
+                format!("smg_cache_aware_policy_branch_total{{branch=\"{branch}\"}} {value}");
+            assert!(
+                rendered.lines().any(|l| l == series),
+                "{series} missing; rendered:\n{rendered}"
+            );
+        }
+        for (le, count) in [
+            ("0", "1"),
+            ("0.7", "1"),
+            ("0.8", "2"),
+            ("1", "2"),
+            ("+Inf", "2"),
+        ] {
+            let series = format!("smg_cache_aware_match_ratio_bucket{{le=\"{le}\"}} {count}");
+            assert!(
+                rendered.lines().any(|l| l == series),
+                "{series} missing; rendered:\n{rendered}"
+            );
+        }
+        assert!(
+            rendered
+                .lines()
+                .any(|l| l == "smg_cache_aware_match_ratio_count 2"),
+            "histogram count missing; rendered:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("smg_cache_aware_match_ratio{quantile="),
+            "match ratio rendered as a summary; rendered:\n{rendered}"
+        );
     }
 
     #[test]

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -1632,10 +1632,16 @@ impl CacheAwarePolicy {
         matched_tenants: &[TenantId],
         model_id: &str,
     ) {
-        let matched_ratio = if input_units == 0 {
-            0.0
+        // The branch mirrors the selection's f32 arithmetic; the histogram
+        // divides in f64 so exact deciles stay in their bucket (widening the
+        // f32 ratio would turn 1/10 into 0.100000001 > 0.1).
+        let (matched_ratio, histogram_ratio) = if input_units == 0 {
+            (0.0, 0.0)
         } else {
-            matched_units as f32 / input_units as f32
+            (
+                matched_units as f32 / input_units as f32,
+                matched_units as f64 / input_units as f64,
+            )
         };
         let branch = match selected_url {
             None => "first_healthy_fallback",
@@ -1649,7 +1655,7 @@ impl CacheAwarePolicy {
             }
         };
         Metrics::record_worker_cache_aware_policy_branch(branch);
-        Metrics::record_cache_aware_match_ratio(f64::from(matched_ratio));
+        Metrics::record_cache_aware_match_ratio(histogram_ratio);
         debug!(
             index = "tree",
             branch,
@@ -2107,7 +2113,7 @@ impl Default for CacheAwarePolicy {
 #[cfg(test)]
 mod tests {
     use kv_index::{compute_content_hash, SequenceHash, StoredBlock, WorkerBlockMap};
-    use metrics_exporter_prometheus::PrometheusBuilder;
+    use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
     use openai_protocol::worker::{
         HealthCheckConfig, SchedulerLoadSnapshot, WorkerLoadResponse, WorkerStatus,
     };
@@ -2146,7 +2152,10 @@ mod tests {
         );
         CacheAwarePolicy::affinity_score_group(&candidates, tuning.selection_temperature)
     }
-    use crate::worker::{BasicWorkerBuilder, WorkerType};
+    use crate::{
+        observability::metrics::CACHE_AWARE_MATCH_RATIO_BUCKETS,
+        worker::{BasicWorkerBuilder, WorkerType},
+    };
 
     fn no_health_check() -> HealthCheckConfig {
         HealthCheckConfig {
@@ -3264,7 +3273,9 @@ mod tests {
     }
 
     /// The branch counter and match-ratio histogram are recorded on every
-    /// tree decision, independent of whether the debug line is enabled.
+    /// tree decision, independent of whether the debug line is enabled, and
+    /// the ratio is bucketed the way `start_prometheus` registers it: an
+    /// exact decile (32 of 320) must land in `le="0.1"`, not widen past it.
     #[test]
     fn token_tree_selection_records_branch_and_match_ratio_metrics() {
         let policy = CacheAwarePolicy::with_config(test_config());
@@ -3272,11 +3283,20 @@ mod tests {
         let tokens: Vec<u32> = (0..32).collect();
         seed_token_tenants(&policy, &workers, &tokens, &["http://w1:8000"]);
         let novel: Vec<u32> = (1000..1064).collect();
+        let decile: Vec<u32> = (0..320).collect();
 
-        let recorder = PrometheusBuilder::new().build_recorder();
+        let recorder = PrometheusBuilder::new()
+            .set_buckets_for_metric(
+                Matcher::Full(String::from("smg_cache_aware_match_ratio")),
+                CACHE_AWARE_MATCH_RATIO_BUCKETS,
+            )
+            .unwrap()
+            .build_recorder();
         let handle = recorder.handle();
         metrics::with_local_recorder(&recorder, || {
-            for request in [&tokens, &novel] {
+            // A full-prefix hit (1.0), a novel prompt (0.0), and a prompt
+            // sharing only the seeded 32 tokens of 320 (0.1).
+            for request in [&tokens, &novel, &decile] {
                 policy
                     .select_worker(
                         &workers,
@@ -3290,12 +3310,14 @@ mod tests {
         });
         let rendered = handle.render();
 
-        // One full-prefix hit (ratio 1.0) and one novel prompt (ratio 0.0).
         for series in [
             "smg_cache_aware_policy_branch_total{branch=\"tree_match\"} 1",
-            "smg_cache_aware_policy_branch_total{branch=\"expected_wait_fallback\"} 1",
-            "smg_cache_aware_match_ratio_sum 1",
-            "smg_cache_aware_match_ratio_count 2",
+            "smg_cache_aware_policy_branch_total{branch=\"expected_wait_fallback\"} 2",
+            "smg_cache_aware_match_ratio_bucket{le=\"0\"} 1",
+            "smg_cache_aware_match_ratio_bucket{le=\"0.1\"} 2",
+            "smg_cache_aware_match_ratio_bucket{le=\"0.9\"} 2",
+            "smg_cache_aware_match_ratio_bucket{le=\"1\"} 3",
+            "smg_cache_aware_match_ratio_count 3",
         ] {
             assert!(
                 rendered.lines().any(|l| l == series),

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -1620,8 +1620,9 @@ impl CacheAwarePolicy {
         candidates.last().map(|c| c.idx)
     }
 
-    /// One decision line per tree-routed request. `selected_url == None`
-    /// means the caller fell back to `fallback_url` (first healthy).
+    /// One decision per tree-routed request: the branch counter and match
+    /// ratio histogram always, the debug line when enabled. `selected_url ==
+    /// None` means the caller fell back to `fallback_url` (first healthy).
     fn log_tree_decision(
         &self,
         selected_url: Option<&str>,
@@ -1631,9 +1632,6 @@ impl CacheAwarePolicy {
         matched_tenants: &[TenantId],
         model_id: &str,
     ) {
-        if !tracing::enabled!(tracing::Level::DEBUG) {
-            return;
-        }
         let matched_ratio = if input_units == 0 {
             0.0
         } else {
@@ -1650,6 +1648,8 @@ impl CacheAwarePolicy {
                 }
             }
         };
+        Metrics::record_worker_cache_aware_policy_branch(branch);
+        Metrics::record_cache_aware_match_ratio(f64::from(matched_ratio));
         debug!(
             index = "tree",
             branch,
@@ -2107,6 +2107,7 @@ impl Default for CacheAwarePolicy {
 #[cfg(test)]
 mod tests {
     use kv_index::{compute_content_hash, SequenceHash, StoredBlock, WorkerBlockMap};
+    use metrics_exporter_prometheus::PrometheusBuilder;
     use openai_protocol::worker::{
         HealthCheckConfig, SchedulerLoadSnapshot, WorkerLoadResponse, WorkerStatus,
     };
@@ -3260,6 +3261,47 @@ mod tests {
             )
             .unwrap();
         assert!(logs_contain("expected_wait_fallback"));
+    }
+
+    /// The branch counter and match-ratio histogram are recorded on every
+    /// tree decision, independent of whether the debug line is enabled.
+    #[test]
+    fn token_tree_selection_records_branch_and_match_ratio_metrics() {
+        let policy = CacheAwarePolicy::with_config(test_config());
+        let workers = make_workers(&["http://w1:8000", "http://w2:8000"]);
+        let tokens: Vec<u32> = (0..32).collect();
+        seed_token_tenants(&policy, &workers, &tokens, &["http://w1:8000"]);
+        let novel: Vec<u32> = (1000..1064).collect();
+
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            for request in [&tokens, &novel] {
+                policy
+                    .select_worker(
+                        &workers,
+                        &SelectWorkerInfo {
+                            tokens: Some(request),
+                            ..Default::default()
+                        },
+                    )
+                    .unwrap();
+            }
+        });
+        let rendered = handle.render();
+
+        // One full-prefix hit (ratio 1.0) and one novel prompt (ratio 0.0).
+        for series in [
+            "smg_cache_aware_policy_branch_total{branch=\"tree_match\"} 1",
+            "smg_cache_aware_policy_branch_total{branch=\"expected_wait_fallback\"} 1",
+            "smg_cache_aware_match_ratio_sum 1",
+            "smg_cache_aware_match_ratio_count 2",
+        ] {
+            assert!(
+                rendered.lines().any(|l| l == series),
+                "{series} missing; rendered:\n{rendered}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

Operating `cache_aware` in production (smg 1.10.1, two lanes), the per-request routing decision is only observable through the DEBUG line `Cache-aware selection` emitted by `log_tree_decision` in `model_gateway/src/policies/cache_aware.rs`, and `smg_worker_selection_total` carries only a `policy` label. So without turning on debug logging fleet-wide and joining logs, an operator cannot see:

- how often the policy takes each branch (`tree_match` / `spill` / `expected_wait_fallback` / `first_healthy_fallback`) — i.e. how often affinity actually wins vs. is abandoned for load;
- the distribution of `matched_ratio` (best prefix match / prompt length) across requests.

We ended up enabling the debug line fleet-wide and doing a per-request log join against the engines' cache results to measure this. Aggregate counters make it a Grafana panel instead.

### Solution

Record two aggregate metrics on every tree-mode decision, alongside the existing debug line, in the same style as the sibling `smg_manual_policy_branch_total` / `smg_consistent_hashing_policy_branch_total` / `smg_prefix_hash_policy_branch_total` counters:

| metric | type | labels | notes |
| --- | --- | --- | --- |
| `smg_cache_aware_policy_branch_total` | counter | `branch` ∈ `tree_match`, `spill`, `expected_wait_fallback`, `first_healthy_fallback` | one increment per tree decision (token and string trees) |
| `smg_cache_aware_match_ratio` | histogram | none | best prefix match ratio `matched/input`, buckets `0.0, 0.1, …, 1.0` (+`+Inf`); `le="0"` isolates requests with no cached prefix at all |

The histogram's buckets are registered in `start_prometheus` via `Matcher::Full("smg_cache_aware_match_ratio")`: the ratio is dimensionless, so none of the `_seconds` matchers apply and without an explicit bucket set `metrics-exporter-prometheus` renders it as a summary (quantile lines only, not heatmap-able) — same reason the event-loop canary has its own buckets.

Behaviour-neutral: metrics only, no change to worker selection. The debug line is unchanged; its `enabled!(DEBUG)` early-return in `log_tree_decision` is dropped because `branch` is now needed for the counter regardless (`debug!` still gates itself). Per-request cost is one static-label counter increment and one histogram record, the same class as the sibling branch counters.

The histogram value is divided in f64 from the integer counts, while the branch classification keeps the selection's f32 arithmetic: widening the f32 ratio would push exact deciles past their bucket edge (1/10 → 0.100000001 > 0.1, landing in `le="0.2"`).

Scope deliberately kept to the approximate-tree modes, which are the ones with a match ratio. The hash-index (`index="hash"`) and event-driven decision lines, and the fleet-wide KV-pressure fallback, are left as they are; happy to extend the same counter to them in a follow-up if wanted. Labels are `branch` only, matching the sibling counters (no `model` label).

## Changes

- `model_gateway/src/observability/metrics.rs`
  - `describe_counter!("smg_cache_aware_policy_branch_total", …)` and `describe_histogram!("smg_cache_aware_match_ratio", …)` next to the cache-tree gauges.
  - `Metrics::record_worker_cache_aware_policy_branch(branch: &'static str)` and `Metrics::record_cache_aware_match_ratio(ratio: f64)`.
  - `CACHE_AWARE_MATCH_RATIO_BUCKETS` (deciles) registered in `start_prometheus` with `Matcher::Full`.
  - Test `cache_aware_decision_metrics_render_counter_and_bucketed_histogram`: renders through a `PrometheusBuilder` with the same bucket override and asserts the counter series and `_bucket{le=…}` lines (and that no `quantile=` summary lines appear).
- `model_gateway/src/policies/cache_aware.rs`
  - `log_tree_decision` computes `matched_ratio` (f32, for the branch) and the f64 histogram ratio unconditionally, records both metrics, then emits the unchanged debug line.
  - Test `token_tree_selection_records_branch_and_match_ratio_metrics`: a seeded full-prefix hit (1.0), a novel prompt (0.0) and a 32-of-320 partial match (0.1), rendered through the production bucket set, yield `branch="tree_match"` 1, `branch="expected_wait_fallback"` 2 and bucket lines `le="0"` 1, `le="0.1"` 2, `le="0.9"` 2, `le="1"` 3, `_count 3`. With the f32 widening the 0.1 sample lands in `le="0.2"` and the test fails.

## Test Plan

Scenario the new policy test reproduces: two workers, `w1` seeded as the tenant of a 32-token prefix; select for that exact prompt (full match, ratio 1.0 → `tree_match`), for a novel 64-token prompt (ratio 0.0 → `expected_wait_fallback`), and for a 320-token prompt sharing only the seeded 32 tokens (ratio 0.1 → `expected_wait_fallback`). Scrape output contains:

```
smg_cache_aware_policy_branch_total{branch="tree_match"} 1
smg_cache_aware_policy_branch_total{branch="expected_wait_fallback"} 2
smg_cache_aware_match_ratio_bucket{le="0"} 1
smg_cache_aware_match_ratio_bucket{le="0.1"} 2
smg_cache_aware_match_ratio_bucket{le="0.9"} 2
smg_cache_aware_match_ratio_bucket{le="1"} 3
smg_cache_aware_match_ratio_count 3
```

and, in the metrics-module test with the same bucket set, ratios 0.0 and 0.75 render as

```
smg_cache_aware_match_ratio_bucket{le="0"} 1
smg_cache_aware_match_ratio_bucket{le="0.7"} 1
smg_cache_aware_match_ratio_bucket{le="0.8"} 2
smg_cache_aware_match_ratio_bucket{le="1"} 2
smg_cache_aware_match_ratio_bucket{le="+Inf"} 2
```

To reproduce against a live gateway: run `smg` with `--policy cache_aware` and Prometheus enabled, send the same prompt twice and then an unrelated one, and `curl -s :29000/metrics | grep smg_cache_aware`.

Gate output (local):

```
$ cargo +nightly fmt --all -- --check
(no output)

$ cargo clippy -p smg --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 40s

$ cargo check -p smg
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 47s

$ cargo test -p smg --lib -- policies::cache_aware observability::metrics
test result: ok. 129 passed; 0 failed; 0 ignored; 0 measured; 1635 filtered out; finished in 1.31s

$ cargo test -p smg --lib -- token_tree_selection_records_branch_and_match_ratio_metrics cache_aware_decision_metrics_render_counter_and_bucketed_histogram token_tree_selection_emits_decision_line
test observability::metrics::tests::cache_aware_decision_metrics_render_counter_and_bucketed_histogram ... ok
test policies::cache_aware::tests::token_tree_selection_emits_decision_line ... ok
test policies::cache_aware::tests::token_tree_selection_records_branch_and_match_ratio_metrics ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1761 filtered out; finished in 0.00s
```

Clippy was run without `--all-features` (no system OpenCV on the build box, per the CONTRIBUTING note); the touched code is not feature-gated.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (`-p smg`, see note above)
- [ ] (Optional) Documentation updated — the two metric names/labels above are the docs delta if the metrics reference in smg-docs should list them
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
